### PR TITLE
refactor(payouts): second simplify pass on audit residuals

### DIFF
--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -193,10 +193,11 @@ export class ConnectAccountService extends BaseService {
 
     const chargesEnabled = stripeAccount.charges_enabled ?? false;
     const payoutsEnabled = stripeAccount.payouts_enabled ?? false;
+    const isActive = chargesEnabled && payoutsEnabled;
 
     // Determine status from capabilities
     let status: 'onboarding' | 'active' | 'restricted' | 'disabled';
-    if (chargesEnabled && payoutsEnabled) {
+    if (isActive) {
       status = 'active';
     } else if (stripeAccount.requirements?.disabled_reason) {
       status = 'disabled';
@@ -215,8 +216,7 @@ export class ConnectAccountService extends BaseService {
         chargesEnabled,
         payoutsEnabled,
         status,
-        onboardingCompletedAt:
-          chargesEnabled && payoutsEnabled ? new Date() : null,
+        onboardingCompletedAt: isActive ? new Date() : null,
         updatedAt: new Date(),
       })
       .where(eq(stripeConnectAccounts.stripeAccountId, stripeAccountId))

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -1027,14 +1027,11 @@ export class SubscriptionService extends BaseService {
     // stripe.transfers.create() are hardcoded to CURRENCY.GBP — silently
     // letting a non-GBP invoice through would cause a currency mismatch at
     // Stripe. Cross-currency support is a tracked future feature.
-    const invoiceCurrency = stripeInvoice.currency?.toLowerCase();
-    if (invoiceCurrency && invoiceCurrency !== CURRENCY.GBP) {
-      throw new UnsupportedCurrencyError(invoiceCurrency, [CURRENCY.GBP], {
-        invoiceId: stripeInvoice.id,
-        subscriptionId: sub.id,
-        stripeSubscriptionId: stripeSubId,
-      });
-    }
+    this.assertGbpOnly(stripeInvoice.currency, {
+      invoiceId: stripeInvoice.id,
+      subscriptionId: sub.id,
+      stripeSubscriptionId: stripeSubId,
+    });
 
     // Execute revenue transfers
     await this.executeTransfers(
@@ -2393,13 +2390,11 @@ export class SubscriptionService extends BaseService {
         // lack the column fall back to CURRENCY.GBP (schema default is 'gbp'
         // but defence-in-depth never hurts).
         const payoutCurrency = (payout.currency || CURRENCY.GBP).toLowerCase();
-        if (payoutCurrency !== CURRENCY.GBP) {
-          throw new UnsupportedCurrencyError(payoutCurrency, [CURRENCY.GBP], {
-            pendingPayoutId: payout.id,
-            subscriptionId: payout.subscriptionId,
-            organizationId: orgId,
-          });
-        }
+        this.assertGbpOnly(payoutCurrency, {
+          pendingPayoutId: payout.id,
+          subscriptionId: payout.subscriptionId,
+          organizationId: orgId,
+        });
 
         // Codex-m644n: min-transfer floor gate. Walk the per-creator override
         // chain so a low-volume creator with a high floor accumulates further
@@ -2471,6 +2466,30 @@ export class SubscriptionService extends BaseService {
   }
 
   // ─── Private Helpers ─────────────────────────────────────────────────────
+
+  /**
+   * Throw `UnsupportedCurrencyError` unless `currency` is GBP (or absent).
+   *
+   * Centralises the GBP-only guard shared by `handleInvoicePaymentSucceeded`
+   * and `resolvePendingPayouts`. Both downstream paths feed
+   * `stripe.transfers.create()` which is hardcoded to `CURRENCY.GBP`; this
+   * guard prevents silent currency mismatch. Cross-currency support is a
+   * tracked future feature (Codex-yv18n).
+   *
+   * Passing `null`/`undefined` is treated as "no currency on this Stripe
+   * object" and skipped — preserves the prior behaviour of letting Stripe
+   * payloads without a `currency` field through (the schema default for
+   * pendingPayouts is 'gbp', so the row branch normalises before calling).
+   */
+  private assertGbpOnly(
+    currency: string | null | undefined,
+    context: Record<string, unknown>
+  ): void {
+    if (!currency) return;
+    const normalised = currency.toLowerCase();
+    if (normalised === CURRENCY.GBP) return;
+    throw new UnsupportedCurrencyError(normalised, [CURRENCY.GBP], context);
+  }
 
   private async getSubscriptionOrThrow(
     userId: string,


### PR DESCRIPTION
## Summary
Second simplification pass over production-code changes from the payouts audit (epic Codex-b1hgr, closed) that didn't receive PR #182's dedicated simplify pass.

Two small dedup wins in production code:
- `SubscriptionService.assertGbpOnly` — centralises the GBP-only currency guard that was hand-rolled at both `handleInvoicePaymentSucceeded` (PR #180) and the `resolvePendingPayouts` row loop (PR #175 + PR #180). Per-site context objects keep their distinct correlation IDs; helper preserves the prior absent-currency short-circuit exactly.
- `ConnectAccountService.handleAccountUpdated` — names the `chargesEnabled && payoutsEnabled` conjunction once as `isActive` instead of computing it inline in two places (status decision + `onboardingCompletedAt` set).

Tests untouched. No public API changes. No migrations. No regions overlapping PR #182's simplify-pass SHAs (`63a74b7e`, `3475f411`, `05da27f1`, `dbc6e1b5`, `73148dfd`).

Sibling of PR #182's in-PR simplify pass. Per [[project_payouts_audit]] post-close hygiene.

## Test plan
- [x] pnpm --filter @codex/subscription test --run (86 passed; 5 DB-integration suites unchanged from baseline — fail without DATABASE_URL_LOCAL_PROXY)
- [x] pnpm --filter @codex/service-errors test --run (47/47 passed)
- [x] pnpm --filter ecom-api test --run (298/298 passed)
- [x] pnpm --filter @codex/subscription typecheck (subscription-service.ts clean; pre-existing tier-service.ts cascade unchanged)
- [x] pnpm --filter @codex/service-errors typecheck (clean)
- [x] pnpm --filter ecom-api typecheck (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)