### PR TITLE
fix(subscription): minification-safe error assertions in yv18n tests (Codex-rljgc)

### DIFF
--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -24,6 +24,7 @@ import {
   subscriptionTiers,
   users,
 } from '@codex/database/schema';
+import { UnsupportedCurrencyError } from '@codex/service-errors';
 import {
   createMockStripe,
   createMockStripeInvoice,
@@ -5670,14 +5671,14 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
       const transferSpy = vi.mocked(stripe.transfers.create);
       transferSpy.mockClear();
 
-      await expect(
-        service.handleInvoicePaymentSucceeded(mockInvoice)
-      ).rejects.toMatchObject({
-        name: 'UnsupportedCurrencyError',
-        code: 'UNSUPPORTED_CURRENCY',
-        statusCode: 400,
-        received: 'usd',
-      });
+      // constructor.name is mangled by esbuild — use toBeInstanceOf (static class import) instead of .name on the error
+      const err = await service
+        .handleInvoicePaymentSucceeded(mockInvoice)
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(UnsupportedCurrencyError);
+      expect(err.code).toBe('UNSUPPORTED_CURRENCY');
+      expect(err.statusCode).toBe(400);
+      expect(err.received).toBe('usd');
 
       expect(transferSpy).not.toHaveBeenCalled();
     });
@@ -5702,7 +5703,8 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
         .handleInvoicePaymentSucceeded(mockInvoice)
         .catch((e) => e);
 
-      expect(err?.name).toBe('UnsupportedCurrencyError');
+      // constructor.name is mangled by esbuild — use toBeInstanceOf (static class import) instead of .name on the error
+      expect(err).toBeInstanceOf(UnsupportedCurrencyError);
       expect(err?.received).toBe('eur');
       expect(err?.supported).toEqual(['gbp']);
       expect(err?.context).toMatchObject({
@@ -5868,16 +5870,13 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
 
   describe('UnsupportedCurrencyError contract', () => {
     it('round-trips received + supported + context fields', async () => {
-      const { UnsupportedCurrencyError } = await import(
-        '@codex/service-errors'
-      );
       const err = new UnsupportedCurrencyError('usd', ['gbp'], {
         invoiceId: 'in_test',
         subscriptionId: 'sub_test',
       });
 
+      // constructor.name is mangled by esbuild — toBeInstanceOf is the type-safe alternative
       expect(err).toBeInstanceOf(UnsupportedCurrencyError);
-      expect(err.name).toBe('UnsupportedCurrencyError');
       expect(err.code).toBe('UNSUPPORTED_CURRENCY');
       expect(err.statusCode).toBe(400);
       expect(err.received).toBe('usd');


### PR DESCRIPTION
## Summary

Fixes the yv18n payouts test failures currently RED on main CI:
- `expect(err?.name).toBe('UnsupportedCurrencyError')` returned `'U'` because esbuild mangles class names in production builds
- `toMatchObject({ name: 'UnsupportedCurrencyError' })` failed for the same reason
- The class name is set via `this.name = this.constructor.name` in `ServiceError` — minification collapses the constructor's name

Replaced 3 brittle assertions with `toBeInstanceOf(UnsupportedCurrencyError)` using the static class import (the import binding survives minification). Pass/fail semantics unchanged — positive and negative paths still tested.

Reference: `feedback_service_error_test_instanceof` in memory.

## Sites fixed (all in `packages/subscription/src/services/__tests__/subscription-service.test.ts`)

1. **USD invoice reject** test — `toMatchObject({ name: ..., ... })` → `.catch((e) => e)` + `toBeInstanceOf` + per-field property checks
2. **EUR invoice reject** test — `expect(err?.name).toBe(...)` → `toBeInstanceOf`
3. **UnsupportedCurrencyError contract** test — removed the brittle `.name` assertion (already had `toBeInstanceOf`)

Each fix carries a 1-line comment explaining the minification gotcha.

## Test plan

- [x] `pnpm --filter @codex/subscription test --run subscription-service.test` — 139/139 passing
- [x] `pnpm --filter @codex/subscription typecheck` — clean
- [x] `pnpm --filter @codex/purchase typecheck` — clean
- [x] `pnpm exec biome check --write` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)