### PR TITLE
test(web/access-revoked): AccessRevokedOverlay behavior coverage (Codex-o8ifc)

### DIFF
--- a/apps/web/src/lib/components/AccessRevokedOverlay/AccessRevokedOverlay.svelte.test.ts
+++ b/apps/web/src/lib/components/AccessRevokedOverlay/AccessRevokedOverlay.svelte.test.ts
@@ -2,13 +2,21 @@
  * AccessRevokedOverlay unit tests.
  *
  * Covers each revocation reason variant renders the documented copy + CTAs,
- * and the generic fallback when no reason is supplied. Interaction paths
- * (reactivate / billing portal) hit remote functions and are verified via
- * E2E tests — here we assert the control surface stays stable.
+ * the generic fallback when no reason is supplied, and the interaction
+ * surfaces (reactivate / billing portal / href navigation). Regression
+ * guard for `feedback_stripe_portal_lockdown`: the `View plan` secondary
+ * CTA MUST navigate to `/account/subscriptions`, NEVER directly to the
+ * Stripe portal — the portal is reachable only via the dedicated
+ * `Update payment` CTA on payment_failed (and even then is locked down
+ * server-side by a configuration id that disables tier changes).
  */
 
-import { afterEach, describe, expect, test, vi } from 'vitest';
-import { mount, unmount } from '$tests/utils/component-test-utils.svelte';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
 
 // Remote fns need to exist as mocks before the component imports them.
 vi.mock('$lib/remote/subscription.remote', () => ({
@@ -18,13 +26,29 @@ vi.mock('$lib/remote/account.remote', () => ({
   openBillingPortal: vi.fn(),
 }));
 vi.mock('$lib/components/ui/Toast', () => ({
-  toast: { error: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 vi.mock('$app/state', () => ({
   page: { url: new URL('http://localhost/') },
 }));
 
+import { toast } from '$lib/components/ui/Toast';
+import { openBillingPortal } from '$lib/remote/account.remote';
+import { reactivateSubscription } from '$lib/remote/subscription.remote';
 import AccessRevokedOverlay from './AccessRevokedOverlay.svelte';
+
+const ORG_ID = '00000000-0000-0000-0000-000000000000';
+
+/**
+ * Find a button by visible label (textContent).
+ */
+function buttonByLabel(label: string): HTMLButtonElement | null {
+  return (
+    Array.from(document.body.querySelectorAll('button')).find(
+      (b) => (b.textContent ?? '').trim() === label
+    ) ?? null
+  );
+}
 
 type Variant =
   | 'subscription_deleted'
@@ -60,6 +84,10 @@ const variants: Record<
 describe('AccessRevokedOverlay', () => {
   let component: ReturnType<typeof mount> | null = null;
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     if (component) {
       unmount(component);
@@ -74,7 +102,7 @@ describe('AccessRevokedOverlay', () => {
     const expected = variants[reason];
     component = mount(AccessRevokedOverlay, {
       target: document.body,
-      props: { reason, organizationId: '00000000-0000-0000-0000-000000000000' },
+      props: { reason, organizationId: ORG_ID },
     });
 
     const root = document.body.querySelector('.access-revoked');
@@ -120,5 +148,106 @@ describe('AccessRevokedOverlay', () => {
       document.body.querySelectorAll('button')
     ).filter((b) => /close|dismiss/i.test(b.getAttribute('aria-label') ?? ''));
     expect(closeButtons.length).toBe(0);
+  });
+
+  test('Reactivate CTA calls reactivateSubscription with org id and fires onreactivated', async () => {
+    const reactivateMock = vi.mocked(reactivateSubscription);
+    reactivateMock.mockResolvedValueOnce({ success: true } as never);
+    const onreactivated = vi.fn();
+
+    component = mount(AccessRevokedOverlay, {
+      target: document.body,
+      props: {
+        reason: 'subscription_deleted',
+        organizationId: ORG_ID,
+        onreactivated,
+      },
+    });
+
+    const primary = buttonByLabel('Reactivate');
+    expect(primary).toBeTruthy();
+    primary?.click();
+    // Drain microtasks so the awaited reactivateSubscription resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    // Regression guard for feedback_stripe_portal_lockdown:
+    // reactivate path MUST go through the dedicated remote command
+    // (which targets `/account/subscriptions` flows), not the Stripe
+    // billing portal — the portal cannot perform reactivation.
+    expect(reactivateMock).toHaveBeenCalledTimes(1);
+    expect(reactivateMock).toHaveBeenCalledWith({ organizationId: ORG_ID });
+    expect(vi.mocked(openBillingPortal)).not.toHaveBeenCalled();
+    expect(onreactivated).toHaveBeenCalledTimes(1);
+  });
+
+  test('Reactivate without organizationId surfaces a toast and does NOT call the remote', () => {
+    component = mount(AccessRevokedOverlay, {
+      target: document.body,
+      // organizationId intentionally omitted — multi-org user landed on
+      // an overlay rendered without org context.
+      props: { reason: 'subscription_deleted' },
+    });
+
+    buttonByLabel('Reactivate')?.click();
+    flushSync();
+
+    expect(vi.mocked(reactivateSubscription)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast).error).toHaveBeenCalledTimes(1);
+  });
+
+  test('View plan secondary CTA navigates to /account/subscriptions (NOT Stripe portal)', () => {
+    component = mount(AccessRevokedOverlay, {
+      target: document.body,
+      props: { reason: 'subscription_deleted', organizationId: ORG_ID },
+    });
+
+    // jsdom: replace window.location with a spy-able descriptor so we
+    // can observe the assignment from the component's handleAction.
+    const hrefSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        get href() {
+          return 'http://localhost/';
+        },
+        set href(value: string) {
+          hrefSpy(value);
+        },
+      },
+    });
+
+    buttonByLabel('View plan')?.click();
+    flushSync();
+
+    // Regression guard for feedback_stripe_portal_lockdown: the secondary
+    // CTA MUST land users in the in-app subscription manager, not deep
+    // link to Stripe (which would bypass our locked-down portal config).
+    expect(hrefSpy).toHaveBeenCalledWith('/account/subscriptions');
+    expect(hrefSpy.mock.calls[0][0]).not.toMatch(/stripe\.com/);
+    expect(vi.mocked(openBillingPortal)).not.toHaveBeenCalled();
+  });
+
+  test('multi-org disambiguation: organizationId prop scopes the reactivate call to one org', async () => {
+    // Simulates user holding subs in 3 orgs (a, b, c); only `b` is
+    // revoked. The overlay must reactivate ONLY `b` — not blanket-call
+    // for every org.
+    const reactivateMock = vi.mocked(reactivateSubscription);
+    reactivateMock.mockResolvedValueOnce({ success: true } as never);
+    const orgB = '11111111-1111-1111-1111-111111111111';
+
+    component = mount(AccessRevokedOverlay, {
+      target: document.body,
+      props: { reason: 'subscription_deleted', organizationId: orgB },
+    });
+
+    buttonByLabel('Reactivate')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(reactivateMock).toHaveBeenCalledTimes(1);
+    expect(reactivateMock.mock.calls[0][0]).toEqual({ organizationId: orgB });
   });
 });


### PR DESCRIPTION
Closes Codex-o8ifc (child of Codex-oal4l). Sister of Codex-70lic — final P1 frontend tasks in the epic.

## Summary
- Extended the existing 6-test copy/variant suite with 4 new behaviour tests (10 tests total)
- New coverage: reactivate calls `reactivateSubscription` with org id + fires `onreactivated`; missing-org guard surfaces a toast; `View plan` secondary navigates to `/account/subscriptions` (NOT Stripe portal — regression guard for `feedback_stripe_portal_lockdown`); multi-org disambiguation via `organizationId` prop
- Mocks `$lib/remote/subscription.remote`, `$lib/remote/account.remote`, `$lib/components/ui/Toast`, and `$app/state` at the seam
- No production changes

## Test plan
- [x] `pnpm --filter web test AccessRevokedOverlay.svelte.test.ts` — 10 passed
- [x] biome — clean (auto-formatted)
- [x] `pnpm --filter web typecheck` — pre-existing errors only (unrelated `__denoise_proofs__` + `content.ts` types, present on `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)