### PR TITLE
fix(cache): fan library invalidation on content mutations (Codex-c01do)

### DIFF
--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -162,10 +162,37 @@ Check on `visibilitychange`, diff against stored manifest, invalidate only what 
 | Key | Client manifest? | Bumped when |
 |---|---|---|
 | `cache:version:{userId}` | ✅ Yes | Profile updated, prefs changed |
-| `cache:version:user:{userId}:library` | ✅ Yes | Purchase completed (cross-device library staleness) |
+| `cache:version:user:{userId}:library` | ✅ Yes | Purchase completed; subscription lifecycle event; **content mutation (update/publish/unpublish/delete); membership role change; follow/unfollow** |
+| `cache:version:user:{userId}:subscription:{orgId}` | ✅ Yes | Subscription checkout / tier change / cancel / reactivate / webhook events |
 | `cache:version:{orgId}` | ✅ Yes | Org settings/branding changed |
 | `cache:version:content:published` | ❌ Server KV only | Any content published/unpublished/updated |
 | `cache:version:org:{orgId}:content` | ❌ Server KV only | Content in this org changed |
+
+### Content mutation fanout (Codex-c01do)
+
+Content-scoped mutations (`update`, `publish`, `unpublish`, `delete`) fan
+per-user library version bumps in addition to the catalogue version bumps.
+The fanout set is the union of:
+
+- Completed purchasers of the content (from `purchases`)
+- Active/cancelling subscribers to the owning org (from `subscriptions`)
+- Management members (owner/admin/creator) of the owning org
+- Optionally — followers of the org when `includeFollowers: true` is passed
+
+A safety cap (`DEFAULT_MAX_LIBRARY_FANOUT = 500`) skips the per-user fanout
+for unbounded audiences (popular follower-gated content) and logs a warning
+— the platform layout's `visibilitychange → invalidate('cache:versions')`
+loop catches up on the user's next focus event.
+
+Membership (`inviteMember`, `updateMemberRole`, `removeMember`) and follower
+(`followOrganization`, `unfollowOrganization`) mutations bump the single
+affected user's library version — no fanout query needed because the target
+user id is already known.
+
+Implementation: `packages/content/src/services/content-invalidation.ts`
+(entry points: `invalidateContentAccess`, `invalidateOrgMembership`).
+Wired into content-api routes (`workers/content-api/src/routes/content.ts`)
+and organization-api routes (`workers/organization-api/src/routes/{members,followers}.ts`).
 
 **Why content keys are server-only:** Content availability is "server-authoritative always" — SSR renders the correct published list on every page load. There's no localStorage-backed `contentCollection` to invalidate. Bumping the key on the server means the next SSR request gets a fresh DB fetch instead of a stale KV list.
 

--- a/docs/content-cache-audit/README.md
+++ b/docs/content-cache-audit/README.md
@@ -1,0 +1,128 @@
+# Content Mutation Cache Integrity (Codex-c01do)
+
+Sibling epic to the subscription cache audit (`docs/subscription-cache-audit/`).
+Where that epic closed the subscription-lifecycle invalidation gaps, this one
+closes the **content-mutation** invalidation gaps: content update (access-config
+edits), unpublish, delete, publish, membership role changes, and follow/unfollow.
+
+## The gap
+
+`libraryCollection` in `apps/web/src/lib/collections/library.ts` is localStorage-
+backed. Each entry carries per-item access metadata (`accessType`, `priceCents`,
+`minimumTierId`). The per-user library version key
+`COLLECTION_USER_LIBRARY(userId)` only bumped on:
+
+- Purchase webhook (ecom-api)
+- Subscription lifecycle events (`packages/subscription/src/services/subscription-invalidation.ts`)
+
+Content mutations did **not** bump the per-user key. As a result:
+
+- Creator edits a content item's accessType (free → subscribers)
+- User's library UI on another device still shows the old accessType until
+  the next `visibilitychange → invalidate('cache:versions')` roundtrip
+
+Access decisions at click time are always live (server-side), so this is
+**UX drift, not a security bug**. But per `feedback_dont_defer_cache_issues`
+cache gaps warrant proactive target solutions.
+
+## Design — Option A (per-user fanout) + existing revocation (Option D)
+
+We evaluated four options:
+
+| Option | Trade-off | Chosen? |
+|---|---|---|
+| **A — Per-user fanout** | Precise, O(N) KV writes where N = users with access. Cap required for unbounded audiences. | ✅ Yes |
+| **B — Per-org library version** (`org:{orgId}:library`) | Cheap (1 write), but noisy for content-heavy orgs. | Future work |
+| **C — SSE/WebSocket broadcast** | Real-time, large architectural shift. | Parked |
+| **D — `AccessRevocation` KV block-list** | Already live for subscription lifecycle. Complements rather than replaces A. | ✅ (already in place) |
+
+### Fanout cost analysis
+
+Per-mutation fanout size (realistic platform-scale reasoning):
+
+| Access mode | Fanout set | Typical size |
+|---|---|---|
+| `team` | org management roles | 5–50 |
+| `subscribers` | active subs at org | 100s–1000s |
+| `paid` / hybrid | purchasers ∪ subs | dozens–hundreds |
+| `followers` | org followers | can be very large |
+
+Option A is fine for bounded sets. For `followers` content, the union can
+exceed any reasonable cap, so `invalidateContentAccess` defaults
+`includeFollowers: false` and applies a hard cap
+(`DEFAULT_MAX_LIBRARY_FANOUT = 500`). Above the cap we log + skip per-user
+fanout and rely on the visibility-change roundtrip.
+
+## Implementation summary
+
+Helper location: `packages/content/src/services/content-invalidation.ts`.
+
+| Entry point | Scope | Callers |
+|---|---|---|
+| `invalidateContentAccess(args)` | Per-content fanout + catalogue | content-api content.update/publish/unpublish/delete |
+| `invalidateOrgMembership(args)` | Single user | organization-api members.{invite,update-role,remove}, followers.{follow,unfollow} |
+
+Each entry point follows the `subscription-invalidation.ts` pattern:
+- Fire-and-forget via `waitUntil`
+- Swallow KV failures through an optional `logger`
+- ValidationError on missing required ids (no silent no-op)
+
+See:
+- `packages/content/src/services/content-invalidation.ts`
+- `workers/content-api/src/routes/content.ts` (`fanContentInvalidation`)
+- `workers/organization-api/src/routes/members.ts` (`bumpUserLibrary`)
+- `workers/organization-api/src/routes/followers.ts` (`bumpUserLibrary`)
+
+## Test matrix
+
+### Unit (`packages/content/src/services/__tests__/content-invalidation.test.ts`)
+
+- Catalogue bumps fire unconditionally
+- Org-collection bump skipped for personal content (`organizationId === null`)
+- Per-user union across purchases + subscribers + management
+- Deduplication when a user is in multiple sources
+- `includeFollowers` opt-in adds followers
+- Fanout cap — above the cap, bumps are skipped and a warning is logged
+- KV rejections swallowed via `.catch`
+- `waitUntil` called synchronously per bump
+- `ValidationError` on missing/empty `contentId`
+- Membership helper: positive + negative + ValidationError paths
+- Exports stable `DEFAULT_MAX_LIBRARY_FANOUT = 500`
+
+### Integration (out of scope for PR 1)
+
+The worker route layer re-uses existing integration test infrastructure for
+content-api / organization-api. Adding KV-assertion tests there is tracked
+as a follow-up bead — the helper itself is fully unit tested and the route
+wiring is a one-line call.
+
+### Manual / E2E
+
+- Admin edits content accessType → subscribed user's library reflects the
+  new value after one invalidate roundtrip, no page reload
+- Admin toggles content subscription-inclusion → user's library card
+  updates within a few seconds without reload
+- Existing subscription-lifecycle tests still green (no double-bumps, no
+  missed bumps)
+
+## Files changed (PR — Codex-c01do)
+
+| File | Change |
+|---|---|
+| `packages/content/src/services/content-invalidation.ts` | **new** — shared helpers |
+| `packages/content/src/services/index.ts` | export new helpers |
+| `packages/content/src/index.ts` | re-export from package root |
+| `packages/content/src/services/__tests__/content-invalidation.test.ts` | **new** — 15 unit tests |
+| `workers/content-api/src/routes/content.ts` | new `fanContentInvalidation` helper; wire into update/publish/unpublish/delete |
+| `workers/organization-api/src/routes/members.ts` | new `bumpUserLibrary` helper; wire into invite/update-role/remove |
+| `workers/organization-api/src/routes/followers.ts` | new `bumpUserLibrary` helper; wire into follow/unfollow |
+| `docs/caching-strategy.md` | document new invalidation triggers |
+| `docs/content-cache-audit/README.md` | **new** — this file |
+
+## Open follow-ups
+
+- Consider adding Option B (per-org library version) alongside Option A for
+  follower-heavy orgs where the cap is routinely hit.
+- Add KV-level integration tests for content-api + organization-api routes
+  asserting that the version keys are bumped after each mutation.
+- Playwright cross-device spec mirroring `apps/web/e2e/account-subscription-cancel.spec.ts`.

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -60,8 +60,18 @@
 // Services
 // ============================================================================
 
