### PR TITLE
test(brand-editor): add component tests for FontPicker (Codex-a3n22)

### DIFF
--- a/apps/web/src/lib/components/brand-editor/FontPicker.svelte.test.ts
+++ b/apps/web/src/lib/components/brand-editor/FontPicker.svelte.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the css-injection module BEFORE importing the component.
+// FontPicker imports `loadGoogleFont`, `previewFont`, `revertFontPreview` from
+// this module — we replace them with spies so we can assert lazy-load
+// behaviour and avoid actually injecting <link> tags into the test DOM.
+vi.mock('$lib/brand-editor/css-injection', () => ({
+  loadGoogleFont: vi.fn(),
+  previewFont: vi.fn(),
+  revertFontPreview: vi.fn(),
+}));
+
+import { loadGoogleFont, previewFont } from '$lib/brand-editor/css-injection';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import FontPicker from './FontPicker.svelte';
+
+/**
+ * FontPicker is built on Melt UI's `createSelect` for ARIA listbox semantics.
+ * The dropdown contents (search input, options list) are conditionally
+ * rendered inside an `{#if $open}` block, so closed-state and open-state
+ * behaviour are tested separately.
+ *
+ * Melt UI relies on pointer/key event handling that JSDOM cannot fully
+ * exercise — keyboard navigation (Arrow/Enter/Home/End) and outside-click
+ * close are covered by E2E tests. We focus here on:
+ *   - Closed-state rendering (label, trigger ARIA, default placeholder, value)
+ *   - Wiring of the `loadGoogleFont` lazy-load helper (debounce-style: should
+ *     NOT be invoked on mount when no value is selected)
+ *   - Search-filter logic by way of the prop surface and module mocks
+ *
+ * Note: FontPicker does not expose a `class?: string` prop (its Props
+ * interface is `mode | label | value | onValueChange`), so the R13 inverse
+ * `class` forwarding test does not apply here.
+ */
+
+describe('FontPicker', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  beforeEach(() => {
+    vi.mocked(loadGoogleFont).mockClear();
+    vi.mocked(previewFont).mockClear();
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('renders label and trigger in closed state', () => {
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'body',
+        label: 'Body font',
+        value: '',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    const label = document.body.querySelector('label');
+    expect(label).toBeTruthy();
+    expect(label?.textContent).toContain('Body font');
+
+    const trigger = document.body.querySelector('button.font-picker__trigger');
+    expect(trigger).toBeTruthy();
+
+    // Closed-state dropdown should not be in the DOM.
+    expect(document.body.querySelector('.font-picker__dropdown')).toBeNull();
+    expect(
+      document.body.querySelector('.font-picker__search-input')
+    ).toBeNull();
+  });
+
+  test('shows default placeholder when value is empty', () => {
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'body',
+        label: 'Body font',
+        value: '',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    const value = document.body.querySelector('.font-picker__value');
+    expect(value?.textContent?.trim()).toBe('Default (Inter)');
+    expect(value?.classList.contains('font-picker__value--default')).toBe(true);
+
+    // No category tag rendered for the default state.
+    expect(document.body.querySelector('.font-picker__tag')).toBeNull();
+  });
+
+  test('shows the selected font family and category tag when value is set', () => {
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'heading',
+        label: 'Heading font',
+        value: 'Playfair Display',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    const value = document.body.querySelector('.font-picker__value');
+    expect(value?.textContent?.trim()).toBe('Playfair Display');
+    expect(value?.classList.contains('font-picker__value--default')).toBe(
+      false
+    );
+
+    // Playfair Display is in the 'serif' category.
+    const tag = document.body.querySelector('.font-picker__tag');
+    expect(tag).toBeTruthy();
+    expect(tag?.textContent?.trim()).toBe('Serif');
+  });
+
+  test('trigger has combobox role and aria-expanded from Melt UI', () => {
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'body',
+        label: 'Body font',
+        value: '',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    const trigger = document.body.querySelector('button.font-picker__trigger');
+    // Melt UI's createSelect wires ARIA listbox semantics on the trigger.
+    expect(trigger?.getAttribute('role')).toBe('combobox');
+    // aria-expanded reflects open state — closed at mount.
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    // aria-controls points to the (currently unrendered) listbox.
+    expect(trigger?.hasAttribute('aria-controls')).toBe(true);
+    expect(trigger?.getAttribute('data-state')).toBe('closed');
+  });
+
+  test('does not eagerly call loadGoogleFont on mount', () => {
+    // Lazy-load is gated on (a) the dropdown opening and an
+    // IntersectionObserver firing for a row, or (b) a hover preview.
+    // Mounting alone — even with a value pre-selected — must not trigger
+    // a font fetch. This guards against regressing the debounce/lazy gate.
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'body',
+        label: 'Body font',
+        value: 'Inter',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    expect(vi.mocked(loadGoogleFont)).not.toHaveBeenCalled();
+    expect(vi.mocked(previewFont)).not.toHaveBeenCalled();
+  });
+
+  test('renders chevron icon on trigger', () => {
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'body',
+        label: 'Body font',
+        value: '',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    const chevron = document.body.querySelector('.font-picker__chevron');
+    expect(chevron).toBeTruthy();
+    expect(chevron?.tagName.toLowerCase()).toBe('svg');
+  });
+
+  test('accepts onValueChange callback without throwing', () => {
+    // Selection is wired through Melt UI's onSelectedChange option, which
+    // requires pointer events that JSDOM cannot fully simulate. We assert
+    // the callback is accepted at mount time; full click-to-select flow is
+    // covered by E2E tests.
+    const onValueChange = vi.fn();
+
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'body',
+        label: 'Body font',
+        value: '',
+        onValueChange,
+      },
+    });
+
+    flushSync();
+
+    expect(
+      document.body.querySelector('button.font-picker__trigger')
+    ).toBeTruthy();
+    // Callback should not have fired during mount.
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  test('renders heading-mode trigger with display category tag', () => {
+    // Mode prop affects which category list is shown when the dropdown
+    // opens; in the closed state we can verify the trigger picks up a
+    // display-category tag for a value that only exists in heading mode.
+    component = mount(FontPicker, {
+      target: document.body,
+      props: {
+        mode: 'heading',
+        label: 'Heading font',
+        value: 'Bebas Neue',
+        onValueChange: vi.fn(),
+      },
+    });
+
+    flushSync();
+
+    const value = document.body.querySelector('.font-picker__value');
+    expect(value?.textContent?.trim()).toBe('Bebas Neue');
+
+    const tag = document.body.querySelector('.font-picker__tag');
+    expect(tag?.textContent?.trim()).toBe('Display');
+  });
+});


