### PR TITLE
fix(studio): ds-review iter-026 token migration batch

### DIFF
--- a/apps/web/src/lib/components/studio/CreateOrganizationDialog.svelte
+++ b/apps/web/src/lib/components/studio/CreateOrganizationDialog.svelte
@@ -261,17 +261,17 @@
     font-family: inherit;
   }
 
-  .field-input:focus {
+  .field-input:focus-visible {
     outline: var(--border-width-thick) solid var(--color-focus);
-    outline-offset: -1px;
+    outline-offset: calc(-1 * var(--border-width));
     border-color: var(--color-border-focus);
   }
 
-  .field-input.input-available:not(:focus) {
+  .field-input.input-available:not(:focus-visible) {
     border-color: var(--color-success-500);
   }
 
-  .field-input.input-taken:not(:focus) {
+  .field-input.input-taken:not(:focus-visible) {
     border-color: var(--color-error-500);
   }
 
@@ -288,9 +288,9 @@
     resize: vertical;
   }
 
-  .field-textarea:focus {
+  .field-textarea:focus-visible {
     outline: var(--border-width-thick) solid var(--color-focus);
-    outline-offset: -1px;
+    outline-offset: calc(-1 * var(--border-width));
     border-color: var(--color-border-focus);
   }
 
@@ -321,12 +321,20 @@
     border-radius: var(--radius-full);
     border: var(--border-width-thick) solid var(--color-text-muted);
     border-top-color: transparent;
-    animation: spin 0.6s linear infinite;
+    animation: spin var(--duration-slower) linear infinite;
   }
 
   @keyframes spin {
     to {
       transform: rotate(360deg);
+    }
+  }
+
+  /* Infinite spin bypasses the global token-level duration collapse —
+     neutralise here for vestibular safety (ref 03 §9 Skeleton Contract). */
+  @media (prefers-reduced-motion: reduce) {
+    .status-dot {
+      animation: none;
     }
   }
 

--- a/apps/web/src/lib/components/studio/LogoUpload.svelte
+++ b/apps/web/src/lib/components/studio/LogoUpload.svelte
@@ -200,8 +200,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 160px;
-    height: 160px;
+    /* 10rem (160px) — fixed media preview frame; sits above --space-24 (6rem)
+       and below --container-sm (40rem). No matching spacing/container token. */
+    width: 10rem;
+    height: 10rem;
     border: var(--border-width) var(--border-style) var(--color-border);
     border-radius: var(--radius-lg);
     background-color: var(--color-surface);
@@ -227,12 +229,14 @@
     justify-content: center;
     gap: var(--space-2);
     padding: var(--space-6) var(--space-4);
-    border: 2px dashed var(--color-border);
+    border: var(--border-width-thick) dashed var(--color-border);
     border-radius: var(--radius-lg);
     background-color: var(--color-surface);
     cursor: pointer;
     transition: var(--transition-colors);
-    max-width: 320px;
+    /* 20rem (320px) — drop-zone width sized to roughly twice the preview frame.
+       Sits between --container-xs (no token) and --container-sm (40rem). */
+    max-width: 20rem;
   }
 
   .drop-zone:hover,

--- a/apps/web/src/lib/components/studio/content-form/AccessSection.svelte
+++ b/apps/web/src/lib/components/studio/content-form/AccessSection.svelte
@@ -375,9 +375,9 @@
     font-family: inherit;
   }
 
-  .field-input:focus {
+  .field-input:focus-visible {
     outline: var(--border-width-thick) solid var(--color-focus);
-    outline-offset: -1px;
+    outline-offset: calc(-1 * var(--border-width));
     border-color: var(--color-border-focus, var(--color-focus));
   }
 

--- a/apps/web/src/lib/components/studio/content-form/OrganizeSection.svelte
+++ b/apps/web/src/lib/components/studio/content-form/OrganizeSection.svelte
@@ -118,9 +118,9 @@
     font-family: inherit;
   }
 
-  .field-input:focus {
+  .field-input:focus-visible {
     outline: var(--border-width-thick) solid var(--color-focus);
-    outline-offset: -1px;
+    outline-offset: calc(-1 * var(--border-width));
     border-color: var(--color-border-focus, var(--color-focus));
   }
 

--- a/apps/web/src/lib/components/studio/content-form/SlugField.svelte
+++ b/apps/web/src/lib/components/studio/content-form/SlugField.svelte
@@ -144,9 +144,9 @@
     font-family: inherit;
   }
 