+export type {
+  ContentInvalidationReason,
+  InvalidateContentAccessArgs,
+  InvalidateOrgMembershipArgs,
+  InvalidationLogger,
+  WaitUntilFn,
+} from './services';
 export {
   ContentService,
+  DEFAULT_MAX_LIBRARY_FANOUT,
+  invalidateContentAccess,
+  invalidateOrgMembership,
   MediaItemService,
 } from './services';
 

--- a/packages/content/src/services/__tests__/content-invalidation.test.ts
+++ b/packages/content/src/services/__tests__/content-invalidation.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Unit tests for the shared content-mutation cache invalidation helper
+ * (Codex-c01do).
+ *
+ * Pure unit tests — no DB, no KV, no Hono. Both `VersionedCache` and the
+ * Drizzle `db.query.*.findMany` surface are mocked so we can assert exactly
+ * which keys would be invalidated, and exercise the fanout cap + error
+ * swallowing paths without spinning up Neon.
+ *
+ * Coverage mirrors the subscription-invalidation test matrix:
+ *   - Catalogue bumps fire unconditionally
+ *   - Per-user fanout query union of purchases + subscribers + management
+ *   - `includeFollowers` opt-in adds followers to the fanout
+ *   - Deduplication across sources (a user who is both purchaser + subscriber
+ *     is bumped once)
+ *   - Fanout cap — above the cap, we log + skip per-user bumps
+ *   - KV rejection is swallowed via `.catch`, never surfaces
+ *   - waitUntil is called synchronously per bump (fire-and-forget semantics)
+ *   - ValidationError on missing/empty contentId for the content helper
+ *   - ValidationError on missing/empty userId for the membership helper
+ */
+
+import { CacheType, type VersionedCache } from '@codex/cache';
+import type { Database } from '@codex/database';
+import { ValidationError } from '@codex/service-errors';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MAX_LIBRARY_FANOUT,
+  type InvalidationLogger,
+  invalidateContentAccess,
+  invalidateOrgMembership,
+  type WaitUntilFn,
+} from '../content-invalidation';
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+interface QueryFixture {
+  purchases: Array<{ customerId: string }>;
+  subscriptions: Array<{ userId: string }>;
+  organizationMemberships: Array<{ userId: string }>;
+  organizationFollowers: Array<{ userId: string }>;
+}
+
+function makeDb(fixture: Partial<QueryFixture> = {}): Database {
+  const defaults: QueryFixture = {
+    purchases: [],
+    subscriptions: [],
+    organizationMemberships: [],
+    organizationFollowers: [],
+  };
+  const rows = { ...defaults, ...fixture };
+
+  // Only .findMany is exercised by the helper.
+  const mock = {
+    query: {
+      purchases: {
+        findMany: vi.fn().mockResolvedValue(rows.purchases),
+      },
+      subscriptions: {
+        findMany: vi.fn().mockResolvedValue(rows.subscriptions),
+      },
+      organizationMemberships: {
+        findMany: vi.fn().mockResolvedValue(rows.organizationMemberships),
+      },
+      organizationFollowers: {
+        findMany: vi.fn().mockResolvedValue(rows.organizationFollowers),
+      },
+    },
+  };
+  // Drizzle has a much larger surface; we narrow it here because the helper
+  // only uses `db.query.*.findMany`. Casting via unknown is the standard
+  // pattern (see subscription-invalidation.test.ts) — not `as any`.
+  return mock as unknown as Database;
+}
+
+function makeCache(
+  invalidate: (id: string) => Promise<void> = () => Promise.resolve()
+): { cache: VersionedCache; invalidate: ReturnType<typeof vi.fn> } {
+  const fn = vi.fn(invalidate);
+  const cache = { invalidate: fn } as unknown as VersionedCache;
+  return { cache, invalidate: fn };
+}
+
+function makeWaitUntil(): {
+  waitUntil: WaitUntilFn;
+  promises: Array<Promise<unknown>>;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const promises: Array<Promise<unknown>> = [];
+  const spy = vi.fn((promise: Promise<unknown>) => {
+    promises.push(promise);
+  });
+  return { waitUntil: spy, promises, spy };
+}
+
+const CONTENT_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+
+// ============================================================================
+// Tests — invalidateContentAccess
+// ============================================================================
+
+describe('invalidateContentAccess', () => {
+  it('bumps the catalogue keys even when no users are affected', async () => {
+    const db = makeDb();
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+    });
+
+    await Promise.all(promises);
+
+    // COLLECTION_CONTENT_PUBLISHED + COLLECTION_ORG_CONTENT
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_CONTENT_PUBLISHED
+    );
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_ORG_CONTENT(ORG_ID)
+    );
+    // No per-user bumps — user set is empty
+    const userLibraryCalls = invalidate.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0].startsWith('user:')
+    );
+    expect(userLibraryCalls).toHaveLength(0);
+  });
+
+  it('skips the org collection bump when organizationId is null (personal content)', async () => {
+    const db = makeDb();
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: null,
+      reason: 'content_deleted',
+    });
+
+    await Promise.all(promises);
+
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_CONTENT_PUBLISHED
+    );
+    expect(invalidate).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^org:.*:content$/)
+    );
+  });
+
+  it('unions purchasers, subscribers, and management members and fans per-user bumps', async () => {
+    const db = makeDb({
+      purchases: [{ customerId: 'u-purchase' }],
+      subscriptions: [{ userId: 'u-subscriber' }],
+      organizationMemberships: [{ userId: 'u-management' }],
+    });
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+    });
+
+    await Promise.all(promises);
+
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u-purchase')
+    );
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u-subscriber')
+    );
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u-management')
+    );
+  });
+
+  it('deduplicates when a user appears in multiple sources', async () => {
+    const db = makeDb({
+      purchases: [{ customerId: 'u-overlap' }],
+      subscriptions: [{ userId: 'u-overlap' }],
+      organizationMemberships: [{ userId: 'u-overlap' }],
+    });
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+    });
+
+    await Promise.all(promises);
+
+    const overlapKey = CacheType.COLLECTION_USER_LIBRARY('u-overlap');
+    const overlapCalls = invalidate.mock.calls.filter(
+      (args) => args[0] === overlapKey
+    );
+    expect(overlapCalls).toHaveLength(1);
+  });
+
+  it('excludes followers from fanout by default', async () => {
+    const db = makeDb({
+      organizationFollowers: [{ userId: 'u-follower' }],
+    });
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+      // includeFollowers defaults to false
+    });
+
+    await Promise.all(promises);
+
+    expect(invalidate).not.toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u-follower')
+    );
+  });
+
+  it('includes followers when includeFollowers=true', async () => {
+    const db = makeDb({
+      organizationFollowers: [{ userId: 'u-follower' }],
+    });
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+      includeFollowers: true,
+    });
+
+    await Promise.all(promises);
+
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u-follower')
+    );
+  });
+
+  it('skips per-user fanout and logs a warning when the cap is exceeded', async () => {
+    // 3 users, cap=2 → skip fanout
+    const db = makeDb({
+      organizationMemberships: [
+        { userId: 'u1' },
+        { userId: 'u2' },
+        { userId: 'u3' },
+      ],
+    });
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+    const warn = vi.fn();
+    const logger: InvalidationLogger = { warn };
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+      logger,
+      maxFanout: 2,
+    });
+
+    await Promise.all(promises);
+
+    // Catalogue bumps still happen
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_CONTENT_PUBLISHED
+    );
+    // But no per-user bumps
+    expect(invalidate).not.toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u1')
+    );
+    expect(invalidate).not.toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u2')
+    );
+    expect(invalidate).not.toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u3')
+    );
+    // And the cap warning fires
+    expect(warn).toHaveBeenCalledWith(
+      'content-invalidation: fanout skipped (cap exceeded)',
+      expect.objectContaining({
+        contentId: CONTENT_ID,
+        organizationId: ORG_ID,
+        reason: 'content_updated',
+        userCount: 3,
+        maxFanout: 2,
+      })
+    );
+  });
+
+  it('swallows cache.invalidate rejections and routes them through the logger', async () => {
+    const boom = new Error('KV unavailable');
+    const db = makeDb({ purchases: [{ customerId: 'u-1' }] });
+    const { cache } = makeCache(() => Promise.reject(boom));
+    const { waitUntil, promises } = makeWaitUntil();
+    const warn = vi.fn();
+    const logger: InvalidationLogger = { warn };
+
+    await expect(
+      invalidateContentAccess({
+        db,
+        cache,
+        waitUntil,
+        contentId: CONTENT_ID,
+        organizationId: ORG_ID,
+        reason: 'content_updated',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(Promise.all(promises)).resolves.toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+
+    // One warn per failed bump (content:published, org:content, user:library)
+    expect(warn).toHaveBeenCalledWith(
+      'content-invalidation: bump failed',
+      expect.objectContaining({
+        reason: 'content_updated',
+        error: 'KV unavailable',
+      })
+    );
+  });
+
+  it('hands each bump to waitUntil synchronously (fire-and-forget)', async () => {
+    // Each cache.invalidate returns a pending promise we control manually.
+    const resolvers: Array<() => void> = [];
+    const { cache } = makeCache(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const db = makeDb({ purchases: [{ customerId: 'u-1' }] });
+    const { waitUntil, promises, spy } = makeWaitUntil();
+
+    await invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId: CONTENT_ID,
+      organizationId: ORG_ID,
+      reason: 'content_updated',
+    });
+
+    // Three bumps: content:published, org:content, user:library(u-1).
+    // All three should be queued to waitUntil even though the underlying
+    // KV writes are still pending.
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(resolvers).toHaveLength(3);
+
+    // Now resolve them all and flush.
+    for (const r of resolvers) r();
+    await Promise.all(promises);
+  });
+
+  it('throws ValidationError when contentId is missing', async () => {
+    const db = makeDb();
+    const { cache } = makeCache();
+    const { waitUntil } = makeWaitUntil();
+
+    await expect(
+      invalidateContentAccess({
+        db,
+        cache,
+        waitUntil,
+        // Simulate a caller that lost the content id somewhere — this is
+        // the runtime guard, distinct from the compile-time type.
+        contentId: '' as string,
+        organizationId: ORG_ID,
+        reason: 'content_updated',
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('respects the default cap constant', () => {
+    // Sanity check that the export is stable — route code relies on the
+    // documented default (500) to set its own overrides.
+    expect(DEFAULT_MAX_LIBRARY_FANOUT).toBe(500);
+  });
+});
+
+// ============================================================================
+// Tests — invalidateOrgMembership
+// ============================================================================
+
+describe('invalidateOrgMembership', () => {
+  it('bumps the COLLECTION_USER_LIBRARY key for the target user', async () => {
+    const { cache, invalidate } = makeCache();
+    const { waitUntil, promises } = makeWaitUntil();
+
+    invalidateOrgMembership({
+      cache,
+      waitUntil,
+      userId: 'u-123',
+      organizationId: ORG_ID,
+      reason: 'membership_role_changed',
+    });
+
+    await Promise.all(promises);
+
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(invalidate).toHaveBeenCalledWith(
+      CacheType.COLLECTION_USER_LIBRARY('u-123')
+    );
+  });
+
+  it('calls waitUntil synchronously before any KV work completes', async () => {
+    const resolvers: Array<() => void> = [];
+    const { cache } = makeCache(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const { waitUntil, promises, spy } = makeWaitUntil();
+
+    invalidateOrgMembership({
+      cache,
+      waitUntil,
+      userId: 'u-123',
+      organizationId: ORG_ID,
+      reason: 'membership_removed',
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(resolvers).toHaveLength(1);
+    for (const r of resolvers) r();
+    await Promise.all(promises);
+  });
+
+  it('swallows KV rejections via the logger', async () => {
+    const boom = new Error('KV unavailable');
+    const { cache } = makeCache(() => Promise.reject(boom));
+    const { waitUntil, promises } = makeWaitUntil();
+    const warn = vi.fn();
+
+    invalidateOrgMembership({
+      cache,
+      waitUntil,
+      userId: 'u-123',
+      organizationId: ORG_ID,
+      reason: 'follower_added',
+      logger: { warn },
+    });
+
+    await expect(Promise.all(promises)).resolves.toEqual([undefined]);
+    expect(warn).toHaveBeenCalledWith(
+      'content-invalidation: bump failed',
+      expect.objectContaining({
+        userId: 'u-123',
+        organizationId: ORG_ID,
+        reason: 'follower_added',
+        error: 'KV unavailable',
+      })
+    );
+  });
+
+  it('throws ValidationError when userId is missing', () => {
+    const { cache } = makeCache();
+    const { waitUntil } = makeWaitUntil();
+
+    expect(() =>
+      invalidateOrgMembership({
+        cache,
+        waitUntil,
+        userId: '',
+        organizationId: ORG_ID,
+        reason: 'membership_role_changed',
+      })
+    ).toThrow(ValidationError);
+  });
+});

--- a/packages/content/src/services/content-invalidation.ts
+++ b/packages/content/src/services/content-invalidation.ts
@@ -1,0 +1,439 @@
+/**
+ * Shared content-mutation cache invalidation helper.
+ *
+ * Epic: "Content Mutation Cache Integrity" (Codex-c01do) — the sibling of
+ * `packages/subscription/src/services/subscription-invalidation.ts`. Where that
+ * helper fans invalidations on **subscription lifecycle** events, this helper
+ * fans invalidations on **content mutation** events (update access-config,
+ * unpublish, delete, membership role changes, follow/unfollow).
+ *
+ * The gap this closes: `libraryCollection` stores `accessType` per item in
+ * localStorage. When a creator edits a content item's accessType (e.g. moves
+ * free→subscribers or paid→free), **only** the catalogue collection versions
+ * (`COLLECTION_CONTENT_PUBLISHED`, `COLLECTION_ORG_CONTENT`) are bumped. The
+ * per-user library version (`COLLECTION_USER_LIBRARY`) is not — so the user's
+ * library UI shows stale access flags until the next visibility-change
+ * staleness roundtrip. Access decisions at click time are always live
+ * (server-side), so this is **UX drift, not a security bug** — but per user
+ * feedback `feedback_dont_defer_cache_issues` cache gaps need proactive target
+ * solutions.
+ *
+ * See docs/caching-strategy.md and docs/content-cache-audit/ for the full
+ * invalidation gap matrix and design rationale.
+ *
+ * Design — Option A (per-user fanout) with safety cap:
+ *
+ * - Catalogue versions (`COLLECTION_CONTENT_PUBLISHED` + `COLLECTION_ORG_CONTENT`)
+ *   are always bumped — this is the existing behaviour preserved.
+ * - Per-user library version (`COLLECTION_USER_LIBRARY`) is bumped for every
+ *   user currently holding this content in their library, discovered via a
+ *   union query over purchases + active subscriptions + org management
+ *   memberships + (optionally) followers.
+ * - A `MAX_LIBRARY_FANOUT` hard cap guards against runaway writes for
+ *   unboundedly popular content (e.g. follower-gated posts on a large org).
+ *   When the cap is exceeded, we log a warning and skip per-user fanout —
+ *   the platform-layout `visibilitychange → invalidate('cache:versions')`
+ *   loop will pick up changes on the user's next focus event.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { invalidateContentAccess } from '@codex/content';
+ * import { VersionedCache } from '@codex/cache';
+ *
+ * const cache = new VersionedCache({ kv: env.CACHE_KV });
+ * await invalidateContentAccess({
+ *   db,
+ *   cache,
+ *   waitUntil: ctx.executionCtx.waitUntil.bind(ctx.executionCtx),
+ *   contentId,
+ *   organizationId,
+ *   reason: 'content_updated',
+ * });
+ * ```
+ *
+ * Fire-and-forget: returns once the user set is resolved and all bumps are
+ * handed to `waitUntil`. Individual KV failures are swallowed and logged.
+ */
+
+import { CacheType, type VersionedCache } from '@codex/cache';
+import {
+  ORGANIZATION_ROLES,
+  PURCHASE_STATUS,
+  SUBSCRIPTION_STATUS,
+} from '@codex/constants';
+import type { Database } from '@codex/database';
+import {
+  organizationFollowers,
+  organizationMemberships,
+  purchases,
+  subscriptions,
+} from '@codex/database/schema';
+import { ValidationError } from '@codex/service-errors';
+import { and, eq, gt, inArray } from 'drizzle-orm';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Why the invalidation fired. Used for observability only — does not affect
+ * which cache keys are bumped.
+ *
+ * Matches the taxonomy of content-adjacent mutations that can change what a
+ * given user sees in their library.
+ */
+export type ContentInvalidationReason =
+  | 'content_updated'
+  | 'content_unpublished'
+  | 'content_deleted'
+  | 'content_published'
+  | 'membership_role_changed'
+  | 'membership_removed'
+  | 'membership_invited'
+  | 'follower_added'
+  | 'follower_removed';
+
+/**
+ * Narrow waitUntil signature. We intentionally do not depend on Hono or
+ * workers-types here so this helper stays portable.
+ */
+export type WaitUntilFn = (promise: Promise<unknown>) => void;
+
+/**
+ * Optional logger surface — matches the subset of `ObservabilityClient` the
+ * helper uses. Omitted by default so the helper has no runtime deps.
+ */
+export interface InvalidationLogger {
+  warn: (message: string, context?: Record<string, unknown>) => void;
+  info?: (message: string, context?: Record<string, unknown>) => void;
+}
+
+/**
+ * Arguments for `invalidateContentAccess` — content-scoped invalidation.
+ */
+export interface InvalidateContentAccessArgs {
+  db: Database;
+  cache: VersionedCache;
+  waitUntil: WaitUntilFn;
+  /** Content that was mutated. Required. */
+  contentId: string;
+  /** Organization that owns the content, if any. Controls org-collection + org-user fanout. */
+  organizationId: string | null;
+  /** Observability tag. */
+  reason: ContentInvalidationReason;
+  /** Optional logger for fire-and-forget failures. */
+  logger?: InvalidationLogger;
+  /**
+   * Include organization followers in the fanout. Default `false` — follower
+   * counts can be very large and follower-gated content is the common case
+   * where Option B (per-org library version) would be cheaper. We default to
+   * false and let `hasFollowerGating` callers opt in.
+   */
+  includeFollowers?: boolean;
+  /**
+   * Override the fanout cap. Defaults to `DEFAULT_MAX_LIBRARY_FANOUT` (500).
+   * Above this, per-user fanout is skipped (warning logged) and we rely on
+   * the client-side visibility staleness check.
+   */
+  maxFanout?: number;
+}
+
+/**
+ * Arguments for `invalidateOrgMembership` — membership/follower-scoped
+ * invalidation when a single user's (org, role/follow) tuple changes.
+ */
+export interface InvalidateOrgMembershipArgs {
+  cache: VersionedCache;
+  waitUntil: WaitUntilFn;
+  /** User whose library is now stale. Required. */
+  userId: string;
+  /** Org that changed membership or follower set. Used for observability only. */
+  organizationId: string;
+  reason:
+    | 'membership_role_changed'
+    | 'membership_removed'
+    | 'membership_invited'
+    | 'follower_added'
+    | 'follower_removed';
+  logger?: InvalidationLogger;
+}
+
+/**
+ * Default cap — see note on `maxFanout`.
+ *
+ * 500 is chosen as a pragmatic upper bound: Cloudflare KV allows ~1000
+ * writes/sec per namespace. One bulk mutation can comfortably burn half a
+ * second of write budget before the user-facing request returns. Above that,
+ * we fall back to the cheaper visibility-change loop instead of DOS'ing KV.
+ */
+export const DEFAULT_MAX_LIBRARY_FANOUT = 500;
+
+// ============================================================================
+// Per-content invalidation (the main entry point)
+// ============================================================================
+
+/**
+ * Fan content-mutation invalidation to every user who currently has the
+ * content in their library, plus bump the catalogue version keys.
+ *
+ * Behaviour:
+ *
+ * 1. Always bumps `COLLECTION_CONTENT_PUBLISHED` (fire-and-forget).
+ * 2. If `organizationId` is present, bumps `COLLECTION_ORG_CONTENT(orgId)`
+ *    (fire-and-forget).
+ * 3. Resolves the set of users with library-visibility:
+ *    - Purchasers of the specific content (via `purchases.status='completed'`)
+ *    - Active/cancelling subscribers to the org (subscription cache is keyed
+ *      per-user, not per-content, so any subscription-gated content mutation
+ *      stales the whole library entry)
+ *    - Management members (owner/admin/creator) of the org
+ *    - Optional: followers of the org (gated by `includeFollowers`)
+ * 4. If the set exceeds `maxFanout`, logs a warning and skips step 5 — the
+ *    visibility-change staleness check will resolve drift on next focus.
+ * 5. For each user, fire-and-forget bumps
+ *    `COLLECTION_USER_LIBRARY(userId)` via `cache.invalidate`.
+ *
+ * Returns once the user set is resolved and every bump is handed to
+ * `waitUntil`. Individual KV failures are swallowed and logged.
+ *
+ * Throws `ValidationError` on missing/empty `contentId` — callers should
+ * never reach this helper without a resolved content id.
+ */
+export async function invalidateContentAccess(
+  args: InvalidateContentAccessArgs
+): Promise<void> {
+  const {
+    db,
+    cache,
+    waitUntil,
+    contentId,
+    organizationId,
+    reason,
+    logger,
+    includeFollowers = false,
+    maxFanout = DEFAULT_MAX_LIBRARY_FANOUT,
+  } = args;
+
+  if (typeof contentId !== 'string' || contentId.length === 0) {
+    throw new ValidationError(
+      'invalidateContentAccess requires a non-empty contentId',
+      { reason }
+    );
+  }
+
+  // --- Catalogue bumps (always) -------------------------------------------
+  bumpWithLogger(
+    cache,
+    waitUntil,
+    CacheType.COLLECTION_CONTENT_PUBLISHED,
+    { reason, contentId, key: 'content:published' },
+    logger
+  );
+
+  if (organizationId) {
+    bumpWithLogger(
+      cache,
+      waitUntil,
+      CacheType.COLLECTION_ORG_CONTENT(organizationId),
+      { reason, contentId, key: 'org:content' },
+      logger
+    );
+  }
+
+  // --- Resolve affected user set ------------------------------------------
+  const affectedUserIds = await resolveAffectedUsers({
+    db,
+    contentId,
+    organizationId,
+    includeFollowers,
+  });
+
+  if (affectedUserIds.size === 0) {
+    return;
+  }
+
+  if (affectedUserIds.size > maxFanout) {
+    logger?.warn('content-invalidation: fanout skipped (cap exceeded)', {
+      contentId,
+      organizationId,
+      reason,
+      userCount: affectedUserIds.size,
+      maxFanout,
+    });
+    return;
+  }
+
+  // --- Per-user library bumps (fire-and-forget) ---------------------------
+  for (const userId of affectedUserIds) {
+    bumpWithLogger(
+      cache,
+      waitUntil,
+      CacheType.COLLECTION_USER_LIBRARY(userId),
+      { reason, contentId, organizationId, userId, key: 'user:library' },
+      logger
+    );
+  }
+
+  logger?.info?.('content-invalidation: fanout complete', {
+    contentId,
+    organizationId,
+    reason,
+    userCount: affectedUserIds.size,
+  });
+}
+
+// ============================================================================
+// Per-user-in-org invalidation (membership + follower mutations)
+// ============================================================================
+
+/**
+ * Bump exactly one user's library version. Used for org-membership and
+ * follower mutations where we already know the specific user whose library
+ * just changed (inviteMember, updateMemberRole, removeMember,
+ * followOrganization, unfollowOrganization).
+ *
+ * Fire-and-forget via `waitUntil` — returns synchronously.
+ *
+ * Throws `ValidationError` on missing/empty `userId` — callers should never
+ * reach this helper without a resolved user id.
+ */
+export function invalidateOrgMembership(
+  args: InvalidateOrgMembershipArgs
+): void {
+  const { cache, waitUntil, userId, organizationId, reason, logger } = args;
+
+  if (typeof userId !== 'string' || userId.length === 0) {
+    throw new ValidationError(
+      'invalidateOrgMembership requires a non-empty userId',
+      { reason, organizationId }
+    );
+  }
+
+  bumpWithLogger(
+    cache,
+    waitUntil,
+    CacheType.COLLECTION_USER_LIBRARY(userId),
+    { reason, userId, organizationId, key: 'user:library' },
+    logger
+  );
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+interface ResolveArgs {
+  db: Database;
+  contentId: string;
+  organizationId: string | null;
+  includeFollowers: boolean;
+}
+
+/**
+ * Union-query the set of user ids whose library currently includes (or could
+ * include) this content. Mirrors the decision tree in
+ * `ContentAccessService.hasContentAccess` so the invalidation fanout is a
+ * superset of users who could be holding the item.
+ *
+ * Intentionally a superset: we invalidate a few users who never had access,
+ * rather than miss anyone who does. Library items are looked up on reload
+ * anyway (the cache is only a UI-flash optimisation), so the cost of a
+ * superfluous bump is one extra `GET /api/library` on next focus.
+ *
+ * The per-source queries run in parallel for minimum latency.
+ */
+async function resolveAffectedUsers(args: ResolveArgs): Promise<Set<string>> {
+  const { db, contentId, organizationId, includeFollowers } = args;
+
+  const MANAGEMENT_ROLES: string[] = [
+    ORGANIZATION_ROLES.OWNER,
+    ORGANIZATION_ROLES.ADMIN,
+    ORGANIZATION_ROLES.CREATOR,
+  ];
+
+  const emptyUserRows: Promise<Array<{ userId: string }>> = Promise.resolve([]);
+
+  const purchasePromise = db.query.purchases
+    .findMany({
+      where: and(
+        eq(purchases.contentId, contentId),
+        eq(purchases.status, PURCHASE_STATUS.COMPLETED)
+      ),
+      columns: { customerId: true },
+    })
+    .then((rows) =>
+      // Adapt `customerId` to `userId` so the merge loop is uniform.
+      rows.map((r) => ({ userId: r.customerId }))
+    );
+
+  const subscriberPromise: Promise<Array<{ userId: string }>> = organizationId
+    ? db.query.subscriptions.findMany({
+        where: and(
+          eq(subscriptions.organizationId, organizationId),
+          inArray(subscriptions.status, [
+            SUBSCRIPTION_STATUS.ACTIVE,
+            SUBSCRIPTION_STATUS.CANCELLING,
+          ]),
+          gt(subscriptions.currentPeriodEnd, new Date())
+        ),
+        columns: { userId: true },
+      })
+    : emptyUserRows;
+
+  const managementPromise: Promise<Array<{ userId: string }>> = organizationId
+    ? db.query.organizationMemberships.findMany({
+        where: and(
+          eq(organizationMemberships.organizationId, organizationId),
+          eq(organizationMemberships.status, 'active'),
+          inArray(organizationMemberships.role, MANAGEMENT_ROLES)
+        ),
+        columns: { userId: true },
+      })
+    : emptyUserRows;
+
+  const followerPromise: Promise<Array<{ userId: string }>> =
+    organizationId && includeFollowers
+      ? db.query.organizationFollowers.findMany({
+          where: eq(organizationFollowers.organizationId, organizationId),
+          columns: { userId: true },
+        })
+      : emptyUserRows;
+
+  const [purchaseRows, subscriberRows, managementRows, followerRows] =
+    await Promise.all([
+      purchasePromise,
+      subscriberPromise,
+      managementPromise,
+      followerPromise,
+    ]);
+
+  const ids = new Set<string>();
+  for (const r of purchaseRows) ids.add(r.userId);
+  for (const r of subscriberRows) ids.add(r.userId);
+  for (const r of managementRows) ids.add(r.userId);
+  for (const r of followerRows) ids.add(r.userId);
+  return ids;
+}
+
+/**
+ * Internal: queue a single KV version bump via `waitUntil`, swallowing and
+ * optionally logging any failure. Mirrors the shape used by
+ * `subscription-invalidation.ts` so the two sibling helpers behave
+ * identically in the face of KV outages.
+ */
+function bumpWithLogger(
+  cache: VersionedCache,
+  waitUntil: WaitUntilFn,
+  key: string,
+  ctx: Record<string, unknown>,
+  logger?: InvalidationLogger
+): void {
+  const promise = cache.invalidate(key).catch((error: unknown) => {
+    logger?.warn('content-invalidation: bump failed', {
+      ...ctx,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  waitUntil(promise);
+}

--- a/packages/content/src/services/index.ts
+++ b/packages/content/src/services/index.ts
@@ -5,8 +5,19 @@
  * Provides both service classes and factory functions.
  */
 
+// Content Cache Invalidation Helpers (Codex-c01do — content mutation sibling
+// of subscription-invalidation)
+export {
+  type ContentInvalidationReason,
+  DEFAULT_MAX_LIBRARY_FANOUT,
+  type InvalidateContentAccessArgs,
+  type InvalidateOrgMembershipArgs,
+  type InvalidationLogger,
+  invalidateContentAccess,
+  invalidateOrgMembership,
+  type WaitUntilFn,
+} from './content-invalidation';
 // Content Service
 export { ContentService } from './content-service';
-
 // Media Item Service
 export { MediaItemService } from './media-service';

--- a/workers/content-api/src/routes/content.ts
+++ b/workers/content-api/src/routes/content.ts
@@ -18,8 +18,8 @@
 
 import { CacheType, VersionedCache } from '@codex/cache';
 import { AUTH_ROLES } from '@codex/constants';
-import { createDbClient, eq, schema } from '@codex/database';
 import type {
+  ContentInvalidationReason,
   ContentResponse,
   CreateContentResponse,
   DeleteContentResponse,
@@ -32,8 +32,10 @@ import {
   checkContentSlugSchema,
   contentQuerySchema,
   createContentSchema,
+  invalidateContentAccess,
   updateContentSchema,
 } from '@codex/content';
+import { createDbClient, eq, schema } from '@codex/database';
 import {
   MAX_IMAGE_SIZE_BYTES,
   SUPPORTED_IMAGE_MIME_TYPES,
@@ -89,6 +91,58 @@ function bumpOrgContentVersion(
       })(),
     ]).catch((err: unknown) => {
       obs?.warn('Cache invalidation failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    })
+  );
+}
+
+/**
+ * Fan per-user library cache invalidation after a content mutation.
+ *
+ * Codex-c01do — content mutations (update-access-config, unpublish, delete,
+ * publish) previously bumped ONLY catalogue version keys. The per-user
+ * library cache (`COLLECTION_USER_LIBRARY`) was untouched, so library UI
+ * showed stale accessType flags until the next visibility-change staleness
+ * roundtrip. Access decisions at click time are always live (server-side)
+ * — this is UX drift, not a security bug — but per feedback_dont_defer_cache_issues
+ * we close the gap proactively.
+ *
+ * Fire-and-forget: the whole block is wrapped in `waitUntil` so the route
+ * response is never blocked on KV writes.
+ */
+function fanContentInvalidation(
+  env: HonoEnv['Bindings'],
+  executionCtx: ExecutionContext,
+  contentId: string,
+  organizationId: string | null | undefined,
+  reason: ContentInvalidationReason,
+  obs?: Logger,
+  options: { includeFollowers?: boolean } = {}
+): void {
+  if (!env.CACHE_KV) return;
+  const cache = new VersionedCache({ kv: env.CACHE_KV });
+  const db = createDbClient(env);
+  const waitUntil = executionCtx.waitUntil.bind(executionCtx);
+
+  // Wrap the whole fanout in waitUntil so the DB `resolveAffectedUsers`
+  // query does not block the response. The helper internally hands each
+  // per-user KV bump to waitUntil as well.
+  executionCtx.waitUntil(
+    invalidateContentAccess({
+      db,
+      cache,
+      waitUntil,
+      contentId,
+      organizationId: organizationId ?? null,
+      reason,
+      logger: obs,
+      includeFollowers: options.includeFollowers ?? false,
+    }).catch((err: unknown) => {
+      obs?.warn('content-invalidation: fanout failed', {
+        contentId,
+        organizationId,
+        reason,
         error: err instanceof Error ? err.message : String(err),
       });
     })
@@ -197,11 +251,22 @@ app.patch(
       body: updateContentSchema,
     },
     handler: async (ctx): Promise<UpdateContentResponse['data']> => {
-      return await ctx.services.content.update(
+      const result = await ctx.services.content.update(
         ctx.input.params.id,
         ctx.input.body,
         ctx.user.id
       );
+      // Fan per-user library invalidation (Codex-c01do). Covers access-config
+      // edits — the most common cause of stale accessType flags in library UI.
+      fanContentInvalidation(
+        ctx.env,
+        ctx.executionCtx,
+        result.id,
+        result.organizationId,
+        'content_updated',
+        ctx.obs
+      );
+      return result;
     },
   })
 );
@@ -254,6 +319,16 @@ app.post(
         result.organizationId,
         ctx.obs
       );
+      // Fan per-user library invalidation (Codex-c01do). A publish adds the
+      // item to subscribers'/members' libraries — they need a fresh view.
+      fanContentInvalidation(
+        ctx.env,
+        ctx.executionCtx,
+        result.id,
+        result.organizationId,
+        'content_published',
+        ctx.obs
+      );
 
       // TODO: Send new-content-published email to subscribers
       // Requires a subscriber query (users with contentAccess in this org).
@@ -291,6 +366,16 @@ app.post(
         result.organizationId,
         ctx.obs
       );
+      // Fan per-user library invalidation (Codex-c01do). Unpublish must
+      // remove the item from subscribers'/members' libraries.
+      fanContentInvalidation(
+        ctx.env,
+        ctx.executionCtx,
+        result.id,
+        result.organizationId,
+        'content_unpublished',
+        ctx.obs
+      );
       return result;
     },
   })
@@ -314,19 +399,34 @@ app.delete(
     input: { params: createIdParamsSchema() },
     successStatus: 204,
     handler: async (ctx): Promise<DeleteContentResponse> => {
-      // Read org before delete so we can bump its version
+      // Read org BEFORE delete so we can (a) bump its version and (b) fan
+      // per-user library invalidation while the row is still readable.
+      // Note: the per-user fanout query in `invalidateContentAccess` runs
+      // against the content-id — we want to resolve affected users using the
+      // pre-delete state (purchases, subscribers, members) which survives
+      // the soft-delete unchanged. It's safe to call after delete because
+      // we key by contentId and purchases/subscriptions/memberships don't
+      // soft-delete alongside content.
       let organizationId: string | undefined;
+      const contentId = ctx.input.params.id;
       try {
-        const content = await ctx.services.content.get(
-          ctx.input.params.id,
-          ctx.user.id
-        );
+        const content = await ctx.services.content.get(contentId, ctx.user.id);
         organizationId = content?.organizationId ?? undefined;
       } catch {
         // Pre-fetch for cache invalidation is non-critical
       }
-      await ctx.services.content.delete(ctx.input.params.id, ctx.user.id);
+      await ctx.services.content.delete(contentId, ctx.user.id);
       bumpOrgContentVersion(ctx.env, ctx.executionCtx, organizationId, ctx.obs);
+      // Fan per-user library invalidation (Codex-c01do). Soft-delete must
+      // remove the item from everyone's library UI immediately.
+      fanContentInvalidation(
+        ctx.env,
+        ctx.executionCtx,
+        contentId,
+        organizationId ?? null,
+        'content_deleted',
+        ctx.obs
+      );
       return null;
     },
   })

--- a/workers/organization-api/src/routes/followers.ts
+++ b/workers/organization-api/src/routes/followers.ts
@@ -12,11 +12,34 @@
  * - GET    /count  - Get follower count (public)
  */
 
+import { CacheType, VersionedCache } from '@codex/cache';
 import type { HonoEnv } from '@codex/shared-types';
 import { uuidSchema } from '@codex/validation';
 import { procedure } from '@codex/worker-utils';
 import { Hono } from 'hono';
 import { z } from 'zod';
+
+/**
+ * Bump one user's library KV version key (Codex-c01do).
+ *
+ * Follow/unfollow toggles access to `followers`-gated content on the org.
+ * Library UI needs to reflect the change immediately — without this bump,
+ * the follower-gated items stay with stale access flags until the next
+ * visibility-change staleness roundtrip.
+ *
+ * Fire-and-forget via waitUntil.
+ */
+function bumpUserLibrary(
+  env: HonoEnv['Bindings'],
+  executionCtx: ExecutionContext,
+  userId: string
+): void {
+  if (!env.CACHE_KV || !userId) return;
+  const cache = new VersionedCache({ kv: env.CACHE_KV });
+  executionCtx.waitUntil(
+    cache.invalidate(CacheType.COLLECTION_USER_LIBRARY(userId)).catch(() => {})
+  );
+}
 
 const app = new Hono<HonoEnv>();
 
@@ -37,6 +60,10 @@ app.post(
         ctx.input.params.id,
         ctx.user.id
       );
+      // Codex-c01do — follow unlocks follower-gated content; bump the
+      // actor's library cache so their UI reflects access changes on next
+      // load.
+      bumpUserLibrary(ctx.env, ctx.executionCtx, ctx.user.id);
       return null;
     },
   })
@@ -58,6 +85,9 @@ app.delete(
         ctx.input.params.id,
         ctx.user.id
       );
+      // Codex-c01do — unfollow revokes follower-gated access; bump the
+      // actor's library cache so their UI reflects the change.
+      bumpUserLibrary(ctx.env, ctx.executionCtx, ctx.user.id);
       return null;
     },
   })

--- a/workers/organization-api/src/routes/members.ts
+++ b/workers/organization-api/src/routes/members.ts
@@ -13,7 +13,7 @@
  * - DELETE /:userId         - Remove member
  */
 
-import { VersionedCache } from '@codex/cache';
+import { CacheType, VersionedCache } from '@codex/cache';
 import { createDbClient, eq, schema } from '@codex/database';
 import type { HonoEnv } from '@codex/shared-types';
 import {
@@ -79,6 +79,29 @@ function deleteMembershipCache(ctx: CacheCtx, orgId: string, userId: string) {
     .CACHE_KV as import('@cloudflare/workers-types').KVNamespace;
   ctx.executionCtx.waitUntil(
     kv.delete(memberCacheKey(orgId, userId)).catch(() => {})
+  );
+}
+
+/**
+ * Bump one user's library KV version key (Codex-c01do).
+ *
+ * Membership mutations (invite/update-role/remove) can change what a user
+ * sees in their library:
+ *   - owner/admin/creator role grants `team` content access
+ *   - role changes can grant/revoke management-content access
+ *   - removing a member revokes all management-conditional content
+ *
+ * Fires once per affected user, fire-and-forget via waitUntil. Mirrors
+ * the shape of `invalidateOrgMembership()` in `@codex/content` without
+ * pulling the content package as a dep of organization-api.
+ */
+function bumpUserLibrary(ctx: CacheCtx, userId: string): void {
+  if (!ctx.env.CACHE_KV || !userId) return;
+  const cache = new VersionedCache({
+    kv: ctx.env.CACHE_KV as import('@cloudflare/workers-types').KVNamespace,
+  });
+  ctx.executionCtx.waitUntil(
+    cache.invalidate(CacheType.COLLECTION_USER_LIBRARY(userId)).catch(() => {})
   );
 }
 
@@ -175,6 +198,9 @@ app.post(
         ctx.input.body.role
       );
       invalidateOrgSlugCache(ctx);
+      // Invalidate invited user's library cache (Codex-c01do) — gaining a
+      // management role unlocks team-only content in their library UI.
+      bumpUserLibrary(ctx, result.userId);
 
       // Send invitation email (fire-and-forget)
       sendEmailToWorker(ctx.env, ctx.executionCtx, {
@@ -224,6 +250,9 @@ app.patch(
         ctx.input.body.role
       );
       invalidateOrgSlugCache(ctx);
+      // Invalidate the role-target user's library cache (Codex-c01do) — role
+      // changes toggle management-content access.
+      bumpUserLibrary(ctx, ctx.input.params.userId);
       return result;
     },
   })
@@ -251,6 +280,9 @@ app.delete(
       );
       deleteMembershipCache(ctx, ctx.input.params.id, ctx.input.params.userId);
       invalidateOrgSlugCache(ctx);
+      // Invalidate the removed user's library cache (Codex-c01do) — they
+      // lose all management-conditional content access.
+      bumpUserLibrary(ctx, ctx.input.params.userId);
       return null;
     },
   })


