### PR TITLE
test(subscription): Stripe transfers.create duplicate-response idempotency (Codex-fzal7)

### DIFF
--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -4708,6 +4708,108 @@ describe('SubscriptionService', () => {
       expect(after.stripeTransferId).toBe(replayedTransferId);
     });
 
+    // Codex-fzal7: tighten the duplicate-response contract. The prior test
+    // (90ocz-idem-dup, above) covered the happy result shape, but did not
+    // assert (a) that the transferred amount in the SDK call equals the
+    // row's amountCents — Stripe-side dedupe is only safe if our retry uses
+    // identical params; (b) that no spurious pending-payout row is
+    // inserted as a side-effect of the duplicate-response branch (single
+    // DB write contract — exactly one row exists for this payout id, in
+    // the resolved state, after the call returns).
+    it('duplicate-response: transferred amount equals row.amountCents and no extra DB rows are written', async () => {
+      const { org, sub, stripeAccountId } = await seedConnectAndSubscription(
+        'fzal7-idem-dup-strong'
+      );
+
+      const [row] = await db
+        .insert(pendingPayoutsTable)
+        .values([
+          {
+            userId: creatorId,
+            organizationId: org.id,
+            subscriptionId: sub.id,
+            amountCents: 4242,
+            currency: 'gbp',
+            reason: 'connect_not_ready',
+          },
+        ])
+        .returning();
+
+      // Snapshot the total pending-payout row count for this user+org BEFORE
+      // the call, so we can prove no spurious rows are inserted by the
+      // duplicate-response branch (e.g. a "retry" row, audit row, etc.).
+      const { eq, and } = await import('drizzle-orm');
+      const rowsBefore = await db
+        .select()
+        .from(pendingPayoutsTable)
+        .where(
+          and(
+            eq(pendingPayoutsTable.userId, creatorId),
+            eq(pendingPayoutsTable.organizationId, org.id)
+          )
+        );
+      expect(rowsBefore).toHaveLength(1);
+
+      // Stripe returns the ORIGINAL transfer (same id, same amount, same
+      // destination) when called with a previously-seen idempotency key.
+      // The amount in the response MUST equal what we sent — that's the
+      // dedupe contract: identical params → identical response.
+      const replayedTransferId = 'tr_replayed_fzal7';
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+      transferSpy.mockImplementationOnce(
+        (params: Record<string, unknown>): unknown =>
+          Promise.resolve({
+            id: replayedTransferId,
+            amount: params.amount, // echo: dedupe → identical response
+            currency: params.currency,
+            destination: params.destination,
+            metadata: params.metadata ?? {},
+          })
+      );
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      // Contract: duplicate-response counts as success — `resolved` ticks,
+      // `failed` MUST stay zero. A regression that mis-classifies the
+      // dedupe response as an error would flip this to { 0, 1 }.
+      expect(result).toEqual({ resolved: 1, failed: 0 });
+      expect(transferSpy).toHaveBeenCalledTimes(1);
+
+      // Transferred amount equals the row's amountCents (the params our
+      // service passed to Stripe). Stripe-side dedupe is only safe under
+      // this invariant — different params with the same key would 400.
+      const [params] = transferSpy.mock.calls[0] as [
+        Record<string, unknown>,
+        { idempotencyKey?: string } | undefined,
+      ];
+      expect(params.amount).toBe(row.amountCents);
+      expect(params.currency).toBe('gbp');
+      expect(params.destination).toBe(stripeAccountId);
+
+      // DB row is stamped resolved with the (replayed) transfer id, AND
+      // the total row count for this user+org has not grown — the
+      // duplicate-response branch is a single-write path (UPDATE only).
+      const rowsAfter = await db
+        .select()
+        .from(pendingPayoutsTable)
+        .where(
+          and(
+            eq(pendingPayoutsTable.userId, creatorId),
+            eq(pendingPayoutsTable.organizationId, org.id)
+          )
+        );
+      expect(rowsAfter).toHaveLength(1);
+      const [after] = rowsAfter;
+      expect(after.id).toBe(row.id);
+      expect(after.resolvedAt).not.toBeNull();
+      expect(after.stripeTransferId).toBe(replayedTransferId);
+      expect(after.amountCents).toBe(row.amountCents);
+    });
+
     it('warns and returns empty when the (orgId, stripeAccountId) pair has no Connect account row', async () => {
       const { org } = await createFullOrg('w4jjk-acct-not-found');
 


### PR DESCRIPTION
## Summary

Closes **Codex-fzal7** (parent epic **Codex-hu4ou**).

PR #175 (Codex-90ocz) added `idempotencyKey: payout_<id>` to `resolvePendingPayouts` and shipped tests that verify the KEY FORMAT. A subsequent test (90ocz-idem-dup) covered the duplicate-response result shape. Two narrow gaps remained:

1. The transferred `amount` in the SDK call was never asserted to equal `row.amountCents` — Stripe-side dedupe is only safe when the retry uses identical params. A regression that passed the wrong amount (e.g. `amountCents - fee`) under the same key would 400 in production but slip past tests.
2. "No double DB-write" was implicit only — the duplicate-response branch must be a single UPDATE, never insert an audit/retry row as a side-effect.

This PR adds one new case under the existing `resolvePendingPayouts` describe block: `duplicate-response: transferred amount equals row.amountCents and no extra DB rows are written`.

## Scenarios covered

- **Happy duplicate-response**: Stripe replays the original transfer (`tr_replayed_fzal7`) with `amount` echoing the request. Asserts: `{ resolved: 1, failed: 0 }`, `transfers.create` called once, `params.amount === row.amountCents`, `params.currency === 'gbp'`, `params.destination === stripeAccountId`, DB row count for (userId, orgId) unchanged at 1, row stamped `resolvedAt + stripeTransferId = replayedTransferId`, `amountCents` unchanged.

## Scenario 2 (idempotency_key_in_use) — not filed

`resolvePendingPayouts` has no dedicated error-mapping branch for Stripe error codes — all throws are caught by the generic `try/catch` that increments `failed++` and continues. The existing failure-isolation test (`w4jjk-partial-fail`) already proves this path. A separate "idempotency_key_in_use" case would only duplicate that coverage without locking a stricter contract. Skipped to keep the test surface lean.

## Pre-commit gates

- `pnpm check packages/subscription/src/services/__tests__/subscription-service.test.ts` — clean on edited file.
- `pnpm --filter @codex/subscription test --run subscription-service` — new test passes; **39 pre-existing failures on main are unrelated** (confirmed by running on `origin/main` with my change reverted: 39 failed / 151 passed; with my change: 39 failed / **152 passed** — net +1 passing test, zero regressions). Failures are in `Codex-yv18n` currency tests blocked by `applyMinPlatformFeeFloor` missing from `@codex/purchase` exports + a pre-existing `err.constructor.name === 'U'` minification issue ([[feedback_service_error_test_instanceof]]).
- `pnpm --filter @codex/subscription typecheck` — pre-existing TS2305 error on main, unrelated to this change.

## Test plan

- [x] New test green locally
- [x] No new test failures introduced (delta verified against `origin/main`)
- [x] Linter clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)