-  .field-input:focus {
+  .field-input:focus-visible {
     outline: var(--border-width-thick) solid var(--color-focus);
-    outline-offset: -1px;
+    outline-offset: calc(-1 * var(--border-width));
     border-color: var(--color-border-focus);
   }
 

--- a/apps/web/src/lib/components/studio/content-list/ContentFeatureSlab.svelte
+++ b/apps/web/src/lib/components/studio/content-list/ContentFeatureSlab.svelte
@@ -202,7 +202,7 @@
 
   @media (prefers-reduced-motion: no-preference) {
     .slab-thumb:hover {
-      transform: translateY(-2px);
+      transform: translateY(calc(-1 * var(--space-0-5)));
       box-shadow:
         0 var(--space-2) var(--space-6) color-mix(in srgb, var(--color-text) 10%, transparent);
     }
@@ -336,13 +336,13 @@
       currentColor
     );
     background-repeat: no-repeat;
-    background-size: 0% 1px;
+    background-size: 0% var(--border-width);
     background-position: 0 100%;
     transition: background-size var(--duration-normal) var(--ease-out);
   }
 
   .slab-title-link:hover {
-    background-size: 100% 1px;
+    background-size: 100% var(--border-width);
     color: var(--color-interactive);
   }
 

--- a/apps/web/src/lib/components/studio/content-list/ContentListCommandBar.svelte
+++ b/apps/web/src/lib/components/studio/content-list/ContentListCommandBar.svelte
@@ -407,7 +407,7 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .create-btn:hover { transform: translateY(-1px); }
+    .create-btn:hover { transform: translateY(calc(-1 * var(--border-width))); }
   }
 
   @media (--below-sm) {

--- a/apps/web/src/lib/components/studio/media-library/MediaLibraryCommandBar.svelte
+++ b/apps/web/src/lib/components/studio/media-library/MediaLibraryCommandBar.svelte
@@ -309,8 +309,8 @@
   .filter-segment {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
-    padding: 2px;
+    gap: var(--space-0-5);
+    padding: var(--space-0-5);
     border-radius: var(--radius-full, 9999px);
     border: var(--border-width) var(--border-style) var(--color-border);
     background: color-mix(in srgb, var(--color-surface-secondary) 60%, var(--color-surface));
@@ -412,7 +412,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 2px;
+    padding: var(--space-0-5);
     border: none;
     background: none;
     color: var(--color-text-muted);

--- a/apps/web/src/lib/components/studio/media-library/MediaLibraryCommandBar.svelte
+++ b/apps/web/src/lib/components/studio/media-library/MediaLibraryCommandBar.svelte
@@ -468,7 +468,7 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .upload-btn:hover { transform: translateY(-1px); }
+    .upload-btn:hover { transform: translateY(calc(-1 * var(--border-width))); }
   }
 
   @media (--below-sm) {

--- a/apps/web/src/lib/components/studio/media-library/MediaTile.svelte
+++ b/apps/web/src/lib/components/studio/media-library/MediaTile.svelte
@@ -294,7 +294,7 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .tile:hover { transform: translateY(-2px); }
+    .tile:hover { transform: translateY(calc(-1 * var(--space-0-5))); }
   }
 
   /* ── Thumbnail frame ──────────────────────────────────── */
@@ -457,7 +457,7 @@
     display: inline-flex;
     gap: var(--space-1);
     opacity: 0;
-    transform: translateY(-4px);
+    transform: translateY(calc(-1 * var(--space-1)));
     transition:
       opacity var(--duration-fast) var(--ease-out),
       transform var(--duration-fast) var(--ease-out);

--- a/apps/web/src/routes/_org/[slug]/studio/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/+error.svelte
@@ -103,4 +103,8 @@
     background-color: var(--color-surface-secondary);
   }
 
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/analytics/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/analytics/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/billing/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/billing/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/content/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/content/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/content/[contentId]/edit/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/content/[contentId]/edit/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/content/new/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/content/new/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/customers/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/customers/+error.svelte
@@ -102,4 +102,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/media/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/media/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/settings/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/+error.svelte
@@ -102,4 +102,8 @@
     background-color: var(--color-surface-secondary);
   }
 
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>