### PR DESCRIPTION
Closes the content-mutation sibling of the subscription-cache-audit epic (Codex-v8bub). Previously, `COLLECTION_USER_LIBRARY` only bumped on purchases and subscription-lifecycle events — content edits, unpublish, delete, membership role changes, and follow/unfollow left per-user library caches stale until the next visibility-change roundtrip.

Per `feedback_dont_defer_cache_issues`, this is UX-drift, not a security bug (access decisions at click time are always live), but we still close the gap proactively.

## Phase 1 — Investigation findings

**Membership mutations that change library content (audited in `packages/organization/src/services/organization-service.ts`):**

| Method | Line | Library-affecting? |
|---|---|---|
| `inviteMember` | 842 | Yes — grants management-content access when role is owner/admin/creator |
| `updateMemberRole` | 928 | Yes — promotes/demotes management access |
| `removeMember` | 998 | Yes — sets status=inactive, revokes team access |
| `followOrganization` | 1264 | Yes — unlocks `followers` access mode |
| `unfollowOrganization` | 1284 | Yes — revokes follower access |

None were bumping `COLLECTION_USER_LIBRARY`.

**Fanout cost (reasoning from schema + realistic scale):**

| Access mode | Union-set size | Option A fit |
|---|---|---|
| `team` | 5-50 mgmt members | perfect |
| `subscribers` | 100s-1000s active | good |
| `paid` / hybrid | dozens-hundreds | perfect |
| `followers` | can be very large | needs cap or opt-out |

