### PR TITLE
test(ecom-api/checkout): align currency assertion with GBP default (Codex-iqxzz)

### DIFF
--- a/workers/ecom-api/src/handlers/__tests__/checkout.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/checkout.test.ts
@@ -596,13 +596,15 @@ describe('handleCheckoutCompleted', () => {
 
   describe('currency handling', () => {
     /**
-     * NOTE: The handler currently hardcodes currency to 'usd'.
-     * This test documents the current behavior.
+     * Platform default currency is GBP (see root CLAUDE.md "Currency" rule).
+     * The handler hardcodes `CURRENCY.GBP` when calling `completePurchase`,
+     * ignoring `session.currency`. This is intentional for the single-currency
+     * MVP — Stripe Checkout sessions are created with GBP upstream.
      *
-     * Future consideration: Should we use session.currency instead?
-     * For now, we only support USD purchases.
+     * If multi-currency support is added later, the handler must read
+     * `session.currency` and these tests must be updated together.
      */
-    it('should use hardcoded USD currency regardless of session currency', async () => {
+    it('passes GBP through to completePurchase for a GBP session', async () => {
       const event = createMockStripeCheckoutEvent({
         metadata: {
           customerId: 'user_123',
@@ -610,19 +612,49 @@ describe('handleCheckoutCompleted', () => {
           organizationId: 'org_789',
         },
       }) as unknown as Stripe.Event;
-      // Even though session has currency, handler uses hardcoded 'usd'
+      (event.data.object as Stripe.Checkout.Session).currency = 'gbp';
+
+      const { context } = createContext();
+
+      await handleCheckoutCompleted(event, mockStripe, context);
+
+      expect(mockCompletePurchase).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          currency: CURRENCY.GBP,
+        })
+      );
+    });
+
+    it('still records GBP even when session.currency drifts (defends platform default)', async () => {
+      const event = createMockStripeCheckoutEvent({
+        metadata: {
+          customerId: 'user_123',
+          contentId: 'content_456',
+          organizationId: 'org_789',
+        },
+      }) as unknown as Stripe.Event;
+      // Defence-in-depth: even if a session leaks through with a non-GBP
+      // currency, the handler must persist GBP until multi-currency lands.
       (event.data.object as Stripe.Checkout.Session).currency = 'eur';
 
       const { context } = createContext();
 
       await handleCheckoutCompleted(event, mockStripe, context);
 
-      // Handler hardcodes currency to 'usd'
       expect(mockCompletePurchase).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           currency: CURRENCY.GBP,
         })
+      );
+      expect(mockCompletePurchase).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ currency: 'usd' })
+      );
+      expect(mockCompletePurchase).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ currency: 'eur' })
       );
     });
   });


### PR DESCRIPTION
Closes Codex-iqxzz (child of Codex-oal4l).

## Summary
Investigated `workers/ecom-api/src/handlers/__tests__/checkout.test.ts:605` ("should use hardcoded USD currency regardless of session currency") against the production handler at `workers/ecom-api/src/handlers/checkout.ts`.

**Case B (test name lie):** Production correctly hardcodes `CURRENCY.GBP` ('gbp') on line 150 when calling `purchaseService.completePurchase()`. The test's *assertion* was already asserting `CURRENCY.GBP` — only the test name and inline comments were stale from a pre-GBP USD MVP. No production bug.

## Changes
- Renamed test from "should use hardcoded USD currency..." to "passes GBP through to completePurchase for a GBP session" + corrected GBP session input.
- Rewrote the `/** NOTE */` block to describe the actual GBP-MVP single-currency intent and the upgrade path for multi-currency.
- Added a second test ("still records GBP even when session.currency drifts") that explicitly asserts the handler does NOT pass `'usd'` or `'eur'` to `completePurchase` — a drift-defence guard for the platform default.

## Currency hardcoding scan
`grep -rn -i "currency.*usd|'usd'|\"usd\"|CURRENCY\.USD" workers/ecom-api packages/purchase` — only hits are:
- `workers/ecom-api/GEMINI.md` + `packages/purchase/GEMINI.md` — stale Gemini-authored docs (not runtime code, out of scope for this task).
- The 3 comment lines inside the test that this PR rewrites.

No production code paths hardcode USD. The `CURRENCY` constant at `packages/constants/src/commerce.ts:94` exposes `GBP`, `USD`, `EUR` — production picks `GBP`.

## Test plan
- [x] `pnpm --filter ecom-api test --run src/handlers/__tests__/checkout.test.ts` — **21 / 21 passed** (includes both new currency tests).
- [x] `npx @biomejs/biome check --write workers/ecom-api/src/handlers/checkout.ts workers/ecom-api/src/handlers/__tests__/checkout.test.ts` — clean, no fixes applied.
- [x] Pre-existing `tsc` error in `workers/ecom-api/src/routes/admin.ts:55` (`reconcileFromStripe` missing on `SubscriptionService`) is on `origin/main` and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)