### PR TITLE
refactor(database): extract dateWindow() helper, adopt across analytics + subscription

### DIFF
--- a/packages/admin/src/services/analytics-service.ts
+++ b/packages/admin/src/services/analytics-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { ANALYTICS, PURCHASE_STATUS } from '@codex/constants';
-import { schema, toIso } from '@codex/database';
+import { dateWindow, schema, toIso } from '@codex/database';
 import { BaseService, NotFoundError } from '@codex/service-errors';
 import type {
   PaginatedListResponse,
@@ -19,10 +19,8 @@ import {
   desc,
   eq,
   gt,
-  gte,
   inArray,
   isNull,
-  lte,
   or,
   sql,
 } from 'drizzle-orm';
@@ -124,8 +122,7 @@ export class AdminAnalyticsService extends BaseService {
     const baseConditions = [
       eq(schema.purchases.organizationId, organizationId),
       eq(schema.purchases.status, PURCHASE_STATUS.COMPLETED),
-      gte(schema.purchases.purchasedAt, effectiveStart),
-      lte(schema.purchases.purchasedAt, effectiveEnd),
+      ...dateWindow(schema.purchases.purchasedAt, effectiveStart, effectiveEnd),
     ];
 
     // Independent queries — neither consumes the other's value. Launch via
@@ -264,7 +261,11 @@ export class AdminAnalyticsService extends BaseService {
                 'past_due',
                 'cancelling',
               ]),
-              lte(schema.subscriptions.createdAt, effectiveEnd),
+              ...dateWindow(
+                schema.subscriptions.createdAt,
+                undefined,
+                effectiveEnd
+              ),
               or(
                 isNull(schema.subscriptions.cancelledAt),
                 gt(schema.subscriptions.cancelledAt, effectiveEnd)
@@ -278,8 +279,11 @@ export class AdminAnalyticsService extends BaseService {
           .where(
             and(
               eq(schema.subscriptions.organizationId, organizationId),
-              gte(schema.subscriptions.createdAt, effectiveStart),
-              lte(schema.subscriptions.createdAt, effectiveEnd)
+              ...dateWindow(
+                schema.subscriptions.createdAt,
+                effectiveStart,
+                effectiveEnd
+              )
             )
           ),
         // Churned in period: cancelledAt within [start, end]
@@ -289,8 +293,11 @@ export class AdminAnalyticsService extends BaseService {
           .where(
             and(
               eq(schema.subscriptions.organizationId, organizationId),
-              gte(schema.subscriptions.cancelledAt, effectiveStart),
-              lte(schema.subscriptions.cancelledAt, effectiveEnd)
+              ...dateWindow(
+                schema.subscriptions.cancelledAt,
+                effectiveStart,
+                effectiveEnd
+              )
             )
           ),
         // Daily new subscribers, grouped by DATE(createdAt), most recent first
@@ -303,8 +310,11 @@ export class AdminAnalyticsService extends BaseService {
           .where(
             and(
               eq(schema.subscriptions.organizationId, organizationId),
-              gte(schema.subscriptions.createdAt, effectiveStart),
-              lte(schema.subscriptions.createdAt, effectiveEnd)
+              ...dateWindow(
+                schema.subscriptions.createdAt,
+                effectiveStart,
+                effectiveEnd
+              )
             )
           )
           .groupBy(sql`DATE(${schema.subscriptions.createdAt})`)
@@ -408,7 +418,11 @@ export class AdminAnalyticsService extends BaseService {
         .where(
           and(
             eq(schema.organizationFollowers.organizationId, organizationId),
-            lte(schema.organizationFollowers.createdAt, effectiveEnd)
+            ...dateWindow(
+              schema.organizationFollowers.createdAt,
+              undefined,
+              effectiveEnd
+            )
           )
         ),
       // New followers in period: createdAt within [start, end]
@@ -418,8 +432,11 @@ export class AdminAnalyticsService extends BaseService {
         .where(
           and(
             eq(schema.organizationFollowers.organizationId, organizationId),
-            gte(schema.organizationFollowers.createdAt, effectiveStart),
-            lte(schema.organizationFollowers.createdAt, effectiveEnd)
+            ...dateWindow(
+              schema.organizationFollowers.createdAt,
+              effectiveStart,
+              effectiveEnd
+            )
           )
         ),
       // Daily new followers, grouped by DATE(createdAt), most recent first
@@ -432,8 +449,11 @@ export class AdminAnalyticsService extends BaseService {
         .where(
           and(
             eq(schema.organizationFollowers.organizationId, organizationId),
-            gte(schema.organizationFollowers.createdAt, effectiveStart),
-            lte(schema.organizationFollowers.createdAt, effectiveEnd)
+            ...dateWindow(
+              schema.organizationFollowers.createdAt,
+              effectiveStart,
+              effectiveEnd
+            )
           )
         )
         .groupBy(sql`DATE(${schema.organizationFollowers.createdAt})`)
@@ -571,8 +591,11 @@ export class AdminAnalyticsService extends BaseService {
           and(
             eq(schema.purchases.organizationId, organizationId),
             eq(schema.purchases.status, PURCHASE_STATUS.COMPLETED),
-            gte(schema.purchases.purchasedAt, effectiveStart),
-            lte(schema.purchases.purchasedAt, effectiveEnd)
+            ...dateWindow(
+              schema.purchases.purchasedAt,
+              effectiveStart,
+              effectiveEnd
+            )
           )
         )
         .groupBy(
@@ -606,10 +629,13 @@ export class AdminAnalyticsService extends BaseService {
             and(
               eq(schema.purchases.organizationId, organizationId),
               eq(schema.purchases.status, PURCHASE_STATUS.COMPLETED),
-              // Non-null assertions are safe here: wantsCompare is only true
-              // when both compareFrom and compareTo are defined.
-              gte(schema.purchases.purchasedAt, options!.compareFrom!),
-              lte(schema.purchases.purchasedAt, options!.compareTo!),
+              // Helper's truthy checks make non-null asserts redundant — the
+              // outer wantsCompare guard still selects this code path.
+              ...dateWindow(
+                schema.purchases.purchasedAt,
+                options?.compareFrom,
+                options?.compareTo
+              ),
               inArray(schema.purchases.contentId, contentIds)
             )
           )
@@ -705,8 +731,13 @@ export class AdminAnalyticsService extends BaseService {
           .where(
             and(
               inArray(schema.videoPlayback.contentId, contentIds),
-              gte(schema.videoPlayback.updatedAt, options!.compareFrom!),
-              lte(schema.videoPlayback.updatedAt, options!.compareTo!)
+              // Helper's truthy checks make non-null asserts redundant — the
+              // outer wantsCompare guard still selects this code path.
+              ...dateWindow(
+                schema.videoPlayback.updatedAt,
+                options?.compareFrom,
+                options?.compareTo
+              )
             )
           )
           .groupBy(schema.videoPlayback.contentId);
@@ -790,8 +821,7 @@ export class AdminAnalyticsService extends BaseService {
         schema.videoPlayback,
         and(
           eq(schema.videoPlayback.contentId, schema.content.id),
-          gte(schema.videoPlayback.updatedAt, startDate),
-          lte(schema.videoPlayback.updatedAt, endDate)
+          ...dateWindow(schema.videoPlayback.updatedAt, startDate, endDate)
         )
       )
       .where(
@@ -1054,12 +1084,9 @@ export class AdminAnalyticsService extends BaseService {
         eq(schema.purchases.status, PURCHASE_STATUS.COMPLETED),
         inArray(schema.content.creatorId, creatorIds),
       ];
-      if (startDate) {
-        purchaseConditions.push(gte(schema.purchases.purchasedAt, startDate));
-      }
-      if (endDate) {
-        purchaseConditions.push(lte(schema.purchases.purchasedAt, endDate));
-      }
+      purchaseConditions.push(
+        ...dateWindow(schema.purchases.purchasedAt, startDate, endDate)
+      );
 
       // Three independent aggregates over creator-keyed data — fire concurrently
       // (R12 hard rule). Pending-payouts queries are scoped by BOTH userId AND

--- a/packages/database/src/utils/date-window.ts
+++ b/packages/database/src/utils/date-window.ts
@@ -1,0 +1,27 @@
+import { gte, lte, type SQL } from 'drizzle-orm';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
+
+/**
+ * Builds SQL conditions for a single-column date window. Returns an array
+ * of `SQL` conditions suitable for spreading into Drizzle's `and(...)`.
+ *
+ * Accepts ISO strings (from query params) OR Date objects (already parsed
+ * by callers). Returns empty array when both bounds are absent.
+ *
+ * For NULL-fallback date windows (e.g. purchases.purchasedAt → createdAt),
+ * use the specialised purchaseDateWindow helper in purchase-service.
+ */
+export function dateWindow(
+  column: AnyPgColumn,
+  from?: string | Date | null,
+  to?: string | Date | null
+): SQL[] {
+  const conditions: SQL[] = [];
+  if (from) {
+    conditions.push(gte(column, from instanceof Date ? from : new Date(from)));
+  }
+  if (to) {
+    conditions.push(lte(column, to instanceof Date ? to : new Date(to)));
+  }
+  return conditions;
+}

--- a/packages/database/src/utils/index.ts
+++ b/packages/database/src/utils/index.ts
@@ -6,6 +6,8 @@
  * - Query helper functions (soft delete filtering, scoping, pagination)
  */
 
+// Date-window helper
+export * from './date-window';
 // Error detection utilities
 export * from './db-errors';
 // ISO-date serialisation helper

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -35,7 +35,7 @@ import {
   FEES,
   SUBSCRIPTION_STATUS,
 } from '@codex/constants';
-import { isUniqueViolation, toIso } from '@codex/database';
+import { dateWindow, isUniqueViolation, toIso } from '@codex/database';
 import {
   creatorOrganizationAgreements,
   organizationFollowers,
@@ -65,12 +65,10 @@ import {
   and,
   desc,
   eq,
-  gte,
   inArray,
   isNotNull,
   isNull,
   lt,
-  lte,
   sql,
 } from 'drizzle-orm';
 import type Stripe from 'stripe';
@@ -2535,12 +2533,7 @@ export class SubscriptionService extends BaseService {
       conditions.push(isNull(pendingPayouts.resolvedAt));
     }
 
-    if (fromDate) {
-      conditions.push(gte(pendingPayouts.createdAt, new Date(fromDate)));
-    }
-    if (toDate) {
-      conditions.push(lte(pendingPayouts.createdAt, new Date(toDate)));
-    }
+    conditions.push(...dateWindow(pendingPayouts.createdAt, fromDate, toDate));
 
     const [items, [totalResult]] = await Promise.all([
       this.db


### PR DESCRIPTION
## Summary

Generalises the simple single-column date-range filter pattern that PR #193 specialised for purchase. `purchaseDateWindow()` stays put — its NULL-fallback (`purchasedAt → createdAt`) semantics are specific to the nullable purchase column. This PR introduces a generic helper for the much more common single-column case.

- New `dateWindow(column, from?, to?): SQL[]` in `@codex/database/utils`, exported alongside the other query helpers
- Accepts `string | Date | null | undefined` — handles ISO strings (query params) or pre-parsed Dates uniformly; returns empty array when both bounds absent
- 11 call sites in `analytics-service.ts` converted (purchases/subscriptions/followers windows, top-content current + compare, content-performance LEFT JOIN + compare, creator revenue split)
- 1 call site in `subscription-service.ts` `listPayoutsByOrg()` converted (`fromDate`/`toDate` strings → spread)
- Dropped now-unused `gte`/`lte` imports from both consumer files

### Sites converted

| File | Site | Notes |
|---|---|---|
| analytics-service.ts | `computeRevenueBlock` baseConditions | gte/lte pair |
| analytics-service.ts | `computeSubscriberBlock` active (lte only) | single-bound — helper handles |
| analytics-service.ts | `computeSubscriberBlock` new in period | gte/lte pair |
| analytics-service.ts | `computeSubscriberBlock` churned | gte/lte pair |
| analytics-service.ts | `computeSubscriberBlock` daily | gte/lte pair |
| analytics-service.ts | `computeFollowerBlock` total (lte only) | single-bound |
| analytics-service.ts | `computeFollowerBlock` new | gte/lte pair |
| analytics-service.ts | `computeFollowerBlock` daily | gte/lte pair |
| analytics-service.ts | `getTopContent` current | gte/lte pair |
| analytics-service.ts | `getTopContent` compare | gte/lte pair; non-null asserts dropped (helper truthy-checks suffice — outer `wantsCompare` guard still selects the code path) |
| analytics-service.ts | `getContentPerformance` compare | same pattern as above |
| analytics-service.ts | `runContentPerformanceWindow` LEFT JOIN predicate | gte/lte pair |
| analytics-service.ts | `getCreatorRevenueSplit` purchaseConditions | conditional pushes collapsed |
| subscription-service.ts | `listPayoutsByOrg` fromDate/toDate | strings now passed directly; helper parses |

### Sites NOT converted

None. Every single-column gte/lte window in the two target files was a candidate and was converted. `purchaseDateWindow()` in `packages/purchase` was intentionally left alone (different semantics — NULL-fallback coalesce).

## Test plan

- [x] `pnpm --filter @codex/database --filter @codex/admin --filter @codex/subscription typecheck` → green
- [x] Test failures reproduced against baseline (stash + re-run) — all pre-existing env-config (`DATABASE_URL_LOCAL_PROXY`) failures; no new failures introduced
- [x] Visual diff confirms generated SQL is identical to inline form for every site

Stacks on PR #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)