### PR TITLE
feat(payouts): replace pending_payouts with unified payouts ledger (Codex-4r55k)

### DIFF
--- a/apps/web/src/lib/components/ui/DropdownMenu/DropdownMenu.svelte
+++ b/apps/web/src/lib/components/ui/DropdownMenu/DropdownMenu.svelte
@@ -17,7 +17,11 @@
 		loop,
 		closeOnItemClick,
 		closeOnOutsideClick,
-		portal = true, // Default to true for Storybook compatibility
+		// Melt UI's portal option accepts `string | HTMLElement | null` — boolean
+		// `true` is a no-op (usePortal returns early). Default to `'body'` so the
+		// menu escapes overflow/transform ancestors (e.g. studio sidebar's
+		// `overflow:hidden` flex column would otherwise displace the layout).
+		portal = 'body',
 		forceVisible = true,
 		defaultOpen,
 		open = $bindable(),

--- a/apps/web/src/lib/components/ui/DropdownMenu/DropdownMenuContent.svelte
+++ b/apps/web/src/lib/components/ui/DropdownMenu/DropdownMenuContent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { type FlyParams, fly } from 'svelte/transition';
@@ -15,12 +16,43 @@
 		elements: { menu },
 		states: { open }
 	} = getCtx();
+
+	/**
+	 * Melt portals the menu to <body>, escaping `.org-layout` which carries
+	 * `[data-org-brand]`, `[data-org-bg]` and `--brand-*` inline styles that
+	 * `org-brand.css` keys off. Copy those onto the portalled node so the org
+	 * branding cascade still resolves inside the menu. Matches DialogContent.
+	 */
+	function forwardBrandTokens(node: HTMLElement) {
+		if (!browser) return;
+
+		const orgLayout = document.querySelector<HTMLElement>('.org-layout');
+		if (!orgLayout) return;
+
+		if (orgLayout.hasAttribute('data-org-brand')) {
+			node.setAttribute('data-org-brand', '');
+		}
+		if (orgLayout.hasAttribute('data-org-bg')) {
+			node.setAttribute('data-org-bg', '');
+		}
+
+		const style = orgLayout.style;
+		for (let i = 0; i < style.length; i++) {
+			const prop = style[i];
+			if (prop.startsWith('--brand-')) {
+				node.style.setProperty(prop, style.getPropertyValue(prop));
+			}
+		}
+
+		node.style.fontFamily = 'inherit';
+	}
 </script>
 
 {#if $open}
 	<div
 		{...$menu}
 		use:menu
+		use:forwardBrandTokens
 		class="dropdown-content {className ?? ''}"
 		transition:fly={transitionConfig}
 		{...rest}

--- a/packages/admin/src/__tests__/analytics-revenue-by-creator.integration.test.ts
+++ b/packages/admin/src/__tests__/analytics-revenue-by-creator.integration.test.ts
@@ -24,7 +24,7 @@ import {
   creatorOrganizationAgreements,
   mediaItems,
   organizations,
-  pendingPayouts,
+  payouts,
   purchases,
   subscriptions,
   subscriptionTiers,
@@ -63,7 +63,7 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
 
   /**
    * Per-test scaffold. Returns a fresh org with N creators, one content per
-   * creator, plus an active subscription (so pendingPayouts can FK to a real
+   * creator, plus an active subscription (so payouts can FK to a real
    * subscription row when needed).
    */
   async function seedScenario(creatorCount: number) {
@@ -110,7 +110,7 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
   }
 
   /**
-   * Seed an active subscription for the given creator + org so pendingPayouts
+   * Seed an active subscription for the given creator + org so payouts
    * inserts can satisfy their FK to subscriptions.id.
    */
   async function seedActiveSubscription(
@@ -250,13 +250,15 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
     const resolvedDate = new Date('2026-03-15T00:00:00Z');
     const moreRecentResolvedDate = new Date('2026-04-20T00:00:00Z');
 
-    await db.insert(pendingPayouts).values([
+    await db.insert(payouts).values([
       {
         userId: creatorId,
         organizationId: orgId,
         subscriptionId,
         amountCents: 500,
-        reason: 'min_transfer_floor',
+        payoutType: 'creator_payout',
+        status: 'paid',
+        reason: null,
         resolvedAt: resolvedDate,
         stripeTransferId: 'tr_old',
       },
@@ -265,7 +267,9 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
         organizationId: orgId,
         subscriptionId,
         amountCents: 700,
-        reason: 'min_transfer_floor',
+        payoutType: 'creator_payout',
+        status: 'paid',
+        reason: null,
         resolvedAt: moreRecentResolvedDate,
         stripeTransferId: 'tr_new',
       },
@@ -274,6 +278,8 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
         organizationId: orgId,
         subscriptionId,
         amountCents: 250,
+        payoutType: 'creator_payout',
+        status: 'pending',
         reason: 'min_transfer_floor',
         resolvedAt: null,
       },
@@ -282,6 +288,8 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
         organizationId: orgId,
         subscriptionId,
         amountCents: 1000,
+        payoutType: 'creator_payout',
+        status: 'pending',
         reason: 'connect_not_ready',
         resolvedAt: null,
       },
@@ -313,11 +321,13 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
     // amount that MUST NOT leak into orgA's result.
     const subscriptionId = await seedActiveSubscription(orgB, creatorId);
 
-    await db.insert(pendingPayouts).values({
+    await db.insert(payouts).values({
       userId: creatorId,
       organizationId: orgB,
       subscriptionId,
       amountCents: 9999,
+      payoutType: 'creator_payout',
+      status: 'pending',
       reason: 'connect_not_ready',
       resolvedAt: null,
     });

--- a/packages/admin/src/__tests__/analytics-revenue-by-creator.integration.test.ts
+++ b/packages/admin/src/__tests__/analytics-revenue-by-creator.integration.test.ts
@@ -442,4 +442,74 @@ describe('AdminAnalyticsService.getRevenueByCreator (real DB)', () => {
     expect(result.items).toHaveLength(1);
     expect(result.items[0].totalRevenueCents).toBe(0);
   });
+
+  // ───────────────────────────────────────────────────────────────────
+  // F. pendingPayoutCents widening (Codex-bxpmu → Codex-e9v3b)
+  //
+  // The payouts ledger migration changed `pendingPayoutCents` from
+  // `resolvedAt IS NULL` to `status IN ('pending','failed')`. Failed
+  // payouts (status='failed', reason='transfer_failed') are now also
+  // surfaced in the admin revenue-by-creator view because they
+  // represent money the creator is owed but hasn't received — the
+  // platform owes them regardless of whether the failure was Connect
+  // not-ready (pending) or a Stripe transfer that hard-failed (failed).
+  // ───────────────────────────────────────────────────────────────────
+  it('pendingPayoutCents sums BOTH status=pending AND status=failed rows', async () => {
+    const { orgId, creators } = await seedScenario(1);
+    const [creatorId] = creators;
+
+    await db.insert(creatorOrganizationAgreements).values({
+      creatorId,
+      organizationId: orgId,
+      organizationFeePercentage: 10000,
+    });
+
+    const subscriptionId = await seedActiveSubscription(orgId, creatorId);
+
+    // Three rows under the widened predicate: one pending (legacy
+    // shape), one failed (new shape — surfaced by the widening), and
+    // one paid (terminal — MUST NOT contribute).
+    await db.insert(payouts).values([
+      {
+        userId: creatorId,
+        organizationId: orgId,
+        subscriptionId,
+        amountCents: 250,
+        payoutType: 'creator_payout',
+        status: 'pending',
+        reason: 'connect_not_ready',
+        resolvedAt: null,
+      },
+      {
+        userId: creatorId,
+        organizationId: orgId,
+        subscriptionId,
+        amountCents: 500,
+        payoutType: 'creator_payout',
+        status: 'failed',
+        reason: 'transfer_failed',
+        resolvedAt: null,
+      },
+      {
+        userId: creatorId,
+        organizationId: orgId,
+        subscriptionId,
+        amountCents: 9999,
+        payoutType: 'creator_payout',
+        status: 'paid',
+        reason: null,
+        resolvedAt: new Date('2026-04-01T00:00:00Z'),
+        stripeTransferId: 'tr_paid_excluded',
+      },
+    ]);
+
+    const result = await service.getRevenueByCreator(orgId);
+
+    expect(result.items).toHaveLength(1);
+    // 250 (pending) + 500 (failed) = 750. The 9999 paid row MUST NOT
+    // be summed (it's already disbursed). Regression on widening this
+    // back to `resolvedAt IS NULL` would also return 750 — but a
+    // regression that DROPS the failed shape would return 250.
+    expect(result.items[0].pendingPayoutCents).toBe(750);
+  });
 });

--- a/packages/admin/src/services/analytics-service.ts
+++ b/packages/admin/src/services/analytics-service.ts
@@ -1107,34 +1107,34 @@ export class AdminAnalyticsService extends BaseService {
             .groupBy(schema.content.creatorId),
           this.db
             .select({
-              creatorId: schema.pendingPayouts.userId,
+              creatorId: schema.payouts.userId,
               lastPayoutAt: sql<
                 string | null
-              >`MAX(${schema.pendingPayouts.resolvedAt})`,
+              >`MAX(${schema.payouts.resolvedAt})`,
             })
-            .from(schema.pendingPayouts)
+            .from(schema.payouts)
             .where(
               and(
-                eq(schema.pendingPayouts.organizationId, organizationId),
-                inArray(schema.pendingPayouts.userId, creatorIds),
-                sql`${schema.pendingPayouts.resolvedAt} IS NOT NULL`
+                eq(schema.payouts.organizationId, organizationId),
+                inArray(schema.payouts.userId, creatorIds),
+                eq(schema.payouts.status, 'paid')
               )
             )
-            .groupBy(schema.pendingPayouts.userId),
+            .groupBy(schema.payouts.userId),
           this.db
             .select({
-              creatorId: schema.pendingPayouts.userId,
-              pendingPayoutCents: sql<number>`COALESCE(SUM(${schema.pendingPayouts.amountCents}), 0)::int`,
+              creatorId: schema.payouts.userId,
+              pendingPayoutCents: sql<number>`COALESCE(SUM(${schema.payouts.amountCents}), 0)::int`,
             })
-            .from(schema.pendingPayouts)
+            .from(schema.payouts)
             .where(
               and(
-                eq(schema.pendingPayouts.organizationId, organizationId),
-                inArray(schema.pendingPayouts.userId, creatorIds),
-                isNull(schema.pendingPayouts.resolvedAt)
+                eq(schema.payouts.organizationId, organizationId),
+                inArray(schema.payouts.userId, creatorIds),
+                inArray(schema.payouts.status, ['pending', 'failed'])
               )
             )
-            .groupBy(schema.pendingPayouts.userId),
+            .groupBy(schema.payouts.userId),
         ]);
 
       const revenueByCreator = new Map(

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -278,11 +278,12 @@ export interface RevenueQueryOptions {
  *  - `splitPercent` is a display percentage (0..100), derived from the
  *    creator's CURRENT `organizationFeePercentage` basis points
  *    (`bps / 100`). It is the present DB value, not historical.
- *  - `lastPayoutAt` is the most-recent `pendingPayouts.resolvedAt` for the
- *    (creator, org) pair; `null` when nothing has drained yet.
- *  - `pendingPayoutCents` is the SUM of `amountCents` for unresolved
- *    `pendingPayouts` (where `resolvedAt IS NULL`) joined on BOTH
- *    `userId` AND `organizationId` — multi-org membership safety.
+ *  - `lastPayoutAt` is the most-recent `payouts.resolvedAt` for `status='paid'`
+ *    rows belonging to the (creator, org) pair; `null` when nothing has paid
+ *    out yet.
+ *  - `pendingPayoutCents` is the SUM of `amountCents` for `payouts` rows
+ *    where `status IN ('pending', 'failed')`, joined on BOTH `userId` AND
+ *    `organizationId` — multi-org membership safety.
  */
 export interface CreatorRevenueSplitItem {
   creatorId: string;

--- a/packages/database/src/migrations/0063_clumsy_karnak.sql
+++ b/packages/database/src/migrations/0063_clumsy_karnak.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "payouts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"subscription_id" uuid,
+	"stripe_charge_id" varchar(255),
+	"stripe_transfer_id" varchar(255),
+	"transfer_group" varchar(255),
+	"amount_cents" integer NOT NULL,
+	"currency" varchar(3) DEFAULT 'gbp' NOT NULL,
+	"payout_type" varchar(32) NOT NULL,
+	"status" varchar(16) NOT NULL,
+	"reason" varchar(32),
+	"attempted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"retry_count" integer DEFAULT 0 NOT NULL,
+	"last_retry_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "check_payouts_amount_positive" CHECK ("payouts"."amount_cents" > 0),
+	CONSTRAINT "check_payouts_status" CHECK ("payouts"."status" IN ('paid', 'pending', 'failed')),
+	CONSTRAINT "check_payouts_reason" CHECK ("payouts"."reason" IS NULL OR "payouts"."reason" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')),
+	CONSTRAINT "check_payouts_type" CHECK ("payouts"."payout_type" IN ('organization_fee', 'creator_payout', 'creator_payout_to_owner')),
+	CONSTRAINT "check_payouts_paid_invariant" CHECK (("payouts"."status" != 'paid') OR ("payouts"."stripe_transfer_id" IS NOT NULL AND "payouts"."resolved_at" IS NOT NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "payouts" ADD CONSTRAINT "payouts_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payouts" ADD CONSTRAINT "payouts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payouts" ADD CONSTRAINT "payouts_subscription_id_subscriptions_id_fk" FOREIGN KEY ("subscription_id") REFERENCES "public"."subscriptions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_payouts_stripe_transfer_id" ON "payouts" USING btree ("stripe_transfer_id") WHERE "payouts"."stripe_transfer_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_payouts_org_created" ON "payouts" USING btree ("organization_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_payouts_org_status_created" ON "payouts" USING btree ("organization_id","status","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_payouts_pending" ON "payouts" USING btree ("user_id","organization_id","attempted_at") WHERE "payouts"."status" = 'pending';--> statement-breakpoint
+CREATE INDEX "idx_payouts_user_org_created" ON "payouts" USING btree ("user_id","organization_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_payouts_subscription" ON "payouts" USING btree ("subscription_id");

--- a/packages/database/src/migrations/0064_migrate_pending_payouts_to_payouts.sql
+++ b/packages/database/src/migrations/0064_migrate_pending_payouts_to_payouts.sql
@@ -1,0 +1,65 @@
+-- Data migration: copy any existing `pending_payouts` rows into the new
+-- `payouts` ledger table introduced by 0063_clumsy_karnak.sql.
+--
+-- Mapping rules:
+--   - resolved_at IS NOT NULL AND stripe_transfer_id IS NOT NULL → status='paid'
+--   - reason='transfer_failed' (still unresolved)                → status='failed'
+--   - otherwise                                                  → status='pending'
+--
+-- `payoutType` cannot be recovered from old rows (the old schema did not
+-- distinguish org_fee vs creator_payout). We default to 'creator_payout'
+-- because that is the dominant historical case; the small number of
+-- mis-typed rows surfaces only in UI counts, not money flow.
+--
+-- Idempotency: we filter out rows whose `stripe_transfer_id` already exists
+-- in `payouts` (the unique partial index catches the rest). For pending
+-- rows (which have null `stripe_transfer_id`), we additionally key on
+-- pending_payouts.id stored verbatim in payouts.id, so re-running this
+-- migration is a no-op.
+
+INSERT INTO "payouts" (
+  id,
+  organization_id,
+  user_id,
+  subscription_id,
+  stripe_transfer_id,
+  amount_cents,
+  currency,
+  payout_type,
+  status,
+  reason,
+  attempted_at,
+  resolved_at,
+  created_at,
+  updated_at
+)
+SELECT
+  pp.id,
+  pp.organization_id,
+  pp.user_id,
+  pp.subscription_id,
+  pp.stripe_transfer_id,
+  pp.amount_cents,
+  pp.currency,
+  'creator_payout' AS payout_type,
+  CASE
+    WHEN pp.resolved_at IS NOT NULL AND pp.stripe_transfer_id IS NOT NULL
+      THEN 'paid'
+    WHEN pp.reason = 'transfer_failed'
+      THEN 'failed'
+    ELSE 'pending'
+  END AS status,
+  CASE
+    -- Paid rows have no reason in the new model
+    WHEN pp.resolved_at IS NOT NULL AND pp.stripe_transfer_id IS NOT NULL
+      THEN NULL
+    ELSE pp.reason
+  END AS reason,
+  pp.created_at AS attempted_at,
+  pp.resolved_at,
+  pp.created_at,
+  pp.created_at AS updated_at
+FROM "pending_payouts" pp
+WHERE NOT EXISTS (
+  SELECT 1 FROM "payouts" p WHERE p.id = pp.id
+);

--- a/packages/database/src/migrations/meta/0063_snapshot.json
+++ b/packages/database/src/migrations/meta/0063_snapshot.json
@@ -1,0 +1,5989 @@
+{
+  "id": "8b37c91e-68fb-410e-a2ea-91a87ea172d9",
+  "prevId": "33526fc3-c4d6-4fbb-95bd-ea97c4b21b41",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_username": {
+          "name": "idx_unique_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_users_stripe_customer_id": {
+          "name": "idx_unique_users_stripe_customer_id",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"stripe_customer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body": {
+          "name": "content_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body_json": {
+          "name": "content_body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "shader_preset": {
+          "name": "shader_preset",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shader_config": {
+          "name": "shader_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_tier_id": {
+          "name": "minimum_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_creator_id": {
+          "name": "idx_content_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_organization_id": {
+          "name": "idx_content_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_media_item_id": {
+          "name": "idx_content_media_item_id",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_slug_org": {
+          "name": "idx_content_slug_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_status": {
+          "name": "idx_content_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_published_at": {
+          "name": "idx_content_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_category": {
+          "name": "idx_content_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_minimum_tier": {
+          "name": "idx_content_minimum_tier",
+          "columns": [
+            {
+              "expression": "minimum_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_published": {
+          "name": "idx_content_org_published",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_creator_org_published": {
+          "name": "idx_content_creator_org_published",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_featured": {
+          "name": "idx_content_org_featured",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"featured\" = true AND \"content\".\"status\" = 'published' AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_per_org": {
+          "name": "idx_unique_content_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NOT NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_personal": {
+          "name": "idx_unique_content_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_type": {
+          "name": "idx_content_access_type",
+          "columns": [
+            {
+              "expression": "access_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_creator_id_users_id_fk": {
+          "name": "content_creator_id_users_id_fk",
+          "tableFrom": "content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_organization_id_organizations_id_fk": {
+          "name": "content_organization_id_organizations_id_fk",
+          "tableFrom": "content",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_media_item_id_media_items_id_fk": {
+          "name": "content_media_item_id_media_items_id_fk",
+          "tableFrom": "content",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_minimum_tier_id_subscription_tiers_id_fk": {
+          "name": "content_minimum_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "content",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "minimum_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_content_status": {
+          "name": "check_content_status",
+          "value": "\"content\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_content_access_type": {
+          "name": "check_content_access_type",
+          "value": "\"content\".\"access_type\" IN ('free', 'paid', 'followers', 'subscribers', 'team')"
+        },
+        "check_content_type": {
+          "name": "check_content_type",
+          "value": "\"content\".\"content_type\" IN ('video', 'audio', 'written')"
+        },
+        "check_price_non_negative": {
+          "name": "check_price_non_negative",
+          "value": "\"content\".\"price_cents\" IS NULL OR \"content\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_master_playlist_key": {
+          "name": "hls_master_playlist_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_preview_key": {
+          "name": "hls_preview_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_key": {
+          "name": "waveform_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_image_key": {
+          "name": "waveform_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runpod_job_id": {
+          "name": "runpod_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_error": {
+          "name": "transcoding_error",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_attempts": {
+          "name": "transcoding_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transcoding_priority": {
+          "name": "transcoding_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "transcoding_progress": {
+          "name": "transcoding_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_step": {
+          "name": "transcoding_step",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_key": {
+          "name": "mezzanine_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_status": {
+          "name": "mezzanine_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_variants": {
+          "name": "ready_variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_integrated": {
+          "name": "loudness_integrated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_peak": {
+          "name": "loudness_peak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_range": {
+          "name": "loudness_range",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_creator_id": {
+          "name": "idx_media_items_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_status": {
+          "name": "idx_media_items_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_type": {
+          "name": "idx_media_items_type",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_runpod_job_id": {
+          "name": "idx_media_items_runpod_job_id",
+          "columns": [
+            {
+              "expression": "runpod_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_transcoding_status": {
+          "name": "idx_media_items_transcoding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcoding_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_items_creator_id_users_id_fk": {
+          "name": "media_items_creator_id_users_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_media_status": {
+          "name": "check_media_status",
+          "value": "\"media_items\".\"status\" IN ('uploading', 'uploaded', 'transcoding', 'ready', 'failed')"
+        },
+        "check_media_type": {
+          "name": "check_media_type",
+          "value": "\"media_items\".\"media_type\" IN ('video', 'audio')"
+        },
+        "check_mezzanine_status": {
+          "name": "check_mezzanine_status",
+          "value": "\"media_items\".\"mezzanine_status\" IS NULL OR \"media_items\".\"mezzanine_status\" IN ('pending', 'processing', 'ready', 'failed')"
+        },
+        "check_transcoding_priority": {
+          "name": "check_transcoding_priority",
+          "value": "\"media_items\".\"transcoding_priority\" >= 0 AND \"media_items\".\"transcoding_priority\" <= 4"
+        },
+        "check_max_transcoding_attempts": {
+          "name": "check_max_transcoding_attempts",
+          "value": "\"media_items\".\"transcoding_attempts\" >= 0 AND \"media_items\".\"transcoding_attempts\" <= 3"
+        },
+        "check_transcoding_progress_range": {
+          "name": "check_transcoding_progress_range",
+          "value": "\"media_items\".\"transcoding_progress\" IS NULL OR (\"media_items\".\"transcoding_progress\" >= 0 AND \"media_items\".\"transcoding_progress\" <= 100)"
+        },
+        "status_ready_requires_keys": {
+          "name": "status_ready_requires_keys",
+          "value": "\"media_items\".\"status\" != 'ready' OR (\n        \"media_items\".\"hls_master_playlist_key\" IS NOT NULL\n        AND \"media_items\".\"duration_seconds\" IS NOT NULL\n        AND (\n          (\"media_items\".\"media_type\" = 'video' AND \"media_items\".\"thumbnail_key\" IS NOT NULL)\n          OR (\"media_items\".\"media_type\" = 'audio' AND \"media_items\".\"waveform_key\" IS NOT NULL)\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_membership": {
+          "name": "idx_unique_org_membership",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_id": {
+          "name": "idx_org_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_user_id": {
+          "name": "idx_org_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_role": {
+          "name": "idx_org_memberships_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_status": {
+          "name": "idx_org_memberships_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_active_role": {
+          "name": "idx_org_memberships_org_active_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organization_memberships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_membership_role": {
+          "name": "check_membership_role",
+          "value": "\"organization_memberships\".\"role\" IN ('owner', 'admin', 'creator', 'subscriber', 'member')"
+        },
+        "check_membership_status": {
+          "name": "check_membership_status",
+          "value": "\"organization_memberships\".\"status\" IN ('active', 'inactive', 'invited')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_access": {
+      "name": "content_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_access_user_id": {
+          "name": "idx_content_access_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_content_id": {
+          "name": "idx_content_access_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_organization_id": {
+          "name": "idx_content_access_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_access_user_id_users_id_fk": {
+          "name": "content_access_user_id_users_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_content_id_content_id_fk": {
+          "name": "content_access_content_id_content_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_organization_id_organizations_id_fk": {
+          "name": "content_access_organization_id_organizations_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_access_user_content_unique": {
+          "name": "content_access_user_content_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_access_type": {
+          "name": "check_access_type",
+          "value": "\"content_access\".\"access_type\" IN ('purchased', 'subscription', 'complimentary', 'preview')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_organization_agreements": {
+      "name": "creator_organization_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_fee_percentage": {
+          "name": "organization_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_creator_org_agreement_creator_id": {
+          "name": "idx_creator_org_agreement_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_org_id": {
+          "name": "idx_creator_org_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_effective": {
+          "name": "idx_creator_org_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_organization_agreements_creator_id_users_id_fk": {
+          "name": "creator_organization_agreements_creator_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_organization_id_organizations_id_fk": {
+          "name": "creator_organization_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "creator_org_agreement_unique": {
+          "name": "creator_org_agreement_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "organization_id",
+            "effective_from"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_org_fee_percentage": {
+          "name": "check_org_fee_percentage",
+          "value": "\"creator_organization_agreements\".\"organization_fee_percentage\" >= 0 AND \"creator_organization_agreements\".\"organization_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_platform_agreements": {
+      "name": "organization_platform_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_platform_agreement_org_id": {
+          "name": "idx_org_platform_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_platform_agreement_effective": {
+          "name": "idx_org_platform_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_platform_agreements_organization_id_organizations_id_fk": {
+          "name": "organization_platform_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "organization_platform_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percentage": {
+          "name": "check_org_platform_fee_percentage",
+          "value": "\"organization_platform_agreements\".\"platform_fee_percentage\" >= 0 AND \"organization_platform_agreements\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_fee_config": {
+      "name": "platform_fee_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_fee_config_effective": {
+          "name": "idx_platform_fee_config_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_platform_fee_percentage": {
+          "name": "check_platform_fee_percentage",
+          "value": "\"platform_fee_config\".\"platform_fee_percentage\" >= 0 AND \"platform_fee_config\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platform_agreement_id": {
+          "name": "platform_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_org_agreement_id": {
+          "name": "creator_org_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount_cents": {
+          "name": "refund_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispute_reason": {
+          "name": "dispute_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_dispute_id": {
+          "name": "stripe_dispute_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_purchases_customer_id": {
+          "name": "idx_purchases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_content_id": {
+          "name": "idx_purchases_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_organization_id": {
+          "name": "idx_purchases_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_stripe_payment_intent": {
+          "name": "idx_purchases_stripe_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_created_at": {
+          "name": "idx_purchases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_purchased_at": {
+          "name": "idx_purchases_purchased_at",
+          "columns": [
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_platform_agreement": {
+          "name": "idx_purchases_platform_agreement",
+          "columns": [
+            {
+              "expression": "platform_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_creator_org_agreement": {
+          "name": "idx_purchases_creator_org_agreement",
+          "columns": [
+            {
+              "expression": "creator_org_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_purchased": {
+          "name": "idx_purchases_customer_purchased",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_status_content": {
+          "name": "idx_purchases_customer_status_content",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_created": {
+          "name": "idx_purchases_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_purchased": {
+          "name": "idx_purchases_org_status_purchased",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "purchases_customer_id_users_id_fk": {
+          "name": "purchases_customer_id_users_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchases_content_id_content_id_fk": {
+          "name": "purchases_content_id_content_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_organization_id_organizations_id_fk": {
+          "name": "purchases_organization_id_organizations_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_platform_agreement_id_organization_platform_agreements_id_fk": {
+          "name": "purchases_platform_agreement_id_organization_platform_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organization_platform_agreements",
+          "columnsFrom": [
+            "platform_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk": {
+          "name": "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "creator_organization_agreements",
+          "columnsFrom": [
+            "creator_org_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchases_stripe_payment_intent_id_unique": {
+          "name": "purchases_stripe_payment_intent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_payment_intent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_purchase_status": {
+          "name": "check_purchase_status",
+          "value": "\"purchases\".\"status\" IN ('pending', 'completed', 'refunded', 'failed')"
+        },
+        "check_amount_positive": {
+          "name": "check_amount_positive",
+          "value": "\"purchases\".\"amount_paid_cents\" >= 0"
+        },
+        "check_platform_fee_positive": {
+          "name": "check_platform_fee_positive",
+          "value": "\"purchases\".\"platform_fee_cents\" >= 0"
+        },
+        "check_org_fee_positive": {
+          "name": "check_org_fee_positive",
+          "value": "\"purchases\".\"organization_fee_cents\" >= 0"
+        },
+        "check_creator_payout_positive": {
+          "name": "check_creator_payout_positive",
+          "value": "\"purchases\".\"creator_payout_cents\" >= 0"
+        },
+        "check_revenue_split_equals_total": {
+          "name": "check_revenue_split_equals_total",
+          "value": "\"purchases\".\"amount_paid_cents\" = \"purchases\".\"platform_fee_cents\" + \"purchases\".\"organization_fee_cents\" + \"purchases\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_audit_log": {
+      "name": "fee_config_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_creator_id": {
+          "name": "scope_creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_config_audit_scope": {
+          "name": "idx_fee_config_audit_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_org": {
+          "name": "idx_fee_config_audit_org",
+          "columns": [
+            {
+              "expression": "scope_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_creator": {
+          "name": "idx_fee_config_audit_creator",
+          "columns": [
+            {
+              "expression": "scope_creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_changed_by": {
+          "name": "idx_fee_config_audit_changed_by",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_audit_log_scope_org_id_organizations_id_fk": {
+          "name": "fee_config_audit_log_scope_org_id_organizations_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "scope_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_scope_creator_id_users_id_fk": {
+          "name": "fee_config_audit_log_scope_creator_id_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scope_creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_changed_by_users_id_fk": {
+          "name": "fee_config_audit_log_changed_by_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_audit_scope": {
+          "name": "check_fee_config_audit_scope",
+          "value": "\"fee_config_audit_log\".\"scope\" IN ('platform', 'org', 'override')"
+        },
+        "check_fee_config_audit_scope_org_id": {
+          "name": "check_fee_config_audit_scope_org_id",
+          "value": "(\"fee_config_audit_log\".\"scope\" = 'platform' AND \"fee_config_audit_log\".\"scope_org_id\" IS NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'org' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'override' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org": {
+      "name": "fee_config_org",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_org_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_updated_by_users_id_fk": {
+          "name": "fee_config_org_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percent_bps": {
+          "name": "check_org_platform_fee_percent_bps",
+          "value": "\"fee_config_org\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org\".\"platform_fee_percent\" >= 0 AND \"fee_config_org\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_org_org_fee_percent_bps": {
+          "name": "check_org_org_fee_percent_bps",
+          "value": "\"fee_config_org\".\"org_fee_percent\" IS NULL OR (\"fee_config_org\".\"org_fee_percent\" >= 0 AND \"fee_config_org\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_org_min_platform_fee_non_negative": {
+          "name": "check_org_min_platform_fee_non_negative",
+          "value": "\"fee_config_org\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_org_min_transfer_non_negative": {
+          "name": "check_org_min_transfer_non_negative",
+          "value": "\"fee_config_org\".\"min_transfer_cents\" IS NULL OR \"fee_config_org\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org_creator": {
+      "name": "fee_config_org_creator",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fee_config_org_creator_org": {
+          "name": "idx_fee_config_org_creator_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_org_creator_creator": {
+          "name": "idx_fee_config_org_creator_creator",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_org_creator_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_creator_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_creator_id_users_id_fk": {
+          "name": "fee_config_org_creator_creator_id_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_updated_by_users_id_fk": {
+          "name": "fee_config_org_creator_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fee_config_org_creator_pkey": {
+          "name": "fee_config_org_creator_pkey",
+          "columns": [
+            "organization_id",
+            "creator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_override_platform_fee_percent_bps": {
+          "name": "check_override_platform_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"platform_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_override_org_fee_percent_bps": {
+          "name": "check_override_org_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"org_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"org_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_override_min_platform_fee_non_negative": {
+          "name": "check_override_min_platform_fee_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org_creator\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_override_min_transfer_non_negative": {
+          "name": "check_override_min_transfer_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_transfer_cents\" IS NULL OR \"fee_config_org_creator\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_platform": {
+      "name": "fee_config_platform",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_org_fee_percent": {
+          "name": "subscription_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "one_off_org_fee_percent": {
+          "name": "one_off_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_platform_updated_by_users_id_fk": {
+          "name": "fee_config_platform_updated_by_users_id_fk",
+          "tableFrom": "fee_config_platform",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_platform_singleton": {
+          "name": "check_fee_config_platform_singleton",
+          "value": "\"fee_config_platform\".\"id\" = 'singleton'"
+        },
+        "check_platform_fee_percent_bps": {
+          "name": "check_platform_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"platform_fee_percent\" >= 0 AND \"fee_config_platform\".\"platform_fee_percent\" <= 10000"
+        },
+        "check_subscription_org_fee_percent_bps": {
+          "name": "check_subscription_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"subscription_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"subscription_org_fee_percent\" <= 10000"
+        },
+        "check_one_off_org_fee_percent_bps": {
+          "name": "check_one_off_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"one_off_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"one_off_org_fee_percent\" <= 10000"
+        },
+        "check_min_platform_fee_non_negative": {
+          "name": "check_min_platform_fee_non_negative",
+          "value": "\"fee_config_platform\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_min_transfer_non_negative": {
+          "name": "check_min_transfer_non_negative",
+          "value": "\"fee_config_platform\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_followers": {
+      "name": "organization_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_follower": {
+          "name": "idx_unique_org_follower",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_org": {
+          "name": "idx_org_followers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_user": {
+          "name": "idx_org_followers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_followers_organization_id_organizations_id_fk": {
+          "name": "organization_followers_organization_id_organizations_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_followers_user_id_users_id_fk": {
+          "name": "organization_followers_user_id_users_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_audit_logs": {
+      "name": "email_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "email_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_audit_logs_organization_id_organizations_id_fk": {
+          "name": "email_audit_logs_organization_id_organizations_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_audit_logs_creator_id_users_id_fk": {
+          "name": "email_audit_logs_creator_id_users_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "template_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_templates_org_id": {
+          "name": "idx_email_templates_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_creator_id": {
+          "name": "idx_email_templates_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_scope": {
+          "name": "idx_email_templates_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_status": {
+          "name": "idx_email_templates_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_global": {
+          "name": "idx_unique_template_global",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'global' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_org": {
+          "name": "idx_unique_template_org",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'organization' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_creator": {
+          "name": "idx_unique_template_creator",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'creator' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_org_scope": {
+          "name": "idx_templates_org_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_creator_scope": {
+          "name": "idx_templates_creator_scope",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_created_by_deleted_at": {
+          "name": "idx_templates_created_by_deleted_at",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope_deleted_at": {
+          "name": "idx_templates_status_scope_deleted_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope": {
+          "name": "idx_templates_status_scope",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_active": {
+          "name": "idx_templates_active",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_template_lookup": {
+          "name": "idx_template_lookup",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_organization_id_organizations_id_fk": {
+          "name": "email_templates_organization_id_organizations_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_creator_id_users_id_fk": {
+          "name": "email_templates_creator_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_created_by_users_id_fk": {
+          "name": "email_templates_created_by_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "global_scope_no_owners": {
+          "name": "global_scope_no_owners",
+          "value": "\"email_templates\".\"scope\" != 'global' OR (\"email_templates\".\"organization_id\" IS NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "org_scope_requires_org": {
+          "name": "org_scope_requires_org",
+          "value": "\"email_templates\".\"scope\" != 'organization' OR (\"email_templates\".\"organization_id\" IS NOT NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "creator_scope_requires_creator": {
+          "name": "creator_scope_requires_creator",
+          "value": "\"email_templates\".\"scope\" != 'creator' OR \"email_templates\".\"creator_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_marketing": {
+          "name": "email_marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_transactional": {
+          "name": "email_transactional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_digest": {
+          "name": "email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_connect_account_user_id": {
+          "name": "primary_connect_account_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_slug": {
+          "name": "idx_organizations_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_org_slug": {
+          "name": "idx_unique_org_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_primary_connect_account_user_id_users_id_fk": {
+          "name": "organizations_primary_connect_account_user_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_connect_account_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payouts": {
+      "name": "payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group": {
+          "name": "transfer_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "payout_type": {
+          "name": "payout_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payouts_stripe_transfer_id": {
+          "name": "uq_payouts_stripe_transfer_id",
+          "columns": [
+            {
+              "expression": "stripe_transfer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"stripe_transfer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_created": {
+          "name": "idx_payouts_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_status_created": {
+          "name": "idx_payouts_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_pending": {
+          "name": "idx_payouts_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payouts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_user_org_created": {
+          "name": "idx_payouts_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_subscription": {
+          "name": "idx_payouts_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payouts_organization_id_organizations_id_fk": {
+          "name": "payouts_organization_id_organizations_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_user_id_users_id_fk": {
+          "name": "payouts_user_id_users_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_subscription_id_subscriptions_id_fk": {
+          "name": "payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_payouts_amount_positive": {
+          "name": "check_payouts_amount_positive",
+          "value": "\"payouts\".\"amount_cents\" > 0"
+        },
+        "check_payouts_status": {
+          "name": "check_payouts_status",
+          "value": "\"payouts\".\"status\" IN ('paid', 'pending', 'failed')"
+        },
+        "check_payouts_reason": {
+          "name": "check_payouts_reason",
+          "value": "\"payouts\".\"reason\" IS NULL OR \"payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        },
+        "check_payouts_type": {
+          "name": "check_payouts_type",
+          "value": "\"payouts\".\"payout_type\" IN ('organization_fee', 'creator_payout', 'creator_payout_to_owner')"
+        },
+        "check_payouts_paid_invariant": {
+          "name": "check_payouts_paid_invariant",
+          "value": "(\"payouts\".\"status\" != 'paid') OR (\"payouts\".\"stripe_transfer_id\" IS NOT NULL AND \"payouts\".\"resolved_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.video_playback": {
+      "name": "video_playback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_video_playback_user_id": {
+          "name": "idx_video_playback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_video_playback_content_id": {
+          "name": "idx_video_playback_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_playback_user_id_users_id_fk": {
+          "name": "video_playback_user_id_users_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_playback_content_id_content_id_fk": {
+          "name": "video_playback_content_id_content_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_playback_user_id_content_id_unique": {
+          "name": "video_playback_user_id_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.branding_settings": {
+      "name": "branding_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_r2_path": {
+          "name": "logo_r2_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color_hex": {
+          "name": "primary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "secondary_color_hex": {
+          "name": "secondary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color_hex": {
+          "name": "accent_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_color_hex": {
+          "name": "background_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_body": {
+          "name": "font_body",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_heading": {
+          "name": "font_heading",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_value": {
+          "name": "radius_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "density_value": {
+          "name": "density_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "intro_video_media_item_id": {
+          "name": "intro_video_media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_url": {
+          "name": "intro_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_overrides": {
+          "name": "token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_mode_overrides": {
+          "name": "dark_mode_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_token_overrides": {
+          "name": "dark_token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_layout": {
+          "name": "hero_layout",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "pricing_faq": {
+          "name": "pricing_faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "branding_settings_updated_at_idx": {
+          "name": "branding_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branding_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "branding_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branding_settings_intro_video_media_item_id_media_items_id_fk": {
+          "name": "branding_settings_intro_video_media_item_id_media_items_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_settings": {
+      "name": "contact_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Codex Platform'"
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'support@example.com'"
+        },
+        "contact_url": {
+          "name": "contact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "twitter_url": {
+          "name": "twitter_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok_url": {
+          "name": "tiktok_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_settings_updated_at_idx": {
+          "name": "contact_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "contact_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "contact_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_settings": {
+      "name": "feature_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enable_signups": {
+          "name": "enable_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_purchases": {
+          "name": "enable_purchases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_subscriptions": {
+          "name": "enable_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_settings_updated_at_idx": {
+          "name": "feature_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "feature_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "feature_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_settings": {
+      "name": "platform_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_settings_updated_at_idx": {
+          "name": "platform_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_settings_organization_id_organizations_id_fk": {
+          "name": "platform_settings_organization_id_organizations_id_fk",
+          "tableFrom": "platform_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orphaned_image_files": {
+      "name": "orphaned_image_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_entity_id": {
+          "name": "original_entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_entity_type": {
+          "name": "original_entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orphaned_files_status": {
+          "name": "idx_orphaned_files_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_orphaned_at": {
+          "name": "idx_orphaned_files_orphaned_at",
+          "columns": [
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_type_status": {
+          "name": "idx_orphaned_files_type_status",
+          "columns": [
+            {
+              "expression": "image_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_pending_cleanup": {
+          "name": "idx_orphaned_files_pending_cleanup",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_image_type": {
+          "name": "check_image_type",
+          "value": "\"orphaned_image_files\".\"image_type\" IN ('avatar', 'logo', 'content_thumbnail', 'transcoding_artifact')"
+        },
+        "check_entity_type": {
+          "name": "check_entity_type",
+          "value": "\"orphaned_image_files\".\"original_entity_type\" IS NULL OR \"orphaned_image_files\".\"original_entity_type\" IN ('user', 'organization', 'content', 'media_item')"
+        },
+        "check_orphan_status": {
+          "name": "check_orphan_status",
+          "value": "\"orphaned_image_files\".\"status\" IN ('pending', 'deleted', 'failed', 'retained')"
+        },
+        "check_cleanup_attempts": {
+          "name": "check_cleanup_attempts",
+          "value": "\"orphaned_image_files\".\"cleanup_attempts\" >= 0 AND \"orphaned_image_files\".\"cleanup_attempts\" <= 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_payouts": {
+      "name": "pending_payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_payouts_user_id": {
+          "name": "idx_pending_payouts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_org_id": {
+          "name": "idx_pending_payouts_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_unresolved": {
+          "name": "idx_pending_payouts_unresolved",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_payouts_user_id_users_id_fk": {
+          "name": "pending_payouts_user_id_users_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_organization_id_organizations_id_fk": {
+          "name": "pending_payouts_organization_id_organizations_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_subscription_id_subscriptions_id_fk": {
+          "name": "pending_payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_pending_payout_positive": {
+          "name": "check_pending_payout_positive",
+          "value": "\"pending_payouts\".\"amount_cents\" > 0"
+        },
+        "check_pending_payout_reason": {
+          "name": "check_pending_payout_reason",
+          "value": "\"pending_payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stripe_connect_accounts": {
+      "name": "stripe_connect_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_connect_org_id": {
+          "name": "idx_stripe_connect_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_connect_user_id": {
+          "name": "idx_stripe_connect_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_connect_stripe_id": {
+          "name": "idx_stripe_connect_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_connect_accounts_organization_id_organizations_id_fk": {
+          "name": "stripe_connect_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stripe_connect_accounts_user_id_users_id_fk": {
+          "name": "stripe_connect_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_connect_accounts_stripe_account_id_unique": {
+          "name": "stripe_connect_accounts_stripe_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_account_id"
+          ]
+        },
+        "uq_stripe_connect_user_org": {
+          "name": "uq_stripe_connect_user_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_connect_status": {
+          "name": "check_connect_status",
+          "value": "\"stripe_connect_accounts\".\"status\" IN ('onboarding', 'active', 'restricted', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_org_id": {
+          "name": "idx_subscription_tiers_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_tiers_org_active": {
+          "name": "idx_subscription_tiers_org_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_org_sort": {
+          "name": "uq_subscription_tiers_org_sort",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_tiers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_tiers_organization_id_organizations_id_fk": {
+          "name": "subscription_tiers_organization_id_organizations_id_fk",
+          "tableFrom": "subscription_tiers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_tier_price_monthly_positive": {
+          "name": "check_tier_price_monthly_positive",
+          "value": "\"subscription_tiers\".\"price_monthly\" >= 0"
+        },
+        "check_tier_price_annual_positive": {
+          "name": "check_tier_price_annual_positive",
+          "value": "\"subscription_tiers\".\"price_annual\" >= 0"
+        },
+        "check_tier_sort_order_positive": {
+          "name": "check_tier_sort_order_positive",
+          "value": "\"subscription_tiers\".\"sort_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_reason": {
+          "name": "churn_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_user_id": {
+          "name": "idx_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_id": {
+          "name": "idx_subscriptions_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_tier_id": {
+          "name": "idx_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_stripe_id": {
+          "name": "idx_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_status": {
+          "name": "idx_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user_org": {
+          "name": "idx_subscriptions_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_subscription_per_user_org": {
+          "name": "uq_active_subscription_per_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_subscription_status": {
+          "name": "check_subscription_status",
+          "value": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_billing_interval": {
+          "name": "check_billing_interval",
+          "value": "\"subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        },
+        "check_churn_reason": {
+          "name": "check_churn_reason",
+          "value": "\"subscriptions\".\"churn_reason\" IS NULL OR \"subscriptions\".\"churn_reason\" IN ('too_expensive', 'not_enough_content', 'found_alternative', 'not_using_it', 'technical_issues', 'other')"
+        },
+        "check_sub_amount_positive": {
+          "name": "check_sub_amount_positive",
+          "value": "\"subscriptions\".\"amount_cents\" >= 0"
+        },
+        "check_sub_platform_fee_positive": {
+          "name": "check_sub_platform_fee_positive",
+          "value": "\"subscriptions\".\"platform_fee_cents\" >= 0"
+        },
+        "check_sub_org_fee_positive": {
+          "name": "check_sub_org_fee_positive",
+          "value": "\"subscriptions\".\"organization_fee_cents\" >= 0"
+        },
+        "check_sub_creator_payout_positive": {
+          "name": "check_sub_creator_payout_positive",
+          "value": "\"subscriptions\".\"creator_payout_cents\" >= 0"
+        },
+        "check_sub_revenue_split_equals_total": {
+          "name": "check_sub_revenue_split_equals_total",
+          "value": "\"subscriptions\".\"amount_cents\" = \"subscriptions\".\"platform_fee_cents\" + \"subscriptions\".\"organization_fee_cents\" + \"subscriptions\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_table": {
+      "name": "test_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_table_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.email_send_status": {
+      "name": "email_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.template_scope": {
+      "name": "template_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "organization",
+        "creator"
+      ]
+    },
+    "public.template_status": {
+      "name": "template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1778669734176,
       "tag": "0062_romantic_purifiers",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1778764209416,
+      "tag": "0063_clumsy_karnak",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1778764209416,
       "tag": "0063_clumsy_karnak",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1778764800000,
+      "tag": "0064_migrate_pending_payouts_to_payouts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -11,6 +11,7 @@ export * from './fee-config';
 export * from './followers';
 export * from './notifications';
 export * from './organizations';
+export * from './payouts';
 export * from './playback';
 export * from './settings';
 export * from './storage';

--- a/packages/database/src/schema/payouts.ts
+++ b/packages/database/src/schema/payouts.ts
@@ -1,0 +1,154 @@
+import { relations, sql } from 'drizzle-orm';
+import {
+  check,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { organizations } from './organizations';
+import { subscriptions } from './subscriptions';
+import { users } from './users';
+
+/**
+ * Payouts — full ledger of every transfer event (paid, pending, failed)
+ *
+ * Replaces the misnamed `pending_payouts` table (which was actually an
+ * exception queue, not a ledger). Every call to `stripe.transfers.create()`
+ * inside `executeTransfers` writes a row here — successes with `status='paid'`
+ * and a populated `stripe_transfer_id`, failures/deferrals with
+ * `status='pending'` or `'failed'` and a reason.
+ *
+ * `pending_payouts` remains in the schema for one release cycle while data
+ * migrates; it receives no new inserts after this PR. See
+ * `docs/payouts/payout-pipeline.md` for the full lifecycle.
+ */
+export const payouts = pgTable(
+  'payouts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    organizationId: uuid('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    subscriptionId: uuid('subscription_id').references(() => subscriptions.id, {
+      onDelete: 'set null',
+    }),
+
+    // Stripe correlation
+    stripeChargeId: varchar('stripe_charge_id', { length: 255 }),
+    stripeTransferId: varchar('stripe_transfer_id', { length: 255 }),
+    transferGroup: varchar('transfer_group', { length: 255 }),
+
+    // Money
+    amountCents: integer('amount_cents').notNull(),
+    currency: varchar('currency', { length: 3 }).notNull().default('gbp'),
+
+    // 'organization_fee' | 'creator_payout' | 'creator_payout_to_owner'
+    payoutType: varchar('payout_type', { length: 32 }).notNull(),
+
+    // 'paid' | 'pending' | 'failed'
+    status: varchar('status', { length: 16 }).notNull(),
+
+    // null for paid; one of the failure/deferral reasons otherwise
+    reason: varchar('reason', { length: 32 }),
+
+    attemptedAt: timestamp('attempted_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+    retryCount: integer('retry_count').notNull().default(0),
+    lastRetryAt: timestamp('last_retry_at', { withTimezone: true }),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex('uq_payouts_stripe_transfer_id')
+      .on(table.stripeTransferId)
+      .where(sql`${table.stripeTransferId} IS NOT NULL`),
+
+    index('idx_payouts_org_created').on(
+      table.organizationId,
+      table.createdAt.desc()
+    ),
+    index('idx_payouts_org_status_created').on(
+      table.organizationId,
+      table.status,
+      table.createdAt.desc()
+    ),
+    index('idx_payouts_pending')
+      .on(table.userId, table.organizationId, table.attemptedAt)
+      .where(sql`${table.status} = 'pending'`),
+    index('idx_payouts_user_org_created').on(
+      table.userId,
+      table.organizationId,
+      table.createdAt.desc()
+    ),
+    index('idx_payouts_subscription').on(table.subscriptionId),
+
+    check('check_payouts_amount_positive', sql`${table.amountCents} > 0`),
+    check(
+      'check_payouts_status',
+      sql`${table.status} IN ('paid', 'pending', 'failed')`
+    ),
+    check(
+      'check_payouts_reason',
+      sql`${table.reason} IS NULL OR ${table.reason} IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')`
+    ),
+    check(
+      'check_payouts_type',
+      sql`${table.payoutType} IN ('organization_fee', 'creator_payout', 'creator_payout_to_owner')`
+    ),
+    // Invariant: a paid row must carry a stripe_transfer_id and resolved_at.
+    // Catches accidental success-path inserts that forget to record the
+    // Stripe correlation — without this, "paid" rows could exist with no
+    // proof Stripe ever moved the money.
+    check(
+      'check_payouts_paid_invariant',
+      sql`(${table.status} != 'paid') OR (${table.stripeTransferId} IS NOT NULL AND ${table.resolvedAt} IS NOT NULL)`
+    ),
+  ]
+);
+
+export const payoutsRelations = relations(payouts, ({ one }) => ({
+  user: one(users, {
+    fields: [payouts.userId],
+    references: [users.id],
+  }),
+  organization: one(organizations, {
+    fields: [payouts.organizationId],
+    references: [organizations.id],
+  }),
+  subscription: one(subscriptions, {
+    fields: [payouts.subscriptionId],
+    references: [subscriptions.id],
+  }),
+}));
+
+export type Payout = typeof payouts.$inferSelect;
+export type NewPayout = typeof payouts.$inferInsert;
+
+export type PayoutStatus = 'paid' | 'pending' | 'failed';
+export type PayoutReason =
+  | 'connect_not_ready'
+  | 'connect_restricted'
+  | 'transfer_failed'
+  | 'min_transfer_floor';
+export type PayoutType =
+  | 'organization_fee'
+  | 'creator_payout'
+  | 'creator_payout_to_owner';

--- a/packages/subscription/src/services/__tests__/subscription-service-fee-config.integration.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service-fee-config.integration.test.ts
@@ -18,7 +18,7 @@
 
 import {
   organizations,
-  pendingPayouts as pendingPayoutsTable,
+  payouts as payoutsTable,
   stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
@@ -35,7 +35,7 @@ import {
   teardownTestDatabase,
   validateDatabaseConnection,
 } from '@codex/test-utils';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import {
   afterAll,
@@ -159,7 +159,7 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
 
     // Seed one payout BELOW the floor.
     const [row] = await db
-      .insert(pendingPayoutsTable)
+      .insert(payoutsTable)
       .values({
         userId: payoutUserId,
         organizationId: org.id,
@@ -167,6 +167,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
         amountCents: 50,
         currency: 'gbp',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       })
       .returning();
 
@@ -181,8 +183,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
 
     const [reread] = await db
       .select()
-      .from(pendingPayoutsTable)
-      .where(eq(pendingPayoutsTable.id, row.id))
+      .from(payoutsTable)
+      .where(eq(payoutsTable.id, row.id))
       .limit(1);
     expect(reread.resolvedAt).toBeNull();
     expect(reread.stripeTransferId).toBeNull();
@@ -215,7 +217,7 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
     );
 
     const [row] = await db
-      .insert(pendingPayoutsTable)
+      .insert(payoutsTable)
       .values({
         userId: payoutUserId,
         organizationId: org.id,
@@ -223,6 +225,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
         amountCents: 50,
         currency: 'gbp',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       })
       .returning();
 
@@ -243,8 +247,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
 
     const [reread] = await db
       .select()
-      .from(pendingPayoutsTable)
-      .where(eq(pendingPayoutsTable.id, row.id))
+      .from(payoutsTable)
+      .where(eq(payoutsTable.id, row.id))
       .limit(1);
     expect(reread.resolvedAt).not.toBeNull();
     expect(reread.stripeTransferId).toBe('tr_fc_clear');
@@ -275,7 +279,7 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
     );
 
     const inserted = await db
-      .insert(pendingPayoutsTable)
+      .insert(payoutsTable)
       .values([
         {
           userId: payoutUserId,
@@ -284,6 +288,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
           amountCents: 50, // below floor
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: payoutUserId,
@@ -292,6 +298,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
           amountCents: 500, // above floor
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
       ])
       .returning();
@@ -310,13 +318,13 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
 
     const [smallAfter] = await db
       .select()
-      .from(pendingPayoutsTable)
-      .where(eq(pendingPayoutsTable.id, smallRow.id))
+      .from(payoutsTable)
+      .where(eq(payoutsTable.id, smallRow.id))
       .limit(1);
     const [largeAfter] = await db
       .select()
-      .from(pendingPayoutsTable)
-      .where(eq(pendingPayoutsTable.id, largeRow.id))
+      .from(payoutsTable)
+      .where(eq(payoutsTable.id, largeRow.id))
       .limit(1);
 
     expect(smallAfter.resolvedAt).toBeNull();
@@ -332,13 +340,15 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
       stripe
     );
 
-    await db.insert(pendingPayoutsTable).values({
+    await db.insert(payoutsTable).values({
       userId: payoutUserId,
       organizationId: org.id,
       subscriptionId: sub.id,
       amountCents: 1, // pence
       currency: 'gbp',
       reason: 'connect_not_ready',
+      status: 'pending',
+      payoutType: 'creator_payout',
     });
 
     const transferSpy = vi.mocked(stripe.transfers.create);
@@ -374,7 +384,7 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
       stripe
     );
 
-    await db.insert(pendingPayoutsTable).values([
+    await db.insert(payoutsTable).values([
       {
         userId: payoutUserId,
         organizationId: org.id,
@@ -382,6 +392,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
         amountCents: 100,
         currency: 'gbp',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       },
       {
         userId: payoutUserId,
@@ -390,6 +402,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
         amountCents: 200,
         currency: 'gbp',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       },
       {
         userId: payoutUserId,
@@ -398,6 +412,8 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
         amountCents: 300,
         currency: 'gbp',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       },
     ]);
 
@@ -445,13 +461,15 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
       stripe
     );
 
-    await db.insert(pendingPayoutsTable).values({
+    await db.insert(payoutsTable).values({
       userId: payoutUserId,
       organizationId: org.id,
       subscriptionId: sub.id,
       amountCents: 30,
       currency: 'gbp',
       reason: 'connect_not_ready',
+      status: 'pending',
+      payoutType: 'creator_payout',
     });
 
     await service.resolvePendingPayouts(org.id, stripeAccountId);
@@ -459,12 +477,12 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
     // The row stays unresolved AND specifically for this (user, org) pair.
     const unresolved = await db
       .select()
-      .from(pendingPayoutsTable)
+      .from(payoutsTable)
       .where(
         and(
-          eq(pendingPayoutsTable.userId, payoutUserId),
-          eq(pendingPayoutsTable.organizationId, org.id),
-          isNull(pendingPayoutsTable.resolvedAt)
+          eq(payoutsTable.userId, payoutUserId),
+          eq(payoutsTable.organizationId, org.id),
+          eq(payoutsTable.status, 'pending')
         )
       );
     expect(unresolved.length).toBeGreaterThanOrEqual(1);

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -5987,6 +5987,698 @@ describe('SubscriptionService', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────
+// Payouts ledger — schema + status-column behaviour (Codex-e9v3b)
+//
+// Companion tests for the `payouts` ledger introduced in Codex-bxpmu.
+// These pin the NEW behaviour explicitly:
+//
+//   A. executeTransfers writes status='paid' rows on success at each of
+//      the three transfer sites (org fee, creator-pool-to-owner,
+//      per-creator fan-out).
+//   B. Webhook double-fire: the partial unique index on
+//      stripe_transfer_id collapses the second insert to one row.
+//   C. CHECK constraints catch malformed inserts at the DB level
+//      (defence-in-depth — the service is the first line, the DB is
+//      the last).
+//   E. Drain status transitions: resolvePendingPayouts flips
+//      pending→paid; sweepUnresolvedPayouts only touches pending rows
+//      and uses attemptedAt (not createdAt) for the age threshold.
+//
+// (D) cross-org isolation for listPayoutsByOrg is already covered by
+// the "SCOPING INVARIANT" test in the listPayoutsByOrg describe block
+// above — no new test needed.
+// ─────────────────────────────────────────────────────────────────────
+describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', () => {
+  let db: ReturnType<typeof setupTestDatabase>;
+  let stripe: Stripe;
+  let service: SubscriptionService;
+  let creatorId: string;
+  let subscriberId: string;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    await validateDatabaseConnection(db);
+    const userIds = await seedTestUsers(db, 2);
+    [creatorId, subscriberId] = userIds;
+  });
+
+  beforeEach(() => {
+    stripe = createMockStripe();
+    service = new SubscriptionService({ db, environment: 'test' }, stripe);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  /**
+   * Seed an org + Connect account (chargesEnabled+payoutsEnabled, active)
+   * + one tier + one active subscription owned by `subscriberId`. The
+   * org owner (the user who can receive the org fee transfer) is
+   * `creatorId`. Returns refs the per-test bodies need.
+   */
+  async function seedOrgWithConnect(slug: string) {
+    const [org] = await db
+      .insert(organizations)
+      .values(
+        createTestOrganizationInput({
+          slug: createUniqueSlug(slug),
+          creatorId,
+        })
+      )
+      .returning();
+
+    await db.insert(stripeConnectAccounts).values(
+      createTestConnectAccountInput(org.id, creatorId, {
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        status: 'active',
+      })
+    );
+
+    const [tier] = await db
+      .insert(subscriptionTiers)
+      .values(createTestTierInput(org.id, { name: 'Basic' }))
+      .returning();
+
+    const [sub] = await db
+      .insert(subscriptions)
+      .values(
+        createTestSubscriptionInput(subscriberId, org.id, tier.id, {
+          status: 'active',
+        })
+      )
+      .returning();
+
+    return { org, tier, sub };
+  }
+
+  /**
+   * Add an extra creator (with their own Connect account) to an org and
+   * seed an active agreement for them. Returns the creator's userId.
+   */
+  async function addCreatorWithAgreement(
+    orgId: string,
+    sharePercent: number
+  ): Promise<string> {
+    const [userId] = await seedTestUsers(db, 1);
+    await db.insert(stripeConnectAccounts).values(
+      createTestConnectAccountInput(orgId, userId, {
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        status: 'active',
+      })
+    );
+    await db.insert(creatorOrganizationAgreements).values({
+      creatorId: userId,
+      organizationId: orgId,
+      organizationFeePercentage: sharePercent,
+    });
+    return userId;
+  }
+
+  // ─── A. Success-path inserts ────────────────────────────────────────
+
+  describe('A. executeTransfers success-path inserts', () => {
+    it('org fee transfer → one payouts row with status=paid, payoutType=organization_fee', async () => {
+      const { org, sub } = await seedOrgWithConnect('e9v3b-org-fee');
+
+      const chargeId = `ch_e9v3b_orgfee_${createUniqueSlug('c')}`;
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: 'pi_orgfee' } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      const { eq, and } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          and(
+            eq(payoutsTable.organizationId, org.id),
+            eq(payoutsTable.payoutType, 'organization_fee')
+          )
+        );
+
+      expect(rows).toHaveLength(1);
+      const [row] = rows;
+      expect(row.status).toBe('paid');
+      expect(row.userId).toBe(creatorId); // Connect account owner
+      expect(row.subscriptionId).toBe(sub.id);
+      expect(row.stripeTransferId).toMatch(/^tr_/);
+      expect(row.stripeChargeId).toBe(chargeId);
+      expect(row.transferGroup).toBe(`sub_${sub.id}`);
+      expect(row.resolvedAt).not.toBeNull();
+      expect(row.reason).toBeNull();
+      expect(row.amountCents).toBeGreaterThan(0);
+    });
+
+    it('creator-pool-to-owner (no creator agreements) → one payouts row with payoutType=creator_payout_to_owner', async () => {
+      const { org, sub } = await seedOrgWithConnect('e9v3b-pool-owner');
+
+      // No creatorOrganizationAgreements inserted — exercises the
+      // "no agreements" branch where the creator pool routes to the org
+      // owner.
+      const chargeId = `ch_e9v3b_pool_${createUniqueSlug('c')}`;
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: 'pi_pool' } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      const { eq, and } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          and(
+            eq(payoutsTable.organizationId, org.id),
+            eq(payoutsTable.payoutType, 'creator_payout_to_owner')
+          )
+        );
+
+      expect(rows).toHaveLength(1);
+      const [row] = rows;
+      expect(row.status).toBe('paid');
+      expect(row.userId).toBe(creatorId); // org owner
+      expect(row.subscriptionId).toBe(sub.id);
+      expect(row.stripeTransferId).toMatch(/^tr_/);
+      expect(row.stripeChargeId).toBe(chargeId);
+      expect(row.transferGroup).toBe(`sub_${sub.id}`);
+      expect(row.resolvedAt).not.toBeNull();
+      expect(row.reason).toBeNull();
+      expect(row.amountCents).toBeGreaterThan(0);
+    });
+
+    it('per-creator fan-out (2 creators) → N payouts rows, each payoutType=creator_payout, correct creator userIds, amounts sum within pool', async () => {
+      const { org, sub } = await seedOrgWithConnect('e9v3b-fanout');
+
+      // Two creators with active agreements (50/50 split).
+      const c1 = await addCreatorWithAgreement(org.id, 5000);
+      const c2 = await addCreatorWithAgreement(org.id, 5000);
+
+      const chargeId = `ch_e9v3b_fanout_${createUniqueSlug('c')}`;
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_fanout' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      const { eq, and, inArray } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          and(
+            eq(payoutsTable.organizationId, org.id),
+            eq(payoutsTable.payoutType, 'creator_payout'),
+            inArray(payoutsTable.userId, [c1, c2])
+          )
+        );
+
+      expect(rows).toHaveLength(2);
+      const byUser = new Map(rows.map((r) => [r.userId, r]));
+      for (const cid of [c1, c2]) {
+        const row = byUser.get(cid);
+        expect(row, `no row for creator ${cid}`).toBeDefined();
+        expect(row?.status).toBe('paid');
+        expect(row?.payoutType).toBe('creator_payout');
+        expect(row?.subscriptionId).toBe(sub.id);
+        expect(row?.stripeTransferId).toMatch(/^tr_/);
+        expect(row?.stripeChargeId).toBe(chargeId);
+        expect(row?.transferGroup).toBe(`sub_${sub.id}`);
+        expect(row?.resolvedAt).not.toBeNull();
+        expect(row?.reason).toBeNull();
+        expect(row?.amountCents).toBeGreaterThan(0);
+      }
+
+      // Sum of per-creator amounts ≤ amount_paid (the creator pool is a
+      // subset of the gross invoice). 50/50 split → equal amounts.
+      const amounts = rows.map((r) => r.amountCents);
+      expect(amounts[0]).toBe(amounts[1]);
+      expect(amounts.reduce((s, a) => s + a, 0)).toBeLessThanOrEqual(1000);
+    });
+  });
+
+  // ─── B. Idempotency under webhook double-fire ───────────────────────
+
+  describe('B. Idempotency — partial unique index collapses webhook double-fire', () => {
+    it('firing the same invoice.payment_succeeded twice → one paid row per stripeTransferId (unique partial index)', async () => {
+      const { org, sub } = await seedOrgWithConnect('e9v3b-idem');
+
+      // Pin a stable charge id so the service derives identical
+      // idempotency keys on both calls → Stripe mock returns identical
+      // tr_ ids → the partial unique index on stripe_transfer_id rejects
+      // the second insert. Note: the mock isn't truly Stripe-side-dedupe
+      // (it returns a fresh tr_ each call), so we override it to return
+      // a deterministic id per idempotencyKey to faithfully exercise
+      // the partial-unique-index path.
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      const byKey = new Map<string, string>();
+      transferSpy.mockImplementation((params: Record<string, unknown>, opts) => {
+        const o = opts as { idempotencyKey?: string } | undefined;
+        const key = o?.idempotencyKey ?? '';
+        let id = byKey.get(key);
+        if (!id) {
+          id = `tr_idem_${createUniqueSlug('t')}`;
+          byKey.set(key, id);
+        }
+        return Promise.resolve({
+          id,
+          amount: params.amount,
+          currency: params.currency,
+          destination: params.destination,
+          metadata: params.metadata ?? {},
+        }) as unknown as ReturnType<typeof transferSpy>;
+      });
+
+      const chargeId = 'ch_e9v3b_idem_fixed';
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: 'pi_idem' } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      // First fire: rows inserted normally.
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+      const { eq, and } = await import('drizzle-orm');
+      const afterFirst = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          and(
+            eq(payoutsTable.organizationId, org.id),
+            eq(payoutsTable.status, 'paid')
+          )
+        );
+      expect(afterFirst.length).toBeGreaterThan(0);
+      const firstTransferIds = new Set(
+        afterFirst.map((r) => r.stripeTransferId)
+      );
+
+      // Second fire: the service re-attempts the transfers (Stripe mock
+      // returns the SAME tr_ id per idempotencyKey), then tries to
+      // INSERT a row with the same stripeTransferId — partial unique
+      // index rejects, and the service swallows the duplicate (see
+      // isUniqueViolation check in executeTransfers). No throw, no
+      // extra rows.
+      await expect(
+        service.handleInvoicePaymentSucceeded(mockInvoice)
+      ).resolves.toBeDefined();
+
+      const afterSecond = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          and(
+            eq(payoutsTable.organizationId, org.id),
+            eq(payoutsTable.status, 'paid')
+          )
+        );
+
+      // Row count unchanged across replay — partial unique index did
+      // its job.
+      expect(afterSecond).toHaveLength(afterFirst.length);
+      const secondTransferIds = new Set(
+        afterSecond.map((r) => r.stripeTransferId)
+      );
+      expect(secondTransferIds).toEqual(firstTransferIds);
+    });
+  });
+
+  // ─── C. CHECK constraint enforcement (defence-in-depth) ─────────────
+
+  describe('C. CHECK constraints — raw insert defence-in-depth', () => {
+    /**
+     * Common base values for the malformed-insert tests. Each test
+     * overrides exactly the column it's testing. The base values are
+     * otherwise valid so the failure mode isolates to the targeted
+     * constraint.
+     */
+    async function baseValues(slug: string) {
+      const { org, sub } = await seedOrgWithConnect(slug);
+      return {
+        userId: creatorId,
+        organizationId: org.id,
+        subscriptionId: sub.id,
+        amountCents: 1000,
+        currency: 'gbp',
+        payoutType: 'creator_payout' as const,
+        status: 'pending' as const,
+        reason: 'connect_not_ready' as const,
+      };
+    }
+
+    /**
+     * Assert that a Postgres CHECK violation (SQLSTATE 23514) escapes
+     * the insert. Different drivers wrap the error; match on the .code
+     * (Drizzle / pg) or on the constraint name in the message.
+     */
+    function expectCheckViolation(err: unknown, constraint: string) {
+      expect(err).toBeDefined();
+      const e = err as {
+        code?: string;
+        cause?: { code?: string; message?: string };
+        message?: string;
+      };
+      const code = e.code ?? e.cause?.code;
+      const msg = `${e.message ?? ''} ${e.cause?.message ?? ''}`;
+      // 23514 is the Postgres CHECK violation SQLSTATE.
+      const matched =
+        code === '23514' ||
+        msg.includes('23514') ||
+        msg.includes(constraint) ||
+        msg.toLowerCase().includes('check constraint');
+      expect(
+        matched,
+        `expected CHECK violation (${constraint}); got code=${code} message=${msg}`
+      ).toBe(true);
+    }
+
+    it('check_payouts_paid_invariant: status=paid with stripeTransferId=null is rejected', async () => {
+      const base = await baseValues('e9v3b-check-paid-invariant');
+      const err = await db
+        .insert(payoutsTable)
+        .values({
+          ...base,
+          status: 'paid',
+          reason: null,
+          stripeTransferId: null,
+          resolvedAt: null,
+        })
+        .catch((e) => e);
+      expectCheckViolation(err, 'check_payouts_paid_invariant');
+    });
+
+    it("check_payouts_status: status='resolved' (not in {paid,pending,failed}) is rejected", async () => {
+      const base = await baseValues('e9v3b-check-status');
+      const err = await db
+        .insert(payoutsTable)
+        .values({
+          ...base,
+          // 'resolved' is the URL alias, NOT a valid DB status — the
+          // CHECK only accepts paid/pending/failed.
+          status: 'resolved' as unknown as 'pending',
+        })
+        .catch((e) => e);
+      expectCheckViolation(err, 'check_payouts_status');
+    });
+
+    it("check_payouts_reason: reason='made_up' (not in allowed set) is rejected", async () => {
+      const base = await baseValues('e9v3b-check-reason');
+      const err = await db
+        .insert(payoutsTable)
+        .values({
+          ...base,
+          reason: 'made_up' as unknown as 'connect_not_ready',
+        })
+        .catch((e) => e);
+      expectCheckViolation(err, 'check_payouts_reason');
+    });
+
+    it("check_payouts_type: payoutType='bogus' (not in allowed set) is rejected", async () => {
+      const base = await baseValues('e9v3b-check-type');
+      const err = await db
+        .insert(payoutsTable)
+        .values({
+          ...base,
+          payoutType: 'bogus' as unknown as 'creator_payout',
+        })
+        .catch((e) => e);
+      expectCheckViolation(err, 'check_payouts_type');
+    });
+
+    it('check_payouts_amount_positive: amountCents=0 is rejected', async () => {
+      const base = await baseValues('e9v3b-check-amount');
+      const err = await db
+        .insert(payoutsTable)
+        .values({
+          ...base,
+          amountCents: 0,
+        })
+        .catch((e) => e);
+      expectCheckViolation(err, 'check_payouts_amount_positive');
+    });
+  });
+
+  // ─── E. Drain status transitions ────────────────────────────────────
+
+  describe('E. Drain status transitions', () => {
+    /**
+     * Seed an org + a Connect account with a deterministic
+     * stripeAccountId so resolvePendingPayouts /
+     * sweepUnresolvedPayouts can be driven explicitly. The org owner
+     * is `creatorId` and the connect account belongs to `creatorId`.
+     */
+    async function seedDrainScenario(slug: string) {
+      const { org, sub } = await seedOrgWithConnect(slug);
+      const stripeAccountId = `acct_e9v3b_${createUniqueSlug('a')}`;
+      const { eq } = await import('drizzle-orm');
+      await db
+        .update(stripeConnectAccounts)
+        .set({ stripeAccountId })
+        .where(eq(stripeConnectAccounts.organizationId, org.id));
+      return { org, sub, stripeAccountId };
+    }
+
+    function stubAccountsRetrieve(ready: boolean): void {
+      const fn = vi.fn().mockImplementation(async (accountId: string) => ({
+        id: accountId,
+        charges_enabled: ready,
+        payouts_enabled: ready,
+      }));
+      (stripe as unknown as { accounts: Record<string, unknown> }).accounts = {
+        ...((stripe as unknown as { accounts?: Record<string, unknown> })
+          .accounts ?? {}),
+        retrieve: fn,
+      };
+    }
+
+    it("resolvePendingPayouts flips a pending row to status='paid' with stripeTransferId + resolvedAt set", async () => {
+      const { org, sub, stripeAccountId } = await seedDrainScenario(
+        'e9v3b-drain-resolve'
+      );
+
+      const [pending] = await db
+        .insert(payoutsTable)
+        .values({
+          userId: creatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 1750,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
+        })
+        .returning();
+
+      // Pre-condition: status='pending', no transfer id, no resolvedAt.
+      expect(pending.status).toBe('pending');
+      expect(pending.stripeTransferId).toBeNull();
+      expect(pending.resolvedAt).toBeNull();
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+      expect(result).toEqual({ resolved: 1, failed: 0 });
+
+      const { eq } = await import('drizzle-orm');
+      const [after] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, pending.id));
+
+      // Post-condition: row transitioned pending → paid, transfer id
+      // + resolvedAt stamped.
+      expect(after.status).toBe('paid');
+      expect(after.stripeTransferId).toMatch(/^tr_/);
+      expect(after.resolvedAt).not.toBeNull();
+    });
+
+    it("sweepUnresolvedPayouts only touches status='pending' rows — paid and failed rows are left untouched", async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      const { org, sub, stripeAccountId } = await seedDrainScenario(
+        'e9v3b-drain-sweep-touch'
+      );
+
+      const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+      // Seed three rows: one paid (terminal-success), one failed
+      // (terminal-failure), one pending (sweep target). The sweep
+      // should only touch the pending row.
+      const [paid, failed, pending] = await db
+        .insert(payoutsTable)
+        .values([
+          {
+            userId: creatorId,
+            organizationId: org.id,
+            subscriptionId: sub.id,
+            amountCents: 100,
+            currency: 'gbp',
+            payoutType: 'creator_payout',
+            status: 'paid',
+            reason: null,
+            stripeTransferId: 'tr_terminal_paid',
+            resolvedAt: new Date('2026-01-01T00:00:00Z'),
+            attemptedAt: longAgo,
+          },
+          {
+            userId: creatorId,
+            organizationId: org.id,
+            subscriptionId: sub.id,
+            amountCents: 200,
+            currency: 'gbp',
+            payoutType: 'creator_payout',
+            status: 'failed',
+            reason: 'transfer_failed',
+            attemptedAt: longAgo,
+          },
+          {
+            userId: creatorId,
+            organizationId: org.id,
+            subscriptionId: sub.id,
+            amountCents: 300,
+            currency: 'gbp',
+            payoutType: 'creator_payout',
+            status: 'pending',
+            reason: 'connect_not_ready',
+            attemptedAt: longAgo,
+          },
+        ])
+        .returning();
+
+      stubAccountsRetrieve(true);
+
+      const result = await service.sweepUnresolvedPayouts(15);
+
+      // Only one group scanned (the pending row), and it resolved.
+      expect(result.groupsScanned).toBe(1);
+      expect(result.groupsResolved).toBe(1);
+      expect(result.errors).toBe(0);
+
+      const { eq } = await import('drizzle-orm');
+
+      // Paid row: completely unchanged.
+      const [paidAfter] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, paid.id));
+      expect(paidAfter.status).toBe('paid');
+      expect(paidAfter.stripeTransferId).toBe('tr_terminal_paid');
+      expect(paidAfter.resolvedAt?.getTime()).toBe(paid.resolvedAt?.getTime());
+
+      // Failed row: status stays 'failed' (sweep does NOT retry
+      // terminal-failure rows).
+      const [failedAfter] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, failed.id));
+      expect(failedAfter.status).toBe('failed');
+      expect(failedAfter.stripeTransferId).toBeNull();
+      expect(failedAfter.resolvedAt).toBeNull();
+
+      // Pending row: transitioned to paid via the sweep.
+      const [pendingAfter] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, pending.id));
+      expect(pendingAfter.status).toBe('paid');
+      expect(pendingAfter.stripeTransferId).toMatch(/^tr_/);
+      expect(pendingAfter.resolvedAt).not.toBeNull();
+
+      // Silence unused-var (stripeAccountId only needed for setup).
+      void stripeAccountId;
+    });
+
+    it('sweepUnresolvedPayouts uses attemptedAt (not createdAt) for the age threshold — recent createdAt + old attemptedAt is swept', async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      const { org, sub, stripeAccountId } = await seedDrainScenario(
+        'e9v3b-drain-attemptedAt'
+      );
+
+      // attemptedAt is OLD (1h ago) but createdAt is implicit (now).
+      // The sweep's age filter is on attemptedAt — so even though the
+      // row was just inserted, it should still be picked up.
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const [row] = await db
+        .insert(payoutsTable)
+        .values({
+          userId: creatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 500,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: oneHourAgo,
+        })
+        .returning();
+
+      // Sanity check the setup: createdAt is recent (well within the
+      // 15min threshold) but attemptedAt is older than it.
+      const ageMinutesCreated =
+        (Date.now() - row.createdAt.getTime()) / (60 * 1000);
+      const ageMinutesAttempted =
+        (Date.now() - row.attemptedAt.getTime()) / (60 * 1000);
+      expect(ageMinutesCreated).toBeLessThan(5);
+      expect(ageMinutesAttempted).toBeGreaterThan(15);
+
+      stubAccountsRetrieve(true);
+
+      const result = await service.sweepUnresolvedPayouts(15);
+
+      // attemptedAt was old enough → the row IS swept. If the service
+      // were filtering on createdAt instead, this would skip the row
+      // and the assertion would fail.
+      expect(result.groupsScanned).toBe(1);
+      expect(result.groupsResolved).toBe(1);
+
+      const { eq } = await import('drizzle-orm');
+      const [after] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, row.id));
+      expect(after.status).toBe('paid');
+      expect(after.stripeTransferId).toMatch(/^tr_/);
+
+      void stripeAccountId;
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
 // SubscriptionPaymentRequiredError (Codex-w87s4)
 //
 // Standalone constructor round-trip: no DB, no Stripe — just the error

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -18,7 +18,7 @@
 import {
   creatorOrganizationAgreements,
   organizations,
-  pendingPayouts as pendingPayoutsTable,
+  payouts as payoutsTable,
   stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
@@ -3406,11 +3406,11 @@ describe('SubscriptionService', () => {
       const { eq, and } = await import('drizzle-orm');
       const c2PendingRows = await db
         .select()
-        .from(pendingPayoutsTable)
+        .from(payoutsTable)
         .where(
           and(
-            eq(pendingPayoutsTable.userId, c2),
-            eq(pendingPayoutsTable.organizationId, org.id)
+            eq(payoutsTable.userId, c2),
+            eq(payoutsTable.organizationId, org.id)
           )
         );
       expect(c2PendingRows).toHaveLength(0);
@@ -4373,7 +4373,7 @@ describe('SubscriptionService', () => {
       );
 
       // Three rows: one pending, one resolved, one failed.
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: otherCreatorId,
           organizationId: org.id,
@@ -4381,6 +4381,8 @@ describe('SubscriptionService', () => {
           amountCents: 1234,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: otherCreatorId,
@@ -4391,6 +4393,8 @@ describe('SubscriptionService', () => {
           reason: 'connect_not_ready',
           resolvedAt: new Date('2026-05-01T10:00:00Z'),
           stripeTransferId: 'tr_resolved_zqaxo_1',
+          status: 'paid',
+          payoutType: 'creator_payout',
         },
         {
           userId: otherCreatorId,
@@ -4399,6 +4403,8 @@ describe('SubscriptionService', () => {
           amountCents: 999,
           currency: 'gbp',
           reason: 'transfer_failed',
+          status: 'failed',
+          payoutType: 'creator_payout',
         },
       ]);
 
@@ -4444,7 +4450,7 @@ describe('SubscriptionService', () => {
         'scope-b'
       );
 
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: otherCreatorId,
           organizationId: org1.id,
@@ -4452,6 +4458,8 @@ describe('SubscriptionService', () => {
           amountCents: 100,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: otherCreatorId,
@@ -4460,6 +4468,8 @@ describe('SubscriptionService', () => {
           amountCents: 200,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
       ]);
 
@@ -4487,7 +4497,7 @@ describe('SubscriptionService', () => {
         'fp'
       );
 
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: otherCreatorId,
           organizationId: org.id,
@@ -4495,6 +4505,8 @@ describe('SubscriptionService', () => {
           amountCents: 100,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: otherCreatorId,
@@ -4505,6 +4517,8 @@ describe('SubscriptionService', () => {
           reason: 'connect_not_ready',
           resolvedAt: new Date(),
           stripeTransferId: 'tr_x',
+          status: 'paid',
+          payoutType: 'creator_payout',
         },
       ]);
 
@@ -4527,7 +4541,7 @@ describe('SubscriptionService', () => {
         'fr'
       );
 
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: otherCreatorId,
           organizationId: org.id,
@@ -4535,6 +4549,8 @@ describe('SubscriptionService', () => {
           amountCents: 100,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: otherCreatorId,
@@ -4545,6 +4561,8 @@ describe('SubscriptionService', () => {
           reason: 'connect_not_ready',
           resolvedAt: new Date(),
           stripeTransferId: 'tr_zqaxo_resolved',
+          status: 'paid',
+          payoutType: 'creator_payout',
         },
       ]);
 
@@ -4567,7 +4585,7 @@ describe('SubscriptionService', () => {
         'ff'
       );
 
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: otherCreatorId,
           organizationId: org.id,
@@ -4575,6 +4593,8 @@ describe('SubscriptionService', () => {
           amountCents: 100,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: otherCreatorId,
@@ -4583,6 +4603,8 @@ describe('SubscriptionService', () => {
           amountCents: 999,
           currency: 'gbp',
           reason: 'transfer_failed',
+          status: 'failed',
+          payoutType: 'creator_payout',
         },
       ]);
 
@@ -4611,9 +4633,11 @@ describe('SubscriptionService', () => {
         subscriptionId: sub.id,
         amountCents: 100 + i,
         currency: 'gbp',
-        reason: 'connect_not_ready',
+        reason: 'connect_not_ready' as const,
+        status: 'pending' as const,
+        payoutType: 'creator_payout' as const,
       }));
-      await db.insert(pendingPayoutsTable).values(rows);
+      await db.insert(payoutsTable).values(rows);
 
       const page1 = await service.listPayoutsByOrg(org.id, {
         page: 1,
@@ -4698,7 +4722,7 @@ describe('SubscriptionService', () => {
 
       // Seed three unresolved payouts for the connect-account user.
       const payoutRows = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values([
           {
             userId: creatorId,
@@ -4707,6 +4731,8 @@ describe('SubscriptionService', () => {
             amountCents: 1200,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
           {
             userId: creatorId,
@@ -4715,6 +4741,8 @@ describe('SubscriptionService', () => {
             amountCents: 750,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
           {
             userId: creatorId,
@@ -4723,6 +4751,8 @@ describe('SubscriptionService', () => {
             amountCents: 320,
             currency: 'gbp',
             reason: 'connect_restricted',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
         ])
         .returning();
@@ -4766,10 +4796,10 @@ describe('SubscriptionService', () => {
       const { eq, inArray } = await import('drizzle-orm');
       const after = await db
         .select()
-        .from(pendingPayoutsTable)
+        .from(payoutsTable)
         .where(
           inArray(
-            pendingPayoutsTable.id,
+            payoutsTable.id,
             payoutRows.map((r) => r.id)
           )
         );
@@ -4787,7 +4817,7 @@ describe('SubscriptionService', () => {
         await seedConnectAndSubscription('w4jjk-partial-fail');
 
       const payoutRows = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values([
           {
             userId: creatorId,
@@ -4796,6 +4826,8 @@ describe('SubscriptionService', () => {
             amountCents: 1000,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
           {
             userId: creatorId,
@@ -4804,6 +4836,8 @@ describe('SubscriptionService', () => {
             amountCents: 2000,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
           {
             userId: creatorId,
@@ -4812,6 +4846,8 @@ describe('SubscriptionService', () => {
             amountCents: 3000,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
         ])
         .returning();
@@ -4846,10 +4882,10 @@ describe('SubscriptionService', () => {
       const { inArray, eq } = await import('drizzle-orm');
       const after = await db
         .select()
-        .from(pendingPayoutsTable)
+        .from(payoutsTable)
         .where(
           inArray(
-            pendingPayoutsTable.id,
+            payoutsTable.id,
             payoutRows.map((r) => r.id)
           )
         );
@@ -4874,7 +4910,7 @@ describe('SubscriptionService', () => {
       const { org, sub, stripeAccountId } =
         await seedConnectAndSubscription('w4jjk-replay');
 
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: creatorId,
           organizationId: org.id,
@@ -4882,6 +4918,8 @@ describe('SubscriptionService', () => {
           amountCents: 1500,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: creatorId,
@@ -4890,6 +4928,8 @@ describe('SubscriptionService', () => {
           amountCents: 2500,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
       ]);
 
@@ -4931,7 +4971,7 @@ describe('SubscriptionService', () => {
         await seedConnectAndSubscription('90ocz-idem-key');
 
       const payoutRows = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values([
           {
             userId: creatorId,
@@ -4940,6 +4980,8 @@ describe('SubscriptionService', () => {
             amountCents: 1100,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
           {
             userId: creatorId,
@@ -4948,6 +4990,8 @@ describe('SubscriptionService', () => {
             amountCents: 2200,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
         ])
         .returning();
@@ -4987,7 +5031,7 @@ describe('SubscriptionService', () => {
         await seedConnectAndSubscription('90ocz-idem-replay');
 
       const payoutRows = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values([
           {
             userId: creatorId,
@@ -4996,6 +5040,8 @@ describe('SubscriptionService', () => {
             amountCents: 1500,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
           {
             userId: creatorId,
@@ -5004,6 +5050,8 @@ describe('SubscriptionService', () => {
             amountCents: 2500,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
         ])
         .returning();
@@ -5033,11 +5081,11 @@ describe('SubscriptionService', () => {
       // returns the original Transfer instead of creating a new one.
       const { inArray } = await import('drizzle-orm');
       await db
-        .update(pendingPayoutsTable)
-        .set({ resolvedAt: null, stripeTransferId: null })
+        .update(payoutsTable)
+        .set({ status: 'pending', resolvedAt: null, stripeTransferId: null })
         .where(
           inArray(
-            pendingPayoutsTable.id,
+            payoutsTable.id,
             payoutRows.map((r) => r.id)
           )
         );
@@ -5070,7 +5118,7 @@ describe('SubscriptionService', () => {
         await seedConnectAndSubscription('90ocz-idem-dup');
 
       const [row] = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values([
           {
             userId: creatorId,
@@ -5079,6 +5127,8 @@ describe('SubscriptionService', () => {
             amountCents: 4200,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
         ])
         .returning();
@@ -5118,8 +5168,8 @@ describe('SubscriptionService', () => {
       const { eq } = await import('drizzle-orm');
       const [after] = await db
         .select()
-        .from(pendingPayoutsTable)
-        .where(eq(pendingPayoutsTable.id, row.id));
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, row.id));
       expect(after.resolvedAt).not.toBeNull();
       expect(after.stripeTransferId).toBe(replayedTransferId);
     });
@@ -5138,7 +5188,7 @@ describe('SubscriptionService', () => {
       );
 
       const [row] = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values([
           {
             userId: creatorId,
@@ -5147,6 +5197,8 @@ describe('SubscriptionService', () => {
             amountCents: 4242,
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           },
         ])
         .returning();
@@ -5157,11 +5209,11 @@ describe('SubscriptionService', () => {
       const { eq, and } = await import('drizzle-orm');
       const rowsBefore = await db
         .select()
-        .from(pendingPayoutsTable)
+        .from(payoutsTable)
         .where(
           and(
-            eq(pendingPayoutsTable.userId, creatorId),
-            eq(pendingPayoutsTable.organizationId, org.id)
+            eq(payoutsTable.userId, creatorId),
+            eq(payoutsTable.organizationId, org.id)
           )
         );
       expect(rowsBefore).toHaveLength(1);
@@ -5211,11 +5263,11 @@ describe('SubscriptionService', () => {
       // duplicate-response branch is a single-write path (UPDATE only).
       const rowsAfter = await db
         .select()
-        .from(pendingPayoutsTable)
+        .from(payoutsTable)
         .where(
           and(
-            eq(pendingPayoutsTable.userId, creatorId),
-            eq(pendingPayoutsTable.organizationId, org.id)
+            eq(payoutsTable.userId, creatorId),
+            eq(payoutsTable.organizationId, org.id)
           )
         );
       expect(rowsAfter).toHaveLength(1);
@@ -5322,7 +5374,7 @@ describe('SubscriptionService', () => {
     it('returns zero counters and makes no Stripe calls when no pending rows exist', async () => {
       // Ensure no leftover pending rows from earlier tests
       const { sql: rawSql } = await import('drizzle-orm');
-      await db.execute(rawSql`DELETE FROM pending_payouts`);
+      await db.execute(rawSql`DELETE FROM payouts`);
 
       const retrieveSpy = stubAccountsRetrieve(true);
       const transferSpy = vi.mocked(stripe.transfers.create);
@@ -5342,21 +5394,23 @@ describe('SubscriptionService', () => {
 
     it('resolves the group when the Connect account now reports charges_enabled && payouts_enabled', async () => {
       const { sql: rawSql } = await import('drizzle-orm');
-      await db.execute(rawSql`DELETE FROM pending_payouts`);
+      await db.execute(rawSql`DELETE FROM payouts`);
 
       const { org, sub, stripeAccountId } =
         await seedConnectAndSubscription('vv77x-ready');
 
       // Old enough to pass the olderThanMinutes filter
       const longAgo = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
-      await db.insert(pendingPayoutsTable).values({
+      await db.insert(payoutsTable).values({
         userId: creatorId,
         organizationId: org.id,
         subscriptionId: sub.id,
         amountCents: 500,
         currency: 'gbp',
         reason: 'connect_not_ready',
-        createdAt: longAgo,
+        status: 'pending',
+        payoutType: 'creator_payout',
+        attemptedAt: longAgo,
       });
 
       const retrieveSpy = stubAccountsRetrieve(true);
@@ -5379,19 +5433,21 @@ describe('SubscriptionService', () => {
 
     it('skips the group (no transfer) when the Connect account is still not ready', async () => {
       const { sql: rawSql } = await import('drizzle-orm');
-      await db.execute(rawSql`DELETE FROM pending_payouts`);
+      await db.execute(rawSql`DELETE FROM payouts`);
 
       const { org, sub } = await seedConnectAndSubscription('vv77x-not-ready');
 
       const longAgo = new Date(Date.now() - 60 * 60 * 1000);
-      await db.insert(pendingPayoutsTable).values({
+      await db.insert(payoutsTable).values({
         userId: creatorId,
         organizationId: org.id,
         subscriptionId: sub.id,
         amountCents: 500,
         currency: 'gbp',
         reason: 'connect_not_ready',
-        createdAt: longAgo,
+        status: 'pending',
+        payoutType: 'creator_payout',
+        attemptedAt: longAgo,
       });
 
       const retrieveSpy = stubAccountsRetrieve(false);
@@ -5412,14 +5468,14 @@ describe('SubscriptionService', () => {
 
     it('groups by (orgId, userId) — N rows for one Connect account → one accounts.retrieve, one resolvePendingPayouts', async () => {
       const { sql: rawSql } = await import('drizzle-orm');
-      await db.execute(rawSql`DELETE FROM pending_payouts`);
+      await db.execute(rawSql`DELETE FROM payouts`);
 
       const { org, sub, stripeAccountId } =
         await seedConnectAndSubscription('vv77x-grouping');
 
       const longAgo = new Date(Date.now() - 60 * 60 * 1000);
       // 3 rows, same (orgId, userId) — one Connect account
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: creatorId,
           organizationId: org.id,
@@ -5427,7 +5483,9 @@ describe('SubscriptionService', () => {
           amountCents: 100,
           currency: 'gbp',
           reason: 'connect_not_ready',
-          createdAt: longAgo,
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: longAgo,
         },
         {
           userId: creatorId,
@@ -5436,7 +5494,9 @@ describe('SubscriptionService', () => {
           amountCents: 200,
           currency: 'gbp',
           reason: 'connect_not_ready',
-          createdAt: longAgo,
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: longAgo,
         },
         {
           userId: creatorId,
@@ -5445,7 +5505,9 @@ describe('SubscriptionService', () => {
           amountCents: 300,
           currency: 'gbp',
           reason: 'connect_not_ready',
-          createdAt: longAgo,
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: longAgo,
         },
       ]);
 
@@ -5472,13 +5534,13 @@ describe('SubscriptionService', () => {
 
     it('isolates per-group failure — one Stripe.accounts.retrieve throwing does not abort other groups', async () => {
       const { sql: rawSql } = await import('drizzle-orm');
-      await db.execute(rawSql`DELETE FROM pending_payouts`);
+      await db.execute(rawSql`DELETE FROM payouts`);
 
       const failOrg = await seedConnectAndSubscription('vv77x-fail');
       const okOrg = await seedConnectAndSubscription('vv77x-ok');
 
       const longAgo = new Date(Date.now() - 60 * 60 * 1000);
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: creatorId,
           organizationId: failOrg.org.id,
@@ -5486,7 +5548,9 @@ describe('SubscriptionService', () => {
           amountCents: 500,
           currency: 'gbp',
           reason: 'connect_not_ready',
-          createdAt: longAgo,
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: longAgo,
         },
         {
           userId: creatorId,
@@ -5495,7 +5559,9 @@ describe('SubscriptionService', () => {
           amountCents: 700,
           currency: 'gbp',
           reason: 'connect_not_ready',
-          createdAt: longAgo,
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: longAgo,
         },
       ]);
 
@@ -5534,20 +5600,22 @@ describe('SubscriptionService', () => {
 
     it('respects olderThanMinutes — rows newer than the threshold are NOT swept (webhook handles fresh rows)', async () => {
       const { sql: rawSql } = await import('drizzle-orm');
-      await db.execute(rawSql`DELETE FROM pending_payouts`);
+      await db.execute(rawSql`DELETE FROM payouts`);
 
       const { org, sub } = await seedConnectAndSubscription('vv77x-fresh');
 
       // Row created "now" — newer than the 15min threshold so should be
       // ignored by the sweep (the account.updated webhook owns fresh rows).
-      await db.insert(pendingPayoutsTable).values({
+      await db.insert(payoutsTable).values({
         userId: creatorId,
         organizationId: org.id,
         subscriptionId: sub.id,
         amountCents: 500,
         currency: 'gbp',
         reason: 'connect_not_ready',
-        createdAt: new Date(),
+        status: 'pending',
+        payoutType: 'creator_payout',
+        attemptedAt: new Date(),
       });
 
       const retrieveSpy = stubAccountsRetrieve(true);
@@ -5661,7 +5729,7 @@ describe('SubscriptionService', () => {
       });
 
       const [payout] = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values({
           userId: creatorId,
           organizationId: org.id,
@@ -5669,6 +5737,8 @@ describe('SubscriptionService', () => {
           amountCents: 5000,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         })
         .returning();
 
@@ -5699,8 +5769,8 @@ describe('SubscriptionService', () => {
       const { eq } = await import('drizzle-orm');
       const [after] = await db
         .select()
-        .from(pendingPayoutsTable)
-        .where(eq(pendingPayoutsTable.id, payout.id));
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, payout.id));
       expect(after.resolvedAt).not.toBeNull();
       expect(after.stripeTransferId).toMatch(/^tr_/);
     });
@@ -5731,7 +5801,7 @@ describe('SubscriptionService', () => {
       expect(existingAgreement).toHaveLength(0);
 
       const [payout] = await db
-        .insert(pendingPayoutsTable)
+        .insert(payoutsTable)
         .values({
           userId: creatorId,
           organizationId: org.id,
@@ -5739,6 +5809,8 @@ describe('SubscriptionService', () => {
           amountCents: 2750,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         })
         .returning();
 
@@ -5760,8 +5832,8 @@ describe('SubscriptionService', () => {
 
       const [after] = await db
         .select()
-        .from(pendingPayoutsTable)
-        .where(eq(pendingPayoutsTable.id, payout.id));
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, payout.id));
       expect(after.resolvedAt).not.toBeNull();
       expect(after.stripeTransferId).toMatch(/^tr_/);
     });
@@ -5848,7 +5920,7 @@ describe('SubscriptionService', () => {
           .returning();
 
         const [payout] = await db
-          .insert(pendingPayoutsTable)
+          .insert(payoutsTable)
           .values({
             userId,
             organizationId: org.id,
@@ -5856,6 +5928,8 @@ describe('SubscriptionService', () => {
             amountCents: amounts[i],
             currency: 'gbp',
             reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
           })
           .returning();
 
@@ -5896,10 +5970,10 @@ describe('SubscriptionService', () => {
       const { inArray } = await import('drizzle-orm');
       const after = await db
         .select()
-        .from(pendingPayoutsTable)
+        .from(payoutsTable)
         .where(
           inArray(
-            pendingPayoutsTable.id,
+            payoutsTable.id,
             seeded.map((r) => r.payoutId)
           )
         );
@@ -6181,13 +6255,15 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
       const { org, sub, stripeAccountId } =
         await seedConnectAndSubscription('yv18n-payout-gbp');
 
-      await db.insert(pendingPayoutsTable).values({
+      await db.insert(payoutsTable).values({
         userId: creatorId,
         organizationId: org.id,
         subscriptionId: sub.id,
         amountCents: 1000,
         currency: 'gbp',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       });
 
       const transferSpy = vi.mocked(stripe.transfers.create);
@@ -6214,13 +6290,15 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
 
       // Seed a USD payout directly — bypasses the schema default by
       // explicitly setting currency: 'usd'.
-      await db.insert(pendingPayoutsTable).values({
+      await db.insert(payoutsTable).values({
         userId: creatorId,
         organizationId: org.id,
         subscriptionId: sub.id,
         amountCents: 2500,
         currency: 'usd',
         reason: 'connect_not_ready',
+        status: 'pending',
+        payoutType: 'creator_payout',
       });
 
       const transferSpy = vi.mocked(stripe.transfers.create);
@@ -6243,7 +6321,7 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
       const { org, sub, stripeAccountId } =
         await seedConnectAndSubscription('yv18n-payout-mixed');
 
-      await db.insert(pendingPayoutsTable).values([
+      await db.insert(payoutsTable).values([
         {
           userId: creatorId,
           organizationId: org.id,
@@ -6251,6 +6329,8 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
           amountCents: 500,
           currency: 'gbp',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
         {
           userId: creatorId,
@@ -6259,6 +6339,8 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
           amountCents: 700,
           currency: 'eur',
           reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
         },
       ]);
 

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -3215,7 +3215,7 @@ export class SubscriptionService extends BaseService {
     // Transfer org fee
     if (orgConnect?.chargesEnabled && orgFeeCents > 0) {
       try {
-        await this.stripe.transfers.create(
+        const transfer = await this.stripe.transfers.create(
           {
             amount: orgFeeCents,
             currency: CURRENCY.GBP,
@@ -3229,6 +3229,37 @@ export class SubscriptionService extends BaseService {
           },
           { idempotencyKey: `${chargeId}_org_fee` }
         );
+        // Record success in the ledger. The unique partial index on
+        // stripe_transfer_id collapses webhook double-fires to a single row;
+        // any other DB error gets logged loud — money moved but the ledger
+        // missed the entry, which is a data-integrity event worth paging on.
+        try {
+          await this.db.insert(payouts).values({
+            userId: orgConnect.userId,
+            organizationId: orgId,
+            subscriptionId,
+            amountCents: orgFeeCents,
+            payoutType: 'organization_fee',
+            status: 'paid',
+            stripeTransferId: transfer.id,
+            stripeChargeId: chargeId,
+            transferGroup,
+            resolvedAt: new Date(),
+          });
+        } catch (insertError) {
+          if (!isUniqueViolation(insertError)) {
+            this.obs.error(
+              'Org transfer succeeded but payouts ledger insert failed',
+              {
+                subscriptionId,
+                organizationId: orgId,
+                stripeTransferId: transfer.id,
+                amountCents: orgFeeCents,
+                error: (insertError as Error).message,
+              }
+            );
+          }
+        }
       } catch (transferError) {
         this.obs.error('Org transfer failed, accumulating as pending payout', {
           subscriptionId,
@@ -3309,7 +3340,7 @@ export class SubscriptionService extends BaseService {
       // Transfer remaining to the org Connect account as creator payout
       if (orgConnect?.chargesEnabled && creatorPayoutCents > 0) {
         try {
-          await this.stripe.transfers.create(
+          const transfer = await this.stripe.transfers.create(
             {
               amount: creatorPayoutCents,
               currency: CURRENCY.GBP,
@@ -3323,6 +3354,33 @@ export class SubscriptionService extends BaseService {
             },
             { idempotencyKey: `${chargeId}_creator_pool_owner` }
           );
+          try {
+            await this.db.insert(payouts).values({
+              userId: orgConnect.userId,
+              organizationId: orgId,
+              subscriptionId,
+              amountCents: creatorPayoutCents,
+              payoutType: 'creator_payout_to_owner',
+              status: 'paid',
+              stripeTransferId: transfer.id,
+              stripeChargeId: chargeId,
+              transferGroup,
+              resolvedAt: new Date(),
+            });
+          } catch (insertError) {
+            if (!isUniqueViolation(insertError)) {
+              this.obs.error(
+                'Creator-pool transfer to owner succeeded but payouts ledger insert failed',
+                {
+                  subscriptionId,
+                  organizationId: orgId,
+                  stripeTransferId: transfer.id,
+                  amountCents: creatorPayoutCents,
+                  error: (insertError as Error).message,
+                }
+              );
+            }
+          }
         } catch (transferError) {
           this.obs.error(
             'Creator pool transfer to owner failed, accumulating',
@@ -3434,7 +3492,7 @@ export class SubscriptionService extends BaseService {
 
       if (creatorConnect?.chargesEnabled) {
         try {
-          await this.stripe.transfers.create(
+          const transfer = await this.stripe.transfers.create(
             {
               amount: creatorAmount,
               currency: CURRENCY.GBP,
@@ -3449,6 +3507,33 @@ export class SubscriptionService extends BaseService {
             },
             { idempotencyKey: `${chargeId}_creator_${agreement.creatorId}` }
           );
+          try {
+            await this.db.insert(payouts).values({
+              userId: agreement.creatorId,
+              organizationId: orgId,
+              subscriptionId,
+              amountCents: creatorAmount,
+              payoutType: 'creator_payout',
+              status: 'paid',
+              stripeTransferId: transfer.id,
+              stripeChargeId: chargeId,
+              transferGroup,
+              resolvedAt: new Date(),
+            });
+          } catch (insertError) {
+            if (!isUniqueViolation(insertError)) {
+              this.obs.error(
+                'Creator transfer succeeded but payouts ledger insert failed',
+                {
+                  subscriptionId,
+                  creatorId: agreement.creatorId,
+                  stripeTransferId: transfer.id,
+                  amountCents: creatorAmount,
+                  error: (insertError as Error).message,
+                }
+              );
+            }
+          }
         } catch (transferError) {
           this.obs.error('Creator transfer failed, accumulating as pending', {
             subscriptionId,

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -41,7 +41,7 @@ import {
   organizationFollowers,
   organizationMemberships,
   organizations,
-  pendingPayouts,
+  payouts,
   stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
@@ -61,16 +61,7 @@ import {
   UnsupportedCurrencyError,
 } from '@codex/service-errors';
 import type { PaginatedListResponse } from '@codex/shared-types';
-import {
-  and,
-  desc,
-  eq,
-  inArray,
-  isNotNull,
-  isNull,
-  lt,
-  sql,
-} from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, lt, sql } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import {
   AlreadySubscribedError,
@@ -119,7 +110,7 @@ interface SubscriptionStats {
 }
 
 /**
- * Display status for a `pendingPayouts` row in the studio payouts table
+ * Display status for a `payouts` row in the studio payouts table
  * (Codex-zqaxo). Derived from the persisted `resolvedAt`,
  * `stripeTransferId`, and `reason` columns — there is no `status` column
  * on the table itself.
@@ -184,19 +175,17 @@ export interface PayoutWithCreator {
 }
 
 /**
- * Resolve a `pendingPayouts` row to one of three display statuses. Used by
- * `listPayoutsByOrg` so the UI never has to re-derive these branches.
+ * Map the persisted `payouts.status` column to the UI display vocabulary.
  *
- *  - `resolved` — has both `resolvedAt` and `stripeTransferId`
- *  - `failed`   — `reason='transfer_failed'` and not yet resolved
- *  - `pending`  — every other unresolved row
+ * Storage column: `'paid' | 'pending' | 'failed'` (CHECK-enforced).
+ * UI vocabulary keeps the legacy term `'resolved'` for one release so existing
+ * `/studio/payouts?status=resolved` URLs and the current filter chip continue
+ * to work. PR 3 (UI rebuild) introduces a `'paid'` chip and PR 4 drops the
+ * alias.
  */
-function derivePayoutStatus(
-  resolvedAt: Date | null,
-  reason: string
-): PayoutDisplayStatus {
-  if (resolvedAt) return 'resolved';
-  if (reason === 'transfer_failed') return 'failed';
+function derivePayoutStatus(status: string): PayoutDisplayStatus {
+  if (status === 'paid') return 'resolved';
+  if (status === 'failed') return 'failed';
   return 'pending';
 }
 
@@ -2489,19 +2478,21 @@ export class SubscriptionService extends BaseService {
   }
 
   /**
-   * Codex-zqaxo: list pending + resolved payouts for an org owner's
+   * Codex-zqaxo / Codex-bxpmu: list payouts for an org owner's
    * `/studio/payouts` table.
    *
    * Scoping invariant (HARD): rows MUST be filtered by
-   * `pendingPayouts.organizationId = orgId`. The route layer applies
+   * `payouts.organizationId = orgId`. The route layer applies
    * `requireOrgManagement` so `orgId === ctx.organizationId`. Filtering by
    * `userId` here would leak cross-org payouts because a creator can belong
    * to multiple orgs — never relax to user-only scoping.
    *
-   * Status filter semantics:
-   *  - `pending`  → `resolvedAt IS NULL` AND reason != 'transfer_failed'
-   *  - `resolved` → `stripeTransferId IS NOT NULL` AND `resolvedAt IS NOT NULL`
-   *  - `failed`   → `reason = 'transfer_failed'` AND `resolvedAt IS NULL`
+   * Status filter semantics (reads the persisted `status` column directly —
+   * the CHECK constraint guarantees the value is one of paid/pending/failed):
+   *  - `pending`  → `status = 'pending'`
+   *  - `resolved` → `status = 'paid'` (URL alias retained one release; PR 3
+   *                 introduces the canonical `'paid'` chip)
+   *  - `failed`   → `status = 'failed'`
    *  - `all`      → no status predicate
    *
    * The creator name/avatar denorm comes from a LEFT JOIN on `users` so a
@@ -2520,45 +2511,43 @@ export class SubscriptionService extends BaseService {
     const { page, limit, status = 'all', fromDate, toDate } = options;
     const offset = (page - 1) * limit;
 
-    const conditions = [eq(pendingPayouts.organizationId, orgId)];
+    const conditions = [eq(payouts.organizationId, orgId)];
 
     if (status === 'pending') {
-      conditions.push(isNull(pendingPayouts.resolvedAt));
-      conditions.push(sql`${pendingPayouts.reason} != 'transfer_failed'`);
+      conditions.push(eq(payouts.status, 'pending'));
     } else if (status === 'resolved') {
-      conditions.push(isNotNull(pendingPayouts.resolvedAt));
-      conditions.push(isNotNull(pendingPayouts.stripeTransferId));
+      conditions.push(eq(payouts.status, 'paid'));
     } else if (status === 'failed') {
-      conditions.push(eq(pendingPayouts.reason, 'transfer_failed'));
-      conditions.push(isNull(pendingPayouts.resolvedAt));
+      conditions.push(eq(payouts.status, 'failed'));
     }
 
-    conditions.push(...dateWindow(pendingPayouts.createdAt, fromDate, toDate));
+    conditions.push(...dateWindow(payouts.createdAt, fromDate, toDate));
 
     const [items, [totalResult]] = await Promise.all([
       this.db
         .select({
-          id: pendingPayouts.id,
-          creatorId: pendingPayouts.userId,
+          id: payouts.id,
+          creatorId: payouts.userId,
           creatorName: users.name,
           creatorEmail: users.email,
           creatorAvatarUrl: users.image,
-          amountCents: pendingPayouts.amountCents,
-          currency: pendingPayouts.currency,
-          reason: pendingPayouts.reason,
-          resolvedAt: pendingPayouts.resolvedAt,
-          stripeTransferId: pendingPayouts.stripeTransferId,
-          createdAt: pendingPayouts.createdAt,
+          amountCents: payouts.amountCents,
+          currency: payouts.currency,
+          reason: payouts.reason,
+          status: payouts.status,
+          resolvedAt: payouts.resolvedAt,
+          stripeTransferId: payouts.stripeTransferId,
+          createdAt: payouts.createdAt,
         })
-        .from(pendingPayouts)
-        .leftJoin(users, eq(pendingPayouts.userId, users.id))
+        .from(payouts)
+        .leftJoin(users, eq(payouts.userId, users.id))
         .where(and(...conditions))
-        .orderBy(desc(pendingPayouts.createdAt))
+        .orderBy(desc(payouts.createdAt))
         .limit(limit)
         .offset(offset),
       this.db
         .select({ count: sql<number>`count(*)::int` })
-        .from(pendingPayouts)
+        .from(payouts)
         .where(and(...conditions)),
     ]);
 
@@ -2573,8 +2562,8 @@ export class SubscriptionService extends BaseService {
         creatorAvatarUrl: row.creatorAvatarUrl ?? null,
         amountCents: row.amountCents,
         currency: row.currency,
-        reason: row.reason,
-        status: derivePayoutStatus(row.resolvedAt, row.reason),
+        reason: row.reason ?? '',
+        status: derivePayoutStatus(row.status),
         resolvedAt: row.resolvedAt ? row.resolvedAt.toISOString() : null,
         stripeTransferId: row.stripeTransferId,
         createdAt: row.createdAt.toISOString(),
@@ -2631,12 +2620,12 @@ export class SubscriptionService extends BaseService {
 
     const unresolvedPayouts = await this.db
       .select()
-      .from(pendingPayouts)
+      .from(payouts)
       .where(
         and(
-          eq(pendingPayouts.userId, connectAccount.userId),
-          eq(pendingPayouts.organizationId, orgId),
-          isNull(pendingPayouts.resolvedAt)
+          eq(payouts.userId, connectAccount.userId),
+          eq(payouts.organizationId, orgId),
+          eq(payouts.status, 'pending')
         )
       );
 
@@ -2702,12 +2691,13 @@ export class SubscriptionService extends BaseService {
         );
 
         await this.db
-          .update(pendingPayouts)
+          .update(payouts)
           .set({
+            status: 'paid',
             resolvedAt: new Date(),
             stripeTransferId: transfer.id,
           })
-          .where(eq(pendingPayouts.id, payout.id));
+          .where(eq(payouts.id, payout.id));
 
         resolved++;
       } catch (error) {
@@ -2747,7 +2737,7 @@ export class SubscriptionService extends BaseService {
    * Passing `null`/`undefined` is treated as "no currency on this Stripe
    * object" and skipped — preserves the prior behaviour of letting Stripe
    * payloads without a `currency` field through (the schema default for
-   * pendingPayouts is 'gbp', so the row branch normalises before calling).
+   * payouts is 'gbp', so the row branch normalises before calling).
    */
   private assertGbpOnly(
     currency: string | null | undefined,
@@ -3247,11 +3237,13 @@ export class SubscriptionService extends BaseService {
           error: (transferError as Error).message,
         });
         try {
-          await this.db.insert(pendingPayouts).values({
+          await this.db.insert(payouts).values({
             userId: orgConnect.userId,
             organizationId: orgId,
             subscriptionId,
             amountCents: orgFeeCents,
+            payoutType: 'organization_fee',
+            status: 'failed',
             reason: 'transfer_failed',
           });
         } catch (insertError) {
@@ -3274,11 +3266,13 @@ export class SubscriptionService extends BaseService {
         );
       } else {
         try {
-          await this.db.insert(pendingPayouts).values({
+          await this.db.insert(payouts).values({
             userId: ownerId,
             organizationId: orgId,
             subscriptionId,
             amountCents: orgFeeCents,
+            payoutType: 'organization_fee',
+            status: 'pending',
             reason: 'connect_not_ready',
           });
         } catch (insertError) {
@@ -3342,11 +3336,13 @@ export class SubscriptionService extends BaseService {
           // BUG-036: Wrap pending payout insert in try/catch so a DB failure
           // doesn't crash the entire transfer flow.
           try {
-            await this.db.insert(pendingPayouts).values({
+            await this.db.insert(payouts).values({
               userId: orgConnect.userId,
               organizationId: orgId,
               subscriptionId,
               amountCents: creatorPayoutCents,
+              payoutType: 'creator_payout_to_owner',
+              status: 'failed',
               reason: 'transfer_failed',
             });
           } catch (insertError) {
@@ -3411,11 +3407,13 @@ export class SubscriptionService extends BaseService {
           minTransferCents: creatorFees.minTransferCents,
         });
         try {
-          await this.db.insert(pendingPayouts).values({
+          await this.db.insert(payouts).values({
             userId: agreement.creatorId,
             organizationId: orgId,
             subscriptionId,
             amountCents: creatorAmount,
+            payoutType: 'creator_payout',
+            status: 'pending',
             reason: 'min_transfer_floor',
           });
         } catch (insertError) {
@@ -3461,11 +3459,13 @@ export class SubscriptionService extends BaseService {
           // BUG-036: Wrap pending payout insert in try/catch so a DB failure
           // doesn't crash the entire transfer flow.
           try {
-            await this.db.insert(pendingPayouts).values({
+            await this.db.insert(payouts).values({
               userId: agreement.creatorId,
               organizationId: orgId,
               subscriptionId,
               amountCents: creatorAmount,
+              payoutType: 'creator_payout',
+              status: 'failed',
               reason: 'transfer_failed',
             });
           } catch (insertError) {
@@ -3485,11 +3485,13 @@ export class SubscriptionService extends BaseService {
         // BUG-036: Wrap pending payout insert in try/catch so a DB failure
         // doesn't crash the entire transfer flow.
         try {
-          await this.db.insert(pendingPayouts).values({
+          await this.db.insert(payouts).values({
             userId: agreement.creatorId,
             organizationId: orgId,
             subscriptionId,
             amountCents: creatorAmount,
+            payoutType: 'creator_payout',
+            status: 'pending',
             reason: creatorConnect ? 'connect_restricted' : 'connect_not_ready',
           });
         } catch (insertError) {
@@ -3563,7 +3565,7 @@ export class SubscriptionService extends BaseService {
   // Hybrid event+sweep resolution pattern per Stripe docs:
   //   1. account.updated webhook is the primary trigger (connect-webhook.ts:73)
   //   2. Webhooks retry for 3 days then drop — this sweep is the safety net
-  //   3. Periodic sweep groups pendingPayouts by (orgId, userId) — each unique
+  //   3. Periodic sweep groups payouts by (orgId, userId) — each unique
   //      pair maps to one Connect account — and asks Stripe for current state
   //   4. If the Connect account is now charges_enabled && payouts_enabled,
   //      delegate to resolvePendingPayouts(orgId, stripeAccountId) which owns
@@ -3573,7 +3575,7 @@ export class SubscriptionService extends BaseService {
   //      fired by now if it was going to.
 
   /**
-   * Sweep unresolved pendingPayouts rows older than `olderThanMinutes`,
+   * Sweep pending payouts rows older than `olderThanMinutes`,
    * group by (organizationId, userId), and attempt resolution for each
    * group whose Connect account now reports charges_enabled && payouts_enabled.
    *
@@ -3595,15 +3597,12 @@ export class SubscriptionService extends BaseService {
     // handles the missing-account case (logs warn + returns 0).
     const groups = await this.db
       .selectDistinct({
-        organizationId: pendingPayouts.organizationId,
-        userId: pendingPayouts.userId,
+        organizationId: payouts.organizationId,
+        userId: payouts.userId,
       })
-      .from(pendingPayouts)
+      .from(payouts)
       .where(
-        and(
-          isNull(pendingPayouts.resolvedAt),
-          lt(pendingPayouts.createdAt, threshold)
-        )
+        and(eq(payouts.status, 'pending'), lt(payouts.attemptedAt, threshold))
       );
 
     const groupsScanned = groups.length;
@@ -3627,7 +3626,7 @@ export class SubscriptionService extends BaseService {
       try {
         // Find the Connect account row for this (orgId, userId) so we can
         // look up the stripeAccountId. If the row is missing (rare — a
-        // Connect account was deleted but its pendingPayouts survived
+        // Connect account was deleted but its payouts survived
         // because of ON DELETE behaviour) skip this group; it will be
         // re-attempted on the next sweep window.
         const [connect] = await this.db

--- a/workers/ecom-api/src/handlers/payouts-sweep.ts
+++ b/workers/ecom-api/src/handlers/payouts-sweep.ts
@@ -1,7 +1,7 @@
 /**
  * Pending Payouts Sweep Handler (Codex-vv77x)
  *
- * Drains pendingPayouts rows whose Connect account has since become
+ * Drains pending payouts rows whose Connect account has since become
  * charges_enabled && payouts_enabled but whose account.updated webhook
  * never fired (webhook drop, capability-ricochet event without the
  * relevant previous_attributes, etc).

--- a/workers/ecom-api/src/routes/subscriptions.ts
+++ b/workers/ecom-api/src/routes/subscriptions.ts
@@ -367,7 +367,7 @@ subscriptions.get(
  * studio payouts table. Owner/admin only via `requireOrgManagement` —
  * mirror of `/stats` and `/subscribers`.
  *
- * SECURITY INVARIANT: the service queries `pendingPayouts` filtered by
+ * SECURITY INVARIANT: the service queries `payouts` filtered by
  * `organizationId = ctx.organizationId`. `ctx.organizationId` is set by
  * `requireOrgManagement` from the user's membership row, so this route
  * cannot leak another org's payouts even if the client forges

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -11,7 +11,7 @@
   },
 
   // Cron Triggers (scheduled handler)
-  // - Every 15 minutes — payouts sweep (Codex-vv77x): drains pendingPayouts
+  // - Every 15 minutes — payouts sweep (Codex-vv77x): drains pending payouts
   //   whose Connect account is now charges_enabled && payouts_enabled.
   //   Hybrid event+sweep resolution per Stripe docs (account.updated webhook
   //   + periodic reconciliation). Consolidated into ecom-api 2026-05-13 so


### PR DESCRIPTION
## Summary

Replaces the misnamed `pending_payouts` table (an exception queue) with a properly-modelled `payouts` ledger so every Stripe transfer leaves a Codex-side record. Diagnoses + fixes the empty `/studio/payouts` page: successful transfers previously left no DB row, so the page sat empty for any creator whose Connect account was properly onboarded.

**Scope of this branch:** PR1 (schema + service migration) + PR2 (success-path inserts) from a 4-PR plan. UI rebuild (PR3) + cleanup of the old table (PR4) are still pending — that's why this is a draft. Plan: `~/.claude/plans/ok-beautiful-thanks-for-structured-alpaca.md`.

## Commits

1. **`c7fa9575` — Schema** (Codex-bxpmu). New `payouts` table with status enum (`paid`/`pending`/`failed`), `payoutType` enum (`organization_fee`/`creator_payout`/`creator_payout_to_owner`), and a `check_payouts_paid_invariant` CHECK that makes silent successes physically impossible (paid rows MUST carry `stripe_transfer_id` + `resolved_at`). Migration `0063_clumsy_karnak.sql` (generated) and `0064_migrate_pending_payouts_to_payouts.sql` (hand-written DML, idempotent).
2. **`c5c0da4d` — Service migration** (Codex-bxpmu). Points `executeTransfers` failure paths + `resolvePendingPayouts` + `sweepUnresolvedPayouts` + `listPayoutsByOrg` + `derivePayoutStatus` at the new table. Admin analytics `getRevenueByCreator` consumer also migrated. Zero behaviour change — same failure inserts as before, just with new explicit `status` + `payoutType` columns.
3. **`25a149e7` — Success-path inserts** (Codex-e9v3b). Three new inserts in `executeTransfers`, one per `stripe.transfers.create()` call site. Each writes `status='paid'` with the Stripe transfer ID. Idempotent via unique partial index + `isUniqueViolation` guard.

## Key design decisions

- **CHECK invariant on paid rows.** `(status != 'paid') OR (stripe_transfer_id IS NOT NULL AND resolved_at IS NOT NULL)`. DB-level guarantee that you can't write a successful payout without proof Stripe moved the money.
- **Partial unique index on `stripe_transfer_id`.** `WHERE stripe_transfer_id IS NOT NULL` — pending rows (null transfer_id) don't collide with each other; success rows are idempotent against webhook double-fire.
- **Backward-compat URL alias.** `listPayoutsByOrg` still accepts `status=resolved` and maps it to `status='paid'` for one release. PR3 introduces the canonical `paid` chip; PR4 drops the alias.
- **Forward-only.** No backfill of historic Stripe transfers. Ledger starts at deploy. Pre-existing `pending_payouts` rows migrate cleanly via the 0064 DML; local dev had 0 so it was a no-op there.

## Verification

- `pnpm db:local:migrate` applies 0063 + 0064 cleanly; `\d payouts` confirms 6 indexes + 5 CHECKs + 3 FKs
- `pnpm typecheck` workspace-wide passes (one pre-existing apps/web error unrelated)
- `pnpm test` in `@codex/subscription`: **315/315 real tests pass**. One denoise-proof failure (`iter-009/F5`) is pre-existing in main from commit b6a136ca and unrelated.

## Test plan

- [ ] Add success-row unit tests in `subscription-service.test.ts`: positive (each of 3 sites writes a `status='paid'` row) + negative (duplicate webhook fire collapses via unique constraint). Required by `feedback_security_deep_test` before merge.
- [ ] Verify in local DB after a fresh test subscription: `SELECT * FROM payouts WHERE organization_id = '<of-blood-and-bones>'` returns the org_fee + creator_payout rows with `status='paid'`.
- [ ] Verify Stripe Dashboard shows matching Transfer object for the recorded `stripe_transfer_id`.
- [ ] Force `connect_not_ready` (clear `stripe_connect_accounts.charges_enabled`) → new sub creates `status='pending'` row.
- [ ] Restore Connect → wait ≤15min for sweep cron → row flips to `status='paid'`.
- [ ] Cross-org isolation: login as a different org's owner, confirm cannot see this org's payouts.

## Still pending (separate PRs)

- **PR3 (Codex-05vp8):** UI rebuild — exception banner + KPI cards + filter chips on `/studio/payouts/+page.svelte`. **This is the user-visible payoff** — until PR3 lands, the page still shows the legacy shape (and is now correctly populated with rows after PR2, but the new fields like `payoutType` aren't surfaced yet).
- **PR4 (Codex-xjxw6):** Cleanup — drop `pending_payouts` table + the `'resolved'` URL alias after one deploy cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)