### PR TITLE
refactor(cache): consolidate KV mocks onto @codex/test-utils (Codex-v878l)

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250102.0",
+    "@codex/test-utils": "workspace:*",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.3",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/cache/src/__tests__/invalidate-helpers.test.ts
+++ b/packages/cache/src/__tests__/invalidate-helpers.test.ts
@@ -1,41 +1,30 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
+import { createMockKVNamespace } from '@codex/test-utils/mocks';
 import { describe, expect, it, vi } from 'vitest';
 import { CacheType } from '../cache-keys';
 import { invalidateUserLibrary } from '../helpers/invalidate';
 
-/**
- * Minimal KV stand-in matching the surface used by VersionedCache.invalidate
- * (`put`). Get/delete are unused in these tests so we stub them.
- */
-function createMockKV(): KVNamespace & { _puts: Array<[string, string]> } {
-  const puts: Array<[string, string]> = [];
-  return {
-    get: vi.fn(async () => null),
-    put: vi.fn(async (key: string, value: string) => {
-      puts.push([key, value]);
-    }),
-    delete: vi.fn(),
-    list: vi.fn(),
-    getWithMetadata: vi.fn(),
-    _puts: puts,
-  } as unknown as KVNamespace & { _puts: Array<[string, string]> };
-}
-
 describe('invalidateUserLibrary', () => {
   it('bumps COLLECTION_USER_LIBRARY version key when kv + userId provided', async () => {
-    const kv = createMockKV();
+    const kv = createMockKVNamespace();
     const tasks: Promise<unknown>[] = [];
     const waitUntil = (p: Promise<unknown>) => {
       tasks.push(p);
     };
 
-    invalidateUserLibrary({ kv, waitUntil, userId: 'user-123' });
+    invalidateUserLibrary({
+      kv: kv as unknown as KVNamespace,
+      waitUntil,
+      userId: 'user-123',
+    });
 
     await Promise.all(tasks);
 
     // VersionedCache.invalidate writes the version key
     const expectedKey = `cache:version:${CacheType.COLLECTION_USER_LIBRARY('user-123')}`;
-    expect(kv._puts.some(([k]) => k === expectedKey)).toBe(true);
+    expect(kv.put.mock.calls.some(([k]: unknown[]) => k === expectedKey)).toBe(
+      true
+    );
   });
 
   it('is a no-op when kv binding is missing', async () => {
@@ -54,20 +43,25 @@ describe('invalidateUserLibrary', () => {
   });
 
   it('is a no-op when userId is empty', async () => {
-    const kv = createMockKV();
+    const kv = createMockKVNamespace();
     const tasks: Promise<unknown>[] = [];
     const waitUntil = (p: Promise<unknown>) => {
       tasks.push(p);
     };
 
-    invalidateUserLibrary({ kv, waitUntil, userId: '' });
+    invalidateUserLibrary({
+      kv: kv as unknown as KVNamespace,
+      waitUntil,
+      userId: '',
+    });
 
     expect(tasks).toHaveLength(0);
   });
 
   it('swallows KV errors and surfaces via logger.warn', async () => {
+    const baseKv = createMockKVNamespace();
     const failingKv = {
-      ...createMockKV(),
+      ...baseKv,
       put: vi.fn(async () => {
         throw new Error('KV down');
       }),

--- a/packages/cache/src/__tests__/versioned-cache.test.ts
+++ b/packages/cache/src/__tests__/versioned-cache.test.ts
@@ -1,105 +1,32 @@
+import type { KVNamespace } from '@cloudflare/workers-types';
+import { createMockKVNamespace } from '@codex/test-utils/mocks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CacheType } from '../cache-keys';
 import { VersionedCache } from '../versioned-cache';
 
 /**
- * Mock KVNamespace for testing
- *
- * Note: We need to be careful with return types since KV.get() returns
- * different types based on the 'type' parameter.
+ * Reset a mock KV: clear backing storage and reset all spy state.
  */
-function createMockKV(): KVNamespace & {
-  _data: Map<string, string>;
-  _reset: () => void;
-  _getMockCalls: () => unknown[][];
-} {
-  const data = new Map<string, string>();
-  const mockCalls: unknown[][] = [];
-
-  return {
-    get: vi.fn(
-      async (key: string, type?: string): Promise<string | null | object> => {
-        const value = data.get(key);
-        if (value === undefined) return null;
-
-        // Simulate KV's type-based return
-        if (type === 'json') {
-          try {
-            return JSON.parse(value);
-          } catch {
-            return null;
-          }
-        }
-        if (type === 'text') {
-          return value;
-        }
-        if (type === 'arrayBuffer') {
-          return new TextEncoder().encode(value).buffer;
-        }
-        if (type === 'stream') {
-          return new ReadableStream({
-            start(controller) {
-              controller.enqueue(new TextEncoder().encode(value));
-              controller.close();
-            },
-          });
-        }
-        return value;
-      }
-    ),
-    put: vi.fn(
-      async (
-        key: string,
-        value: string | ReadableStream | ArrayBuffer,
-        options?: unknown
-      ) => {
-        // Track calls for verification
-        mockCalls.push([key, value, options]);
-
-        if (typeof value === 'string') {
-          data.set(key, value);
-        } else if (value instanceof ArrayBuffer) {
-          data.set(key, new TextDecoder().decode(value));
-        } else {
-          // For streams, we'll just set a placeholder
-          data.set(key, '[stream]');
-        }
-        return void 0;
-      }
-    ),
-    delete: vi.fn(async (key: string) => {
-      data.delete(key);
-    }),
-    list: vi.fn(),
-    getWithMetadata: vi.fn(),
-    _data: data,
-    _reset: () => {
-      data.clear();
-      mockCalls.length = 0;
-    },
-    _getMockCalls: () => [...mockCalls],
-  } as unknown as KVNamespace & {
-    _data: Map<string, string>;
-    _reset: () => void;
-    _getMockCalls: () => unknown[][];
-  };
+function resetMockKV(kv: ReturnType<typeof createMockKVNamespace>): void {
+  kv._storage.clear();
+  kv.get.mockClear();
+  kv.put.mockClear();
+  kv.delete.mockClear();
+  kv.list.mockClear();
+  kv.getWithMetadata.mockClear();
 }
 
 describe('VersionedCache', () => {
-  let mockKV: KVNamespace & {
-    _data: Map<string, string>;
-    _reset: () => void;
-    _getMockCalls: () => unknown[][];
-  };
+  let mockKV: ReturnType<typeof createMockKVNamespace>;
   let cache: VersionedCache;
 
   beforeEach(() => {
-    mockKV = createMockKV();
-    cache = new VersionedCache({ kv: mockKV });
+    mockKV = createMockKVNamespace();
+    cache = new VersionedCache({ kv: mockKV as unknown as KVNamespace });
   });
 
   afterEach(() => {
-    mockKV._reset();
+    resetMockKV(mockKV);
   });
 
   describe('constructor', () => {
@@ -108,12 +35,17 @@ describe('VersionedCache', () => {
     });
 
     it('should use default prefix', () => {
-      const testCache = new VersionedCache({ kv: mockKV });
+      const testCache = new VersionedCache({
+        kv: mockKV as unknown as KVNamespace,
+      });
       expect(testCache).toBeInstanceOf(VersionedCache);
     });
 
     it('should use custom prefix', () => {
-      const testCache = new VersionedCache({ kv: mockKV, prefix: 'custom' });
+      const testCache = new VersionedCache({
+        kv: mockKV as unknown as KVNamespace,
+        prefix: 'custom',
+      });
       expect(testCache).toBeInstanceOf(VersionedCache);
     });
   });
@@ -171,22 +103,24 @@ describe('VersionedCache', () => {
     });
 
     it('should invalidate cache with new version', async () => {
-      const freshMock = createMockKV();
-      const testCache = new VersionedCache({ kv: freshMock });
+      const freshMock = createMockKVNamespace();
+      const testCache = new VersionedCache({
+        kv: freshMock as unknown as KVNamespace,
+      });
 
       // Store some data first
       const fetcher = vi.fn().mockResolvedValue({ data: 'test' });
       await testCache.get('user-123', CacheType.USER_PROFILE, fetcher);
 
       // Clear the mock calls
-      (freshMock.put as ReturnType<typeof vi.fn>).mockClear();
+      freshMock.put.mockClear();
 
       // Invalidate cache
       await testCache.invalidate('user-123');
 
       // Verify invalidate was called with version key
       expect(freshMock.put).toHaveBeenCalledTimes(1);
-      const calls = (freshMock.put as ReturnType<typeof vi.fn>).mock.calls;
+      const calls = freshMock.put.mock.calls;
       expect(calls[0][0]).toBe('cache:version:user-123');
       expect(typeof calls[0][1]).toBe('string'); // version timestamp
     });
@@ -442,7 +376,7 @@ describe('VersionedCache', () => {
 
       // Only ONE version key should exist, regardless of how many types
       // were primed.
-      const versionKeys = [...mockKV._data.keys()].filter((k) =>
+      const versionKeys = [...mockKV._storage.keys()].filter((k) =>
         k.startsWith('cache:version:')
       );
       expect(versionKeys).toEqual([`cache:version:${orgId}`]);
@@ -520,7 +454,7 @@ describe('VersionedCache', () => {
 
   describe('statistics', () => {
     beforeEach(() => {
-      mockKV._reset();
+      resetMockKV(mockKV);
     });
 
     it('should track cache hits and misses', async () => {
@@ -678,16 +612,16 @@ describe('VersionedCache', () => {
     // Note: Custom prefix test is skipped due to mock state management complexity
     // The functionality works correctly in real KV (verified via integration tests)
     it.skip('should use custom prefix in keys', async () => {
-      const freshMock = createMockKV();
+      const freshMock = createMockKVNamespace();
       const customCache = new VersionedCache({
-        kv: freshMock,
+        kv: freshMock as unknown as KVNamespace,
         prefix: 'custom',
       });
       const fetcher = vi.fn().mockResolvedValue({ data: 'test' });
 
       await customCache.get('test-id-unique', 'test:type', fetcher);
 
-      const calls = freshMock._getMockCalls();
+      const calls = freshMock.put.mock.calls;
       const dataKeyCall = calls.find(
         (call) =>
           typeof call[0] === 'string' &&

--- a/packages/test-utils/src/mocks.ts
+++ b/packages/test-utils/src/mocks.ts
@@ -400,7 +400,18 @@ export function createMockKVNamespace(options?: {
     get: vi.fn(async (key: string, type?: string) => {
       const value = storage.get(key);
       if (value === undefined) return null;
-      if (type === 'json') return value;
+      // Match real Cloudflare KV semantics: when callers pass a stringified
+      // JSON payload to put() and request type 'json' on read, KV parses the
+      // string. Non-string values that were stashed directly via
+      // `_storage.set()` for spy-tracking tests pass through unchanged.
+      if (type === 'json') {
+        if (typeof value !== 'string') return value;
+        try {
+          return JSON.parse(value);
+        } catch {
+          return null;
+        }
+      }
       if (type === 'text') return String(value);
       if (type === 'arrayBuffer') return value;
       return value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250102.0
         version: 4.20251121.0
+      '@codex/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: ^22.0.0
         version: 22.13.0


### PR DESCRIPTION
## Summary

Consolidates two local `createMockKV()` helpers in `@codex/cache` tests onto the shared `createMockKVNamespace` from `@codex/test-utils`. PR #186 flagged the ad-hoc inlining anti-pattern; these are the two remaining duplicates.

- `versioned-cache.test.ts`: 36 tests (1 skipped) preserved; `_data` -> `_storage`, custom `_reset()` lifted into a local helper that clears both storage and spy state, `_getMockCalls()` -> `freshMock.put.mock.calls`.
- `invalidate-helpers.test.ts`: 4 tests preserved; `_puts` -> `kv.put.mock.calls`.
- Extended `createMockKVNamespace.get(key, 'json')` to `JSON.parse` string values, matching real Cloudflare KV semantics. Non-string values stashed directly via `_storage` pass through unchanged, so the existing callers in security/session-auth and purchase/fee-config (which drive `get()` via `mockResolvedValue` overrides) are unaffected.
- `packages/cache/package.json` gains `@codex/test-utils` in devDependencies.

Zero test logic changes; case counts identical pre/post migration.

## Test plan

- [x] `pnpm --filter @codex/cache test --run` — 40 tests, 39 passed, 1 skipped (matches baseline)
- [x] `pnpm turbo run typecheck --filter=@codex/cache` — green
- [x] `pnpm check` — biome clean on changed files
- [ ] CI verifies no regression in @codex/security and @codex/purchase consumers of the shared mock

Closes Codex-v878l.