### PR TITLE
feat(subscription): prorationDate in SubscriptionPaymentRequiredError context (Codex-w87s4)

### DIFF
--- a/packages/subscription/src/errors.ts
+++ b/packages/subscription/src/errors.ts
@@ -99,9 +99,38 @@ export class SubscriptionCheckoutError extends BusinessLogicError {
  * subscription stays on the old tier — no reconciliation needed. The
  * frontend surfaces this as a "card declined, please update your payment
  * method" toast.
+ *
+ * `context.prorationDate` is the Unix-seconds timestamp that
+ * `SubscriptionService.changeTier` forwarded to Stripe as `proration_date`
+ * (Codex-w87s4). The pricing dialog uses its presence/identity to branch:
+ *   - if the dialog still holds the same prorationDate, the failure is
+ *     payment-side (declined card / SCA needed) — prompt for a fresh
+ *     payment method, keep the preview;
+ *   - if the dialog has no matching prorationDate (e.g. preview never
+ *     ran, or the user reloaded), refresh `previewTierChange` before
+ *     retrying.
+ *
+ * `context.tierIdAtCommit` is the new tier id the failed commit targeted
+ * — exposed so the dialog can correlate the error to the specific row
+ * the user clicked (defensive: the dialog could in principle be open on
+ * a different tier by the time the error returns).
  */
+export interface SubscriptionPaymentRequiredErrorContext
+  extends Record<string, unknown> {
+  userId: string;
+  organizationId: string;
+  newTierId: string;
+  billingInterval: 'month' | 'year';
+  stripeMessage: string;
+  prorationDate?: number;
+  tierIdAtCommit?: string;
+}
+
 export class SubscriptionPaymentRequiredError extends ServiceError {
-  constructor(message: string, context?: Record<string, unknown>) {
+  constructor(
+    message: string,
+    context?: SubscriptionPaymentRequiredErrorContext
+  ) {
     super(message, 'PAYMENT_REQUIRED', 402, context);
   }
 }

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -1704,9 +1704,22 @@ describe('SubscriptionService', () => {
         }
       ).mockRejectedValueOnce(stripeError);
 
-      await expect(
-        service.changeTier(otherCreatorId, org.id, tier2.id, 'month')
-      ).rejects.toThrow(SubscriptionPaymentRequiredError);
+      let caught: unknown;
+      try {
+        await service.changeTier(otherCreatorId, org.id, tier2.id, 'month');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(SubscriptionPaymentRequiredError);
+      const err = caught as SubscriptionPaymentRequiredError & {
+        context?: Record<string, unknown>;
+      };
+      // Codex-w87s4: prorationDate is always present on the 402 — when
+      // the caller omits it, the service falls back to now() and forwards
+      // that timestamp to Stripe, so the error must mirror it.
+      expect(typeof err.context?.prorationDate).toBe('number');
+      // tierIdAtCommit echoes the new tier id the failed commit targeted.
+      expect(err.context?.tierIdAtCommit).toBe(tier2.id);
 
       // Local row must remain on tier1 with the original amount — Stripe
       // reverted the price update and we mustn't write the new tier.
@@ -1858,10 +1871,11 @@ describe('SubscriptionService', () => {
     //   3. No audit row / no partial commit even though the preview's
     //      prorationDate was pinned.
     //
-    // Note: production currently does NOT include `prorationDate` in the
-    // SubscriptionPaymentRequiredError context. A follow-up bead can add
-    // it so the dialog can distinguish "needs new preview" from "transient
-    // network blip". For now the test asserts what's there.
+    // Codex-w87s4 closed the prorationDate gap: the error context now
+    // carries the exact prorationDate Stripe rejected so the dialog can
+    // tell "needs fresh preview" (prorationDate doesn't match its local
+    // preview) from "transient payment failure" (matches — same window,
+    // just a declined card).
     it('commit fails after successful preview: SubscriptionPaymentRequiredError, NO silent retry, DB untouched', async () => {
       const { org, tier1, tier2 } = await createFullOrg(
         'change-tier-stale-402'
@@ -1911,6 +1925,16 @@ describe('SubscriptionService', () => {
       expect(err.context?.newTierId).toBe(tier2.id);
       expect(err.context?.billingInterval).toBe('month');
       expect(err.context?.stripeMessage).toBe('Your card was declined.');
+      // Codex-w87s4: prorationDate echoes the pinned preview timestamp
+      // — this is what lets the dialog branch "stale preview" from
+      // "transient payment failure" without needing a second round-trip.
+      expect(err.context?.prorationDate).toBe(previewProrationDate);
+      expect(err.context?.tierIdAtCommit).toBe(tier2.id);
+      // userId + organizationId are present so the route can log the
+      // failure against the correct audit subject without re-parsing
+      // the request body.
+      expect(err.context?.userId).toBe(otherCreatorId);
+      expect(err.context?.organizationId).toBe(org.id);
 
       // (b) NO silent retry — Stripe.subscriptions.update is called exactly
       // once. A retry loop here would double-charge if Stripe accepts the
@@ -3970,5 +3994,61 @@ describe('SubscriptionService', () => {
 
       warnSpy.mockRestore();
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// SubscriptionPaymentRequiredError (Codex-w87s4)
+//
+// Standalone constructor round-trip: no DB, no Stripe — just the error
+// class contract. Pins the field set the pricing dialog consumes so a
+// future refactor (e.g. tightening the context type) can't silently
+// drop a field.
+// ─────────────────────────────────────────────────────────────────────
+describe('SubscriptionPaymentRequiredError', () => {
+  it('round-trips every field the pricing dialog branches on', () => {
+    const err = new SubscriptionPaymentRequiredError('Card declined', {
+      userId: 'user_123',
+      organizationId: 'org_456',
+      newTierId: 'tier_789',
+      billingInterval: 'month',
+      stripeMessage: 'Your card was declined.',
+      prorationDate: 1_700_000_000,
+      tierIdAtCommit: 'tier_789',
+    });
+
+    expect(err).toBeInstanceOf(SubscriptionPaymentRequiredError);
+    expect(err.message).toBe('Card declined');
+    expect(err.code).toBe('PAYMENT_REQUIRED');
+    expect(err.statusCode).toBe(402);
+    expect(err.context).toEqual({
+      userId: 'user_123',
+      organizationId: 'org_456',
+      newTierId: 'tier_789',
+      billingInterval: 'month',
+      stripeMessage: 'Your card was declined.',
+      prorationDate: 1_700_000_000,
+      tierIdAtCommit: 'tier_789',
+    });
+  });
+
+  it('omitting optional prorationDate / tierIdAtCommit leaves them undefined (not null, not 0)', () => {
+    const err = new SubscriptionPaymentRequiredError('Card declined', {
+      userId: 'user_123',
+      organizationId: 'org_456',
+      newTierId: 'tier_789',
+      billingInterval: 'year',
+      stripeMessage: 'Insufficient funds.',
+    });
+
+    expect(err.context).toMatchObject({
+      userId: 'user_123',
+      organizationId: 'org_456',
+      newTierId: 'tier_789',
+      billingInterval: 'year',
+      stripeMessage: 'Insufficient funds.',
+    });
+    expect(err.context?.prorationDate).toBeUndefined();
+    expect(err.context?.tierIdAtCommit).toBeUndefined();
   });
 });

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -1784,6 +1784,15 @@ export class SubscriptionService extends BaseService {
               newTierId,
               billingInterval,
               stripeMessage: (stripeError as Error).message,
+              // Codex-w87s4: surface the prorationDate the failed commit
+              // pinned to Stripe so the pricing dialog can branch
+              // "needs fresh preview" vs "transient payment failure"
+              // by comparing against the dialog's local preview state.
+              prorationDate: effectiveProrationDate,
+              // tierIdAtCommit lets the dialog correlate the 402 back to
+              // the specific tier row the commit targeted (defensive
+              // against dialog state drift between submit and response).
+              tierIdAtCommit: newTierId,
             }
           );
         }


### PR DESCRIPTION
Closes Codex-w87s4 (follow-up from Codex-fhqxx / Codex-oal4l).

> **Branch-name note:** opened from `fix/codex-w87s4-prorationdate` rather than `fix/codex-w87s4` because a concurrent agent's worktree had overwritten the canonical branch name with work for a different bead (Codex-lubvz). The remote `fix/codex-w87s4` ref at the time of push pointed at the Codex-lubvz commit, not this one — opening from a unique name keeps that recovery clean.

## Summary
- Adds `prorationDate` (Unix-seconds) and `tierIdAtCommit` to `SubscriptionPaymentRequiredError` context.
- Lets the pricing dialog distinguish "stale preview — refresh" from "transient payment failure — retry" by comparing the error's `prorationDate` against its local preview state.
- Defines `SubscriptionPaymentRequiredErrorContext` so callers can't silently drop fields the dialog branches on.
- Threads through the same `effectiveProrationDate` that `changeTier` forwarded to `stripe.subscriptions.update`.

No consumer-side changes — `apps/web/src/lib/remote/subscription.remote.ts` already optionally surfaces `prorationDate` in its command schema; downstream wiring is out of scope.

## Test plan
- [x] `pnpm --filter @codex/subscription test -t "SubscriptionPaymentRequired"` — 4 passed (existing 402 test, commit-fails-after-preview, plus 2 new round-trip tests).
- [x] `pnpm --filter @codex/subscription test --run` — 261 passed, 1 skipped. One pre-existing unrelated failure in `__denoise_proofs__/iter-009/F5-dup-bump-with-logger.test.ts` (JS-doc syntax bug; identical to origin/main).
- [x] `pnpm --filter @codex/subscription typecheck` — clean.
- [x] `pnpm typecheck` (workspace) — pre-existing `config/vite/package.config.ts` `failOnError` PluginOptions error remains (unrelated to this PR; tracked separately).
- [x] `pnpm exec biome check --write` on the three changed files — no new warnings.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>