### PR TITLE
fix(ci): prevent duplicate workflow runs on PR pushes

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,11 +1,7 @@
 name: Static Analysis
 
 on:
-  push:
-    branches: ['**'] # Run on all branches
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_call: # Allow this workflow to be called by other workflows
+  workflow_call: # Only run when called by other workflows
 
 permissions:
   contents: read

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - "**" # Run on all branches for debugging
+      - "**" # Run on all branches
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ env:
   EXPIRES_IN_DAYS: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
Fixed duplicate CI workflow runs when pushing to PR branches.

## Problem
When pushing to a PR branch, workflows ran 4 times:
- ❌ static_analysis.yml standalone (from `push` trigger)
- ❌ static_analysis.yml via testing.yml (from `workflow_call`)
- ❌ testing.yml (from `pull_request` trigger)  
- ❌ testing.yml again (from `push` trigger)

## Solution
1. **static_analysis.yml**: Removed `push`/`pull_request` triggers, only `workflow_call`
2. **testing.yml**: Updated concurrency group to `github.head_ref || github.ref_name`

Now: 1 workflow run per PR push with proper duplicate cancellation.

## Note
Test failures are pre-existing from `infra/workers` base branch (identity package tests). This PR only changes CI config - doesn't touch test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)