### PR TITLE
feat(studio): payout history UI on /studio/payouts (Codex-zqaxo)

### DIFF
--- a/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
+++ b/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
@@ -32,6 +32,7 @@
     SettingsIcon,
     CoinsIcon,
     CreditCardIcon,
+    BanknoteIcon,
     GlobeIcon,
     UserIcon,
     LogInIcon,
@@ -60,6 +61,7 @@
     customers: UserPlusIcon,
     settings: SettingsIcon,
     monetisation: CoinsIcon,
+    payouts: BanknoteIcon,
     billing: CreditCardIcon,
   };
 

--- a/apps/web/src/lib/components/ui/Icon/BanknoteIcon.svelte
+++ b/apps/web/src/lib/components/ui/Icon/BanknoteIcon.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { IconProps } from './types';
+	import IconBase from './IconBase.svelte';
+	const { size, ...restProps }: IconProps = $props();
+</script>
+
+<IconBase {size} {...restProps}>
+	<rect width="20" height="12" x="2" y="6" rx="2" />
+	<circle cx="12" cy="12" r="2" />
+	<path d="M6 12h.01M18 12h.01" />
+</IconBase>

--- a/apps/web/src/lib/components/ui/Icon/index.ts
+++ b/apps/web/src/lib/components/ui/Icon/index.ts
@@ -4,6 +4,7 @@ export { default as AlertTriangleIcon } from './AlertTriangleIcon.svelte';
 // Navigation
 export { default as ArrowLeftIcon } from './ArrowLeftIcon.svelte';
 export { default as ArrowRightIcon } from './ArrowRightIcon.svelte';
+export { default as BanknoteIcon } from './BanknoteIcon.svelte';
 // Misc
 export { default as CalendarIcon } from './CalendarIcon.svelte';
 export { default as CheckCircleIcon } from './CheckCircleIcon.svelte';

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -19,7 +19,8 @@ export type SidebarIcon =
   | 'customers'
   | 'settings'
   | 'billing'
