### PR TITLE
fix(content): hard-delete all R2 objects on media-item soft-delete (Codex-8x35w)

### DIFF
--- a/packages/content/src/services/__tests__/media-service.test.ts
+++ b/packages/content/src/services/__tests__/media-service.test.ts
@@ -18,15 +18,24 @@
  * - No cleanup needed - fresh database for this file
  */
 
+import type { R2Service } from '@codex/cloudflare-clients';
 import {
   type Database,
   seedTestUsers,
   setupTestDatabase,
   teardownTestDatabase,
 } from '@codex/test-utils';
-import { getOriginalKey } from '@codex/transcoding';
+import { getHlsPrefix, getOriginalKey } from '@codex/transcoding';
 import type { CreateMediaItemInput } from '@codex/validation';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { MediaNotFoundError } from '../../errors';
 import { MediaItemService } from '../media-service';
 
@@ -413,6 +422,286 @@ describe('MediaItemService', () => {
       await expect(service.delete(created.id, creatorId)).rejects.toThrow(
         MediaNotFoundError
       );
+    });
+
+    /**
+     * R2 cleanup tests — uses a service instance with a mocked R2Service so we
+     * can assert the four-prefix sweep behaviour without hitting real R2.
+     *
+     * The list() mock dispatches per prefix via a per-call key map so each
+     * prefix can be primed with its own page set / failure mode.
+     */
+    describe('R2 cleanup', () => {
+      function createMockR2() {
+        return {
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          get: vi.fn(),
+          list: vi.fn(),
+          putJson: vi.fn(),
+          generateSignedUrl: vi.fn(),
+          generateSignedUploadUrl: vi
+            .fn()
+            .mockResolvedValue('https://signed.example.com/upload'),
+        };
+      }
+
+      type MockR2 = ReturnType<typeof createMockR2>;
+
+      /**
+       * Configure mockR2.list to return a fixed page per prefix.
+       * Each entry: prefix → array of object keys (single page, not truncated).
+       */
+      function listByPrefix(
+        mockR2: MockR2,
+        pages: Record<string, string[]>
+      ): void {
+        mockR2.list.mockImplementation(
+          async ({ prefix }: { prefix: string; cursor?: string }) => {
+            const keys = pages[prefix] ?? [];
+            return {
+              objects: keys.map((key) => ({ key })),
+              truncated: false,
+            };
+          }
+        );
+      }
+
+      function createServiceWithR2(mockR2: MockR2): MediaItemService {
+        return new MediaItemService({
+          db,
+          environment: 'test',
+          r2: mockR2 as unknown as R2Service,
+        });
+      }
+
+      function expectedPrefixes(
+        creator: string,
+        mediaId: string
+      ): {
+        originals: string;
+        hls: string;
+        thumbnails: string;
+        waveforms: string;
+      } {
+        return {
+          originals: `${creator}/originals/${mediaId}/`,
+          hls: getHlsPrefix(creator, mediaId),
+          thumbnails: `${creator}/thumbnails/${mediaId}/`,
+          waveforms: `${creator}/waveforms/${mediaId}/`,
+        };
+      }
+
+      async function seedMedia(svc: MediaItemService): Promise<{
+        id: string;
+      }> {
+        const created = await svc.create(
+          {
+            title: 'R2 Cleanup Test',
+            mediaType: 'video',
+            mimeType: 'video/mp4',
+            r2Key: getOriginalKey(
+              creatorId,
+              crypto.randomUUID(),
+              'cleanup.mp4'
+            ),
+            fileSizeBytes: 1024,
+          },
+          creatorId
+        );
+        return { id: created.id };
+      }
+
+      it('lists and deletes objects under each of the four prefixes', async () => {
+        const mockR2 = createMockR2();
+        const svc = createServiceWithR2(mockR2);
+        const { id } = await seedMedia(svc);
+        const prefixes = expectedPrefixes(creatorId, id);
+
+        listByPrefix(mockR2, {
+          [prefixes.originals]: [`${prefixes.originals}media.mp4`],
+          [prefixes.hls]: [
+            `${prefixes.hls}master.m3u8`,
+            `${prefixes.hls}1080p/index.m3u8`,
+            `${prefixes.hls}1080p/segment_001.ts`,
+          ],
+          [prefixes.thumbnails]: [`${prefixes.thumbnails}auto-generated.jpg`],
+          [prefixes.waveforms]: [
+            `${prefixes.waveforms}waveform.json`,
+            `${prefixes.waveforms}waveform.png`,
+          ],
+        });
+
+        await svc.delete(id, creatorId);
+
+        // list() was called once per prefix
+        expect(mockR2.list).toHaveBeenCalledTimes(4);
+        for (const prefix of Object.values(prefixes)) {
+          expect(mockR2.list).toHaveBeenCalledWith(
+            expect.objectContaining({ prefix })
+          );
+        }
+
+        // Every object across all prefixes was deleted
+        const expectedKeys = [
+          `${prefixes.originals}media.mp4`,
+          `${prefixes.hls}master.m3u8`,
+          `${prefixes.hls}1080p/index.m3u8`,
+          `${prefixes.hls}1080p/segment_001.ts`,
+          `${prefixes.thumbnails}auto-generated.jpg`,
+          `${prefixes.waveforms}waveform.json`,
+          `${prefixes.waveforms}waveform.png`,
+        ];
+        for (const key of expectedKeys) {
+          expect(mockR2.delete).toHaveBeenCalledWith(key);
+        }
+        expect(mockR2.delete).toHaveBeenCalledTimes(expectedKeys.length);
+      });
+
+      it('isolates per-prefix list failures — other prefixes still sweep', async () => {
+        const mockR2 = createMockR2();
+        const svc = createServiceWithR2(mockR2);
+        const { id } = await seedMedia(svc);
+        const prefixes = expectedPrefixes(creatorId, id);
+
+        // Originals prefix throws on list; the other three return one key each.
+        mockR2.list.mockImplementation(
+          async ({ prefix }: { prefix: string; cursor?: string }) => {
+            if (prefix === prefixes.originals) {
+              throw new Error('R2 list error on originals');
+            }
+            const keyByPrefix: Record<string, string> = {
+              [prefixes.hls]: `${prefixes.hls}master.m3u8`,
+              [prefixes.thumbnails]: `${prefixes.thumbnails}auto-generated.jpg`,
+              [prefixes.waveforms]: `${prefixes.waveforms}waveform.json`,
+            };
+            const key = keyByPrefix[prefix];
+            return {
+              objects: key ? [{ key }] : [],
+              truncated: false,
+            };
+          }
+        );
+
+        // Outer call must NOT throw — failures are swallowed-and-logged
+        await expect(svc.delete(id, creatorId)).resolves.not.toThrow();
+
+        // All four prefixes were attempted
+        expect(mockR2.list).toHaveBeenCalledTimes(4);
+
+        // The other three prefixes still got their object deleted
+        expect(mockR2.delete).toHaveBeenCalledTimes(3);
+        expect(mockR2.delete).toHaveBeenCalledWith(
+          `${prefixes.hls}master.m3u8`
+        );
+        expect(mockR2.delete).toHaveBeenCalledWith(
+          `${prefixes.thumbnails}auto-generated.jpg`
+        );
+        expect(mockR2.delete).toHaveBeenCalledWith(
+          `${prefixes.waveforms}waveform.json`
+        );
+      });
+
+      it('isolates per-key delete failures — other keys in the same page still delete', async () => {
+        const mockR2 = createMockR2();
+        const svc = createServiceWithR2(mockR2);
+        const { id } = await seedMedia(svc);
+        const prefixes = expectedPrefixes(creatorId, id);
+
+        const hlsKeys = [
+          `${prefixes.hls}master.m3u8`,
+          `${prefixes.hls}1080p/segment_001.ts`,
+          `${prefixes.hls}1080p/segment_002.ts`,
+        ];
+        listByPrefix(mockR2, {
+          [prefixes.originals]: [],
+          [prefixes.hls]: hlsKeys,
+          [prefixes.thumbnails]: [],
+          [prefixes.waveforms]: [],
+        });
+
+        // Middle key fails; the others must still be attempted
+        mockR2.delete.mockImplementation(async (key: string) => {
+          if (key === hlsKeys[1]) {
+            throw new Error('R2 delete error');
+          }
+          return undefined;
+        });
+
+        await expect(svc.delete(id, creatorId)).resolves.not.toThrow();
+
+        // All three HLS keys were attempted, including the failed middle one
+        expect(mockR2.delete).toHaveBeenCalledTimes(hlsKeys.length);
+        for (const key of hlsKeys) {
+          expect(mockR2.delete).toHaveBeenCalledWith(key);
+        }
+      });
+
+      it('follows the cursor across truncated pages within a single prefix', async () => {
+        const mockR2 = createMockR2();
+        const svc = createServiceWithR2(mockR2);
+        const { id } = await seedMedia(svc);
+        const prefixes = expectedPrefixes(creatorId, id);
+
+        // Per-prefix call counter so we can return page 1 then page 2 for HLS only.
+        const callsByPrefix: Record<string, number> = {};
+        mockR2.list.mockImplementation(
+          async ({ prefix, cursor }: { prefix: string; cursor?: string }) => {
+            callsByPrefix[prefix] = (callsByPrefix[prefix] ?? 0) + 1;
+            if (prefix === prefixes.hls) {
+              if (callsByPrefix[prefix] === 1) {
+                expect(cursor).toBeUndefined();
+                return {
+                  objects: [
+                    { key: `${prefixes.hls}1080p/segment_001.ts` },
+                    { key: `${prefixes.hls}1080p/segment_002.ts` },
+                  ],
+                  truncated: true,
+                  cursor: 'next-page',
+                };
+              }
+              expect(cursor).toBe('next-page');
+              return {
+                objects: [{ key: `${prefixes.hls}1080p/segment_003.ts` }],
+                truncated: false,
+              };
+            }
+            return { objects: [], truncated: false };
+          }
+        );
+
+        await svc.delete(id, creatorId);
+
+        // HLS prefix listed twice (page 1 + page 2); other prefixes once each
+        const hlsCalls = mockR2.list.mock.calls.filter(
+          ([opts]: [{ prefix: string }]) => opts.prefix === prefixes.hls
+        );
+        expect(hlsCalls).toHaveLength(2);
+
+        // All three segments across both pages were deleted
+        expect(mockR2.delete).toHaveBeenCalledTimes(3);
+        expect(mockR2.delete).toHaveBeenCalledWith(
+          `${prefixes.hls}1080p/segment_001.ts`
+        );
+        expect(mockR2.delete).toHaveBeenCalledWith(
+          `${prefixes.hls}1080p/segment_002.ts`
+        );
+        expect(mockR2.delete).toHaveBeenCalledWith(
+          `${prefixes.hls}1080p/segment_003.ts`
+        );
+      });
+
+      it('does not call any R2 method when MediaNotFoundError throws inside the transaction', async () => {
+        const mockR2 = createMockR2();
+        const svc = createServiceWithR2(mockR2);
+
+        await expect(
+          svc.delete('00000000-0000-0000-0000-000000000000', creatorId)
+        ).rejects.toThrow(MediaNotFoundError);
+
+        expect(mockR2.list).not.toHaveBeenCalled();
+        expect(mockR2.delete).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/content/src/services/media-service.ts
+++ b/packages/content/src/services/media-service.ts
@@ -28,7 +28,7 @@ import {
   ValidationError,
 } from '@codex/service-errors';
 import type { PaginatedListResponse } from '@codex/shared-types';
-import { getOriginalKey, isValidR2Key } from '@codex/transcoding';
+import { getHlsPrefix, getOriginalKey, isValidR2Key } from '@codex/transcoding';
 import type {
   CreateMediaItemInput,
   UpdateMediaItemInput,
@@ -328,6 +328,16 @@ export class MediaItemService extends BaseService {
    * - Preserves data for content references
    * - Scoped to creator ownership
    *
+   * Side effect: hard-deletes every R2 object under the media item's four
+   * known prefixes (originals, hls, thumbnails, waveforms). R2 cleanup runs
+   * AFTER the soft-delete transaction commits — R2 has no rollback semantics,
+   * so failing inside the DB transaction would leave half-deleted state worse
+   * than no cleanup at all. Errors during the R2 sweep are swallowed and
+   * logged; orphans are recoverable, failed user-deletes are not.
+   *
+   * Mirrors the pattern landed in branding-settings-service.deleteIntroVideo
+   * for HLS cleanup, scaled to four prefixes via a shared helper.
+   *
    * Note: Content referencing this media will still exist but cannot be published
    *
    * @param id - Media item ID
@@ -336,6 +346,7 @@ export class MediaItemService extends BaseService {
    */
   async delete(id: string, creatorId: string): Promise<void> {
     try {
+      // Verify-and-soft-delete inside transaction
       await this.db.transaction(async (tx) => {
         const existing = await tx.query.mediaItems.findFirst({
           where: and(
@@ -358,11 +369,76 @@ export class MediaItemService extends BaseService {
             and(eq(mediaItems.id, id), withCreatorScope(mediaItems, creatorId))
           );
       });
+
+      // After commit: hard-delete R2 objects across all four prefixes.
+      // The helper swallows internally so a list/delete failure on one
+      // prefix doesn't prevent sweeps of the other three.
+      if (this.r2) {
+        await this.deletePrefixObjects(`${creatorId}/originals/${id}/`, id);
+        await this.deletePrefixObjects(getHlsPrefix(creatorId, id), id);
+        await this.deletePrefixObjects(`${creatorId}/thumbnails/${id}/`, id);
+        await this.deletePrefixObjects(`${creatorId}/waveforms/${id}/`, id);
+      }
     } catch (error) {
       if (error instanceof MediaNotFoundError) {
         throw error;
       }
       this.handleError(error, 'delete');
+    }
+  }
+
+  /**
+   * Hard-delete every R2 object under the given prefix.
+   *
+   * Lists with pagination (HLS folders contain manifest + per-variant
+   * playlists + many .ts segments; originals/thumbnails/waveforms are
+   * usually small, but the same loop handles all four). R2 has no
+   * "delete folder" primitive, so list + delete is the canonical approach.
+   *
+   * Errors are logged but never thrown — both the outer list() call and
+   * each per-key delete() call are caught individually so a single failure
+   * cannot prevent cleanup of the remaining objects (or other prefixes).
+   * Orphaned files are recoverable via background cleanup; failing the
+   * user's delete is not.
+   */
+  private async deletePrefixObjects(
+    prefix: string,
+    mediaItemId: string
+  ): Promise<void> {
+    if (!this.r2) return;
+
+    let cursor: string | undefined;
+    let totalDeleted = 0;
+
+    try {
+      do {
+        const page = await this.r2.list({ prefix, cursor });
+        for (const object of page.objects) {
+          try {
+            await this.r2.delete(object.key);
+            totalDeleted++;
+          } catch (error) {
+            this.obs.warn('Failed to delete media R2 object', {
+              mediaItemId,
+              r2Key: object.key,
+              error: String(error),
+            });
+          }
+        }
+        cursor = page.truncated ? page.cursor : undefined;
+      } while (cursor);
+
+      this.obs.info('Deleted media R2 objects', {
+        mediaItemId,
+        prefix,
+        deleted: totalDeleted,
+      });
+    } catch (error) {
+      this.obs.warn('Failed to list media R2 objects for cleanup', {
+        mediaItemId,
+        prefix,
+        error: String(error),
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

- `MediaItemService.delete()` now hard-deletes every R2 object across the four creator-scoped prefixes (`originals/`, `hls/`, `thumbnails/`, `waveforms/`) when a media item is soft-deleted
- R2 cleanup runs AFTER the soft-delete transaction commits, mirroring the swallow-and-log pattern landed in Codex-x1o7h for branding-settings-service.deleteIntroVideo, generalised to four prefixes via a single `deletePrefixObjects(prefix, mediaItemId)` private helper
- Failures during the R2 sweep are logged but never propagate — orphaned files are recoverable; failing the user's delete is not

## Why
Every media deletion via the content-api was leaking the upload + transcode output + thumbnails + waveforms to R2; only the DB row was soft-deleted. Picks Option A (eager cleanup) per the bead description.

## Test plan

- [x] `pnpm --filter @codex/content typecheck` — passes
- [x] `npx vitest run --config vitest.config.content.ts src/services/__tests__/media-service.test.ts` — all 29 tests pass (24 existing + 5 new R2 cleanup tests)
- [x] New tests cover: 4-prefix happy path, per-prefix list-failure isolation, per-key delete-failure isolation, cursor pagination, MediaNotFoundError early-throw never calls R2
- [x] Pre-existing baseline failures in `errors.test.ts` (`ContentAlreadyPublishedError is not a constructor`) and `content-service.test.ts` (visibility column) are unrelated to this change — confirmed they fail identically on `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)