### PR TITLE
refactor(services): adopt toIso() at remaining service boundaries

### DIFF
--- a/packages/access/src/services/ContentAccessService.ts
+++ b/packages/access/src/services/ContentAccessService.ts
@@ -11,7 +11,7 @@ import {
   SUBSCRIPTION_STATUS,
   VIDEO_PROGRESS,
 } from '@codex/constants';
-import { createPerRequestDbClient } from '@codex/database';
+import { createPerRequestDbClient, toIso } from '@codex/database';
 import {
   content,
   mediaItems,
@@ -1025,7 +1025,7 @@ export class ContentAccessService extends BaseService {
           contentId: input.contentId,
           contentType: mediaType,
           hasWaveform: !!waveformUrl,
-          expiresAt: expiresAt.toISOString(),
+          expiresAt: toIso(expiresAt),
         });
 
         return {
@@ -1351,7 +1351,7 @@ export class ContentAccessService extends BaseService {
         durationSeconds: dur,
         completed: row.progressCompleted ?? false,
         percentComplete: dur > 0 ? Math.round((pos / dur) * 100) : 0,
-        updatedAt: row.progressUpdatedAt.toISOString(),
+        updatedAt: toIso(row.progressUpdatedAt),
       };
     };
 

--- a/packages/admin/src/services/analytics-service.ts
+++ b/packages/admin/src/services/analytics-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { ANALYTICS, PURCHASE_STATUS } from '@codex/constants';
-import { schema } from '@codex/database';
+import { schema, toIso } from '@codex/database';
 import { BaseService, NotFoundError } from '@codex/service-errors';
 import type {
   PaginatedListResponse,
@@ -1128,12 +1128,9 @@ export class AdminAnalyticsService extends BaseService {
         .map((row) => {
           const lastPayoutRaw = lastPayoutByCreator.get(row.creatorId) ?? null;
           // `lastPayoutRaw` is typed `string | null` by the SQL builder but
-          // drivers sometimes hand back a Date directly. `new Date(value)`
-          // handles both shapes without an `instanceof` discriminator.
-          const lastPayoutAt =
-            lastPayoutRaw === null
-              ? null
-              : new Date(lastPayoutRaw).toISOString();
+          // drivers sometimes hand back a Date directly. `toIso()` handles
+          // both shapes (Date | string | null) at the service boundary.
+          const lastPayoutAt = toIso(lastPayoutRaw);
           return {
             creatorId: row.creatorId,
             name: row.name ?? '',

--- a/packages/identity/src/services/identity-service.ts
+++ b/packages/identity/src/services/identity-service.ts
@@ -1,7 +1,7 @@
 import type { VersionedCache } from '@codex/cache';
 import { CacheType } from '@codex/cache';
 import type { R2Service } from '@codex/cloudflare-clients';
-import { whereNotDeleted } from '@codex/database';
+import { toIso, whereNotDeleted } from '@codex/database';
 import {
   notificationPreferences,
   organizationMemberships,
@@ -172,7 +172,7 @@ export class IdentityService extends BaseService {
       return {
         role: membership.role,
         status: membership.status,
-        joinedAt: membership.createdAt.toISOString(),
+        joinedAt: toIso(membership.createdAt),
       };
     } catch (error) {
       throw this.handleError(error, 'IdentityService.getMyMembership');

--- a/packages/organization/src/services/organization-service.ts
+++ b/packages/organization/src/services/organization-service.ts
@@ -14,6 +14,7 @@
 import { PAGINATION, RESERVED_SUBDOMAINS_SET } from '@codex/constants';
 import {
   isUniqueViolation,
+  toIso,
   whereNotDeleted,
   withPagination,
 } from '@codex/database';
@@ -565,7 +566,7 @@ export class OrganizationService extends BaseService {
           bio: m.bio ?? null,
           socialLinks: (m.socialLinks as SocialLinks) ?? null,
           role: m.role,
-          joinedAt: m.joinedAt.toISOString(),
+          joinedAt: toIso(m.joinedAt),
           contentCount: Number(m.contentCount ?? 0),
           recentContent: recentContentMap.get(m.userId) ?? [],
           organizations: otherOrgsMap.get(m.userId) ?? [],
@@ -719,7 +720,7 @@ export class OrganizationService extends BaseService {
 
       return {
         role: membership?.role ?? null,
-        joinedAt: membership?.createdAt.toISOString() ?? null,
+        joinedAt: toIso(membership?.createdAt),
       };
     } catch (error) {
       this.handleError(error, 'getMyMembership');
@@ -1044,7 +1045,7 @@ export class OrganizationService extends BaseService {
           name: m.name,
           avatarUrl: m.avatarUrl ?? m.image ?? null,
           role: m.role,
-          joinedAt: m.joinedAt.toISOString(),
+          joinedAt: toIso(m.joinedAt),
         })),
         pagination: {
           page,

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -802,10 +802,7 @@ export class PurchaseService extends BaseService {
         (p): PurchaseListItem => ({
           id: p.id,
           customerId: p.customerId,
-          createdAt:
-            p.createdAt instanceof Date
-              ? p.createdAt.toISOString()
-              : p.createdAt,
+          createdAt: toIso(p.createdAt),
           contentId: p.contentId,
           contentTitle: p.content.title,
           amountCents: p.amountPaidCents,


### PR DESCRIPTION
## Summary

PR #193 introduced \`@codex/database\` \`toIso()\` but six service call sites still inlined \`.toISOString()\`. This sweep brings access/admin/identity/organization/purchase services to the unified helper.

Sites converted:
- \`packages/access/src/services/ContentAccessService.ts\` — \`expiresAt\` log payload + \`updatedAt\` progress row
- \`packages/admin/src/services/analytics-service.ts\` — \`lastPayoutAt\` per-creator revenue (collapses \`new Date(x).toISOString()\` ternary)
- \`packages/identity/src/services/identity-service.ts\` — \`getMyMembership.joinedAt\`
- \`packages/organization/src/services/organization-service.ts\` — three sites: \`getPublicCreators\`, \`getMyMembership\` (collapses \`x?.toISOString() ?? null\` to bare \`toIso(x)\`), \`getPublicMembers\`
- \`packages/purchase/src/services/purchase-service.ts\` — \`createdAt\` in sales list (collapses \`instanceof Date ? ... : ...\` ternary)

No behaviour change — \`toIso\` produces identical output to the patterns it replaces.

## Test plan

- [x] \`pnpm --filter @codex/access --filter @codex/admin --filter @codex/identity --filter @codex/organization --filter @codex/purchase typecheck\` green
- [x] \`pnpm --filter @codex/access --filter @codex/admin --filter @codex/identity --filter @codex/organization --filter @codex/purchase test\` — 84/85 pass; the single failure (\`analytics-revenue-by-creator.integration.test.ts > aggregates purchase revenue per active creator\`) is a pre-existing \`check_revenue_split_equals_total\` DB constraint violation in seed data unrelated to this sweep (100 + 0 + 600 ≠ 1000)

Stacks on PR #193 (toIso helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)