### PR TITLE
fix(brand-editor): ds-review iter-00 + iter-04 polish bundle

### DIFF
--- a/apps/web/src/lib/components/brand-editor/FontPicker.svelte
+++ b/apps/web/src/lib/components/brand-editor/FontPicker.svelte
@@ -345,7 +345,7 @@
   :global(.font-picker__chevron) {
     color: var(--color-text-muted);
     flex-shrink: 0;
-    transition: transform var(--duration-fast);
+    transition: transform var(--duration-fast) var(--ease-default);
   }
 
   .font-picker__trigger:global([data-state='open']) :global(.font-picker__chevron) {
@@ -439,7 +439,7 @@
     cursor: pointer;
     font-size: var(--text-base);
     color: var(--color-text);
-    transition: background-color var(--duration-fast);
+    transition: background-color var(--duration-fast) var(--ease-default);
     background: transparent;
     border: none;
     text-align: left;

--- a/apps/web/src/lib/components/brand-editor/levels/BrandEditorColors.svelte
+++ b/apps/web/src/lib/components/brand-editor/levels/BrandEditorColors.svelte
@@ -6,6 +6,7 @@
     BRAND_DEFAULT_SECONDARY,
     brandEditor,
   } from '$lib/brand-editor';
+  import { MinusIcon, PlusIcon } from '$lib/components/ui/Icon';
   import OklchColorPicker from '../color-picker/OklchColorPicker.svelte';
 
   type ColorField = 'primaryColor' | 'secondaryColor' | 'accentColor' | 'backgroundColor';
@@ -51,7 +52,13 @@
           <span class="colors-level__swatch" style:background={currentValue} aria-hidden="true"></span>
           <span class="colors-level__label">{section.label}</span>
           <span class="colors-level__hex">{currentValue}</span>
-          <span class="colors-level__chevron" aria-hidden="true">{isExpanded ? '−' : '+'}</span>
+          <span class="colors-level__chevron" aria-hidden="true">
+            {#if isExpanded}
+              <MinusIcon size={14} />
+            {:else}
+              <PlusIcon size={14} />
+            {/if}
+          </span>
         </button>
         {#if section.clearable && brandEditor.pending?.backgroundColor}
           <button
@@ -155,10 +162,11 @@
   }
 
   .colors-level__chevron {
-    font-size: var(--text-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     color: var(--color-text-muted);
     width: var(--space-4);
-    text-align: center;
     flex-shrink: 0;
   }
 

--- a/apps/web/src/lib/components/brand-editor/levels/BrandEditorHeaderLayout.svelte
+++ b/apps/web/src/lib/components/brand-editor/levels/BrandEditorHeaderLayout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { HeroLayout } from '@codex/validation';
   import { brandEditor } from '$lib/brand-editor';
+  import { EyeIcon, EyeOffIcon } from '$lib/components/ui/Icon';
   import BrandSliderField from '../BrandSliderField.svelte';
 
   interface LayoutOption {
@@ -216,8 +217,15 @@
           class:layout-editor__toggle--hidden={!visible}
           onclick={() => toggleElement(toggle.key)}
           aria-pressed={visible}
+          aria-label={visible ? `Hide ${toggle.label}` : `Show ${toggle.label}`}
         >
-          <span class="layout-editor__toggle-icon">{visible ? '●' : '○'}</span>
+          <span class="layout-editor__toggle-icon">
+            {#if visible}
+              <EyeIcon size={16} />
+            {:else}
+              <EyeOffIcon size={16} />
+            {/if}
+          </span>
           <span class="layout-editor__toggle-label">{toggle.label}</span>
         </button>
       {/each}
@@ -279,8 +287,7 @@
     border-radius: var(--radius-lg);
     background: var(--color-surface);
     cursor: pointer;
-    transition: border-color var(--duration-fast) var(--ease-default),
-      background var(--duration-fast) var(--ease-default);
+    transition: var(--transition-colors);
     text-align: center;
     width: 100%;
   }
@@ -361,11 +368,12 @@
   }
 
   .layout-editor__toggle-icon {
-    font-size: var(--text-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     color: var(--color-interactive);
     flex-shrink: 0;
     width: var(--space-4);
-    text-align: center;
   }
 
   .layout-editor__toggle--hidden .layout-editor__toggle-icon {

--- a/apps/web/src/lib/components/brand-editor/levels/BrandEditorLogo.svelte
+++ b/apps/web/src/lib/components/brand-editor/levels/BrandEditorLogo.svelte
@@ -14,7 +14,13 @@
     const input = e.target as HTMLInputElement;
     if (!input.files?.length) return;
     // Programmatically submit the hidden form
-    input.form?.requestSubmit();
+    if (input.form) {
+      input.form.requestSubmit();
+    } else {
+      console.warn(
+        '[BrandEditorLogo] handleFileSelect: file input has no associated form; upload not triggered.'
+      );
+    }
   }
 
   async function handleRemove() {
@@ -48,7 +54,7 @@
 <div class="logo-level">
   <div
     class="logo-level__preview"
-    style:background-color={brandEditor.pending?.backgroundColor || 'var(--color-surface)'}
+    style:background-color={brandEditor.pending?.backgroundColor ?? null}
   >
     {#if logoUrl}
       <img src={logoUrl} alt="Organization logo" class="logo-level__image" />
@@ -121,6 +127,7 @@
     border-radius: var(--radius-lg);
     border: var(--border-width) var(--border-style) var(--color-border-subtle);
     padding: var(--space-6);
+    background-color: var(--color-surface);
   }
 
   .logo-level__image {


### PR DESCRIPTION
Brand editor a11y/polish bundle from iter-00 and iter-04 reviews.

Includes:
- Codex-yocy: HeaderLayout visibility toggle aria-label='Hide/Show ${label}' alongside aria-pressed; phantom token cleanup; missing ease values; className guards
- Codex-fyew: glyph→Icon migration; transition shorthand; inline-style literal cleanup

Close-claim referenced commit 0ced018b on this branch.

Closes Codex-yocy, Codex-fyew.