### PR TITLE
fix: Add missing RATE_LIMIT_KV binding to stripe-webhook-handler

### DIFF
--- a/workers/stripe-webhook-handler/wrangler.toml
+++ b/workers/stripe-webhook-handler/wrangler.toml
@@ -7,6 +7,11 @@ compatibility_flags = ["nodejs_compat"]
 [observability]
 enabled = true
 
+# KV Namespaces
+kv_namespaces = [
+  { binding = "RATE_LIMIT_KV", id = "cea7153364974737b16870df08f31083" }
+]
+
 # Production environment
 [env.production]
 name = "stripe-webhook-handler-production"


### PR DESCRIPTION
## Problem
Production deployment was failing with HTTP 530 errors during health checks. The stripe-webhook-handler worker was crashing on startup.

## Root Cause
The worker code uses `RATE_LIMIT_KV` for rate limiting middleware, but the KV namespace binding was not configured in `wrangler.toml`.

## Solution
Added the `RATE_LIMIT_KV` binding to the wrangler.toml configuration (matching the auth worker configuration).

## Testing
- ✅ Worker builds successfully
- ✅ Configuration matches auth worker pattern
- ⏳ Will verify health checks pass in preview deployment

## Changes
- Added KV namespace binding to `workers/stripe-webhook-handler/wrangler.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)