**Decision: Option A (per-user fanout) + hard fanout cap (`DEFAULT_MAX_LIBRARY_FANOUT = 500`)**. Above the cap, log a warning and rely on the existing `visibilitychange → invalidate('cache:versions')` loop. `includeFollowers` defaults to `false` so follower-gated content doesn't routinely hit the cap.

Option D (`AccessRevocation` KV block-list) is **already in place** (Codex-v8bub) and complements — not replaces — this work. The 600s signed-URL TTL policy was already shortened by that epic and needs no further change.

## Phase 2 — Implementation summary

- `packages/content/src/services/content-invalidation.ts` — **new** shared helper mirroring `packages/subscription/src/services/subscription-invalidation.ts` in shape and semantics. Two entry points:
  - `invalidateContentAccess(args)` — per-content fanout + catalogue
  - `invalidateOrgMembership(args)` — single-user bump
- `packages/content/src/services/__tests__/content-invalidation.test.ts` — **new** 15 unit tests
- `packages/content/src/services/index.ts`, `packages/content/src/index.ts` — export new helpers
- `workers/content-api/src/routes/content.ts` — `fanContentInvalidation` wired into `update`/`publish`/`unpublish`/`delete` handlers
- `workers/organization-api/src/routes/members.ts` — `bumpUserLibrary` wired into `invite`/`update-role`/`remove`
- `workers/organization-api/src/routes/followers.ts` — `bumpUserLibrary` wired into `follow`/`unfollow`
- `docs/caching-strategy.md` — new invalidation triggers documented
- `docs/content-cache-audit/README.md` — **new** epic summary

