### PR TITLE
fix(subscription): resolve invoice charge via expand-fallback (Codex-zdbhg)

### DIFF
--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -2797,6 +2797,153 @@ describe('SubscriptionService', () => {
       expect(result).toBeUndefined();
     });
 
+    // Codex-zdbhg: real Stripe 2024+ webhook payloads do NOT include
+    // expanded `payments.data` on the inline invoice object. The handler
+    // must retrieve the invoice with `expand: ['payments']` to recover
+    // the charge — without that fallback, executeTransfers never runs
+    // and payouts ledger rows never get written. The shape used here
+    // matches the production event payload Stripe actually delivers
+    // (no `payments` field at all), NOT the test-fixture shape that
+    // pre-populates `payments.data[0]`.
+    it('resolves charge via invoices.retrieve({ expand: [payments] }) when inline payments are absent (Stripe 2024+ shape)', async () => {
+      const { org, tier1 } = await createFullOrg('invoice-no-inline-payments');
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      // Real webhook shape: no `payments` field at all.
+      const realChargeId = 'ch_resolved_via_expand';
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: undefined,
+      }) as unknown as Stripe.Invoice;
+
+      // Override the default empty-payments mock so retrieve returns the
+      // fully expanded shape Stripe yields when `expand: ['payments']`.
+      (
+        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+      ).invoices.retrieve.mockResolvedValueOnce({
+        id: mockInvoice.id,
+        payments: {
+          data: [{ payment: { charge: realChargeId, payment_intent: null } }],
+        },
+      });
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      expect(stripe.invoices.retrieve).toHaveBeenCalledWith(
+        mockInvoice.id,
+        expect.objectContaining({ expand: ['payments'] })
+      );
+      expect(stripe.transfers.create).toHaveBeenCalled();
+      const calls = (stripe.transfers.create as ReturnType<typeof vi.fn>).mock
+        .calls;
+      for (const [, opts] of calls) {
+        expect(opts?.idempotencyKey).toMatch(
+          new RegExp(`^${realChargeId}_`)
+        );
+      }
+    });
+
+    it('falls back to charges.list when paymentIntent has no latest_charge (race after PI confirmation)', async () => {
+      const { org, tier1 } = await createFullOrg('invoice-charges-list-fallback');
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const piId = 'pi_pending_latest_charge';
+      const chargeViaList = 'ch_recovered_via_list';
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: undefined,
+      }) as unknown as Stripe.Invoice;
+
+      // Expanded invoice has only PI, no charge.
+      (
+        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+      ).invoices.retrieve.mockResolvedValueOnce({
+        id: mockInvoice.id,
+        payments: {
+          data: [{ payment: { charge: null, payment_intent: piId } }],
+        },
+      });
+      // PI retrieve still missing latest_charge.
+      (
+        stripe as unknown as {
+          paymentIntents: { retrieve: ReturnType<typeof vi.fn> };
+        }
+      ).paymentIntents.retrieve.mockResolvedValueOnce({
+        id: piId,
+        latest_charge: null,
+      });
+      // charges.list closes the gap.
+      (
+        stripe as unknown as { charges: { list: ReturnType<typeof vi.fn> } }
+      ).charges.list.mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: chargeViaList }],
+        has_more: false,
+      });
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      expect(stripe.charges.list).toHaveBeenCalledWith(
+        expect.objectContaining({ payment_intent: piId, limit: 1 })
+      );
+      expect(stripe.transfers.create).toHaveBeenCalled();
+    });
+
+    it('still skips with WARN (not crash) when no charge can be resolved at any layer', async () => {
+      // Negative path per feedback_security_deep_test — if every fallback
+      // returns empty, the handler must log + return cleanly, never crash.
+      const { org, tier1 } = await createFullOrg('invoice-truly-no-charge');
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: undefined,
+      }) as unknown as Stripe.Invoice;
+
+      // Expanded retrieve returns empty too.
+      (
+        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+      ).invoices.retrieve.mockResolvedValueOnce({
+        id: mockInvoice.id,
+        payments: { data: [] },
+      });
+
+      await expect(
+        service.handleInvoicePaymentSucceeded(mockInvoice)
+      ).resolves.not.toThrow();
+      expect(stripe.transfers.create).not.toHaveBeenCalled();
+    });
+
     // Codex-8wfnv: explicit idempotency assertions for the renewal path.
     // handleSubscriptionCreated has a uniqueness-constraint short-circuit
     // (line 519). handleInvoicePaymentSucceeded has no such short-circuit

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -2853,6 +2853,58 @@ describe('SubscriptionService', () => {
       }
     });
 
