### PR TITLE
refactor(payouts): simplify getPayoutSummary + rangeLabel (Codex-05vp8)

### DIFF
--- a/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
@@ -181,9 +181,6 @@
     { value: 'needs_attention', label: 'Needs attention' },
   ];
 
-  // KPI label dynamics — "Earned (last 7d)" etc. The "all time" case is
-  // collapsed to the same label as Total earned in practice; we still
-  // render the windowed card to keep the row stable.
   const RANGE_LABELS: Record<DateRange, string> = {
     '7': 'last 7 days',
     '30': 'last 30 days',

--- a/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
@@ -184,15 +184,13 @@
   // KPI label dynamics — "Earned (last 7d)" etc. The "all time" case is
   // collapsed to the same label as Total earned in practice; we still
   // render the windowed card to keep the row stable.
-  const rangeLabel = $derived(
-    rangeFilter === 'all'
-      ? 'all time'
-      : rangeFilter === '7'
-        ? 'last 7 days'
-        : rangeFilter === '90'
-          ? 'last 90 days'
-          : 'last 30 days'
-  );
+  const RANGE_LABELS: Record<DateRange, string> = {
+    '7': 'last 7 days',
+    '30': 'last 30 days',
+    '90': 'last 90 days',
+    all: 'all time',
+  };
+  const rangeLabel = $derived(RANGE_LABELS[rangeFilter]);
 
   // ── Badge variant + label helpers ────────────────────────────────────
   // Token-aligned status mapping: pending = warning, resolved/paid =

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -2632,56 +2632,50 @@ export class SubscriptionService extends BaseService {
   ): Promise<PayoutSummary> {
     const { fromDate, toDate } = options;
 
-    const [earnedInPeriod, totalEarned, inTransit, needsAttention] =
-      await Promise.all([
-        this.db
-          .select({
-            sum: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
-          })
-          .from(payouts)
-          .where(
-            and(
-              eq(payouts.organizationId, orgId),
-              eq(payouts.status, 'paid'),
-              ...dateWindow(payouts.createdAt, fromDate, toDate)
-            )
-          ),
-        this.db
-          .select({
-            sum: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
-          })
-          .from(payouts)
-          .where(
-            and(
-              eq(payouts.organizationId, orgId),
-              eq(payouts.status, 'paid')
-            )
-          ),
-        this.db
-          .select({
-            sum: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
-          })
-          .from(payouts)
-          .where(
-            and(
-              eq(payouts.organizationId, orgId),
-              eq(payouts.status, 'pending')
-            )
-          ),
-        this.db
-          .select({ count: sql<number>`count(*)::int` })
-          .from(payouts)
-          .where(
-            and(
-              eq(payouts.organizationId, orgId),
-              inArray(payouts.status, ['pending', 'failed'])
-            )
-          ),
-      ]);
+    // Three parallel aggregates:
+    // 1. Paid earnings — one query returns both lifetime + windowed via
+    //    CASE WHEN, saving a round-trip vs. two separate SUMs over the
+    //    same WHERE clause.
+    // 2. In-transit (status='pending') sum.
+    // 3. Needs-attention (pending OR failed) count.
+    const dateConditions = dateWindow(payouts.createdAt, fromDate, toDate);
+    const inPeriodPredicate =
+      dateConditions.length > 0
+        ? sql`(${and(...dateConditions)})`
+        : sql`TRUE`;
+
+    const [paid, inTransit, needsAttention] = await Promise.all([
+      this.db
+        .select({
+          inPeriod: sql<number>`COALESCE(SUM(CASE WHEN ${inPeriodPredicate} THEN ${payouts.amountCents} ELSE 0 END),0)::int`,
+          total: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
+        })
+        .from(payouts)
+        .where(
+          and(eq(payouts.organizationId, orgId), eq(payouts.status, 'paid'))
+        ),
+      this.db
+        .select({
+          sum: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
+        })
+        .from(payouts)
+        .where(
+          and(eq(payouts.organizationId, orgId), eq(payouts.status, 'pending'))
+        ),
+      this.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(payouts)
+        .where(
+          and(
+            eq(payouts.organizationId, orgId),
+            inArray(payouts.status, ['pending', 'failed'])
+          )
+        ),
+    ]);
 
     return {
-      earnedInPeriodCents: earnedInPeriod[0]?.sum ?? 0,
-      totalEarnedCents: totalEarned[0]?.sum ?? 0,
+      earnedInPeriodCents: paid[0]?.inPeriod ?? 0,
+      totalEarnedCents: paid[0]?.total ?? 0,
       inTransitCents: inTransit[0]?.sum ?? 0,
       needsAttentionCount: needsAttention[0]?.count ?? 0,
     };

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -2635,19 +2635,20 @@ export class SubscriptionService extends BaseService {
     // Three parallel aggregates:
     // 1. Paid earnings — one query returns both lifetime + windowed via
     //    CASE WHEN, saving a round-trip vs. two separate SUMs over the
-    //    same WHERE clause.
+    //    same WHERE clause. When no date window is set, the windowed
+    //    column collapses to the lifetime aggregate.
     // 2. In-transit (status='pending') sum.
     // 3. Needs-attention (pending OR failed) count.
     const dateConditions = dateWindow(payouts.createdAt, fromDate, toDate);
-    const inPeriodPredicate =
-      dateConditions.length > 0
-        ? sql`(${and(...dateConditions)})`
-        : sql`TRUE`;
+    const inPeriodSum =
+      dateConditions.length === 0
+        ? sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`
+        : sql<number>`COALESCE(SUM(CASE WHEN ${and(...dateConditions)} THEN ${payouts.amountCents} ELSE 0 END),0)::int`;
 
     const [paid, inTransit, needsAttention] = await Promise.all([
       this.db
         .select({
-          inPeriod: sql<number>`COALESCE(SUM(CASE WHEN ${inPeriodPredicate} THEN ${payouts.amountCents} ELSE 0 END),0)::int`,
+          inPeriod: inPeriodSum,
           total: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
         })
         .from(payouts)


### PR DESCRIPTION
## Summary

Follow-up to PR #199 (merged). Two cleanups flagged by the `/simplify` pass after #199 merged.

**1. `getPayoutSummary` query collapse.** `earnedInPeriod` + `totalEarned` aggregates shared a WHERE clause and differed only by a date-window predicate — collapsed into one query via `CASE WHEN`, returning both as separate SELECT columns. **4 parallel queries → 3 per page load.**

**2. `rangeLabel` lookup table.** Flattened a 3-level ternary chain into a static `RANGE_LABELS` map. Adding new date ranges later is a one-line map entry instead of threading another conditional.

## Tests

- `pnpm typecheck` clean
- `pnpm test @codex/subscription`: **338 passed** (no change from #199's baseline)
- The `getPayoutSummary > earnedInPeriodCents honours fromDate` test (added in #199) exercises the new CASE WHEN path
- The cross-org isolation test confirms org-scoping invariant preserved

## What was NOT changed (deferred as follow-up beads)

Per the `/simplify` audit, three more reuse/quality wins were identified but deferred:
- **Extract `setUrlParam` helper** — 3× duplicated across `/studio/{payouts,sales,subscribers}/+page.svelte`. Filed as P3 bead.
- **Add `createTestPayoutInput` factory** to `@codex/test-utils` — inline payouts inserts across two test files. Filed as P3 bead.
- **Batch-fetch `resolveSubscriptionFees`** — N+1 in the `executeTransfers` per-creator loop (in PR2-merged code). Filed as P2 bug bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)