### PR TITLE
feat(subscription): GBP-only currency enforcement (Codex-yv18n)

### DIFF
--- a/packages/service-errors/src/base-errors.ts
+++ b/packages/service-errors/src/base-errors.ts
@@ -127,6 +127,33 @@ export class InternalServiceError extends ServiceError {
 }
 
 /**
+ * Unsupported currency error (400)
+ * Thrown when a charge/payout is in a currency the platform does not yet support.
+ * Currently the platform is GBP-only — cross-currency support is a tracked future
+ * feature. Surfacing this explicitly prevents silent currency mismatch against
+ * downstream providers (e.g. Stripe transfers).
+ */
+export class UnsupportedCurrencyError extends ServiceError {
+  public readonly received: string;
+  public readonly supported: readonly string[];
+
+  constructor(
+    received: string,
+    supported: readonly string[],
+    context?: Record<string, unknown>
+  ) {
+    super(
+      `Unsupported currency '${received}'. Currently supports: ${supported.join(', ')}`,
+      'UNSUPPORTED_CURRENCY',
+      400,
+      context
+    );
+    this.received = received;
+    this.supported = supported;
+  }
+}
+
+/**
  * Type guard to check if error is a ServiceError
  */
 export function isServiceError(error: unknown): error is ServiceError {

--- a/packages/service-errors/src/index.ts
+++ b/packages/service-errors/src/index.ts
@@ -16,6 +16,7 @@ export {
   NotFoundError,
   ServiceError,
   UnauthorizedError,
+  UnsupportedCurrencyError,
   ValidationError,
   wrapError,
 } from './base-errors';

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -4258,3 +4258,343 @@ describe('SubscriptionPaymentRequiredError', () => {
     expect(err.context?.tierIdAtCommit).toBeUndefined();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// Currency GBP-only enforcement (Codex-yv18n)
+//
+// The platform is GBP-only for revenue transfers. Non-GBP invoices and
+// non-GBP pending-payout rows MUST surface an explicit
+// UnsupportedCurrencyError BEFORE any stripe.transfers.create call —
+// silently transferring in the wrong currency would mismatch the source
+// charge currency at Stripe. Cross-currency support is a tracked future
+// feature; until then, this contract MUST hold.
+// ─────────────────────────────────────────────────────────────────────
+describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
+  let db: ReturnType<typeof setupTestDatabase>;
+  let stripe: Stripe;
+  let service: SubscriptionService;
+  let creatorId: string;
+  let subscriberId: string;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    await validateDatabaseConnection(db);
+    const userIds = await seedTestUsers(db, 2);
+    [creatorId, subscriberId] = userIds;
+  });
+
+  beforeEach(() => {
+    stripe = createMockStripe();
+    service = new SubscriptionService({ db, environment: 'test' }, stripe);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  /**
+   * Local copy of createFullOrg — the outer describe's helper is not in
+   * scope. Mirrors the same shape: org + owner membership + connect +
+   * two tiers (monthly+annual).
+   */
+  async function seedOrg(slug: string) {
+    const [org] = await db
+      .insert(organizations)
+      .values(
+        createTestOrganizationInput({
+          slug: createUniqueSlug(slug),
+          creatorId,
+        })
+      )
+      .returning();
+
+    await db.insert(stripeConnectAccounts).values(
+      createTestConnectAccountInput(org.id, creatorId, {
+        chargesEnabled: true,
+        payoutsEnabled: true,
+      })
+    );
+
+    const [tier1] = await db
+      .insert(subscriptionTiers)
+      .values(createTestTierInput(org.id, { name: 'Basic GBP' }))
+      .returning();
+
+    return { org, tier1 };
+  }
+
+  async function seedActiveSubscription(orgId: string, tierId: string) {
+    const [sub] = await db
+      .insert(subscriptions)
+      .values(
+        createTestSubscriptionInput(subscriberId, orgId, tierId, {
+          status: 'active',
+        })
+      )
+      .returning();
+    return sub;
+  }
+
+  describe('handleInvoicePaymentSucceeded — invoice currency guard', () => {
+    it('GBP invoice → transfers fire normally (happy path)', async () => {
+      const { org, tier1 } = await seedOrg('yv18n-gbp');
+      const sub = await seedActiveSubscription(org.id, tier1.id);
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        currency: 'gbp',
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      expect(transferSpy).toHaveBeenCalled();
+      // Every call MUST be GBP — defence-in-depth assertion.
+      for (const call of transferSpy.mock.calls) {
+        const params = call[0] as { currency?: string } | undefined;
+        expect(params?.currency).toBe('gbp');
+      }
+    });
+
+    it('USD invoice → throws UnsupportedCurrencyError BEFORE any transfer fires', async () => {
+      const { org, tier1 } = await seedOrg('yv18n-usd');
+      const sub = await seedActiveSubscription(org.id, tier1.id);
+
+      const mockInvoice = createMockStripeInvoice({
+        id: 'in_test_usd_reject',
+        amount_paid: 499,
+        currency: 'usd',
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      await expect(
+        service.handleInvoicePaymentSucceeded(mockInvoice)
+      ).rejects.toMatchObject({
+        name: 'UnsupportedCurrencyError',
+        code: 'UNSUPPORTED_CURRENCY',
+        statusCode: 400,
+        received: 'usd',
+      });
+
+      expect(transferSpy).not.toHaveBeenCalled();
+    });
+
+    it('EUR invoice → throws UnsupportedCurrencyError BEFORE any transfer fires', async () => {
+      const { org, tier1 } = await seedOrg('yv18n-eur');
+      const sub = await seedActiveSubscription(org.id, tier1.id);
+
+      const mockInvoice = createMockStripeInvoice({
+        id: 'in_test_eur_reject',
+        amount_paid: 499,
+        currency: 'eur',
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const err = await service
+        .handleInvoicePaymentSucceeded(mockInvoice)
+        .catch((e) => e);
+
+      expect(err?.name).toBe('UnsupportedCurrencyError');
+      expect(err?.received).toBe('eur');
+      expect(err?.supported).toEqual(['gbp']);
+      expect(err?.context).toMatchObject({
+        invoiceId: 'in_test_eur_reject',
+        subscriptionId: sub.id,
+        stripeSubscriptionId: sub.stripeSubscriptionId,
+      });
+      expect(transferSpy).not.toHaveBeenCalled();
+    });
+
+    it('upper-case currency (GBP) is normalised to lowercase and accepted', async () => {
+      // Stripe webhooks always lowercase, but the guard MUST not be
+      // case-sensitive — a defensive normalisation prevents a future
+      // refactor from regressing the happy path.
+      const { org, tier1 } = await seedOrg('yv18n-case');
+      const sub = await seedActiveSubscription(org.id, tier1.id);
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        currency: 'GBP',
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+      expect(transferSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('resolvePendingPayouts — payout.currency guard', () => {
+    async function seedConnectAndSubscription(slug: string) {
+      const { org, tier1 } = await seedOrg(slug);
+      const stripeAccountId = `acct_yv18n_${createUniqueSlug('a')}`;
+
+      const { eq } = await import('drizzle-orm');
+      await db
+        .update(stripeConnectAccounts)
+        .set({ stripeAccountId })
+        .where(eq(stripeConnectAccounts.organizationId, org.id));
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(subscriberId, org.id, tier1.id, {
+            status: 'active',
+            stripeSubscriptionId: `sub_yv18n_${createUniqueSlug('s')}`,
+          })
+        )
+        .returning();
+
+      return { org, tier1, sub, stripeAccountId };
+    }
+
+    it("payout.currency='gbp' → transfer fires with currency 'gbp'", async () => {
+      const { org, sub, stripeAccountId } =
+        await seedConnectAndSubscription('yv18n-payout-gbp');
+
+      await db.insert(pendingPayoutsTable).values({
+        userId: creatorId,
+        organizationId: org.id,
+        subscriptionId: sub.id,
+        amountCents: 1000,
+        currency: 'gbp',
+        reason: 'connect_not_ready',
+      });
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      expect(result).toEqual({ resolved: 1, failed: 0 });
+      expect(transferSpy).toHaveBeenCalledTimes(1);
+      const params = transferSpy.mock.calls[0]?.[0] as
+        | {
+            currency?: string;
+          }
+        | undefined;
+      expect(params?.currency).toBe('gbp');
+    });
+
+    it("payout.currency='usd' → no transfer fires; failed++ via the per-row catch", async () => {
+      const { org, sub, stripeAccountId } =
+        await seedConnectAndSubscription('yv18n-payout-usd');
+
+      // Seed a USD payout directly — bypasses the schema default by
+      // explicitly setting currency: 'usd'.
+      await db.insert(pendingPayoutsTable).values({
+        userId: creatorId,
+        organizationId: org.id,
+        subscriptionId: sub.id,
+        amountCents: 2500,
+        currency: 'usd',
+        reason: 'connect_not_ready',
+      });
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      // The guard throws UnsupportedCurrencyError BEFORE
+      // stripe.transfers.create — the per-row catch logs+counts as
+      // failed and continues to the next row. The contract here is:
+      // no Stripe transfer ever fires for the bad-currency row.
+      expect(result).toEqual({ resolved: 0, failed: 1 });
+      expect(transferSpy).not.toHaveBeenCalled();
+    });
+
+    it('mixed batch: GBP row resolves, USD row fails — bad currency does not poison the good rows', async () => {
+      const { org, sub, stripeAccountId } =
+        await seedConnectAndSubscription('yv18n-payout-mixed');
+
+      await db.insert(pendingPayoutsTable).values([
+        {
+          userId: creatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 500,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+        {
+          userId: creatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 700,
+          currency: 'eur',
+          reason: 'connect_not_ready',
+        },
+      ]);
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      expect(result).toEqual({ resolved: 1, failed: 1 });
+      expect(transferSpy).toHaveBeenCalledTimes(1);
+      const params = transferSpy.mock.calls[0]?.[0] as
+        | {
+            currency?: string;
+            amount?: number;
+          }
+        | undefined;
+      expect(params?.currency).toBe('gbp');
+      expect(params?.amount).toBe(500);
+    });
+  });
+
+  describe('UnsupportedCurrencyError contract', () => {
+    it('round-trips received + supported + context fields', async () => {
+      const { UnsupportedCurrencyError } = await import(
+        '@codex/service-errors'
+      );
+      const err = new UnsupportedCurrencyError('usd', ['gbp'], {
+        invoiceId: 'in_test',
+        subscriptionId: 'sub_test',
+      });
+
+      expect(err).toBeInstanceOf(UnsupportedCurrencyError);
+      expect(err.name).toBe('UnsupportedCurrencyError');
+      expect(err.code).toBe('UNSUPPORTED_CURRENCY');
+      expect(err.statusCode).toBe(400);
+      expect(err.received).toBe('usd');
+      expect(err.supported).toEqual(['gbp']);
+      expect(err.message).toContain("Unsupported currency 'usd'");
+      expect(err.message).toContain('gbp');
+      expect(err.context).toMatchObject({
+        invoiceId: 'in_test',
+        subscriptionId: 'sub_test',
+      });
+    });
+  });
+});

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -53,6 +53,7 @@ import {
   InternalServiceError,
   NotFoundError,
   type ServiceConfig,
+  UnsupportedCurrencyError,
 } from '@codex/service-errors';
 import type { PaginatedListResponse } from '@codex/shared-types';
 import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
@@ -950,6 +951,20 @@ export class SubscriptionService extends BaseService {
         updatedAt: new Date(),
       })
       .where(eq(subscriptions.id, sub.id));
+
+    // GBP-only enforcement (Codex-yv18n): explicitly reject non-GBP charges
+    // before triggering transfers. executeTransfers and downstream
+    // stripe.transfers.create() are hardcoded to CURRENCY.GBP — silently
+    // letting a non-GBP invoice through would cause a currency mismatch at
+    // Stripe. Cross-currency support is a tracked future feature.
+    const invoiceCurrency = stripeInvoice.currency?.toLowerCase();
+    if (invoiceCurrency && invoiceCurrency !== CURRENCY.GBP) {
+      throw new UnsupportedCurrencyError(invoiceCurrency, [CURRENCY.GBP], {
+        invoiceId: stripeInvoice.id,
+        subscriptionId: sub.id,
+        stripeSubscriptionId: stripeSubId,
+      });
+    }
 
     // Execute revenue transfers
     await this.executeTransfers(
@@ -2302,10 +2317,23 @@ export class SubscriptionService extends BaseService {
 
     for (const payout of unresolvedPayouts) {
       try {
+        // GBP-only enforcement (Codex-yv18n): honour the row's currency but
+        // explicitly reject any non-GBP value. Historical rows that somehow
+        // lack the column fall back to CURRENCY.GBP (schema default is 'gbp'
+        // but defence-in-depth never hurts).
+        const payoutCurrency = (payout.currency || CURRENCY.GBP).toLowerCase();
+        if (payoutCurrency !== CURRENCY.GBP) {
+          throw new UnsupportedCurrencyError(payoutCurrency, [CURRENCY.GBP], {
+            pendingPayoutId: payout.id,
+            subscriptionId: payout.subscriptionId,
+            organizationId: orgId,
+          });
+        }
+
         const transfer = await this.stripe.transfers.create(
           {
             amount: payout.amountCents,
-            currency: payout.currency,
+            currency: payoutCurrency,
             destination: stripeAccountId,
             metadata: {
               pending_payout_id: payout.id,
@@ -2790,6 +2818,15 @@ export class SubscriptionService extends BaseService {
    * Execute revenue transfers to org and creator(s) after invoice payment.
    * Uses source_transaction to link transfers to the charge.
    * Creators without active Connect accounts have their share accumulated.
+   *
+   * IMPORTANT (Codex-yv18n): This implementation is GBP-only. Every
+   * stripe.transfers.create() call here hardcodes `currency: CURRENCY.GBP`.
+   * Callers MUST reject non-GBP invoices BEFORE invoking executeTransfers —
+   * see the currency guard in handleInvoicePaymentSucceeded() which throws
+   * UnsupportedCurrencyError. Cross-currency support is tracked as a future
+   * feature bead. Do NOT remove the call-site guard or add new call sites
+   * without an equivalent guard + updating tests in
+   * subscription-service.test.ts > "Currency GBP-only enforcement".
    */
   private async executeTransfers(
     subscriptionId: string,


### PR DESCRIPTION
## Summary
- Adds `UnsupportedCurrencyError` (400, `UNSUPPORTED_CURRENCY`) in `@codex/service-errors` with `received` + `supported` fields.
- Enforces GBP-only at the subscription invoice call site — a non-GBP charge throws `UnsupportedCurrencyError` BEFORE `executeTransfers` fires, preventing silent currency mismatch against Stripe transfers.
- Honors `pendingPayouts.currency` on the resolve path with a `CURRENCY.GBP` fallback for historical rows; non-GBP rows surface `UnsupportedCurrencyError` caught by the existing per-row error handler (no Stripe call ever fires).
- JSDoc + TODO at `executeTransfers` documenting the GBP-only contract and pointer to the call-site guard.
- Tests: GBP happy path + case-insensitivity, USD/EUR invoice rejection with `transfers.create` not called, GBP/USD/mixed-batch pending-payout cases, plus a standalone `UnsupportedCurrencyError` contract round-trip.

Cross-currency support is a tracked future feature — see the JSDoc note on `executeTransfers`.

## Test plan
- [x] `pnpm --filter @codex/subscription test --run` — 114 tests pass in `subscription-service.test.ts` (one unrelated pre-existing failure in `__denoise_proofs__/iter-009/F5-dup-bump-with-logger.test.ts` exists on main)
- [x] `pnpm --filter @codex/service-errors test --run` — 47 tests pass
- [x] `pnpm --filter @codex/service-errors typecheck` — clean
- [x] `pnpm --filter @codex/subscription typecheck` — clean
- [ ] Workspace `pnpm typecheck` has pre-existing `apps/web` failures unrelated to this PR

Bead: Codex-yv18n (child of epic Codex-b1hgr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)