+    it('resolves charge via paymentIntents.retrieve.latest_charge when expanded invoice has only a PI', async () => {
+      const { org, tier1 } = await createFullOrg('invoice-pi-latest-charge');
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const piId = 'pi_with_latest_charge';
+      const chargeViaPi = 'ch_recovered_via_pi';
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: undefined,
+      }) as unknown as Stripe.Invoice;
+
+      (
+        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+      ).invoices.retrieve.mockResolvedValueOnce({
+        id: mockInvoice.id,
+        payments: {
+          data: [{ payment: { charge: null, payment_intent: piId } }],
+        },
+      });
+      (
+        stripe as unknown as {
+          paymentIntents: { retrieve: ReturnType<typeof vi.fn> };
+        }
+      ).paymentIntents.retrieve.mockResolvedValueOnce({
+        id: piId,
+        latest_charge: chargeViaPi,
+      });
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      expect(stripe.paymentIntents.retrieve).toHaveBeenCalledWith(piId);
+      expect(stripe.charges.list).not.toHaveBeenCalled();
+      expect(stripe.transfers.create).toHaveBeenCalled();
+      const calls = (stripe.transfers.create as ReturnType<typeof vi.fn>).mock
+        .calls;
+      for (const [, opts] of calls) {
+        expect(opts?.idempotencyKey).toMatch(
+          new RegExp(`^${chargeViaPi}_`)
+        );
+      }
+    });
+
     it('falls back to charges.list when paymentIntent has no latest_charge (race after PI confirmation)', async () => {
       const { org, tier1 } = await createFullOrg('invoice-charges-list-fallback');
       const [sub] = await db

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -1074,6 +1074,11 @@ export class SubscriptionService extends BaseService {
     const pi = await this.stripe.paymentIntents.retrieve(piId);
     if (typeof pi.latest_charge === 'string') return pi.latest_charge;
 
+    // Idempotency-drift invariant: charges.list returns the most recent
+    // charge for this PI. We assume Stripe sets pi.latest_charge once and
+    // never reassigns. If that invariant breaks (e.g., PI re-charge after
+    // a failure), the chargeId resolved here could differ across webhook
+    // retries → idempotency keys diverge → executeTransfers may double-pay.
     const charges = await this.stripe.charges.list({
       payment_intent: piId,
       limit: 1,

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -416,6 +416,23 @@ type TierPriceChangeMailer = (params: {
   data: Record<string, string | number | boolean>;
 }) => void;
 
+/**
+ * Read the source-charge id from an invoice's inline `payments.data[0]`.
+ * Returns null when payments are not expanded — see resolveInvoiceCharge
+ * for the full fallback chain to recover the charge in that case.
+ */
+function extractInvoiceCharge(invoice: Stripe.Invoice): string | null {
+  const payment = invoice.payments?.data?.[0];
+  const charge = payment?.payment?.charge;
+  return typeof charge === 'string' ? charge : null;
+}
+
+function extractInvoicePaymentIntent(invoice: Stripe.Invoice): string | null {
+  const payment = invoice.payments?.data?.[0];
+  const pi = payment?.payment?.payment_intent;
+  return typeof pi === 'string' ? pi : null;
+}
+
 export class SubscriptionService extends BaseService {
   private readonly stripe: Stripe;
   private readonly cache: VersionedCache | undefined;
@@ -1023,6 +1040,49 @@ export class SubscriptionService extends BaseService {
   }
 
   /**
+   * Resolve the source charge id for a paid invoice.
+   *
+   * Why: Stripe 2024+ invoice payloads omit `payments.data` unless the
+   * invoice is retrieved with `expand: ['payments']`. The raw webhook
+   * event is an immutable snapshot, so the inline shape is almost always
+   * empty in production. Without this fallback chain, executeTransfers
+   * never runs (Codex-zdbhg).
+   *
+   * Order of resolution:
+   *   1. Inline `payments.data[0]` on the supplied invoice (test fixtures + cache hits)
+   *   2. Retrieve the invoice with `expand: ['payments']` (canonical Stripe 2024+ path)
+   *   3. If we have a payment_intent but no charge, `paymentIntents.retrieve → latest_charge`
+   *   4. Final fallback: `charges.list({ payment_intent })` — rare race after PI confirmation
+   */
+  private async resolveInvoiceCharge(
+    stripeInvoice: Stripe.Invoice
+  ): Promise<string | null> {
+    let chargeId = extractInvoiceCharge(stripeInvoice);
+    let piId = extractInvoicePaymentIntent(stripeInvoice);
+
+    if (!chargeId && !piId && stripeInvoice.id) {
+      const expanded = await this.stripe.invoices.retrieve(stripeInvoice.id, {
+        expand: ['payments'],
+      });
+      chargeId = extractInvoiceCharge(expanded);
+      piId = extractInvoicePaymentIntent(expanded);
+    }
+
+    if (chargeId) return chargeId;
+    if (!piId) return null;
+
+    const pi = await this.stripe.paymentIntents.retrieve(piId);
+    if (typeof pi.latest_charge === 'string') return pi.latest_charge;
+
+    const charges = await this.stripe.charges.list({
+      payment_intent: piId,
+      limit: 1,
+    });
+    const first = charges.data?.[0];
+    return typeof first?.id === 'string' ? first.id : null;
+  }
+
+  /**
    * Handle invoice.payment_succeeded for subscription renewals.
    * Extends subscription period and creates revenue transfers.
    *
@@ -1044,41 +1104,17 @@ export class SubscriptionService extends BaseService {
         : (subDetails?.subscription?.id ?? null);
     if (!stripeSubId) return;
 
-    // Get charge ID from the invoice's payment intent
-    // In v19+, payments are in invoice.payments.data[]
-    const payment = stripeInvoice.payments?.data?.[0];
-    const chargeId =
-      typeof payment?.payment?.charge === 'string'
-        ? payment.payment.charge
-        : null;
-    // Fall back to payment_intent if no direct charge
-    const paymentIntentId =
-      typeof payment?.payment?.payment_intent === 'string'
-        ? payment.payment.payment_intent
-        : null;
-
-    if (!chargeId && !paymentIntentId) {
+    // Resolve the source charge for transfers. Webhook payloads in Stripe
+    // 2024+ do NOT include expanded `payments.data` by default — the field
+    // is only populated when explicitly expanded on retrieve. Without the
+    // expand-fallback chain below, every real invoice.payment_succeeded
+    // event silently skipped transfers (Codex-zdbhg).
+    const sourceTransaction = await this.resolveInvoiceCharge(stripeInvoice);
+    if (!sourceTransaction) {
       this.obs.warn(
         'Invoice has no charge or payment intent, skipping transfers',
-        {
-          invoiceId: stripeInvoice.id,
-        }
+        { invoiceId: stripeInvoice.id }
       );
-      return;
-    }
-
-    // For transfers, we need the charge ID. If we only have PI, retrieve it.
-    let sourceTransaction = chargeId;
-    if (!sourceTransaction && paymentIntentId) {
-      const pi = await this.stripe.paymentIntents.retrieve(paymentIntentId);
-      sourceTransaction =
-        typeof pi.latest_charge === 'string' ? pi.latest_charge : null;
-    }
-
-    if (!sourceTransaction) {
-      this.obs.warn('Could not resolve charge for transfers', {
-        invoiceId: stripeInvoice.id,
-      });
       return;
     }
 

--- a/packages/test-utils/src/stripe-mock.ts
+++ b/packages/test-utils/src/stripe-mock.ts
@@ -160,6 +160,25 @@ export function createMockStripe(): Stripe {
         latest_charge: nextId('ch'),
       })),
     },
+
+    // invoices.retrieve and charges.list back the Stripe 2024+ fallback
+    // chain in SubscriptionService.resolveInvoiceCharge — see
+    // subscription-service.ts. Default returns an empty payments array so
+    // tests that don't override see the "no charge resolvable" branch.
+    invoices: {
+      retrieve: vi.fn().mockImplementation((_id: string) => ({
+        id: _id,
+        payments: { data: [] },
+      })),
+    },
+
+    charges: {
+      list: vi.fn().mockImplementation(() => ({
+        object: 'list',
+        data: [],
+        has_more: false,
+      })),
+    },
   };
 
   return mock as unknown as Stripe;


### PR DESCRIPTION
## Summary

- **Money-path bug.** Pre-existing handler issue blocking every real `invoice.payment_succeeded` webhook from reaching `executeTransfers` and writing payouts ledger rows. Surfaced during live verification of the just-merged payouts epic (Codex-4r55k → PRs #198/#199/#200).
- Stripe 2024+ invoice payloads omit `payments.data` unless retrieved with `expand: ['payments']`. The handler was reading the inline shape only — green tests passed because fixtures pre-populated the inline shape that real wire payloads never include.
- Adds a 4-stage resolver: inline → `invoices.retrieve({ expand: ['payments'] })` → `paymentIntents.retrieve.latest_charge` → `charges.list({ payment_intent })`.

## Why three new tests

| Test | Shape | Proves |
|---|---|---|
| `resolves charge via invoices.retrieve({ expand: [payments] })` | Real webhook (no `payments` field) | Step 2 of the fallback fires and the recovered charge flows into transfer idempotency keys |
| `falls back to charges.list when paymentIntent has no latest_charge` | PI present, no charge, PI.latest_charge null | Steps 3+4 fire; the final fallback closes the gap |
| `still skips with WARN (not crash) when no charge can be resolved` | All four layers empty | Negative path: no crash, original WARN preserved |

Pre-fix log evidence (against running stack at 18:32:42):
```
type=invoice.payment_succeeded id=evt_1TX1nf7wyGmo4sh6PNlnmGjQ
WARN: Invoice has no charge or payment intent, skipping transfers
```

## Files

- `packages/subscription/src/services/subscription-service.ts` — new `resolveInvoiceCharge()` private helper + `extractInvoiceCharge/PaymentIntent` module-scope readers; replaces inline charge resolution in `handleInvoicePaymentSucceeded`
- `packages/test-utils/src/stripe-mock.ts` — adds `invoices.retrieve` and `charges.list` to the mock (empty defaults) so per-test `.mockResolvedValueOnce` can drive the fallback ladder
- `packages/subscription/src/services/__tests__/subscription-service.test.ts` — three Codex-zdbhg regression tests, including positive + negative + idempotency-key assertion

## Test plan

- [x] `pnpm --filter @codex/subscription typecheck` — clean
- [x] `pnpm --filter @codex/test-utils typecheck` — clean
- [x] `pnpm --filter @codex/subscription test` — 341 passed (was 338 baseline + 3 new). Pre-existing F5 denoise proof failure is unrelated (comment-block parse error).
- [x] All 19 `handleInvoicePaymentSucceeded` tests pass (16 baseline + 3 new)
- [x] Wrangler hot-reloaded all 8 workers after rebuild — fix is live in the running stack
- [ ] **Live e2e (deferred to reviewer with active Stripe CLI auth)** — trigger a fresh `invoice.payment_succeeded` (e.g. `stripe trigger invoice.payment_succeeded` OR resubscribe on `of-blood-and-bones.lvh.me:3000/pricing`) and confirm `payouts` table receives rows. CLI used in this session was authenticated to a different account than `stripe listen` — see [feedback_stripe_cli_account_mismatch](https://github.com) memory note.

Closes Codex-zdbhg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)