--- a/apps/web/src/routes/_org/[slug]/studio/settings/+layout.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/+layout.svelte
@@ -129,10 +129,11 @@
     font-weight: var(--font-medium);
     color: var(--color-text-secondary);
     text-decoration: none;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-    transition: color var(--transition-duration) var(--transition-timing),
-      border-color var(--transition-duration) var(--transition-timing);
+    border-bottom: var(--border-width-thick) var(--border-style) transparent;
+    margin-bottom: calc(-1 * var(--border-width));
+    transition:
+      color var(--duration-fast) var(--ease-default),
+      border-color var(--duration-fast) var(--ease-default);
   }
 
   .tab-trigger:hover {

--- a/apps/web/src/routes/_org/[slug]/studio/settings/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/+page.svelte
@@ -374,9 +374,9 @@
     width: 100%;
   }
 
-  .field-input:focus {
+  .field-input:focus-visible {
     outline: var(--border-width-thick) solid var(--color-focus);
-    outline-offset: -1px;
+    outline-offset: calc(-1 * var(--border-width));
     border-color: var(--color-border-focus);
   }
 

--- a/apps/web/src/routes/_org/[slug]/studio/settings/branding/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/branding/+page.svelte
@@ -122,7 +122,7 @@
               <div class="brand-summary__swatch" style="background-color: {branding.accentColorHex}" title="Accent: {branding.accentColorHex}"></div>
             {/if}
             {#if branding.backgroundColorHex}
-              <div class="brand-summary__swatch" style="background-color: {branding.backgroundColorHex}; border: 1px solid var(--color-border)" title="Background: {branding.backgroundColorHex}"></div>
+              <div class="brand-summary__swatch brand-summary__swatch--bordered" style="background-color: {branding.backgroundColorHex}" title="Background: {branding.backgroundColorHex}"></div>
             {/if}
           </div>
         </div>
@@ -188,10 +188,15 @@
   }
 
   .brand-summary__swatch {
-    width: 32px;
-    height: 32px;
+    width: var(--space-8);
+    height: var(--space-8);
     border-radius: var(--radius-md);
     cursor: default;
+  }
+
+  /* Background-colour swatch needs a visible edge against neutral surfaces. */
+  .brand-summary__swatch--bordered {
+    border: var(--border-width) var(--border-style) var(--color-border);
   }
 
   .brand-summary__value {

--- a/apps/web/src/routes/_org/[slug]/studio/settings/email-templates/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/email-templates/+page.svelte
@@ -73,9 +73,11 @@
 		margin: 0 0 var(--space-3);
 		color: var(--color-text-secondary);
 		font-size: var(--text-sm);
+		/* 480px copy width — narrower than --container-sm (640px) and --breakpoint-sm.
+		   Tracked in bead [ds-review-iter-026] error/empty-state copy width clustering. */
 		max-width: 480px;
 		margin-inline: auto;
-		line-height: 1.6;
+		line-height: var(--leading-relaxed);
 	}
 
 	.empty-state .hint {

--- a/apps/web/src/routes/_org/[slug]/studio/team/+error.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/team/+error.svelte
@@ -101,4 +101,9 @@
   .back-link:hover {
     background-color: var(--color-surface-secondary);
   }
+
+  .back-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
 </style>


### PR DESCRIPTION
## Summary

Bundles 4 ds-review-iter-026 fixes into a single PR for atomic review of the iter-026 token-migration sweep across studio surfaces:

- **Codex-qtl9h** (`92ef05df`): Replace hardcoded `translateY(...)` literals with motion / spacing tokens across studio components.
- **Codex-bz18z** (`8ced043f`): MediaLibraryCommandBar — `2px` literal → `--space-0-5` token.
- **Codex-3fgtn** (`eb71c995`): LogoUpload — sizing migrated from px to rem; border literal → `--border-width-thick` token.
- **Codex-j79ic** (`793cab5a`): Studio `+error.svelte` — adds `:focus-visible` ring per design-system rules.

Each commit is self-contained and can be reviewed independently in the file tree.

## Test plan

- [ ] Studio surfaces render unchanged at all viewport sizes
- [ ] MediaLibraryCommandBar spacing matches design tokens
- [ ] LogoUpload looks identical before/after (rem migration is value-preserving)
- [ ] Studio error page focus ring visible on tab navigation
- [ ] No regressions in design-system review iter-027

Closes Codex-qtl9h, Codex-bz18z, Codex-3fgtn, Codex-j79ic.