The helper uses fire-and-forget `waitUntil` semantics, swallows KV failures through an optional logger, and throws `ValidationError` on missing ids (no silent no-op). Ownership stays in `@codex/content` so `organization-api` doesn't pick up the content package as a dep — it uses a tiny inline one-liner (`cache.invalidate(CacheType.COLLECTION_USER_LIBRARY(userId))`) instead.

## Phase 3 — Verification

- `pnpm --filter @codex/content typecheck` — clean
- `pnpm --filter content-api typecheck` — clean
- `pnpm --filter organization-api typecheck` — clean
- `pnpm --filter @codex/subscription typecheck` + tests — clean, 180/180 tests pass (no regression in Codex-v8bub work)
- 15/15 new unit tests pass (catalogue bumps, union query, dedup, followers opt-in, cap behaviour, KV swallowing, synchronous waitUntil, ValidationError paths)

### Pre-existing unrelated failures (confirmed on main)

- `packages/test-utils/src/factories.ts(290,3)` TS2719 — content type mismatch (not from this PR; blocks `pnpm -r typecheck` + cascades into ecom-api which depends on test-utils)
- `packages/worker-utils/src/middleware.ts(320,17)` + `service-registry.ts(622,11)` — pre-existing middleware/dist-src dual-declaration; confirmed on main via `git stash`
- Various `apps/web` pre-existing type errors (SubscribeButton.svelte.test, CreatorCard, ShaderHero, etc.)
- `packages/content` media-service integration tests fail on `isValidR2Key` — pre-existing, unrelated to this PR

None of these are caused by this PR.

## Scope boundary

- NOT folded into Codex-v8bub — this is the sibling content-mutation concern and gets its own epic header ("Content Mutation Cache Integrity")
- Integration KV-assertion tests at the route layer are tracked as a follow-up — the helper itself has full unit coverage and the route wiring is one-line

## Test plan

- [x] `pnpm --filter @codex/content typecheck` clean
- [x] `pnpm --filter content-api typecheck` clean
- [x] `pnpm --filter organization-api typecheck` clean
- [x] 15 new unit tests pass
- [x] Subscription-invalidation regression tests still green
- [ ] Manual smoke: admin edits accessType → user's library card reflects change after one focus tick (follow-up verification against running dev stack)
- [ ] Cross-device Playwright spec mirroring `apps/web/e2e/account-subscription-cancel.spec.ts` (tracked as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)