### PR TITLE
fix(admin): seed satisfies check_revenue_split_equals_total CHECK

### DIFF
--- a/packages/admin/src/__tests__/analytics-revenue-by-creator.integration.test.ts
+++ b/packages/admin/src/__tests__/analytics-revenue-by-creator.integration.test.ts
@@ -188,7 +188,7 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
         organizationId: orgId,
         amountPaidCents: 1000,
         platformFeeCents: 100,
-        organizationFeeCents: 0,
+        organizationFeeCents: 300,
         creatorPayoutCents: 600,
         stripePaymentIntentId: `pi_b1_${Date.now()}`,
         status: PURCHASE_STATUS.COMPLETED,


### PR DESCRIPTION
## Summary

- The integration test `analytics-revenue-by-creator > aggregates purchase revenue per active creator and converts bps→%` was inserting a purchase row that violated the DB CHECK constraint `check_revenue_split_equals_total` (`amount_paid_cents = platform_fee_cents + organization_fee_cents + creator_payout_cents`).
- PR #191 (commit `befa9f94`) introduced the 3-split fee model (platform + organization + creator); this seed predates that model.
- Failing row: `amountPaidCents=1000, platformFeeCents=100, organizationFeeCents=0, creatorPayoutCents=600` — splits summed to 700, not 1000.

## Fix

Set `organizationFeeCents: 300` on the creatorB seed row so splits sum to 1000.

This preserves all assertions:
- `totalRevenueCents` aggregates `creatorPayoutCents` (still 600 → assertion `second.totalRevenueCents === 600` still passes).
- `splitPercent` is derived from the agreement's `organizationFeePercentage` bps (2500 → 25%), independent of the purchase row's `organizationFeeCents`.

## Test plan

- [x] `pnpm --filter @codex/admin test analytics-revenue-by-creator` — 7/7 pass
- [x] `pnpm --filter @codex/admin test` — 85 pass, 5 skipped, no regressions

Stacks on PR #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)