### PR TITLE
fix(content-form): add (issue) key to SlugField each-block (Codex-i7kyu)

### DIFF
--- a/apps/web/src/lib/components/studio/content-form/SlugField.svelte
+++ b/apps/web/src/lib/components/studio/content-form/SlugField.svelte
@@ -102,7 +102,7 @@
     placeholder={m.studio_content_form_slug_placeholder()}
     oninput={handleSlugInput}
   />
-  {#each form.fields.slug.issues() as issue}
+  {#each form.fields.slug.issues() as issue (issue)}
     <p class="field-error">{issue.message}</p>
   {/each}
   {#if slugCheckStatus === 'checking'}


### PR DESCRIPTION
Adds the missing `(issue)` key to the `{#each issues}` block in `apps/web/src/lib/components/studio/content-form/SlugField.svelte:105`. Without the key, Svelte falls back to identity diffing, causing transient render glitches when the issues list mutates.

Close-claim referenced commit cdedefcb on this branch.

Closes Codex-i7kyu.