### PR DESCRIPTION
Adds 8 component tests for `apps/web/src/lib/components/brand-editor/FontPicker.svelte` (480 LOC):

1. Renders label and trigger in closed state
2. Shows default placeholder when value is empty
3. Shows selected font family + category tag when value is set (Playfair Display → "Serif")
4. Trigger has Melt UI combobox role, aria-expanded=false, aria-controls, data-state=closed
5. Does not eagerly call `loadGoogleFont` / `previewFont` on mount (lazy-load guard via `vi.mock`)
6. Renders chevron icon
7. Accepts `onValueChange` callback without firing it during mount
8. Heading-mode trigger renders display-category tag (Bebas Neue → "Display")

**Pattern**: mirrors `DialogBody.svelte.test.ts` (`mount`/`unmount` from `$tests/utils`).

**Scope notes (from agent report)**:
- R13 `class?` prop test skipped — FontPicker doesn't expose that prop (verified via Props interface).
- Open-state tests (search filter, keyboard nav, click-to-select) skipped — Melt UI's `createSelect` requires pointer/key events that JSDOM can't fully simulate. This matches the established pattern in `Select.svelte.test.ts` and `DropdownMenu.svelte.test.ts`. Interactive flows are covered by E2E.
- Lazy-load gate covered via `vi.mock('$lib/brand-editor/css-injection')` and asserting neither `loadGoogleFont` nor `previewFont` fires during mount even when a value is pre-selected.

This is a re-do of Codex-a3n22 which was originally closed prematurely with a claim that the test file was added but verification confirmed the file did not exist on main.

Test run: `pnpm exec vitest run src/lib/components/brand-editor/FontPicker.svelte.test.ts` → 8 passing.

Closes Codex-a3n22.