-  | 'monetisation';
+  | 'monetisation'
+  | 'payouts';
 
 export interface SidebarLink extends NavLink {
   icon: SidebarIcon;
@@ -67,6 +68,7 @@ export const SIDEBAR_ADMIN_LINKS: SidebarLink[] = [
 /** Studio sidebar — owner-only links */
 export const SIDEBAR_OWNER_LINKS: SidebarLink[] = [
   { href: '/studio/monetisation', label: 'Monetisation', icon: 'monetisation' },
+  { href: '/studio/payouts', label: 'Payouts', icon: 'payouts' },
   { href: '/studio/billing', label: 'Billing', icon: 'billing' },
 ];
 

--- a/apps/web/src/lib/remote/subscription.remote.ts
+++ b/apps/web/src/lib/remote/subscription.remote.ts
@@ -386,6 +386,46 @@ export const getConnectStatus = query(
   }
 );
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Admin: Payouts Query (Codex-zqaxo)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const listPayoutsQueryArgsSchema = z.object({
+  organizationId: z.string().uuid(),
+  status: z.enum(['all', 'pending', 'resolved', 'failed']).default('all'),
+  fromDate: z.string().datetime().optional(),
+  toDate: z.string().datetime().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * List pending + resolved creator payouts for an org (Codex-zqaxo).
+ *
+ * Backs the read-only `/studio/payouts` table. Owner-only — the worker
+ * route enforces `requireOrgManagement` and re-derives scope from the
+ * authenticated session membership; the client-supplied
+ * `organizationId` is only used to build the URL.
+ *
+ * NOT cached as a TanStack DB live collection in Phase 1 — each
+ * filter/page is a fresh snapshot query. See epic Codex-kbfe3 design
+ * decisions.
+ */
+export const listPayouts = query(
+  listPayoutsQueryArgsSchema,
+  async ({ organizationId, status, fromDate, toDate, page, limit }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    const params = new URLSearchParams();
+    if (status) params.set('status', status);
+    if (fromDate) params.set('fromDate', fromDate);
+    if (toDate) params.set('toDate', toDate);
+    params.set('page', String(page));
+    params.set('limit', String(limit));
+    return api.subscription.listPayouts(organizationId, params);
+  }
+);
+
 const connectDashboardCommandSchema = z.object({
   organizationId: z.string().uuid(),
 });

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -51,6 +51,7 @@ import type {
   SessionData,
   UserData,
 } from '@codex/shared-types';
+import type { PayoutWithCreator } from '@codex/subscription';
 import type {
   CancelSubscriptionInput,
   ChangeTierInput,
@@ -1648,6 +1649,23 @@ export function createServerApi(
         return request<PaginatedListResponse<SubscriberItem>>(
           'ecom',
           `/subscriptions/subscribers?${query}`
+        );
+      },
+
+      /**
+       * List pending + resolved creator payouts for an org (owner only,
+       * paginated). Backs the studio payouts table (Codex-zqaxo).
+       *
+       * Forwards `organizationId` in the query string as the route
+       * contract requires it, but the worker re-derives the scope from
+       * the authenticated membership — never trusts the URL value.
+       */
+      listPayouts: (organizationId: string, params?: URLSearchParams) => {
+        const query = new URLSearchParams(params);
+        query.set('organizationId', organizationId);
+        return request<PaginatedListResponse<PayoutWithCreator>>(
+          'ecom',
+          `/subscriptions/payouts?${query}`
         );
       },
     },

--- a/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
@@ -1,0 +1,562 @@
+<!--
+  @component StudioPayouts
+
+  Owner-only payout history table (Codex-zqaxo). Phase 1 of the
+  payouts-visibility epic (Codex-kbfe3) — read-only surface that lists
+  pending + resolved creator payouts for the org so owners can verify
+  Stripe transfers landed after subscription invoices.
+
+  Backend data flow:
+    listPayouts() remote query → api.subscription.listPayouts
+      → GET ecom-api `/subscriptions/payouts`
+      → SubscriptionService.listPayoutsByOrg (org-scoped)
+
+  This page deliberately uses snapshot queries per filter — NO TanStack DB
+  live collection in Phase 1 (epic decision). Each filter/page change
+  re-issues the remote query.
+
+  @prop data - Org info + userRole from parent studio layout
+-->
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { Alert, Badge, EmptyState, Skeleton } from '$lib/components/ui';
+  import * as Card from '$lib/components/ui/Card';
+  import * as Table from '$lib/components/ui/Table';
+  import Select from '$lib/components/ui/Select/Select.svelte';
+  import Button from '$lib/components/ui/Button/Button.svelte';
+  import {
+    BanknoteIcon,
+    CopyIcon,
+    AlertTriangleIcon,
+  } from '$lib/components/ui/Icon';
+  import Avatar from '$lib/components/ui/Avatar/Avatar.svelte';
+  import AvatarImage from '$lib/components/ui/Avatar/AvatarImage.svelte';
+  import AvatarFallback from '$lib/components/ui/Avatar/AvatarFallback.svelte';
+  import { listPayouts } from '$lib/remote/subscription.remote';
+  import { formatDate, formatPrice } from '$lib/utils/format';
+  import type { PayoutWithCreator } from '@codex/subscription';
+
+  /** Shape returned by SvelteKit's query() when called client-side */
+  interface QueryResult<T> {
+    current: T | undefined;
+    loading?: boolean;
+    error?: { message?: string } | null;
+  }
+
+  type PayoutsPage = {
+    items: PayoutWithCreator[];
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      totalPages: number;
+    };
+  };
+
+  let { data } = $props();
+
+  // Role guard — owner only. Mirror the billing/monetisation pages exactly.
+  // The studio layout supplies `data.userRole`; non-owners are redirected to
+  // /studio rather than a 403 page (matches existing owner-only routes).
+  $effect(() => {
+    if (data.userRole !== 'owner') {
+      goto('/studio');
+    }
+  });
+
+  const isOwner = $derived(data.userRole === 'owner');
+  const orgId = $derived(data.org.id);
+
+  // ─── Filter state ──────────────────────────────────────────────────────
+  // Snapshot-style — every change re-runs the remote query. No
+  // optimistic UI / local mutation since this is a read-only surface.
+
+  type StatusFilter = 'all' | 'pending' | 'resolved' | 'failed';
+  let statusFilter = $state<StatusFilter>('all');
+  let page = $state(1);
+  const limit = 20;
+
+  const statusOptions: Array<{ value: StatusFilter; label: string }> = [
+    { value: 'all', label: 'All statuses' },
+    { value: 'pending', label: 'Pending' },
+    { value: 'resolved', label: 'Resolved' },
+    { value: 'failed', label: 'Failed' },
+  ];
+
+  // ─── Remote query ──────────────────────────────────────────────────────
+  // `$derived` re-runs when orgId / statusFilter / page change. We pass the
+  // tagged arg object verbatim — Zod coerces strings/numbers server-side.
+  const payoutsQuery = $derived(
+    isOwner && orgId
+      ? listPayouts({ organizationId: orgId, status: statusFilter, page, limit })
+      : null
+  );
+
+  const payoutsData = $derived(
+    (payoutsQuery as QueryResult<PayoutsPage> | null)?.current
+  );
+  const loading = $derived(
+    (payoutsQuery as QueryResult<PayoutsPage> | null)?.loading ?? true
+  );
+  const queryError = $derived(
+    (payoutsQuery as QueryResult<PayoutsPage> | null)?.error?.message ?? null
+  );
+
+  const items = $derived(payoutsData?.items ?? []);
+  const pagination = $derived(payoutsData?.pagination);
+  const isEmpty = $derived(!loading && items.length === 0);
+
+  // ─── Filter handlers ───────────────────────────────────────────────────
+  function onStatusChange(next: string | undefined) {
+    if (!next) return;
+    statusFilter = next as StatusFilter;
+    page = 1; // reset to first page on filter change
+  }
+
+  function nextPage() {
+    if (pagination && page < pagination.totalPages) page += 1;
+  }
+  function prevPage() {
+    if (page > 1) page -= 1;
+  }
+
+  // ─── Badge variant + label helpers ─────────────────────────────────────
+  // Token-aligned status mapping (epic Codex-kbfe3 decision):
+  //   pending = warning · resolved = success · failed = error.
+  function statusVariant(
+    status: PayoutWithCreator['status']
+  ): 'warning' | 'success' | 'error' {
+    if (status === 'resolved') return 'success';
+    if (status === 'failed') return 'error';
+    return 'warning';
+  }
+
+  function statusLabel(status: PayoutWithCreator['status']): string {
+    if (status === 'resolved') return 'Resolved';
+    if (status === 'failed') return 'Failed';
+    return 'Pending';
+  }
+
+  /**
+   * Human-readable reason string for the `reason` column in the table.
+   * The DB enum is `connect_not_ready | connect_restricted | transfer_failed
+   * | min_transfer_floor` — keep these strings short and operator-friendly.
+   */
+  function reasonLabel(reason: string): string {
+    switch (reason) {
+      case 'connect_not_ready':
+        return 'Connect onboarding incomplete';
+      case 'connect_restricted':
+        return 'Connect account restricted';
+      case 'transfer_failed':
+        return 'Transfer failed';
+      case 'min_transfer_floor':
+        return 'Below minimum transfer';
+      default:
+        return reason;
+    }
+  }
+
+  function getInitials(name: string | null, email: string | null): string {
+    const source = name?.trim() || email?.trim() || '?';
+    return source
+      .split(/\s+|@/)
+      .filter(Boolean)
+      .map((part) => part[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase();
+  }
+
+  /**
+   * Truncate a Stripe Transfer ID (`tr_xxxxxxxxxxxxxxxxxx`) to
+   * `tr_xxxx…xxxx` so the table cell stays readable. The full id is
+   * retained as a `title` tooltip and copy-button payload.
+   */
+  function truncateTransferId(id: string): string {
+    if (id.length <= 12) return id;
+    return `${id.slice(0, 6)}…${id.slice(-4)}`;
+  }
+
+  let copiedTransferId = $state<string | null>(null);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function copyTransferId(id: string) {
+    try {
+      await navigator.clipboard.writeText(id);
+      copiedTransferId = id;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => {
+        copiedTransferId = null;
+      }, 2000);
+    } catch {
+      // navigator.clipboard can be blocked (non-secure context / permissions)
+      // — fail silently; the title attribute lets the user copy manually.
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Payouts | {data.org.name}</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+{#if !isOwner}
+  <!-- Redirecting to /studio... -->
+{:else}
+  <div class="payouts">
+    <header class="payouts-header">
+      <h1 class="payouts-title">Payouts</h1>
+      <p class="payouts-subtitle">
+        Pending and resolved creator payouts for this organisation. Payouts
+        appear here once a subscription invoice is paid and Stripe transfers
+        the creator's share.
+      </p>
+    </header>
+
+    <Card.Root>
+      <Card.Header>
+        <div class="filters">
+          <Select
+            options={statusOptions}
+            value={statusFilter}
+            label="Filter by status"
+            onValueChange={onStatusChange}
+            class="status-filter"
+          />
+        </div>
+      </Card.Header>
+
+      <Card.Content>
+        {#if queryError}
+          <Alert variant="error">
+            Could not load payouts: {queryError}
+          </Alert>
+        {:else if loading}
+          <div class="table-skeleton" aria-busy="true" aria-live="polite">
+            <Skeleton width="100%" height="var(--space-10)" />
+            {#each Array(5) as _, i (i)}
+              <div class="table-skeleton-row">
+                <Skeleton width="22%" height="var(--space-5)" />
+                <Skeleton width="22%" height="var(--space-5)" />
+                <Skeleton width="14%" height="var(--space-5)" />
+                <Skeleton width="14%" height="var(--space-5)" />
+                <Skeleton width="14%" height="var(--space-5)" />
+              </div>
+            {/each}
+          </div>
+        {:else if isEmpty}
+          <EmptyState
+            title="No payouts yet"
+            description="Payouts will appear here once subscriptions resolve and Stripe transfers the creator's share."
+            icon={BanknoteIcon}
+          >
+            {#snippet action()}
+              <a href="/studio/monetisation" class="empty-link">
+                <Button variant="secondary">Go to Monetisation</Button>
+              </a>
+            {/snippet}
+          </EmptyState>
+        {:else}
+          <div class="table-wrapper">
+            <Table.Root>
+              <Table.Header>
+                <Table.Row>
+                  <Table.Head>Date</Table.Head>
+                  <Table.Head>Creator</Table.Head>
+                  <Table.Head class="amount-head">Amount</Table.Head>
+                  <Table.Head>Status</Table.Head>
+                  <Table.Head>Transfer / Reason</Table.Head>
+                  <Table.Head>Resolved</Table.Head>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {#each items as payout (payout.id)}
+                  <Table.Row>
+                    <Table.Cell>
+                      <span
+                        class="date-cell"
+                        title={new Date(payout.createdAt).toISOString()}
+                      >
+                        {formatDate(payout.createdAt)}
+                      </span>
+                    </Table.Cell>
+
+                    <Table.Cell>
+                      <span class="creator-cell">
+                        <Avatar class="creator-avatar">
+                          {#if payout.creatorAvatarUrl}
+                            <AvatarImage
+                              src={payout.creatorAvatarUrl}
+                              alt={payout.creatorName ?? payout.creatorEmail ?? ''}
+                            />
+                          {/if}
+                          <AvatarFallback>
+                            {getInitials(payout.creatorName, payout.creatorEmail)}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span class="creator-name">
+                          {payout.creatorName ?? payout.creatorEmail ?? 'Unknown creator'}
+                        </span>
+                      </span>
+                    </Table.Cell>
+
+                    <Table.Cell class="amount-cell">
+                      {formatPrice(payout.amountCents)}
+                    </Table.Cell>
+
+                    <Table.Cell>
+                      <Badge variant={statusVariant(payout.status)}>
+                        {statusLabel(payout.status)}
+                      </Badge>
+                    </Table.Cell>
+
+                    <Table.Cell>
+                      {#if payout.status === 'resolved' && payout.stripeTransferId}
+                        <span class="transfer-cell">
+                          <code class="transfer-id" title={payout.stripeTransferId}>
+                            {truncateTransferId(payout.stripeTransferId)}
+                          </code>
+                          <button
+                            type="button"
+                            class="copy-btn"
+                            onclick={() => copyTransferId(payout.stripeTransferId!)}
+                            aria-label="Copy Stripe transfer ID {payout.stripeTransferId}"
+                            title={copiedTransferId === payout.stripeTransferId
+                              ? 'Copied!'
+                              : 'Copy transfer ID'}
+                          >
+                            <CopyIcon size={14} />
+                          </button>
+                        </span>
+                      {:else}
+                        <span
+                          class="reason-cell"
+                          class:reason-cell--failed={payout.status === 'failed'}
+                        >
+                          {#if payout.status === 'failed'}
+                            <AlertTriangleIcon size={14} />
+                          {/if}
+                          {reasonLabel(payout.reason)}
+                        </span>
+                      {/if}
+                    </Table.Cell>
+
+                    <Table.Cell>
+                      <span class="date-cell">
+                        {payout.resolvedAt ? formatDate(payout.resolvedAt) : '–'}
+                      </span>
+                    </Table.Cell>
+                  </Table.Row>
+                {/each}
+              </Table.Body>
+            </Table.Root>
+          </div>
+
+          {#if pagination && pagination.totalPages > 1}
+            <nav class="pagination" aria-label="Payout pagination">
+              <Button
+                variant="secondary"
+                disabled={page <= 1}
+                onclick={prevPage}
+              >
+                Previous
+              </Button>
+              <span class="pagination-status">
+                Page {pagination.page} of {pagination.totalPages}
+                <span class="pagination-total">
+                  · {pagination.total} payout{pagination.total === 1 ? '' : 's'}
+                </span>
+              </span>
+              <Button
+                variant="secondary"
+                disabled={page >= pagination.totalPages}
+                onclick={nextPage}
+              >
+                Next
+              </Button>
+            </nav>
+          {/if}
+        {/if}
+      </Card.Content>
+    </Card.Root>
+  </div>
+{/if}
+
+<style>
+  .payouts {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+    max-width: 1200px;
+  }
+
+  .payouts-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .payouts-title {
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-bold);
+    color: var(--color-text);
+    margin: 0;
+    line-height: var(--leading-tight);
+  }
+
+  .payouts-subtitle {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-normal);
+    max-width: 720px;
+    margin: 0;
+  }
+
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    align-items: flex-end;
+  }
+
+  /* Constrain the status select so it doesn't span the full header */
+  .filters :global(.status-filter) {
+    min-width: 220px;
+    max-width: 280px;
+  }
+
+  .table-wrapper {
+    overflow-x: auto;
+  }
+
+  .table-skeleton {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .table-skeleton-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .date-cell {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .creator-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  /* Avatar primitive sets size via its own scoped .avatar class. Force
+     here with !important to match the StudioSidebar avatar pattern —
+     primitive specificity (0,2,0) beats consumer :global (0,1,0). */
+  :global(.creator-avatar) {
+    width: var(--space-7) !important;
+    height: var(--space-7) !important;
+    flex-shrink: 0 !important;
+  }
+
+  .creator-name {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 16ch;
+  }
+
+  :global(.amount-head),
+  :global(.amount-cell) {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: var(--font-medium);
+  }
+
+  .transfer-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .transfer-id {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+    background-color: var(--color-surface-secondary);
+    padding: var(--space-0-5) var(--space-2);
+    border-radius: var(--radius-sm);
+  }
+
+  .copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-7);
+    height: var(--space-7);
+    background: transparent;
+    border: var(--border-width) var(--border-style) transparent;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .copy-btn:hover {
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text);
+  }
+
+  .copy-btn:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .reason-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .reason-cell--failed {
+    color: var(--color-error-700);
+  }
+
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding-top: var(--space-4);
+    border-top: var(--border-width) var(--border-style) var(--color-border);
+    margin-top: var(--space-4);
+    flex-wrap: wrap;
+  }
+
+  .pagination-status {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pagination-total {
+    color: var(--color-text-muted);
+  }
+
+  .empty-link {
+    text-decoration: none;
+    color: inherit;
+  }
+</style>

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -30,8 +30,12 @@ export {
   createTierSchema,
   getCurrentSubscriptionQuerySchema,
   getSubscriptionStatsQuerySchema,
+  type ListPayoutsQueryInput,
   type ListSubscribersQueryInput,
+  listPayoutsQuerySchema,
   listSubscribersQuerySchema,
+  type PayoutStatusFilter,
+  payoutStatusFilterEnum,
   type ReorderTiersInput,
   reorderTiersSchema,
   type SubscriptionStatus,
@@ -76,6 +80,8 @@ export {
   type WaitUntilFn,
 } from './services/subscription-invalidation';
 export type {
+  PayoutDisplayStatus,
+  PayoutWithCreator,
   PropagateTierPriceOptions,
   PropagateTierPriceResult,
   TierChangePreview,

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -4220,6 +4220,318 @@ describe('SubscriptionService', () => {
     });
   });
 
+  // ─── listPayoutsByOrg (Codex-zqaxo) ───────────────────────────────────────
+  //
+  // Powers the read-only `/studio/payouts` table. Org-scoped via
+  // `pendingPayouts.organizationId` — never user-scoped, because a creator
+  // can belong to multiple orgs and we must NEVER leak rows across orgs.
+
+  describe('listPayoutsByOrg', () => {
+    async function seedSubscriptionForOrg(
+      orgId: string,
+      tierId: string,
+      userId: string,
+      slug: string
+    ) {
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(userId, orgId, tierId, {
+            status: 'active',
+            stripeSubscriptionId: `sub_zqaxo_${createUniqueSlug(slug)}`,
+          })
+        )
+        .returning();
+      return sub;
+    }
+
+    it('returns empty paginated result when org has no payouts', async () => {
+      const { org } = await createFullOrg('zqaxo-empty');
+      const result = await service.listPayoutsByOrg(org.id, {
+        page: 1,
+        limit: 20,
+      });
+      expect(result.items).toEqual([]);
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 0,
+        totalPages: 0,
+      });
+    });
+
+    it('returns rows scoped to the requested org, derived statuses, and ISO dates', async () => {
+      const { org, tier1 } = await createFullOrg('zqaxo-mixed');
+      const sub = await seedSubscriptionForOrg(
+        org.id,
+        tier1.id,
+        otherCreatorId,
+        'mixed'
+      );
+
+      // Three rows: one pending, one resolved, one failed.
+      await db.insert(pendingPayoutsTable).values([
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 1234,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 4567,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          resolvedAt: new Date('2026-05-01T10:00:00Z'),
+          stripeTransferId: 'tr_resolved_zqaxo_1',
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 999,
+          currency: 'gbp',
+          reason: 'transfer_failed',
+        },
+      ]);
+
+      const result = await service.listPayoutsByOrg(org.id, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items).toHaveLength(3);
+      const byStatus = new Map(result.items.map((r) => [r.status, r]));
+      expect(byStatus.get('pending')?.amountCents).toBe(1234);
+      expect(byStatus.get('resolved')?.amountCents).toBe(4567);
+      expect(byStatus.get('resolved')?.stripeTransferId).toBe(
+        'tr_resolved_zqaxo_1'
+      );
+      expect(byStatus.get('failed')?.reason).toBe('transfer_failed');
+
+      // Dates must be ISO strings (not Date objects) so the worker → JSON
+      // hop is lossless and the page can hand them straight to formatDate.
+      for (const row of result.items) {
+        expect(typeof row.createdAt).toBe('string');
+        if (row.resolvedAt) expect(typeof row.resolvedAt).toBe('string');
+      }
+    });
+
+    it('SCOPING INVARIANT: never leaks payouts from a different org', async () => {
+      // Codex-zqaxo STOP-rule: listPayoutsByOrg MUST filter by
+      // pendingPayouts.organizationId — filtering by userId alone would
+      // expose another org's rows for the same creator.
+      const { org: org1, tier1: t1 } = await createFullOrg('zqaxo-scope-a');
+      const { org: org2, tier1: t2 } = await createFullOrg('zqaxo-scope-b');
+
+      const subA = await seedSubscriptionForOrg(
+        org1.id,
+        t1.id,
+        otherCreatorId,
+        'scope-a'
+      );
+      const subB = await seedSubscriptionForOrg(
+        org2.id,
+        t2.id,
+        otherCreatorId,
+        'scope-b'
+      );
+
+      await db.insert(pendingPayoutsTable).values([
+        {
+          userId: otherCreatorId,
+          organizationId: org1.id,
+          subscriptionId: subA.id,
+          amountCents: 100,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org2.id,
+          subscriptionId: subB.id,
+          amountCents: 200,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+      ]);
+
+      const a = await service.listPayoutsByOrg(org1.id, {
+        page: 1,
+        limit: 20,
+      });
+      const b = await service.listPayoutsByOrg(org2.id, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(a.items).toHaveLength(1);
+      expect(a.items[0].amountCents).toBe(100);
+      expect(b.items).toHaveLength(1);
+      expect(b.items[0].amountCents).toBe(200);
+    });
+
+    it('applies the pending status filter', async () => {
+      const { org, tier1 } = await createFullOrg('zqaxo-filter-pending');
+      const sub = await seedSubscriptionForOrg(
+        org.id,
+        tier1.id,
+        otherCreatorId,
+        'fp'
+      );
+
+      await db.insert(pendingPayoutsTable).values([
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 100,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 200,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          resolvedAt: new Date(),
+          stripeTransferId: 'tr_x',
+        },
+      ]);
+
+      const result = await service.listPayoutsByOrg(org.id, {
+        page: 1,
+        limit: 20,
+        status: 'pending',
+      });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].status).toBe('pending');
+      expect(result.items[0].amountCents).toBe(100);
+    });
+
+    it('applies the resolved status filter', async () => {
+      const { org, tier1 } = await createFullOrg('zqaxo-filter-resolved');
+      const sub = await seedSubscriptionForOrg(
+        org.id,
+        tier1.id,
+        otherCreatorId,
+        'fr'
+      );
+
+      await db.insert(pendingPayoutsTable).values([
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 100,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 200,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          resolvedAt: new Date(),
+          stripeTransferId: 'tr_zqaxo_resolved',
+        },
+      ]);
+
+      const result = await service.listPayoutsByOrg(org.id, {
+        page: 1,
+        limit: 20,
+        status: 'resolved',
+      });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].status).toBe('resolved');
+      expect(result.items[0].stripeTransferId).toBe('tr_zqaxo_resolved');
+    });
+
+    it('applies the failed status filter (reason=transfer_failed AND unresolved)', async () => {
+      const { org, tier1 } = await createFullOrg('zqaxo-filter-failed');
+      const sub = await seedSubscriptionForOrg(
+        org.id,
+        tier1.id,
+        otherCreatorId,
+        'ff'
+      );
+
+      await db.insert(pendingPayoutsTable).values([
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 100,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 999,
+          currency: 'gbp',
+          reason: 'transfer_failed',
+        },
+      ]);
+
+      const result = await service.listPayoutsByOrg(org.id, {
+        page: 1,
+        limit: 20,
+        status: 'failed',
+      });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].status).toBe('failed');
+      expect(result.items[0].reason).toBe('transfer_failed');
+    });
+
+    it('paginates correctly with totalPages math', async () => {
+      const { org, tier1 } = await createFullOrg('zqaxo-pagination');
+      const sub = await seedSubscriptionForOrg(
+        org.id,
+        tier1.id,
+        otherCreatorId,
+        'pg'
+      );
+
+      const rows = Array.from({ length: 5 }, (_, i) => ({
+        userId: otherCreatorId,
+        organizationId: org.id,
+        subscriptionId: sub.id,
+        amountCents: 100 + i,
+        currency: 'gbp',
+        reason: 'connect_not_ready',
+      }));
+      await db.insert(pendingPayoutsTable).values(rows);
+
+      const page1 = await service.listPayoutsByOrg(org.id, {
+        page: 1,
+        limit: 2,
+      });
+      expect(page1.items).toHaveLength(2);
+      expect(page1.pagination).toEqual({
+        page: 1,
+        limit: 2,
+        total: 5,
+        totalPages: 3,
+      });
+
+      const page3 = await service.listPayoutsByOrg(org.id, {
+        page: 3,
+        limit: 2,
+      });
+      expect(page3.items).toHaveLength(1);
+    });
+  });
+
   // ─── resolvePendingPayouts (Codex-w4jjk) ───────────────────────────────────
   //
   // Called from workers/ecom-api/src/handlers/connect-webhook.ts:75 when a

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -61,7 +61,18 @@ import {
   UnsupportedCurrencyError,
 } from '@codex/service-errors';
 import type { PaginatedListResponse } from '@codex/shared-types';
