### PR TITLE
test(payouts): sweep cron edge cases (Codex-0pqnv)

### DIFF
--- a/workers/ecom-api/src/handlers/__tests__/payouts-sweep.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/payouts-sweep.test.ts
@@ -170,4 +170,146 @@ describe('ecom-api payouts-sweep handler', () => {
 
     spy.mockRestore();
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Production edge cases (Codex-0pqnv)
+  //
+  // These tests lock the handler contract against three production scenarios
+  // that the service tests cover at the impl level but the handler must
+  // surface faithfully:
+  //   - large-scale sweep (no truncation, no transform of large counters)
+  //   - mixed-outcome batches (errors > 0 alongside resolved > 0 = success
+  //     path, NOT obs.error — the service caught + counted the failures)
+  //   - mid-batch Stripe timeout (per-group failure surfaces as result.errors
+  //     and a successful-info log, not a top-level rejection)
+  //
+  // Per-row/per-group impl-level isolation is verified in
+  // subscription-service.test.ts vv77x block — DO NOT duplicate it here.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('propagates large-scale sweep counters faithfully (500 groups, no truncation)', async () => {
+    // Production scenario: a Connect-account outage backed up ~500 pending
+    // groups, the sweep cron drained them all. Verify the handler does not
+    // truncate, transform, or sample the counters before logging/returning.
+    const { SubscriptionService } = await import('@codex/subscription');
+    const largeCounters = {
+      groupsScanned: 500,
+      groupsResolved: 487,
+      groupsSkipped: 10,
+      errors: 3,
+    };
+    const spy = vi
+      .spyOn(SubscriptionService.prototype, 'sweepUnresolvedPayouts')
+      .mockResolvedValue(largeCounters);
+
+    const { obs } = makeObs();
+    const result = await runPayoutsSweep({
+      db: {} as never,
+      stripe: {} as never,
+      obs: obs as never,
+      environment: 'test',
+      olderThanMinutes: 15,
+    });
+
+    // Counters returned verbatim — no clamping, no shape change
+    expect(result).toEqual(largeCounters);
+    // Logged on the success path (obs.info), not the failure path (obs.error)
+    expect(obs.info).toHaveBeenCalledWith(
+      'payouts-sweep cron completed',
+      expect.objectContaining({
+        olderThanMinutes: 15,
+        groupsScanned: 500,
+        groupsResolved: 487,
+        groupsSkipped: 10,
+        errors: 3,
+      })
+    );
+    expect(obs.error).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it('treats mixed-outcome batches (errors > 0 AND resolved > 0) as the success path — service already isolated per-group failures', async () => {
+    // Production scenario: 10 groups, one group's Stripe call threw, the
+    // other 9 resolved. The service caught + counted the one failure and
+    // returned normally. The handler MUST log via obs.info (success path)
+    // — NOT obs.error — because the sweep itself did not fail; it
+    // partially completed, which is the documented contract.
+    const { SubscriptionService } = await import('@codex/subscription');
+    const mixed = {
+      groupsScanned: 10,
+      groupsResolved: 9,
+      groupsSkipped: 0,
+      errors: 1,
+    };
+    const spy = vi
+      .spyOn(SubscriptionService.prototype, 'sweepUnresolvedPayouts')
+      .mockResolvedValue(mixed);
+
+    const { obs } = makeObs();
+    const result = await runPayoutsSweep({
+      db: {} as never,
+      stripe: {} as never,
+      obs: obs as never,
+      environment: 'test',
+    });
+
+    // result.errors AND result.groupsResolved both surface accurately
+    expect(result).toEqual(mixed);
+    expect(result?.errors).toBe(1);
+    expect(result?.groupsResolved).toBe(9);
+    // Critical: NOT routed to obs.error — the handler-level error path is
+    // reserved for top-level rejections (DB outage, etc.), not per-group
+    // failures the service already handled.
+    expect(obs.info).toHaveBeenCalledTimes(1);
+    expect(obs.error).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it('surfaces mid-batch Stripe timeout — sweep returns errors > 0 without throwing, handler returns counters and logs info', async () => {
+    // Production scenario: mid-batch, a single stripe.transfers.create or
+    // accounts.retrieve rejects with a timeout. The service catches at the
+    // per-group try/catch, increments `errors`, and proceeds. The handler
+    // must:
+    //   1. NOT see a thrown Error (service swallowed it)
+    //   2. Return the partial-success counters
+    //   3. Log on the success path with errors > 0 visible
+    const { SubscriptionService } = await import('@codex/subscription');
+    const timeoutOutcome = {
+      groupsScanned: 5,
+      groupsResolved: 4,
+      groupsSkipped: 0,
+      errors: 1, // the one group whose Stripe call timed out
+    };
+    const spy = vi
+      .spyOn(SubscriptionService.prototype, 'sweepUnresolvedPayouts')
+      .mockResolvedValue(timeoutOutcome);
+
+    const { obs } = makeObs();
+    const result = await runPayoutsSweep({
+      db: {} as never,
+      stripe: {} as never,
+      obs: obs as never,
+      environment: 'test',
+      olderThanMinutes: 30,
+    });
+
+    // Partial success — counters returned verbatim
+    expect(result).toEqual(timeoutOutcome);
+    // Success-path logging includes the error count so on-call can alert
+    expect(obs.info).toHaveBeenCalledWith(
+      'payouts-sweep cron completed',
+      expect.objectContaining({
+        olderThanMinutes: 30,
+        errors: 1,
+        groupsResolved: 4,
+      })
+    );
+    // Top-level obs.error is reserved for sweep-itself-rejected, not
+    // per-group timeouts that the service handled internally.
+    expect(obs.error).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Adds 3 handler-level edge-case tests to `workers/ecom-api/src/handlers/__tests__/payouts-sweep.test.ts` covering production scenarios the existing 4 happy-path tests don't exercise.

- **Large-scale sweep (500 groups)** — counters propagated verbatim, no truncation/transform; logs to `obs.info` (success path), not `obs.error`.
- **Mixed-outcome batch (`errors > 0` AND `groupsResolved > 0`)** — service already isolated per-group failures, so the handler MUST treat this as the success path. `obs.info` is invoked; `obs.error` is NOT (the handler's error path is reserved for top-level rejections like DB outages).
- **Mid-batch Stripe timeout** — service catches per-group failure, increments `result.errors`, and returns normally; handler surfaces partial-success counters and logs `errors` count so on-call can alert.

Per-row impl-level isolation (Stripe `accounts.retrieve` throwing, grouping by `(orgId, userId)`, `olderThanMinutes` filter) is already covered in `packages/subscription/src/services/__tests__/subscription-service.test.ts` vv77x block — these new tests cover the **delegation contract** at the handler level only, no duplication.

## Test plan

- [x] `pnpm exec biome check --write workers/ecom-api/src/handlers/__tests__/payouts-sweep.test.ts` — clean
- [x] `pnpm --filter ecom-api test --run payouts-sweep` — 7/7 passing (4 original + 3 new)
- [x] `pnpm --filter ecom-api typecheck` — clean
- [x] No new mock infrastructure introduced (reused existing `makeObs`/spy-on-prototype pattern from the same file)
- [x] No service-test duplication (verified vv77x block already covers impl-level per-group isolation, grouping, threshold filter)

Closes Codex-0pqnv

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)