### PR TITLE
fix(ecom-api): connect-webhook re-checks active state from data.object (Codex-qigid)

### DIFF
--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -138,6 +138,29 @@ export class ConnectAccountService extends BaseService {
   }
 
   /**
+   * Get Connect account by Stripe account id.
+   *
+   * Used by webhook handlers to read CURRENT DB state before applying an
+   * `account.updated` mutation. This is the source of truth for "wasActive"
+   * because Stripe's `previous_attributes` diff is unreliable on capability
+   * ricochet events (verified via Context7 2026-05-13: `account.updated`
+   * fires on ANY status/property change and `previous_attributes` may NOT
+   * contain `charges_enabled`/`payouts_enabled` when the event is triggered
+   * by a tangential capability or requirement field flip).
+   */
+  async getAccountByStripeId(
+    stripeAccountId: string
+  ): Promise<StripeConnectAccount | null> {
+    const [account] = await this.db
+      .select()
+      .from(stripeConnectAccounts)
+      .where(eq(stripeConnectAccounts.stripeAccountId, stripeAccountId))
+      .limit(1);
+
+    return account ?? null;
+  }
+
+  /**
    * Generate a new onboarding link for an existing account.
    * Used to resume abandoned onboarding — Stripe remembers prior progress.
    */

--- a/workers/ecom-api/src/handlers/__tests__/connect-webhook.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/connect-webhook.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Connect Webhook Handler Tests (Codex-qigid)
+ *
+ * Tests the handleConnectWebhook function which processes Stripe Connect
+ * account.updated events.
+ *
+ * Key test scenarios (Codex-qigid — re-check from data.object):
+ * - Active transition is detected from data.object regardless of
+ *   `previous_attributes` content (empty diff, partial diff, ricochet).
+ * - Idempotency: resolvePendingPayouts fires ONLY on the persisted
+ *   transition (DB row chargesEnabled/payoutsEnabled flip false → true).
+ * - Ricochet (active → restricted → active) fires resolvePendingPayouts
+ *   on each first-transition-to-active hop.
+ * - account.application.deauthorized still routes correctly.
+ */
+
+import { STRIPE_EVENTS } from '@codex/constants';
+import { createMockHonoContext, type MockHonoContext } from '@codex/test-utils';
+import type { Context } from 'hono';
+import type Stripe from 'stripe';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StripeWebhookEnv } from '../../types';
+
+// Mock the module under test's dependencies BEFORE importing.
+vi.mock('@codex/subscription', () => ({
+  ConnectAccountService: vi.fn(),
+  SubscriptionService: vi.fn(),
+}));
+
+vi.mock('@codex/worker-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@codex/worker-utils')>();
+  return {
+    ...actual,
+    createWebhookDbClient: vi.fn(),
+  };
+});
+
+import {
+  ConnectAccountService,
+  SubscriptionService,
+} from '@codex/subscription';
+import { createWebhookDbClient } from '@codex/worker-utils';
+import { handleConnectWebhook } from '../connect-webhook';
+
+type StripeConnectRow = {
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+};
+
+function createContext(): {
+  context: Context<StripeWebhookEnv>;
+  mock: MockHonoContext<StripeWebhookEnv['Bindings']>;
+  waitUntilSpy: ReturnType<typeof vi.fn>;
+} {
+  const mock = createMockHonoContext<StripeWebhookEnv['Bindings']>({});
+  const waitUntilSpy = vi.fn(async (p: Promise<unknown>) => {
+    // Drain the promise so .finally(subCleanup) runs in-test.
+    await p;
+  });
+  (mock as unknown as Record<string, unknown>).executionCtx = {
+    waitUntil: waitUntilSpy,
+    passThroughOnException: vi.fn(),
+  };
+  return {
+    context: mock as unknown as Context<StripeWebhookEnv>,
+    mock,
+    waitUntilSpy,
+  };
+}
+
+function createAccountUpdatedEvent(opts: {
+  accountId?: string;
+  orgId?: string | null;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  previousAttributes?: Partial<Stripe.Account>;
+}): Stripe.Event {
+  const account: Partial<Stripe.Account> = {
+    id: opts.accountId ?? 'acct_test_123',
+    object: 'account',
+    charges_enabled: opts.chargesEnabled,
+    payouts_enabled: opts.payoutsEnabled,
+    metadata:
+      opts.orgId === null
+        ? {}
+        : { codex_organization_id: opts.orgId ?? 'org_1' },
+  };
+  return {
+    id: `evt_${Date.now()}_${Math.random()}`,
+    type: STRIPE_EVENTS.ACCOUNT_UPDATED,
+    data: {
+      object: account,
+      previous_attributes: opts.previousAttributes ?? {},
+    },
+  } as unknown as Stripe.Event;
+}
+
+describe('handleConnectWebhook (Codex-qigid: re-check active from data.object)', () => {
+  let mockStripe: Stripe;
+  let mockHandleAccountUpdated: ReturnType<typeof vi.fn>;
+  let mockHandleAccountDeauthorized: ReturnType<typeof vi.fn>;
+  let mockGetAccountByStripeId: ReturnType<typeof vi.fn>;
+  let mockResolvePendingPayouts: ReturnType<typeof vi.fn>;
+  let mockCleanup: ReturnType<typeof vi.fn>;
+  let dbState: StripeConnectRow | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState = null;
+
+    mockHandleAccountUpdated = vi.fn(async (account: Stripe.Account) => {
+      // Mirror the production handleAccountUpdated side-effect on dbState
+      // so subsequent reads in a single test see the updated state.
+      dbState = {
+        chargesEnabled: account.charges_enabled ?? false,
+        payoutsEnabled: account.payouts_enabled ?? false,
+      };
+    });
+    mockHandleAccountDeauthorized = vi.fn().mockResolvedValue(undefined);
+    mockGetAccountByStripeId = vi.fn(async () =>
+      dbState ? { ...dbState } : null
+    );
+    mockResolvePendingPayouts = vi
+      .fn()
+      .mockResolvedValue({ resolved: 0, totalCents: 0 });
+    mockCleanup = vi.fn().mockResolvedValue(undefined);
+
+    mockStripe = {} as Stripe;
+
+    (createWebhookDbClient as ReturnType<typeof vi.fn>).mockReturnValue({
+      db: { mock: 'db' },
+      cleanup: mockCleanup,
+    });
+
+    (
+      ConnectAccountService as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => ({
+      handleAccountUpdated: mockHandleAccountUpdated,
+      handleAccountDeauthorized: mockHandleAccountDeauthorized,
+      getAccountByStripeId: mockGetAccountByStripeId,
+    }));
+
+    (
+      SubscriptionService as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => ({
+      resolvePendingPayouts: mockResolvePendingPayouts,
+    }));
+  });
+
+  // ─── transition detection from data.object ──────────────────────────────
+
+  it('detects activation transition with EMPTY previous_attributes (DB row was inactive)', async () => {
+    // Empty diff is the headline bug: Stripe may fire account.updated with
+    // previous_attributes={} when an unrelated capability/requirement field
+    // changed, but charges/payouts have flipped on at the same time.
+    dbState = { chargesEnabled: false, payoutsEnabled: false };
+    const event = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      previousAttributes: {},
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockHandleAccountUpdated).toHaveBeenCalledOnce();
+    expect(mockResolvePendingPayouts).toHaveBeenCalledOnce();
+    expect(mockResolvePendingPayouts).toHaveBeenCalledWith(
+      'org_1',
+      'acct_test_123'
+    );
+  });
+
+  it('detects activation with PARTIAL previous_attributes (only one field in diff)', async () => {
+    // Real Stripe behaviour: previous_attributes may include only the
+    // capability that flipped. The old code keyed on
+    // previous_attributes.charges_enabled being defined; if `charges_enabled`
+    // was already true in the previous state and only `payouts_enabled`
+    // flipped on, wasActive was incorrectly computed using the now-true
+    // `account.charges_enabled` fallback for the missing field.
+    dbState = { chargesEnabled: true, payoutsEnabled: false };
+    const event = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      previousAttributes: { payouts_enabled: false },
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockResolvePendingPayouts).toHaveBeenCalledOnce();
+  });
+
+  // ─── idempotency: DB-backed debounce ────────────────────────────────────
+
+  it('does NOT call resolvePendingPayouts when DB row is already active', async () => {
+    // Duplicate active-state event after the account is already active.
+    dbState = { chargesEnabled: true, payoutsEnabled: true };
+    const event = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      previousAttributes: {},
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockHandleAccountUpdated).toHaveBeenCalledOnce();
+    expect(mockResolvePendingPayouts).not.toHaveBeenCalled();
+  });
+
+  it('fires resolvePendingPayouts only on FIRST transition across two consecutive active events', async () => {
+    dbState = { chargesEnabled: false, payoutsEnabled: false };
+    const event1 = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+    });
+    const event2 = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event1, mockStripe, context);
+    await handleConnectWebhook(event2, mockStripe, context);
+
+    expect(mockHandleAccountUpdated).toHaveBeenCalledTimes(2);
+    expect(mockResolvePendingPayouts).toHaveBeenCalledOnce();
+  });
+
+  // ─── ricochet: restricted → active → restricted → active ────────────────
+
+  it('fires resolvePendingPayouts on EACH re-activation in a ricochet sequence', async () => {
+    // 1) restricted (initial DB state)
+    dbState = { chargesEnabled: false, payoutsEnabled: false };
+    const { context } = createContext();
+
+    // 2) restricted → active
+    await handleConnectWebhook(
+      createAccountUpdatedEvent({
+        chargesEnabled: true,
+        payoutsEnabled: true,
+      }),
+      mockStripe,
+      context
+    );
+    expect(mockResolvePendingPayouts).toHaveBeenCalledTimes(1);
+
+    // 3) active → restricted (charges flipped off — payouts already off in
+    //    Stripe's view of "restricted"; either field flipping clears active)
+    await handleConnectWebhook(
+      createAccountUpdatedEvent({
+        chargesEnabled: false,
+        payoutsEnabled: false,
+      }),
+      mockStripe,
+      context
+    );
+    expect(mockResolvePendingPayouts).toHaveBeenCalledTimes(1);
+
+    // 4) restricted → active (second activation)
+    await handleConnectWebhook(
+      createAccountUpdatedEvent({
+        chargesEnabled: true,
+        payoutsEnabled: true,
+      }),
+      mockStripe,
+      context
+    );
+    expect(mockResolvePendingPayouts).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── guard rails ────────────────────────────────────────────────────────
+
+  it('skips resolvePendingPayouts when metadata.codex_organization_id is missing', async () => {
+    dbState = { chargesEnabled: false, payoutsEnabled: false };
+    const event = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      orgId: null,
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockHandleAccountUpdated).toHaveBeenCalledOnce();
+    expect(mockResolvePendingPayouts).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire payouts on inactive update (charges on, payouts off)', async () => {
+    dbState = { chargesEnabled: false, payoutsEnabled: false };
+    const event = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: false,
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockResolvePendingPayouts).not.toHaveBeenCalled();
+  });
+
+  // ─── deauthorize path ───────────────────────────────────────────────────
+
+  it('routes account.application.deauthorized to handleAccountDeauthorized', async () => {
+    const event = {
+      id: 'evt_deauth_1',
+      type: STRIPE_EVENTS.ACCOUNT_DEAUTHORIZED,
+      account: 'acct_deauth_1',
+      data: { object: { id: 'ca_app_1', object: 'application' } },
+    } as unknown as Stripe.Event;
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockHandleAccountDeauthorized).toHaveBeenCalledWith('acct_deauth_1');
+  });
+
+  it('logs a warning when deauthorize event has no account id', async () => {
+    const event = {
+      id: 'evt_deauth_2',
+      type: STRIPE_EVENTS.ACCOUNT_DEAUTHORIZED,
+      data: { object: { id: 'ca_app_2', object: 'application' } },
+    } as unknown as Stripe.Event;
+    const { context, mock } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockHandleAccountDeauthorized).not.toHaveBeenCalled();
+    expect(mock._obs.warn).toHaveBeenCalledWith(
+      'Connect deauthorized event missing account ID',
+      expect.objectContaining({ type: STRIPE_EVENTS.ACCOUNT_DEAUTHORIZED })
+    );
+  });
+
+  // ─── cleanup contract ───────────────────────────────────────────────────
+
+  it('always runs cleanup in the finally block', async () => {
+    dbState = { chargesEnabled: false, payoutsEnabled: false };
+    const event = createAccountUpdatedEvent({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+    });
+    const { context } = createContext();
+
+    await handleConnectWebhook(event, mockStripe, context);
+
+    expect(mockCleanup).toHaveBeenCalled();
+  });
+});

