### PR TITLE
feat(commerce): minimum payout + minimum platform fee floors (Codex-a6hop)

### DIFF
--- a/packages/constants/src/commerce.ts
+++ b/packages/constants/src/commerce.ts
@@ -89,7 +89,32 @@ export const FEES = {
   PLATFORM_PERCENT: 1000, // 10.00% of gross
   ORG_PERCENT: 0, // 0% for one-time purchases
   SUBSCRIPTION_ORG_PERCENT: 1500, // 15.00% of post-platform-fee for subscriptions
+  /**
+   * Absolute minimum platform fee in pence (Codex-a6hop).
+   *
+   * Floor applied to the percentage-based platform fee so that micro-transactions
+   * still cover infrastructure cost (Stripe per-txn fee ~20p in UK + KV/Worker/streaming
+   * overhead). Effective rule: platformFeeCents = max(percent_of_gross, MIN_PLATFORM_FEE_CENTS).
+   *
+   * Calibration: At PLATFORM_PERCENT=10%, percentage wins above £3.00 gross
+   * (300p * 10% = 30p). Below £3.00, the floor kicks in.
+   *
+   * Applied identically in:
+   *   - packages/subscription/src/services/revenue-split.ts (subscriptions)
+   *   - packages/purchase/src/services/revenue-calculator.ts (one-time purchases)
+   */
+  MIN_PLATFORM_FEE_CENTS: 30,
 } as const;
