### PR TITLE
refactor(types): demote/suppress 24 unused_types in apps/web (Codex-0ct9w)

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -34,6 +34,10 @@
       "exports": ["ShaderHero"]
     },
     {
+      "file": "apps/web/src/lib/components/ui/ShaderHero/webgl-utils.ts",
+      "exports": ["FBO"]
+    },
+    {
       "file": "apps/web/src/lib/components/ui/Table/index.ts",
       "exports": [
         "Table",
@@ -44,6 +48,10 @@
         "TableHead",
         "TableCell"
       ]
+    },
+    {
+      "file": "apps/web/src/lib/server/content-detail.ts",
+      "exports": ["SubscriptionContext"]
     }
   ],
   "dynamicallyLoaded": [

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -16,6 +16,36 @@
     "apps/web/e2e/**/*.spec.ts"
   ],
   "ignoreDependencies": ["vite-plugin-dts"],
+  "ignoreExports": [
+    {
+      "file": "apps/web/src/lib/components/ui/CreatorCard/index.ts",
+      "exports": ["CreatorProfileDrawer"]
+    },
+    {
+      "file": "apps/web/src/lib/components/ui/Feedback/Spinner/index.ts",
+      "exports": ["Spinner"]
+    },
+    {
+      "file": "apps/web/src/lib/components/ui/Icon/index.ts",
+      "exports": ["MinusCircleIcon"]
+    },
+    {
+      "file": "apps/web/src/lib/components/ui/ShaderHero/index.ts",
+      "exports": ["ShaderHero"]
+    },
+    {
+      "file": "apps/web/src/lib/components/ui/Table/index.ts",
+      "exports": [
+        "Table",
+        "TableHeader",
+        "TableBody",
+        "TableFooter",
+        "TableRow",
+        "TableHead",
+        "TableCell"
+      ]
+    }
+  ],
   "dynamicallyLoaded": [
     "**/*.stories.svelte",
     "**/*.stories.ts",
@@ -32,7 +62,10 @@
     "apps/web/src/hooks.ts",
     "apps/web/src/hooks.server.ts",
     "apps/web/src/hooks.client.ts",
-    "apps/web/src/app.html"
+    "apps/web/src/app.html",
+    "apps/web/src/lib/components/ui/ShaderHero/renderers/*-renderer.ts",
+    "apps/web/src/lib/styles/tokens/breakpoints.css",
+    "scripts/denoise/**/*.ts"
   ],
   "ignorePatterns": [
     "test-media/**",

--- a/apps/web/src/lib/auth/scroll-reset-on-nav.ts
+++ b/apps/web/src/lib/auth/scroll-reset-on-nav.ts
@@ -15,15 +15,9 @@
  * router, DOM, or requestAnimationFrame.
  */
 
-export type NavigationType =
-  | 'enter'
-  | 'form'
-  | 'leave'
-  | 'link'
-  | 'goto'
-  | 'popstate';
+type NavigationType = 'enter' | 'form' | 'leave' | 'link' | 'goto' | 'popstate';
 
-export interface ScrollResetInput {
+interface ScrollResetInput {
   type: NavigationType | undefined;
   fromPathname: string | null | undefined;
   toPathname: string | null | undefined;

--- a/apps/web/src/lib/auth/session-visibility-sync.ts
+++ b/apps/web/src/lib/auth/session-visibility-sync.ts
@@ -22,14 +22,14 @@
 
 export type VisibilityState = 'visible' | 'hidden' | 'prerender';
 
-export type AuthRevalidationDecision =
+type AuthRevalidationDecision =
   | { action: 'none' }
   | {
       action: 'invalidate';
       reason: 'cookie-diff' | 'unauthenticated-recheck';
     };
 
-export interface AuthRevalidationInput {
+interface AuthRevalidationInput {
   visibilityState: VisibilityState;
   /** Whether the session cookie is present RIGHT NOW. */
   nowHasCookie: boolean;

--- a/apps/web/src/lib/brand-editor/index.ts
+++ b/apps/web/src/lib/brand-editor/index.ts
@@ -22,7 +22,6 @@ export { LEVELS } from './levels';
 
 // Brand Editor - Palette Generator (internal use only; import directly from ./palette-generator)
 
-export type { DarkColorOverrides } from './parse-dark-overrides';
 // Brand Editor - Dark-mode override parser (SSR-safe, used by _org/[slug]/+layout.svelte)
 export { parseDarkColorOverrides } from './parse-dark-overrides';
 

--- a/apps/web/src/lib/brand-editor/parse-dark-overrides.ts
+++ b/apps/web/src/lib/brand-editor/parse-dark-overrides.ts
@@ -13,7 +13,7 @@
  * Canonical consumer: `apps/web/src/routes/_org/[slug]/+layout.svelte`.
  * Fix for Codex-lqvyy (dark colors were never reaching non-editor visitors).
  */
-export interface DarkColorOverrides {
+interface DarkColorOverrides {
   primaryColor?: string;
   secondaryColor?: string | null;
   accentColor?: string | null;

--- a/apps/web/src/lib/collections/hydration.ts
+++ b/apps/web/src/lib/collections/hydration.ts
@@ -36,7 +36,7 @@ export const COLLECTION_KEYS = {
   subscription: ['subscription'] as const,
 } as const;
 
-export type CollectionKey = keyof typeof COLLECTION_KEYS;
+type CollectionKey = keyof typeof COLLECTION_KEYS;
 
 /**
  * Hydrate a collection with server-side data

--- a/apps/web/src/lib/collections/progress.ts
+++ b/apps/web/src/lib/collections/progress.ts
@@ -23,7 +23,7 @@ import {
 /**
  * Playback progress data structure
  */
-export interface PlaybackProgress {
+interface PlaybackProgress {
   contentId: string;
   positionSeconds: number;
   durationSeconds: number;

--- a/apps/web/src/lib/components/VideoPlayer/hls.ts
+++ b/apps/web/src/lib/components/VideoPlayer/hls.ts
@@ -32,12 +32,12 @@ import type { ErrorData } from 'hls.js';
  * - Native Safari branch: `hls` is null, `cleanup` detaches the `'error'`
  *   listener the factory attached to the `<video>` element.
  */
-export interface HlsPlayerHandle {
+interface HlsPlayerHandle {
   hls: Hls | null;
   cleanup: () => void;
 }
 
-export interface HlsPlayerOptions {
+interface HlsPlayerOptions {
   media: HTMLMediaElement;
   src: string;
   onError?: (message: string) => void;

--- a/apps/web/src/lib/components/subscription/health-banner-logic.ts
+++ b/apps/web/src/lib/components/subscription/health-banner-logic.ts
@@ -31,7 +31,7 @@ export function filterAttentionSubs(
   return subs.filter((s) => isAttentionStatus(s.status));
 }
 
-export type BannerVariant = 'error' | 'warning';
+type BannerVariant = 'error' | 'warning';
 
 /**
  * Pick the banner's severity paint.

--- a/apps/web/src/lib/components/ui/CreatorCard/types.ts
+++ b/apps/web/src/lib/components/ui/CreatorCard/types.ts
@@ -22,7 +22,7 @@ export interface ContentItem {
   contentType: string;
 }
 
-export interface OrgMembership {
+interface OrgMembership {
   name: string;
   slug: string;
   logoUrl: string | null;

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -5,7 +5,7 @@
  * are defined here as the single source of truth.
  */
 
-export interface NavLink {
+interface NavLink {
   href: string;
   label: string;
 }

--- a/apps/web/src/lib/library/filter-by-org.ts
+++ b/apps/web/src/lib/library/filter-by-org.ts
@@ -15,7 +15,7 @@
  * the slug-based filter.
  */
 
-export interface LibraryItemLike {
+interface LibraryItemLike {
   content?: {
     organizationId?: string | null;
   };

--- a/apps/web/src/lib/remote/library.remote.ts
+++ b/apps/web/src/lib/remote/library.remote.ts
@@ -91,7 +91,7 @@ export const getStreamingUrl = query(z.string().uuid(), async (contentId) => {
  * minus `contentType` — callers already know the content type from their
  * page data; the player only needs the URLs + expiry.
  */
-export interface RefreshStreamingUrlResult {
+interface RefreshStreamingUrlResult {
   streamingUrl: string;
   waveformUrl: string | null;
   expiresAt: string;
@@ -133,7 +133,7 @@ export const refreshStreamingUrl = query(
 /**
  * Normalized progress data returned from getPlaybackProgress
  */
-export interface NormalizedProgress {
+interface NormalizedProgress {
   positionSeconds: number;
   durationSeconds: number;
   completed: boolean;

--- a/apps/web/src/lib/server/content-detail.ts
+++ b/apps/web/src/lib/server/content-detail.ts
@@ -94,12 +94,7 @@ function extractRevocationReason(
  * `accessType` values recognised by the content schema. Mirrors the DB CHECK
  * constraint in packages/database/src/schema/content.ts.
  */
-export type ContentAccessType =
-  | 'free'
-  | 'paid'
-  | 'followers'
-  | 'subscribers'
-  | 'team';
+type ContentAccessType = 'free' | 'paid' | 'followers' | 'subscribers' | 'team';
 
 /**
  * Empty subscription-context fallback used by content detail loaders when

--- a/apps/web/src/lib/subscription/library-access.ts
+++ b/apps/web/src/lib/subscription/library-access.ts
@@ -29,7 +29,7 @@ import { getEffectiveStatus } from './status';
  * The shape consumers need from a library item.
  * Deliberately narrow so we can test without the full `LibraryItem` type.
  */
-export interface LibraryAccessInput {
+interface LibraryAccessInput {
   /** The library item's accessType — only 'subscription' triggers joins. */
   accessType: 'purchased' | 'membership' | 'subscription';
   /** Slug of the owning org (join key against subscriptionCollection). */
@@ -44,7 +44,7 @@ export interface LibraryAccessInput {
  *   revoked    — dimmed card + hover CTA "Subscription ended — reactivate"
  *   past_due   — dimmed card + hover CTA "Payment failed — update payment"
  */
-export type LibraryAccessState =
+type LibraryAccessState =
   | { kind: 'active' }
   | { kind: 'cancelling'; periodEnd: string }
   | { kind: 'revoked' }

--- a/apps/web/src/lib/subscription/status.ts
+++ b/apps/web/src/lib/subscription/status.ts
@@ -27,7 +27,7 @@ export type SubscriptionStatus =
   | 'past_due'
   | 'paused';
 
-export interface SubscriptionStatusInput {
+interface SubscriptionStatusInput {
   /** tierId present = user has a current subscription on this org */
   currentTierId: string | null;
   /** Raw lifecycle status from the API (may be unknown/future values) */
@@ -64,7 +64,7 @@ export function getEffectiveStatus(
  * service method + remote fn now shipped), so the placeholder disabled
  * state has been removed.
  */
-export interface TierCtaDescriptor {
+interface TierCtaDescriptor {
   primary:
     | { kind: 'current'; disabled: true }
     | { kind: 'reactivate'; disabled: false }

--- a/apps/web/src/lib/theme.svelte.ts
+++ b/apps/web/src/lib/theme.svelte.ts
@@ -15,7 +15,7 @@
 
 import { browser } from '$app/environment';
 
-export type Theme = 'light' | 'dark';
+type Theme = 'light' | 'dark';
 
 const STORAGE_KEY = 'theme';
 const COOKIE_NAME = 'theme';
@@ -35,11 +35,6 @@ export const themeState = $state<{ theme: Theme }>({
       : 'light'
     : 'light',
 });
-
-/** Read the current theme from the DOM attribute. Kept for legacy callers. */
-export function getTheme(): Theme {
-  return themeState.theme;
-}
 
 /** Apply a theme to the DOM and persist it; updates the reactive state. */
 function setTheme(theme: Theme): void {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -61,7 +61,7 @@ export interface LayoutOrganization {
  * Organization data for org context (web app extended version)
  * Includes UI-specific fields not present in backend Organization type
  */
-export interface OrgBrandFineTune {
+interface OrgBrandFineTune {
   // Fine-tune values (text/heading/body weight, shadow scale/color, heading
   // colour, etc.) are stored as keys inside tokenOverrides JSON. The
   // previously broken-out columns were dropped in Codex-g49b4.
@@ -90,7 +90,7 @@ export interface OrgBrandFineTune {
  * API call or `+page.server.ts` load — never reach for `as unknown as` to
  * paper over the mismatch in components.
  */
-export type DateAsString<T> = {
+type DateAsString<T> = {
   [K in keyof T]: T[K] extends Date
     ? string
     : T[K] extends Date | null
@@ -178,7 +178,7 @@ export interface OrgTiersContext {
 /**
  * Per-tier subscriber and MRR breakdown.
  */
-export interface TierBreakdown {
+interface TierBreakdown {
   tierId: string;
   tierName: string;
   subscriberCount: number;

--- a/apps/web/src/lib/utils/image.ts
+++ b/apps/web/src/lib/utils/image.ts
@@ -6,7 +6,7 @@
  * The size is the filename, not a suffix — e.g. .../media-thumbnails/{id}/sm.webp
  */
 
-export type ThumbnailSize = 'sm' | 'md' | 'lg';
+type ThumbnailSize = 'sm' | 'md' | 'lg';
 
 const THUMBNAIL_WIDTHS: Record<ThumbnailSize, number> = {
   sm: 200,

--- a/apps/web/src/lib/utils/subdomain.ts
+++ b/apps/web/src/lib/utils/subdomain.ts
@@ -68,7 +68,7 @@ export function isReservedSubdomain(subdomain: string): boolean {
 /**
  * Determine the context type from a subdomain
  */
-export type SubdomainContext =
+type SubdomainContext =
   | { type: 'platform' }
   | { type: 'creators' }
   | { type: 'organization'; slug: string }

--- a/apps/web/src/lib/utils/view-mode.svelte.ts
+++ b/apps/web/src/lib/utils/view-mode.svelte.ts
@@ -12,7 +12,7 @@
 
 import { browser } from '$app/environment';
 
-export type ViewMode = 'grid' | 'list';
+type ViewMode = 'grid' | 'list';
 
 export function useViewMode(
   storageKey = 'codex-view-mode',

--- a/apps/web/src/routes/_org/[slug]/(space)/feed-types.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/feed-types.ts
@@ -25,7 +25,7 @@ export type ContentItem = NonNullable<
  *   editorial  — 60/40 split: lead article spread + vertical list (articles)
  *   bento      — varied-tile grid with 2 hero + 4 minor items (Discover Mix)
  */
-export type FeedLayout =
+type FeedLayout =
   | 'spotlight'
   | 'spread'
   | 'carousel'

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -77,15 +77,20 @@ export {
   enforcePolicyInline,
   type FileFieldConfig,
   type FileSchema,
-  type FileTooLargeError,
+  // FileTooLargeError, InvalidFileTypeError, MissingFileError are runtime
+  // classes (not just types) — exported as values so consumers can `throw new
+  // FileTooLargeError(...)` and use `instanceof FileTooLargeError`. Using
+  // `export type` here previously broke fallow's reachability across the
+  // export-* chain in ./procedure (Codex-taith).
+  FileTooLargeError,
   // Helper utilities (for advanced use cases)
   generateRequestId,
   getClientIP,
   type InferFiles,
   type InferInput,
   type InputSchema,
-  type InvalidFileTypeError,
-  type MissingFileError,
+  InvalidFileTypeError,
+  MissingFileError,
   type MultipartProcedureConfig,
   type MultipartProcedureContext,
   membershipCacheKey,

--- a/packages/worker-utils/src/procedure/index.ts
+++ b/packages/worker-utils/src/procedure/index.ts
@@ -27,7 +27,16 @@
  * ```
  */
 
-export * from './binary-upload-procedure';
+export type {
+  BinaryFileConfig,
+  BinaryUploadContext,
+  BinaryUploadProcedureConfig,
+  ValidatedBinaryFile,
+} from './binary-upload-procedure';
+// Binary upload procedure (raw ArrayBuffer body). Exported via named
+// re-exports rather than `export *` so fallow's reachability analysis can
+// follow each value/type through the barrel chain (Codex-taith).
+export { binaryUploadProcedure } from './binary-upload-procedure';
 export type { OrganizationMembership } from './helpers';
 // Helper exports (for advanced use cases)
 export {
@@ -37,7 +46,24 @@ export {
   getClientIP,
   validateInput,
 } from './helpers';
-export * from './multipart-procedure';
+export type {
+  FileFieldConfig,
+  FileSchema,
+  InferFiles,
+  MultipartProcedureConfig,
+  MultipartProcedureContext,
+  ValidatedFile,
+} from './multipart-procedure';
+// Multipart procedure (FormData uploads). Same rationale as
+// binary-upload-procedure above re: named re-exports vs `export *`. Error
+// classes are runtime values — re-exported as values so consumers can
+// `throw new` and `instanceof` them.
+export {
+  FileTooLargeError,
+  InvalidFileTypeError,
+  MissingFileError,
+  multipartProcedure,
+} from './multipart-procedure';
 // org-helpers: dynamically imported in helpers.ts for code-splitting inside procedure().
 // Re-exported here for direct use by route handlers.
 export { checkOrganizationMembership, membershipCacheKey } from './org-helpers';


### PR DESCRIPTION
All 24 items resolved: 22 demoted (export → no-export) across 4 commits + 2 ignoreExports for FBO cross-file type-import FP and SubscriptionContext backward-compat (per F6 denoise proof).

Commits: f201f397, 9ef6f347, 89cfdc7d, 6a6a3495, d95af6f5

Closes Codex-0ct9w.