--- a/workers/ecom-api/src/handlers/connect-webhook.ts
+++ b/workers/ecom-api/src/handlers/connect-webhook.ts
@@ -36,19 +36,25 @@ export async function handleConnectWebhook(
     switch (event.type) {
       case STRIPE_EVENTS.ACCOUNT_UPDATED: {
         const account = event.data.object as Stripe.Account;
-        // Check previous values to detect activation transition
-        const previousAttributes = event.data.previous_attributes as
-          | Partial<Stripe.Account>
-          | undefined;
-        const wasChargesEnabled =
-          previousAttributes?.charges_enabled !== undefined
-            ? previousAttributes.charges_enabled
-            : account.charges_enabled;
-        const wasPayoutsEnabled =
-          previousAttributes?.payouts_enabled !== undefined
-            ? previousAttributes.payouts_enabled
-            : account.payouts_enabled;
-        const wasActive = wasChargesEnabled && wasPayoutsEnabled;
+
+        // Codex-qigid: detect the active-transition from `data.object`
+        // (Stripe's CURRENT state) rather than from `previous_attributes`.
+        // Context7-verified 2026-05-13: `account.updated` fires on ANY status
+        // or property change and `previous_attributes` may NOT contain the
+        // `charges_enabled` / `payouts_enabled` fields on capability-ricochet
+        // events (e.g. `requirements.past_due` → `restricted` → re-enabled).
+        //
+        // `wasActive` is sourced from the CURRENT DB row BEFORE the update,
+        // so the transition signal is the persisted state-change rather
+        // than Stripe's diff. This also gives idempotency for free: a
+        // duplicate `active → active` event finds `wasActive=true` and
+        // skips the payout resolution. A ricochet (active → restricted →
+        // active) correctly clears `wasActive` to false during the
+        // restricted hop and fires payouts again on re-activation.
+        const currentRecord = await service.getAccountByStripeId(account.id);
+        const wasActive =
+          (currentRecord?.chargesEnabled ?? false) &&
+          (currentRecord?.payoutsEnabled ?? false);
         const isNowActive = account.charges_enabled && account.payouts_enabled;
 
         await service.handleAccountUpdated(account);


### PR DESCRIPTION
## Summary
- Detects Connect active-transition from `data.object` regardless of `previous_attributes` content. Context7-verified 2026-05-13: Stripe's `account.updated` fires on ANY status/property change and `previous_attributes` may NOT contain `charges_enabled`/`payouts_enabled` on capability-ricochet events (e.g. `requirements.past_due → restricted → re-enabled`).
- Sources `wasActive` from the CURRENT DB row before `handleAccountUpdated` runs (added `ConnectAccountService.getAccountByStripeId`). This gives DB-backed idempotency for free: duplicate active-state events skip `resolvePendingPayouts`, while a true ricochet (active → restricted → active) correctly fires payouts on each first transition.
- 10 new tests cover: empty diff, partial diff, double-active idempotency, full ricochet sequence, missing org metadata, deauthorize routing.
- No schema change required — used the existing `charges_enabled`/`payouts_enabled` columns as the persisted "wasActive" signal.

## Test plan
- [x] `pnpm --filter ecom-api test --run` — 294 passed, 7 skipped (incl. 10 new connect-webhook tests)
- [x] `pnpm --filter ecom-api typecheck` — clean
- [x] `pnpm --filter @codex/subscription typecheck` — clean
- [x] `pnpm --filter @codex/database typecheck` — clean
- [x] `pnpm exec biome check --write` on changed files — clean
- [ ] Workspace `pnpm typecheck` — pre-existing `@codex/identity` failure on `failOnError` in `config/vite/package.config.ts` (verified present on origin/main, unrelated)
- [ ] `@codex/subscription` and `@codex/database` integration tests — pre-existing `DATABASE_URL_LOCAL_PROXY` env requirement, verified present on origin/main

Bead: Codex-qigid (child of epic Codex-b1hgr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)