### PR TITLE
fix(build): enable failOnError on dts() across all packages (Codex-76zya)

### DIFF
--- a/config/vite/package.config.ts
+++ b/config/vite/package.config.ts
@@ -132,6 +132,11 @@ export function createPackageConfig(
         // (private fields make classes nominal — same logical class, two paths,
         // two types).
         pathsToAliases: false,
+        // Treat broken .d.ts generation as a build failure rather than a
+        // silent warning. Without this, malformed types ship to consumers
+        // unnoticed (worker-utils + test-utils have shipped broken .d.ts
+        // in past iterations because failOnError defaults to false).
+        failOnError: true,
       }) as PluginOption,
       ...plugins,
     ],


### PR DESCRIPTION
Adds `failOnError: true` to the shared vite-plugin-dts call in `config/vite/package.config.ts`. The default `failOnError: false` lets broken .d.ts generation surface as a console warning rather than a build failure — both `@codex/worker-utils` and `@codex/test-utils` have shipped malformed declarations to consumers in past iterations because of this silent fallthrough.

Verified: all 20 packages still build clean with the gate enabled (`pnpm --filter './packages/*' build` → 0 errors).

This is a re-do of Codex-76zya which had been closed prematurely with an empty close-reason; verification during the ds-review audit (2026-05-06) found `failOnError` literally absent from any vite config or the shared dts() factory.

Closes Codex-76zya.