-import { and, desc, eq, inArray, isNull, lt, sql } from 'drizzle-orm';
+import {
+  and,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  sql,
+} from 'drizzle-orm';
 import type Stripe from 'stripe';
 import {
   AlreadySubscribedError,
@@ -107,6 +118,56 @@ interface SubscriptionStats {
     subscriberCount: number;
     mrrCents: number;
   }>;
+}
+
+/**
+ * Display status for a `pendingPayouts` row in the studio payouts table
+ * (Codex-zqaxo). Derived from the persisted `resolvedAt`,
+ * `stripeTransferId`, and `reason` columns — there is no `status` column
+ * on the table itself.
+ */
+export type PayoutDisplayStatus = 'pending' | 'resolved' | 'failed';
+
+/**
+ * Read-model returned by `SubscriptionService.listPayoutsByOrg`. The
+ * creator denorm fields (`creatorName`, `creatorEmail`, `creatorAvatarUrl`)
+ * come from a LEFT JOIN on `users` — null when the user row has been
+ * removed but the payout history remains.
+ *
+ * Dates are serialised as ISO strings so the worker→Hono→JSON boundary
+ * is lossless and the SvelteKit remote-function consumer can pass them
+ * straight to `formatDate`.
+ */
+export interface PayoutWithCreator {
+  id: string;
+  creatorId: string;
+  creatorName: string | null;
+  creatorEmail: string | null;
+  creatorAvatarUrl: string | null;
+  amountCents: number;
+  currency: string;
+  reason: string;
+  status: PayoutDisplayStatus;
+  resolvedAt: string | null;
+  stripeTransferId: string | null;
+  createdAt: string;
+}
+
+/**
+ * Resolve a `pendingPayouts` row to one of three display statuses. Used by
+ * `listPayoutsByOrg` so the UI never has to re-derive these branches.
+ *
+ *  - `resolved` — has both `resolvedAt` and `stripeTransferId`
+ *  - `failed`   — `reason='transfer_failed'` and not yet resolved
+ *  - `pending`  — every other unresolved row
+ */
+function derivePayoutStatus(
+  resolvedAt: Date | null,
+  reason: string
+): PayoutDisplayStatus {
+  if (resolvedAt) return 'resolved';
+  if (reason === 'transfer_failed') return 'failed';
+  return 'pending';
 }
 
 /**
@@ -2317,6 +2378,111 @@ export class SubscriptionService extends BaseService {
         subscriberCount: t.subscriberCount,
         mrrCents: t.mrrCents ?? 0,
       })),
+    };
+  }
+
+  /**
+   * Codex-zqaxo: list pending + resolved payouts for an org owner's
+   * `/studio/payouts` table.
+   *
+   * Scoping invariant (HARD): rows MUST be filtered by
+   * `pendingPayouts.organizationId = orgId`. The route layer applies
+   * `requireOrgManagement` so `orgId === ctx.organizationId`. Filtering by
+   * `userId` here would leak cross-org payouts because a creator can belong
+   * to multiple orgs — never relax to user-only scoping.
+   *
+   * Status filter semantics:
+   *  - `pending`  → `resolvedAt IS NULL` AND reason != 'transfer_failed'
+   *  - `resolved` → `stripeTransferId IS NOT NULL` AND `resolvedAt IS NOT NULL`
+   *  - `failed`   → `reason = 'transfer_failed'` AND `resolvedAt IS NULL`
+   *  - `all`      → no status predicate
+   *
+   * The creator name/avatar denorm comes from a LEFT JOIN on `users` so a
+   * deleted user row does not drop the payout from the table.
+   */
+  async listPayoutsByOrg(
+    orgId: string,
+    options: {
+      page: number;
+      limit: number;
+      status?: 'all' | 'pending' | 'resolved' | 'failed';
+      fromDate?: string;
+      toDate?: string;
+    }
+  ): Promise<PaginatedListResponse<PayoutWithCreator>> {
+    const { page, limit, status = 'all', fromDate, toDate } = options;
+    const offset = (page - 1) * limit;
+
+    const conditions = [eq(pendingPayouts.organizationId, orgId)];
+
+    if (status === 'pending') {
+      conditions.push(isNull(pendingPayouts.resolvedAt));
+      conditions.push(sql`${pendingPayouts.reason} != 'transfer_failed'`);
+    } else if (status === 'resolved') {
+      conditions.push(isNotNull(pendingPayouts.resolvedAt));
+      conditions.push(isNotNull(pendingPayouts.stripeTransferId));
+    } else if (status === 'failed') {
+      conditions.push(eq(pendingPayouts.reason, 'transfer_failed'));
+      conditions.push(isNull(pendingPayouts.resolvedAt));
+    }
+
+    if (fromDate) {
+      conditions.push(gte(pendingPayouts.createdAt, new Date(fromDate)));
+    }
+    if (toDate) {
+      conditions.push(lte(pendingPayouts.createdAt, new Date(toDate)));
+    }
+
+    const [items, [totalResult]] = await Promise.all([
+      this.db
+        .select({
+          id: pendingPayouts.id,
+          creatorId: pendingPayouts.userId,
+          creatorName: users.name,
+          creatorEmail: users.email,
+          creatorAvatarUrl: users.image,
+          amountCents: pendingPayouts.amountCents,
+          currency: pendingPayouts.currency,
+          reason: pendingPayouts.reason,
+          resolvedAt: pendingPayouts.resolvedAt,
+          stripeTransferId: pendingPayouts.stripeTransferId,
+          createdAt: pendingPayouts.createdAt,
+        })
+        .from(pendingPayouts)
+        .leftJoin(users, eq(pendingPayouts.userId, users.id))
+        .where(and(...conditions))
+        .orderBy(desc(pendingPayouts.createdAt))
+        .limit(limit)
+        .offset(offset),
+      this.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(pendingPayouts)
+        .where(and(...conditions)),
+    ]);
+
+    const total = totalResult?.count ?? 0;
+
+    return {
+      items: items.map((row) => ({
+        id: row.id,
+        creatorId: row.creatorId,
+        creatorName: row.creatorName ?? null,
+        creatorEmail: row.creatorEmail ?? null,
+        creatorAvatarUrl: row.creatorAvatarUrl ?? null,
+        amountCents: row.amountCents,
+        currency: row.currency,
+        reason: row.reason,
+        status: derivePayoutStatus(row.resolvedAt, row.reason),
+        resolvedAt: row.resolvedAt ? row.resolvedAt.toISOString() : null,
+        stripeTransferId: row.stripeTransferId,
+        createdAt: row.createdAt.toISOString(),
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
     };
   }
 

--- a/packages/validation/src/schemas/subscription.ts
+++ b/packages/validation/src/schemas/subscription.ts
@@ -168,6 +168,32 @@ export const listSubscribersQuerySchema = paginationSchema.extend({
   status: subscriptionStatusEnum.optional(),
 });
 
+/**
+ * Payout status filter for the studio payouts table (Codex-zqaxo).
+ *
+ * Phase 1 surfaces three states:
+ *  - `pending`   — row exists, `resolvedAt IS NULL`
+ *  - `resolved`  — `resolvedAt IS NOT NULL` AND `stripeTransferId IS NOT NULL`
+ *  - `failed`    — `reason='transfer_failed'` AND unresolved
+ *  - `all`       — no status filter (default)
+ *
+ * The enum is shared by the worker route's query schema below AND the
+ * frontend remote function so both ends stay in sync.
+ */
+export const payoutStatusFilterEnum = z.enum([
+  'all',
+  'pending',
+  'resolved',
+  'failed',
+]);
+
+export const listPayoutsQuerySchema = paginationSchema.extend({
+  organizationId: uuidSchema,
+  status: payoutStatusFilterEnum.default('all'),
+  fromDate: z.string().datetime().optional(),
+  toDate: z.string().datetime().optional(),
+});
+
 export const getCurrentSubscriptionQuerySchema = z.object({
   organizationId: uuidSchema,
 });
@@ -215,6 +241,9 @@ export type ReactivateSubscriptionInput = z.infer<
   typeof reactivateSubscriptionSchema
 >;
 export type ResumeSubscriptionInput = z.infer<typeof resumeSubscriptionSchema>;
+export type PayoutStatusFilter = z.infer<typeof payoutStatusFilterEnum>;
+export type ListPayoutsQueryInput = z.infer<typeof listPayoutsQuerySchema>;
+
 export type ListSubscribersQueryInput = z.infer<
   typeof listSubscribersQuerySchema
 >;

--- a/workers/ecom-api/src/routes/subscriptions.ts
+++ b/workers/ecom-api/src/routes/subscriptions.ts
@@ -22,6 +22,7 @@ import {
   createSubscriptionCheckoutSchema,
   getCurrentSubscriptionQuerySchema,
   getSubscriptionStatsQuerySchema,
+  listPayoutsQuerySchema,
   listSubscribersQuerySchema,
   reactivateSubscriptionSchema,
   resumeSubscriptionSchema,
@@ -353,6 +354,42 @@ subscriptions.get(
       const result = await ctx.services.subscription.listSubscribers(
         ctx.organizationId,
         ctx.input.query
+      );
+      return new PaginatedResult(result.items, result.pagination);
+    },
+  })
+);
+
+/**
+ * GET /subscriptions/payouts
+ *
+ * Codex-zqaxo: list pending + resolved creator payouts for the org owner's
+ * studio payouts table. Owner/admin only via `requireOrgManagement` —
+ * mirror of `/stats` and `/subscribers`.
+ *
+ * SECURITY INVARIANT: the service queries `pendingPayouts` filtered by
+ * `organizationId = ctx.organizationId`. `ctx.organizationId` is set by
+ * `requireOrgManagement` from the user's membership row, so this route
+ * cannot leak another org's payouts even if the client forges
+ * `query.organizationId`. The Zod schema requires `organizationId` for
+ * the URL contract, but the service ignores it in favour of the
+ * authenticated `ctx.organizationId`.
+ */
+subscriptions.get(
+  '/payouts',
+  procedure({
+    policy: { auth: 'required', requireOrgManagement: true },
+    input: { query: listPayoutsQuerySchema },
+    handler: async (ctx) => {
+      const result = await ctx.services.subscription.listPayoutsByOrg(
+        ctx.organizationId,
+        {
+          page: ctx.input.query.page,
+          limit: ctx.input.query.limit,
+          status: ctx.input.query.status,
+          fromDate: ctx.input.query.fromDate,
+          toDate: ctx.input.query.toDate,
+        }
       );
       return new PaginatedResult(result.items, result.pagination);
     },


### PR DESCRIPTION
## Summary

Round 2 of epic **Codex-kbfe3** (Payouts visibility frontend, Phase 1 — read-only surfaces). Round 1 (`Codex-rs64v` Connect requirements + `Codex-mtv05` multi-creator revenue split) is already on `main` — this branch rebases cleanly on top of both.

- **New owner-only `/studio/payouts` page** lists pending + resolved + failed creator payouts in a table with status badges (warning/success/error), GBP amounts via `formatPrice`, Stripe Transfer ID with copy-to-clipboard, and an empty-state CTA to `/studio/monetisation`.
- **New service method `SubscriptionService.listPayoutsByOrg`** — paginated, status + date-range filtered query against `pendingPayouts` with creator denorm via LEFT JOIN on `users`. Strict org-scoping invariant: rows filtered by `organizationId`, never by `userId` alone (would leak cross-org payouts for shared creators).
- **New worker route `GET /subscriptions/payouts`** on ecom-api with `requireOrgManagement`. Scope re-derived from `ctx.organizationId` — client cannot forge via query.
- **New Zod schema `listPayoutsQuerySchema` + `payoutStatusFilterEnum`** in `@codex/validation`.
- **Sidebar wiring**: `SIDEBAR_OWNER_LINKS` gains a "Payouts" link, new `BanknoteIcon`, `'payouts'` added to `SidebarIcon` union + `ICON_MAP`.
- **Remote function `listPayouts`** appended to `subscription.remote.ts` (rs64v's `getConnectStatus` extension preserved untouched). Phase 1 uses snapshot queries — **no TanStack DB live collection** per epic decision.

## Verification gates

- [x] `pnpm check` (biome): only pre-existing warnings on unrelated files (verified by diffing against `origin/main`).
- [x] `pnpm --filter @codex/subscription test --run`: 7/7 new `listPayoutsByOrg` tests pass (empty / mixed-status derivation / cross-org scoping invariant / per-filter pending / resolved / failed / pagination). The single repo-wide failure (`__denoise_proofs__/iter-009/F5-dup-bump-with-logger.test.ts`) is pre-existing on `main`.
- [x] `pnpm --filter ecom-api typecheck`: clean.
- [x] `pnpm --filter web typecheck`: only pre-existing errors in `src/__denoise_proofs__/iter-029/...` and `src/lib/collections/content.ts` (reproduced against `origin/main` with this branch stashed).
- [x] `pnpm build`: full repo builds; new payouts page chunk (`_page.svelte.js` 30.83 kB) emitted.

## Empty / populated / filter notes

- **Empty state**: when `items.length === 0` the page renders an `EmptyState` with title "No payouts yet", description "Payouts will appear here once subscriptions resolve and Stripe transfers the creator's share.", `BanknoteIcon`, and a secondary-variant link to `/studio/monetisation`.
- **Populated state**: Melt UI Table with columns Date / Creator (avatar + name) / Amount (right-aligned tabular nums) / Status (Badge variant) / Transfer or Reason / Resolved date. Resolved rows show truncated `tr_xxxx…xxxx` + copy button; non-resolved rows show the humanised reason ("Connect onboarding incomplete" etc.). Failed rows render an `AlertTriangleIcon` next to the reason.
- **Filter interaction**: status `<Select>` dropdown resets `page` to 1 on change; pagination renders only when `totalPages > 1`; copy-button feedback flips `title` to "Copied!" for 2s.

## Test plan

**Covered by automated suite** (this PR):
- 7 vitest integration tests in `packages/subscription/src/services/__tests__/subscription-service.test.ts` covering: empty result, mixed-status derivation + ISO date serialisation, cross-org isolation invariant, status filter (pending/resolved/failed), pagination math.
- The cross-org scoping test seeds two orgs sharing the same creator and asserts each `listPayoutsByOrg` call returns only its own row.

**Deferred to manual / live verification** (user is reviewing locally):
- Playwright MCP visual screenshots (populated / empty / failed-row states).
- Lighthouse a11y audit ≥ 95.
- Manual smoke at `lvh.me:3000/{org}/studio/payouts` (sidebar nav active state, filter UX, copy-button behaviour, non-owner redirect to `/studio`).

## Notes

- Branch rebased on `origin/main` which includes `58ae2a7e` (rs64v) and `befa9f94` (mtv05).
- No changes to monetisation page, analytics page, ConnectAccountService, AdminAnalyticsService, admin-api routes, requirement-humanization, or CreatorRevenueTable — strict epic coordination boundary respected.
- Currency hardcoded to GBP via existing `formatPrice` (which uses GBP locale). Amounts are pence-integer in DB, formatted to `£X.XX` in the DOM — never raw pence per [[feedback_currency_gbp]].
- Error assertions use `toBeInstanceOf` (none needed here since `listPayoutsByOrg` doesn't throw typed errors — empty org returns empty page).
- No `tokenOverrides`, no hardcoded px/hex — design tokens throughout per [[feedback_no_hardcoded_css]].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>