+
+/**
+ * Minimum transfer amount in pence (£1.00) — Codex-a6hop.
+ *
+ * The payout sweep (Codex-vv77x) skips any `pendingPayouts` row whose
+ * `amountCents < MIN_TRANSFER_CENTS`, leaving it pending until subsequent
+ * earnings push the balance above the floor. This avoids dust transfers
+ * that would cost more in Stripe per-payout fees than they pay out.
+ */
+export const MIN_TRANSFER_CENTS = 100;
 
 export const CURRENCY = {
   GBP: 'gbp',

--- a/packages/purchase/src/__tests__/revenue-calculator.test.ts
+++ b/packages/purchase/src/__tests__/revenue-calculator.test.ts
@@ -4,6 +4,7 @@
  * Tests for revenue split calculation logic
  */
 
+import { FEES } from '@codex/constants';
 import { describe, expect, it } from 'vitest';
 import { RevenueCalculationError } from '../errors';
 import {
@@ -76,12 +77,13 @@ describe('Revenue Calculator', () => {
     });
 
     describe('rounding behavior', () => {
-      it('rounds platform fee UP (ceil)', () => {
-        // $1.01 (101 cents) with 10% = 10.1 cents -> 11 cents
+      it('rounds platform fee UP (ceil) — floor overrides at 101p (Codex-a6hop)', () => {
+        // 101p with 10% = ceil(10.1) = 11, floor = MIN_PLATFORM_FEE_CENTS = 30
+        // platform = max(11, 30) = 30, creator = 71
         const split = calculateRevenueSplit(101, 1000, 0);
 
-        expect(split.platformFeeCents).toBe(11);
-        expect(split.creatorPayoutCents).toBe(90);
+        expect(split.platformFeeCents).toBe(FEES.MIN_PLATFORM_FEE_CENTS);
+        expect(split.creatorPayoutCents).toBe(71);
         expect(
           split.platformFeeCents +
             split.organizationFeeCents +
@@ -139,12 +141,12 @@ describe('Revenue Calculator', () => {
         expect(split.creatorPayoutCents).toBe(0);
       });
 
-      it('handles 0% platform fee', () => {
+      it('handles 0% platform fee (floor still applies — Codex-a6hop)', () => {
         const split = calculateRevenueSplit(1000, 0, 0);
-
-        expect(split.platformFeeCents).toBe(0);
+        // percent = 0, floor = 30 → platform = 30, creator = 970
+        expect(split.platformFeeCents).toBe(FEES.MIN_PLATFORM_FEE_CENTS);
         expect(split.organizationFeeCents).toBe(0);
-        expect(split.creatorPayoutCents).toBe(1000);
+        expect(split.creatorPayoutCents).toBe(970);
       });
 
       it('handles combined fees totaling 100%', () => {
@@ -287,6 +289,75 @@ describe('Revenue Calculator', () => {
 
     it('DEFAULT_ORG_FEE_PERCENTAGE is 0% (0 basis points)', () => {
       expect(DEFAULT_ORG_FEE_PERCENTAGE).toBe(0);
+    });
+  });
+
+  // ─── Minimum platform-fee floor (Codex-a6hop) ────────────────────────
+  describe('minimum platform-fee floor (FEES.MIN_PLATFORM_FEE_CENTS)', () => {
+    const FLOOR = FEES.MIN_PLATFORM_FEE_CENTS;
+
+    it('floor kicks in when percent fee is below MIN_PLATFORM_FEE_CENTS', () => {
+      // 200p at 10%: percent = 20, floor = 30 → platform = 30
+      const split = calculateRevenueSplit(200, 1000, 0);
+      expect(split.platformFeeCents).toBe(FLOOR);
+      expect(split.creatorPayoutCents).toBe(170);
+      expect(
+        split.platformFeeCents +
+          split.organizationFeeCents +
+          split.creatorPayoutCents
+      ).toBe(200);
+    });
+
+    it('percent wins when percent fee is above MIN_PLATFORM_FEE_CENTS', () => {
+      // 400p at 10%: percent = 40, floor = 30 → platform = 40
+      const split = calculateRevenueSplit(400, 1000, 0);
+      expect(split.platformFeeCents).toBe(40);
+      expect(split.creatorPayoutCents).toBe(360);
+      expect(
+        split.platformFeeCents +
+          split.organizationFeeCents +
+          split.creatorPayoutCents
+      ).toBe(400);
+    });
+
+    it('percent equals floor exactly at break-even (300p at 10%)', () => {
+      const split = calculateRevenueSplit(300, 1000, 0);
+      expect(split.platformFeeCents).toBe(FLOOR);
+      expect(split.creatorPayoutCents).toBe(270);
+    });
+
+    it('floor is capped at amountCents for micro-transactions (10p)', () => {
+      // 10p at 10%: percent = 1, floor = 30, cap = 10 → platform = 10
+      const split = calculateRevenueSplit(10, 1000, 0);
+      expect(split.platformFeeCents).toBe(10);
+      expect(split.organizationFeeCents).toBe(0);
+      expect(split.creatorPayoutCents).toBe(0);
+      expect(
+        split.platformFeeCents +
+          split.organizationFeeCents +
+          split.creatorPayoutCents
+      ).toBe(10);
+    });
+
+    it('amount below MIN_TRANSFER_CENTS still splits correctly (transfer floor is separate concern)', () => {
+      // 99p (just below £1 transfer floor) still gets a normal calculator split.
+      // Transfer-floor logic lives in the sweep cron, not the calculator.
+      const split = calculateRevenueSplit(99, 1000, 0);
+      // percent = ceil(9.9) = 10, floor = 30 → platform = 30, creator = 69
+      expect(split.platformFeeCents).toBe(FLOOR);
+      expect(split.creatorPayoutCents).toBe(69);
+      expect(
+        split.platformFeeCents +
+          split.organizationFeeCents +
+          split.creatorPayoutCents
+      ).toBe(99);
+    });
+
+    it('0 amount bypasses floor (no fee on zero gross)', () => {
+      const split = calculateRevenueSplit(0, 1000, 0);
+      expect(split.platformFeeCents).toBe(0);
+      expect(split.organizationFeeCents).toBe(0);
+      expect(split.creatorPayoutCents).toBe(0);
     });
   });
 });

--- a/packages/purchase/src/services/revenue-calculator.ts
+++ b/packages/purchase/src/services/revenue-calculator.ts
@@ -101,9 +101,21 @@ export function calculateRevenueSplit(
 
   // Step 1: Calculate platform fee (round up)
   // Example: $29.99 * 10% = $2.999 -> $3.00 (300 cents)
-  const platformFeeCents = Math.ceil(
+  const percentPlatformFeeCents = Math.ceil(
     (amountCents * platformFeePercentage) / 10000
   );
+
+  // Step 1b: Apply absolute minimum platform fee floor (Codex-a6hop).
+  // Mirrors the same rule in @codex/subscription's revenue-split.ts — both
+  // calculators MUST stay in lockstep. Capped at amountCents so a sub-floor
+  // gross never produces a negative remainder.
+  const platformFeeCents =
+    amountCents === 0
+      ? 0
+      : Math.min(
+          amountCents,
+          Math.max(percentPlatformFeeCents, FEES.MIN_PLATFORM_FEE_CENTS)
+        );
 
   // Step 2: Calculate remaining after platform fee
   const remainingAfterPlatform = amountCents - platformFeeCents;

--- a/packages/subscription/src/services/__tests__/revenue-split.test.ts
+++ b/packages/subscription/src/services/__tests__/revenue-split.test.ts
@@ -54,12 +54,11 @@ describe('calculateRevenueSplit', () => {
       ).toBe(999);
     });
 
-    it('should calculate correct split for 1p (minimum positive amount)', () => {
+    it('should calculate correct split for 1p (minimum positive amount, capped by amountCents)', () => {
       const result = calculateRevenueSplit(1, PLATFORM, ORG);
-      // platform = ceil(1 * 0.1) = ceil(0.1) = 1
-      // postPlatform = 0
-      // org = ceil(0 * 0.15) = 0
-      // creator = 0
+      // percent = ceil(1 * 0.1) = 1, floor = MIN_PLATFORM_FEE_CENTS = 30
+      // platform = min(1, max(1, 30)) = 1 (cap prevents > amountCents)
+      // postPlatform = 0, org = 0, creator = 0
       expect(result.platformFeeCents).toBe(1);
       expect(result.organizationFeeCents).toBe(0);
       expect(result.creatorPayoutCents).toBe(0);
@@ -82,14 +81,13 @@ describe('calculateRevenueSplit', () => {
       ).toBe(100000);
     });
 
-    it('should calculate correct split for 2p (edge: both ceil effects active)', () => {
+    it('should calculate correct split for 2p (floor capped at amountCents, eats whole gross)', () => {
       const result = calculateRevenueSplit(2, PLATFORM, ORG);
-      // platform = ceil(2 * 0.1) = ceil(0.2) = 1
-      // postPlatform = 1
-      // org = ceil(1 * 0.15) = ceil(0.15) = 1
-      // creator = 1 - 1 = 0
-      expect(result.platformFeeCents).toBe(1);
-      expect(result.organizationFeeCents).toBe(1);
+      // percent = ceil(2 * 0.1) = 1, floor = 30
+      // platform = min(2, max(1, 30)) = 2 (floor wants 30, capped at amountCents)
+      // postPlatform = 0, org = 0, creator = 0
+      expect(result.platformFeeCents).toBe(2);
+      expect(result.organizationFeeCents).toBe(0);
       expect(result.creatorPayoutCents).toBe(0);
       expect(
         result.platformFeeCents +
@@ -136,11 +134,14 @@ describe('calculateRevenueSplit', () => {
   // ─── Custom fee percentages ──────────────────────────────────────────
 
   describe('custom fee percentages', () => {
-    it('should handle 0% platform fee (all goes to org + creator)', () => {
+    it('should handle 0% platform fee (floor still applies — Codex-a6hop)', () => {
       const result = calculateRevenueSplit(1000, 0, 1500);
-      expect(result.platformFeeCents).toBe(0);
-      expect(result.organizationFeeCents).toBe(150);
-      expect(result.creatorPayoutCents).toBe(850);
+      // percent = 0, floor = MIN_PLATFORM_FEE_CENTS = 30
+      // platform = min(1000, max(0, 30)) = 30
+      // postPlatform = 970, org = ceil(970*0.15) = 146, creator = 824
+      expect(result.platformFeeCents).toBe(30);
+      expect(result.organizationFeeCents).toBe(146);
+      expect(result.creatorPayoutCents).toBe(824);
       expect(
         result.platformFeeCents +
           result.organizationFeeCents +
@@ -160,11 +161,12 @@ describe('calculateRevenueSplit', () => {
       ).toBe(1000);
     });
 
-    it('should handle 0% for both fees (all to creator)', () => {
+    it('should handle 0% for both fees (floor still applies — Codex-a6hop)', () => {
       const result = calculateRevenueSplit(1000, 0, 0);
-      expect(result.platformFeeCents).toBe(0);
+      // percent = 0, floor = 30 → platform = 30, creator = 970
+      expect(result.platformFeeCents).toBe(30);
       expect(result.organizationFeeCents).toBe(0);
-      expect(result.creatorPayoutCents).toBe(1000);
+      expect(result.creatorPayoutCents).toBe(970);
     });
 
     it('should handle 100% platform fee (nothing to org or creator)', () => {
@@ -194,13 +196,14 @@ describe('calculateRevenueSplit', () => {
   // ─── Rounding behavior ──────────────────────────────────────────────
 
   describe('rounding behavior (ceil for platform and org, remainder to creator)', () => {
-    it('should ceil platform fee and give remainder to creator', () => {
-      // 101p: platform = ceil(101 * 0.1) = ceil(10.1) = 11
+    it('should apply platform-fee floor when percent < MIN (101p)', () => {
+      // 101p: percent = ceil(10.1) = 11, floor = 30 → platform = 30
+      // postPlatform = 71, org = ceil(71 * 0.15) = ceil(10.65) = 11
+      // creator = 71 - 11 = 60
       const result = calculateRevenueSplit(101, PLATFORM, ORG);
-      expect(result.platformFeeCents).toBe(11);
-      // postPlatform = 90, org = ceil(90 * 0.15) = ceil(13.5) = 14
-      expect(result.organizationFeeCents).toBe(14);
-      expect(result.creatorPayoutCents).toBe(76);
+      expect(result.platformFeeCents).toBe(30);
+      expect(result.organizationFeeCents).toBe(11);
+      expect(result.creatorPayoutCents).toBe(60);
       expect(
         result.platformFeeCents +
           result.organizationFeeCents +
@@ -208,12 +211,13 @@ describe('calculateRevenueSplit', () => {
       ).toBe(101);
     });
 
-    it('should ceil org fee and give remainder to creator', () => {
-      // 103p: platform = ceil(10.3) = 11, post = 92, org = ceil(92*0.15) = ceil(13.8) = 14
+    it('should apply platform-fee floor when percent < MIN (103p)', () => {
+      // 103p: percent = ceil(10.3) = 11, floor = 30 → platform = 30
+      // postPlatform = 73, org = ceil(73 * 0.15) = ceil(10.95) = 11, creator = 62
       const result = calculateRevenueSplit(103, PLATFORM, ORG);
-      expect(result.platformFeeCents).toBe(11);
-      expect(result.organizationFeeCents).toBe(14);
-      expect(result.creatorPayoutCents).toBe(78);
+      expect(result.platformFeeCents).toBe(30);
+      expect(result.organizationFeeCents).toBe(11);
+      expect(result.creatorPayoutCents).toBe(62);
       expect(
         result.platformFeeCents +
           result.organizationFeeCents +
@@ -222,7 +226,7 @@ describe('calculateRevenueSplit', () => {
     });
 
     it('should never produce negative creator payout', () => {
-      // Very small amounts: 3p
+      // Very small amounts: 3p — floor capped at amountCents → platform=3, rest=0
       const result = calculateRevenueSplit(3, PLATFORM, ORG);
       expect(result.creatorPayoutCents).toBeGreaterThanOrEqual(0);
       expect(
@@ -246,7 +250,7 @@ describe('calculateRevenueSplit', () => {
 
     it('should handle exact GBP subscription price (£4.99 = 499p)', () => {
       const result = calculateRevenueSplit(499, PLATFORM, ORG);
-      // platform = ceil(499 * 0.1) = ceil(49.9) = 50
+      // platform = ceil(499 * 0.1) = ceil(49.9) = 50 (> floor 30, percent wins)
       // postPlatform = 449
       // org = ceil(449 * 0.15) = ceil(67.35) = 68
       // creator = 449 - 68 = 381
@@ -258,6 +262,83 @@ describe('calculateRevenueSplit', () => {
           result.organizationFeeCents +
           result.creatorPayoutCents
       ).toBe(499);
+    });
+  });
+
+  // ─── Minimum platform-fee floor (Codex-a6hop) ────────────────────────
+  describe('minimum platform-fee floor (FEES.MIN_PLATFORM_FEE_CENTS)', () => {
+    const FLOOR = FEES.MIN_PLATFORM_FEE_CENTS;
+
+    it('floor kicks in when percent fee is below MIN_PLATFORM_FEE_CENTS', () => {
+      // 200p at 10%: percent = 20, floor = 30 → platform = 30
+      const result = calculateRevenueSplit(200, PLATFORM, ORG);
+      expect(result.platformFeeCents).toBe(FLOOR);
+      // postPlatform = 170, org = ceil(170*0.15) = ceil(25.5) = 26, creator = 144
+      expect(result.organizationFeeCents).toBe(26);
+      expect(result.creatorPayoutCents).toBe(144);
+      expect(
+        result.platformFeeCents +
+          result.organizationFeeCents +
+          result.creatorPayoutCents
+      ).toBe(200);
+    });
+
+    it('percent wins when percent fee is above MIN_PLATFORM_FEE_CENTS', () => {
+      // 400p at 10%: percent = 40, floor = 30 → platform = 40
+      const result = calculateRevenueSplit(400, PLATFORM, ORG);
+      expect(result.platformFeeCents).toBe(40);
+      // postPlatform = 360, org = ceil(360*0.15) = 54, creator = 306
+      expect(result.organizationFeeCents).toBe(54);
+      expect(result.creatorPayoutCents).toBe(306);
+      expect(
+        result.platformFeeCents +
+          result.organizationFeeCents +
+          result.creatorPayoutCents
+      ).toBe(400);
+    });
+
+    it('percent equals floor exactly at break-even (300p)', () => {
+      // 300p at 10%: percent = 30, floor = 30 → platform = 30
+      const result = calculateRevenueSplit(300, PLATFORM, ORG);
+      expect(result.platformFeeCents).toBe(FLOOR);
+      // postPlatform = 270, org = ceil(270*0.15) = ceil(40.5) = 41, creator = 229
+      expect(result.organizationFeeCents).toBe(41);
+      expect(result.creatorPayoutCents).toBe(229);
+      expect(
+        result.platformFeeCents +
+          result.organizationFeeCents +
+          result.creatorPayoutCents
+      ).toBe(300);
+    });
+
+    it('floor is capped at amountCents for micro-transactions (10p)', () => {
+      // 10p at 10%: percent = 1, floor = 30, cap = 10 → platform = 10
+      // postPlatform = 0, org = 0, creator = 0
+      const result = calculateRevenueSplit(10, PLATFORM, ORG);
+      expect(result.platformFeeCents).toBe(10);
+      expect(result.organizationFeeCents).toBe(0);
+      expect(result.creatorPayoutCents).toBe(0);
+      expect(
+        result.platformFeeCents +
+          result.organizationFeeCents +
+          result.creatorPayoutCents
+      ).toBe(10);
+    });
+
+    it('amount below MIN_TRANSFER_CENTS still splits correctly (transfer floor is separate concern)', () => {
+      // 99p (just below £1 transfer floor) still gets a normal split.
+      // Transfer-floor logic lives in the sweep cron, not the calculator.
+      const result = calculateRevenueSplit(99, PLATFORM, ORG);
+      // percent = ceil(9.9) = 10, floor = 30 → platform = 30
+      // postPlatform = 69, org = ceil(69*0.15) = ceil(10.35) = 11, creator = 58
+      expect(result.platformFeeCents).toBe(30);
+      expect(result.organizationFeeCents).toBe(11);
+      expect(result.creatorPayoutCents).toBe(58);
+      expect(
+        result.platformFeeCents +
+          result.organizationFeeCents +
+          result.creatorPayoutCents
+      ).toBe(99);
     });
   });
 });

--- a/packages/subscription/src/services/revenue-split.ts
+++ b/packages/subscription/src/services/revenue-split.ts
@@ -12,6 +12,7 @@
  * Rounding: ceil for platform and org, remainder goes to creators.
  */
 
+import { FEES } from '@codex/constants';
 import { InternalServiceError } from '@codex/service-errors';
 import type { RevenueSplit } from '@codex/shared-types';
 
@@ -42,11 +43,19 @@ export function calculateRevenueSplit(
   }
 
   // Platform fee: ceil to ensure platform never underpaid
-  const platformFeeCents = Math.ceil(
+  const percentPlatformFeeCents = Math.ceil(
     (amountCents * platformFeePercent) / 10000
   );
 
-  // Post-platform remainder
+  // Apply absolute minimum platform fee floor (Codex-a6hop) so that
+  // micro-transactions still cover infrastructure cost. Capped at amountCents
+  // so we never produce a negative post-platform remainder for sub-floor inputs.
+  const platformFeeCents = Math.min(
+    amountCents,
+    Math.max(percentPlatformFeeCents, FEES.MIN_PLATFORM_FEE_CENTS)
+  );
+
+  // Post-platform remainder (recomputed after floor — org+creator shrink)
   const postPlatform = amountCents - platformFeeCents;
 
   // Org fee: ceil, applied to post-platform amount


### PR DESCRIPTION
## Summary
- Adds `MIN_TRANSFER_CENTS` (100p / £1) and `FEES.MIN_PLATFORM_FEE_CENTS` (30p) to `@codex/constants`.
- `calculateRevenueSplit` floors platform fee at greater-of(percentage, absolute), capped at `amountCents` so micro-transactions can't go negative.
- Lockstep application to **both** subscription (`packages/subscription/src/services/revenue-split.ts`) and purchase (`packages/purchase/src/services/revenue-calculator.ts`) calculators.
- Sanity invariant `platform + org + creator === amountCents` preserved.
- Boundary tests added: below-floor, at-floor (break-even at 300p), above-floor, micro-transaction (10p capped), and amount-below-`MIN_TRANSFER_CENTS` (transfer floor is a separate concern owned by the sweep cron — Codex-vv77x).

### Chosen `MIN_PLATFORM_FEE_CENTS` value
**30p (£0.30)** — Stripe UK card fee is ~20p + 1.5%, so the floor must clear Stripe's per-txn cost plus KV/Worker/streaming overhead. At PLATFORM_PERCENT=10%, percentage wins above £3.00 gross (300p × 10% = 30p == floor); below £3.00, floor applies. Documented in `commerce.ts` and in each calculator's inline comment.

## Test plan
- [x] `pnpm --filter @codex/constants test --run` — 56/56 pass
- [x] `pnpm --filter @codex/subscription test --run src/services/__tests__/revenue-split.test.ts` — 23/23 pass
- [x] `pnpm --filter @codex/purchase test --run src/__tests__/revenue-calculator.test.ts` — 31/31 pass
- [x] `pnpm --filter @codex/{constants,subscription,purchase} typecheck` — clean
- [x] Pre-existing failures (DB-integration tests requiring `DATABASE_URL_LOCAL_PROXY`, denoise-proof syntax issue, `config/vite/package.config.ts` `failOnError`) confirmed present on `origin/main` — not introduced by this PR.

Bead: Codex-a6hop (child of epic Codex-b1hgr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)