### PR TITLE
fix(subscription): self-heal webhook ordering race on fresh subs (Codex-t7psp)

### DIFF
--- a/packages/subscription/CLAUDE.md
+++ b/packages/subscription/CLAUDE.md
@@ -74,6 +74,26 @@ Tier-gated (`accessType='subscribers'`) content is **orthogonal** to this hierar
 
 Revenue split defaults: Platform 10%, Org 15% of post-platform, Creators 75% of post-platform. Amounts are in pence (GBP). Defaults are **overridable** via the DB-configurable fee model — see `docs/payouts/fee-configuration.md`.
 
+### Webhook ordering resilience (Codex-t7psp)
+
+Stripe does **NOT** guarantee webhook delivery order. On a fresh subscription, `invoice.payment_succeeded` and `invoice.payment_failed` can arrive **before** `customer.subscription.created`. Without resilience the first payout (race #1) and the first past_due flip (race #2) were silently dropped.
+
+`SubscriptionService.ensureSubscriptionDataPresent(stripeSubId, context)` is the central self-heal helper. It:
+
+1. Fast-paths: SELECT subscription. If present → `{ subscription, justInserted: false }`.
+2. Slow-path: retrieves the subscription from Stripe (or uses caller's `knownStripeSub`), validates `codex_user_id` / `codex_organization_id` / `codex_tier_id` metadata, and inserts `subscriptions` + `organizationFollowers` + `organizationMemberships` rows in one transaction.
+3. On `isUniqueViolation`: another handler raced us — re-SELECT and return `justInserted: false`.
+4. On Stripe 404 or missing metadata: WARN + return `null` (caller exits cleanly with 200).
+5. On Stripe 5xx / DB error: bubble (caller returns 5xx, Stripe retries).
+
+`handleSubscriptionCreated` always fires welcome-email + cache invalidation, even when `justInserted: false` — the old "swallow on unique-violation" was incompatible with self-heal because it silently dropped 5 side effects when self-heal pre-inserted the row. Cost: a rare Stripe redelivery of the create event may send the welcome email twice. Mitigated long-term by event-id dedupe (Layer D, Codex-257ia).
+
+**Hard invariants** (regression-tested):
+- Invoice handlers never log "Invoice for unknown subscription" — they self-heal instead.
+- A `customer.subscription.created` arriving AFTER self-heal still emits welcome email + bumps caches.
+- Concurrent self-heal + create-event yield exactly one row (unique constraint), both invocations complete cleanly.
+- Stripe 404 / metadata-missing on retrieve never crashes the handler — they exit 200.
+
 ### Payout pipeline (audit closed 2026-05-13)
 
 The invoice → transfer → pending-payout → drain flow is documented end-to-end in **`docs/payouts/payout-pipeline.md`**. Read that doc before touching any of:

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -2829,7 +2829,9 @@ describe('SubscriptionService', () => {
       // Override the default empty-payments mock so retrieve returns the
       // fully expanded shape Stripe yields when `expand: ['payments']`.
       (
-        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+        stripe as unknown as {
+          invoices: { retrieve: ReturnType<typeof vi.fn> };
+        }
       ).invoices.retrieve.mockResolvedValueOnce({
         id: mockInvoice.id,
         payments: {
@@ -2847,9 +2849,7 @@ describe('SubscriptionService', () => {
       const calls = (stripe.transfers.create as ReturnType<typeof vi.fn>).mock
         .calls;
       for (const [, opts] of calls) {
-        expect(opts?.idempotencyKey).toMatch(
-          new RegExp(`^${realChargeId}_`)
-        );
+        expect(opts?.idempotencyKey).toMatch(new RegExp(`^${realChargeId}_`));
       }
     });
 
@@ -2875,7 +2875,9 @@ describe('SubscriptionService', () => {
       }) as unknown as Stripe.Invoice;
 
       (
-        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+        stripe as unknown as {
+          invoices: { retrieve: ReturnType<typeof vi.fn> };
+        }
       ).invoices.retrieve.mockResolvedValueOnce({
         id: mockInvoice.id,
         payments: {
@@ -2899,14 +2901,14 @@ describe('SubscriptionService', () => {
       const calls = (stripe.transfers.create as ReturnType<typeof vi.fn>).mock
         .calls;
       for (const [, opts] of calls) {
-        expect(opts?.idempotencyKey).toMatch(
-          new RegExp(`^${chargeViaPi}_`)
-        );
+        expect(opts?.idempotencyKey).toMatch(new RegExp(`^${chargeViaPi}_`));
       }
     });
 
     it('falls back to charges.list when paymentIntent has no latest_charge (race after PI confirmation)', async () => {
-      const { org, tier1 } = await createFullOrg('invoice-charges-list-fallback');
+      const { org, tier1 } = await createFullOrg(
+        'invoice-charges-list-fallback'
+      );
       const [sub] = await db
         .insert(subscriptions)
         .values(
@@ -2928,7 +2930,9 @@ describe('SubscriptionService', () => {
 
       // Expanded invoice has only PI, no charge.
       (
-        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+        stripe as unknown as {
+          invoices: { retrieve: ReturnType<typeof vi.fn> };
+        }
       ).invoices.retrieve.mockResolvedValueOnce({
         id: mockInvoice.id,
         payments: {
@@ -2984,7 +2988,9 @@ describe('SubscriptionService', () => {
 
       // Expanded retrieve returns empty too.
       (
-        stripe as unknown as { invoices: { retrieve: ReturnType<typeof vi.fn> } }
+        stripe as unknown as {
+          invoices: { retrieve: ReturnType<typeof vi.fn> };
+        }
       ).invoices.retrieve.mockResolvedValueOnce({
         id: mockInvoice.id,
         payments: { data: [] },
@@ -3796,6 +3802,404 @@ describe('SubscriptionService', () => {
       expect(result).toBeDefined();
       expect(result?.userId).toBeUndefined();
       expect(result?.orgId).toBeUndefined();
+    });
+  });
+
+  // ─── Webhook ordering self-heal (Codex-t7psp) ─────────────────────
+  //
+  // Stripe does NOT guarantee webhook delivery order. On a fresh
+  // subscription, `invoice.payment_succeeded` and `invoice.payment_failed`
+  // can arrive BEFORE `customer.subscription.created`. Before this fix,
+  // those handlers logged "Invoice for unknown subscription" and silently
+  // dropped the first payout (race #1) or the past_due flip (race #2).
+  //
+  // Fix: `ensureSubscriptionDataPresent` retrieves the sub from Stripe
+  // when the DB row is missing and inserts subscription + follower +
+  // membership in one transaction. Side effects (welcome email, cache
+  // invalidation) stay on the create-event handler so they don't get
+  // dropped by the unique-violation swallow when the real
+  // `customer.subscription.created` lands later.
+  describe('Webhook ordering self-heal (Codex-t7psp)', () => {
+    /** Unique stripe-sub id per call — avoids cross-run collisions in the shared test DB. */
+    function uniqueStripeSubId(prefix: string) {
+      return `sub_${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    /** Build a Stripe subscription mock with the metadata our helper expects. */
+    function buildStripeSubMock(args: {
+      stripeSubId: string;
+      stripeCustomerId: string;
+      userId: string;
+      orgId: string;
+      tierId: string;
+    }) {
+      return createMockStripeSubscription({
+        id: args.stripeSubId,
+        customer: args.stripeCustomerId,
+        metadata: {
+          codex_user_id: args.userId,
+          codex_organization_id: args.orgId,
+          codex_tier_id: args.tierId,
+        },
+      }) as unknown as Stripe.Subscription;
+    }
+
+    it('race #1: invoice.payment_succeeded self-heals missing subscription row and runs transfers', async () => {
+      const { org, tier1 } = await createFullOrg('selfheal-race1');
+      const stripeSubId = uniqueStripeSubId('race1');
+      const stripeCustomerId = `cus_${stripeSubId}`;
+      const chargeId = `ch_${stripeSubId}`;
+
+      // Pre-condition: NO subscriptions row exists for this Stripe sub.
+      // Stripe sub retrieve returns a fully-formed sub with our metadata.
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce(
+        buildStripeSubMock({
+          stripeSubId,
+          stripeCustomerId,
+          userId: otherCreatorId,
+          orgId: org.id,
+          tierId: tier1.id,
+        })
+      );
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: null } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const result = await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      // Helper inserted the subscription + follower + membership rows.
+      const { eq, and } = await import('drizzle-orm');
+      const { organizationFollowers, organizationMemberships } = await import(
+        '@codex/database/schema'
+      );
+      const [inserted] = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
+        .limit(1);
+      expect(inserted).toBeDefined();
+      expect(inserted.userId).toBe(otherCreatorId);
+      expect(inserted.organizationId).toBe(org.id);
+
+      const [follower] = await db
+        .select()
+        .from(organizationFollowers)
+        .where(
+          and(
+            eq(organizationFollowers.organizationId, org.id),
+            eq(organizationFollowers.userId, otherCreatorId)
+          )
+        )
+        .limit(1);
+      expect(follower).toBeDefined();
+
+      const [membership] = await db
+        .select()
+        .from(organizationMemberships)
+        .where(
+          and(
+            eq(organizationMemberships.organizationId, org.id),
+            eq(organizationMemberships.userId, otherCreatorId)
+          )
+        )
+        .limit(1);
+      expect(membership).toBeDefined();
+      expect(membership.role).toBe('subscriber');
+
+      // Money path resumed: transfers fired with chargeId-derived keys.
+      expect(stripe.transfers.create).toHaveBeenCalled();
+      const transferCalls = (
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      for (const [, opts] of transferCalls) {
+        expect(opts?.idempotencyKey).toMatch(new RegExp(`^${chargeId}_`));
+      }
+
+      // Handler returns invalidation tuple so the route bumps caches.
+      expect(result?.userId).toBe(otherCreatorId);
+      expect(result?.orgId).toBe(org.id);
+    });
+
+    it('race #2: invoice.payment_failed self-heals missing row then flips status to past_due', async () => {
+      const { org, tier1 } = await createFullOrg('selfheal-race2');
+      const stripeSubId = uniqueStripeSubId('race2');
+      const stripeCustomerId = `cus_${stripeSubId}`;
+
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce(
+        buildStripeSubMock({
+          stripeSubId,
+          stripeCustomerId,
+          userId: otherCreatorId,
+          orgId: org.id,
+          tierId: tier1.id,
+        })
+      );
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_due: 499,
+        customer_email: 'failed@example.com',
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const result = await service.handleInvoicePaymentFailed(mockInvoice);
+
+      const { eq } = await import('drizzle-orm');
+      const [row] = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
+        .limit(1);
+      expect(row).toBeDefined();
+      expect(row.status).toBe('past_due');
+      expect(result?.userId).toBe(otherCreatorId);
+      expect(result?.orgId).toBe(org.id);
+    });
+
+    it('Stripe 404 on retrieve: handler returns cleanly, no transfer, no row inserted', async () => {
+      const stripeSubId = uniqueStripeSubId('stripe404');
+
+      // Simulate Stripe returning 404 — type marker matches the
+      // detection branch in ensureSubscriptionDataPresent.
+      const stripe404 = new Error('No such subscription') as Error & {
+        type?: string;
+      };
+      stripe404.type = 'StripeInvalidRequestError';
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockRejectedValueOnce(stripe404);
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const callsBefore = (stripe.transfers.create as ReturnType<typeof vi.fn>)
+        .mock.calls.length;
+      const result = await service.handleInvoicePaymentSucceeded(mockInvoice);
+      const callsAfter = (stripe.transfers.create as ReturnType<typeof vi.fn>)
+        .mock.calls.length;
+
+      expect(result).toBeUndefined();
+      expect(callsAfter).toBe(callsBefore);
+
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('metadata missing on retrieved sub: helper returns null, no row inserted', async () => {
+      const stripeSubId = uniqueStripeSubId('nometa');
+
+      // Default mock returns a sub with empty metadata — exactly the
+      // shape that should trip the "missing metadata" guard.
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce(
+        createMockStripeSubscription({
+          id: stripeSubId,
+          metadata: {},
+        }) as unknown as Stripe.Subscription
+      );
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+      }) as unknown as Stripe.Invoice;
+
+      const result = await service.handleInvoicePaymentSucceeded(mockInvoice);
+      expect(result).toBeUndefined();
+
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('concurrent self-heal: two parallel invoice handlers insert exactly one row, both run transfers', async () => {
+      const { org, tier1 } = await createFullOrg('selfheal-concurrent');
+      const stripeSubId = uniqueStripeSubId('concurrent');
+      const stripeCustomerId = `cus_${stripeSubId}`;
+      const chargeId = `ch_${stripeSubId}`;
+
+      // Both parallel invocations will call retrieve — return the same
+      // metadata on every call so the second insert sees a unique-violation.
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockImplementation(() =>
+        buildStripeSubMock({
+          stripeSubId,
+          stripeCustomerId,
+          userId: otherCreatorId,
+          orgId: org.id,
+          tierId: tier1.id,
+        })
+      );
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: null } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      // Fire both handlers in parallel — exactly the racing-webhooks shape.
+      await Promise.all([
+        service.handleInvoicePaymentSucceeded(mockInvoice),
+        service.handleInvoicePaymentSucceeded(mockInvoice),
+      ]);
+
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId));
+      expect(rows).toHaveLength(1);
+
+      // Both invocations ran transfers, every call carries a chargeId-derived
+      // idempotency key — Stripe will dedupe the duplicate transfer at its end.
+      const transferCalls = (
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      expect(transferCalls.length).toBeGreaterThanOrEqual(2);
+      for (const [, opts] of transferCalls) {
+        expect(opts?.idempotencyKey).toMatch(new RegExp(`^${chargeId}_`));
+      }
+    });
+
+    it('regression: customer.subscription.created lands AFTER self-heal pre-insert → side effects still fire', async () => {
+      // Sequence:
+      //   1. invoice.payment_succeeded arrives FIRST → self-heal inserts row
+      //   2. customer.subscription.created arrives SECOND → must NOT swallow
+      //      the welcome email + cache invalidation just because the row
+      //      pre-existed. This is the regression-prevention guarantee.
+      const { org, tier1 } = await createFullOrg('selfheal-create-after');
+      const stripeSubId = uniqueStripeSubId('createafter');
+      const stripeCustomerId = `cus_${stripeSubId}`;
+
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce(
+        buildStripeSubMock({
+          stripeSubId,
+          stripeCustomerId,
+          userId: otherCreatorId,
+          orgId: org.id,
+          tierId: tier1.id,
+        })
+      );
+
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: `ch_${stripeSubId}`, payment_intent: null } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      // Step 1: invoice arrives first, self-heals row.
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      // Step 2: real create event arrives — the Stripe sub object the
+      // ecom-api webhook would dispatch to handleSubscriptionCreated.
+      const mockCreateEventSub = buildStripeSubMock({
+        stripeSubId,
+        stripeCustomerId,
+        userId: otherCreatorId,
+        orgId: org.id,
+        tierId: tier1.id,
+      });
+
+      const result =
+        await service.handleSubscriptionCreated(mockCreateEventSub);
+
+      // The previous unique-violation swallow returned `void` here, dropping
+      // the welcome email + cache invalidation. After the fix, the handler
+      // MUST return `{ userId, orgId }` so the route bumps both caches and
+      // dispatches the welcome email.
+      expect(result).toBeDefined();
+      expect(result?.userId).toBe(otherCreatorId);
+      expect(result?.orgId).toBe(org.id);
+    });
+
+    it('regression: Stripe redelivers create event after 5xx-after-insert → side effects fire on redelivery', async () => {
+      // Pre-insert via self-heal to simulate "first delivery 5xx'd
+      // after we inserted the row" — the second attempt finds the row
+      // already present. With the old swallow, the email was lost
+      // forever; the new behavior fires it on redelivery.
+      const { org, tier1 } = await createFullOrg('selfheal-redeliver');
+      const stripeSubId = uniqueStripeSubId('redeliver');
+      const stripeCustomerId = `cus_${stripeSubId}`;
+
+      (
+        stripe.subscriptions.retrieve as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce(
+        buildStripeSubMock({
+          stripeSubId,
+          stripeCustomerId,
+          userId: otherCreatorId,
+          orgId: org.id,
+          tierId: tier1.id,
+        })
+      );
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 499,
+        parent: {
+          subscription_details: { subscription: stripeSubId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: `ch_${stripeSubId}`, payment_intent: null } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      // Now fire the create event TWICE — simulating Stripe redelivery.
+      const createSub = buildStripeSubMock({
+        stripeSubId,
+        stripeCustomerId,
+        userId: otherCreatorId,
+        orgId: org.id,
+        tierId: tier1.id,
+      });
+      const first = await service.handleSubscriptionCreated(createSub);
+      const second = await service.handleSubscriptionCreated(createSub);
+
+      // Both invocations return invalidation tuples — neither swallows
+      // the side effects despite the row already being present.
+      expect(first?.userId).toBe(otherCreatorId);
+      expect(first?.orgId).toBe(org.id);
+      expect(second?.userId).toBe(otherCreatorId);
+      expect(second?.orgId).toBe(org.id);
     });
   });
 
@@ -4961,9 +5365,7 @@ describe('SubscriptionService', () => {
       // UI-derived display status is still 'resolved' until PR4 drops the alias.
       expect(result.items[0]!.status).toBe('resolved');
       expect(result.items[0]!.amountCents).toBe(250);
-      expect(result.items[0]!.stripeTransferId).toBe(
-        'tr_05vp8_canonical_paid'
-      );
+      expect(result.items[0]!.stripeTransferId).toBe('tr_05vp8_canonical_paid');
     });
 
     it('projects payoutType from the payouts row', async () => {
@@ -5284,7 +5686,7 @@ describe('SubscriptionService', () => {
       expect(result.inTransitCents).toBe(400); // 150 + 250 only
     });
 
-    it("needsAttentionCount counts pending + failed rows (excludes paid)", async () => {
+    it('needsAttentionCount counts pending + failed rows (excludes paid)', async () => {
       const { org, tier1 } = await createFullOrg('05vp8-sum-needs-attn');
       const sub = await seedSubscriptionForOrg(
         org.id,
@@ -6858,7 +7260,9 @@ describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', ()
           subscription_details: { subscription: sub.stripeSubscriptionId },
         },
         payments: {
-          data: [{ payment: { charge: chargeId, payment_intent: 'pi_orgfee' } }],
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_orgfee' } },
+          ],
         },
       }) as unknown as Stripe.Invoice;
 
@@ -7004,22 +7408,24 @@ describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', ()
       // the partial-unique-index path.
       const transferSpy = vi.mocked(stripe.transfers.create);
       const byKey = new Map<string, string>();
-      transferSpy.mockImplementation((params: Record<string, unknown>, opts) => {
-        const o = opts as { idempotencyKey?: string } | undefined;
-        const key = o?.idempotencyKey ?? '';
-        let id = byKey.get(key);
-        if (!id) {
-          id = `tr_idem_${createUniqueSlug('t')}`;
-          byKey.set(key, id);
+      transferSpy.mockImplementation(
+        (params: Record<string, unknown>, opts) => {
+          const o = opts as { idempotencyKey?: string } | undefined;
+          const key = o?.idempotencyKey ?? '';
+          let id = byKey.get(key);
+          if (!id) {
+            id = `tr_idem_${createUniqueSlug('t')}`;
+            byKey.set(key, id);
+          }
+          return Promise.resolve({
+            id,
+            amount: params.amount,
+            currency: params.currency,
+            destination: params.destination,
+            metadata: params.metadata ?? {},
+          }) as unknown as ReturnType<typeof transferSpy>;
         }
-        return Promise.resolve({
-          id,
-          amount: params.amount,
-          currency: params.currency,
-          destination: params.destination,
-          metadata: params.metadata ?? {},
-        }) as unknown as ReturnType<typeof transferSpy>;
-      });
+      );
 
       const chargeId = 'ch_e9v3b_idem_fixed';
       const mockInvoice = createMockStripeInvoice({

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -41,8 +41,8 @@ import {
   organizationFollowers,
   organizationMemberships,
   organizations,
-  payouts,
   type PayoutType,
+  payouts,
   stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
@@ -62,7 +62,16 @@ import {
   UnsupportedCurrencyError,
 } from '@codex/service-errors';
 import type { PaginatedListResponse } from '@codex/shared-types';
-import { aliasedTable, and, desc, eq, inArray, isNull, lt, sql } from 'drizzle-orm';
+import {
+  aliasedTable,
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  sql,
+} from 'drizzle-orm';
 import type Stripe from 'stripe';
 import {
   AlreadySubscribedError,
@@ -830,24 +839,82 @@ export class SubscriptionService extends BaseService {
   // ─── Webhook Handlers ──────────────────────────────────────────────────────
 
   /**
-   * Handle checkout.session.completed for subscription mode.
-   * Creates the subscription record in our database.
-   * Idempotent via stripeSubscriptionId unique constraint.
+   * Ensure subscription, follower, and membership rows exist for the given
+   * Stripe subscription. Idempotent — safe to call from both the create-event
+   * handler and the self-heal path in invoice handlers.
    *
-   * Returns a result object with:
-   * - userId for cache invalidation
-   * - email payload for the subscription-created notification
+   * Stripe does not guarantee webhook delivery order (Codex-t7psp): on a
+   * fresh subscription, `invoice.payment_succeeded` can arrive BEFORE
+   * `customer.subscription.created`. Without self-heal the invoice handler
+   * would log "Invoice for unknown subscription" and drop the first payout.
    *
-   * @param stripeSubscription The Stripe subscription object
-   * @param webAppUrl The web app base URL for email links (optional)
+   * If the row is missing, retrieves the subscription from Stripe and
+   * inserts subscription + follower + membership in one transaction. The
+   * unique constraint on `stripe_subscription_id` makes this safe under
+   * concurrent self-heal + create-event delivery.
+   *
+   * Does NOT fire side effects (welcome email, cache invalidation) — those
+   * remain the create-event handler's responsibility so they run once per
+   * Stripe delivery of `customer.subscription.created`, regardless of
+   * whether the row was pre-inserted by self-heal.
+   *
+   * Returns:
+   * - `{ subscription, justInserted: true }`  — we inserted the row in this call.
+   * - `{ subscription, justInserted: false }` — row already existed (raced or earlier event).
+   * - `null` — permanent failure (Stripe 404, missing metadata). Caller exits cleanly.
+   *
+   * Bubbles transient errors (Stripe 5xx, DB connection) so the procedure
+   * layer returns 5xx and Stripe retries.
    */
-  async handleSubscriptionCreated(
-    stripeSubscription: Stripe.Subscription,
-    webAppUrl?: string
-  ): Promise<WebhookHandlerResult | void> {
-    const stripeSubId = stripeSubscription.id;
-    const metadata = stripeSubscription.metadata;
+  private async ensureSubscriptionDataPresent(
+    stripeSubId: string,
+    context: {
+      invoiceId?: string;
+      eventType: string;
+      /** Pre-loaded Stripe subscription, avoids a second retrieve on the create path. */
+      knownStripeSub?: Stripe.Subscription;
+    }
+  ): Promise<{ subscription: Subscription; justInserted: boolean } | null> {
+    // Fast path: row already exists. No Stripe call, no insert.
+    const [existing] = await this.db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
+      .limit(1);
+    if (existing) {
+      return { subscription: existing, justInserted: false };
+    }
 
+    // Slow path: row missing. Retrieve from Stripe unless caller already has it.
+    let stripeSub: Stripe.Subscription;
+    if (context.knownStripeSub) {
+      stripeSub = context.knownStripeSub;
+    } else {
+      try {
+        stripeSub = await this.stripe.subscriptions.retrieve(stripeSubId);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          'type' in error &&
+          (error as { type?: string }).type === 'StripeInvalidRequestError'
+        ) {
+          this.obs.warn(
+            'Subscription self-heal failed: Stripe returned not-found',
+            {
+              stripeSubscriptionId: stripeSubId,
+              invoiceId: context.invoiceId,
+              eventType: context.eventType,
+            }
+          );
+          return null;
+        }
+        throw error;
+      }
+    }
+
+    // Defensive `?? {}` — handles minimal Stripe mocks in test harnesses
+    // that omit the metadata field. Production payloads always have it.
+    const metadata = stripeSub.metadata ?? {};
     const userId = metadata.codex_user_id;
     const orgId = metadata.codex_organization_id;
     const tierId = metadata.codex_tier_id;
@@ -857,45 +924,31 @@ export class SubscriptionService extends BaseService {
         stripeSubscriptionId: stripeSubId,
         metadata,
       });
-      return;
+      return null;
     }
 
-    // Get amount actually charged from the latest invoice (respects coupons, trials, prorations)
-    // Matches the pattern used in handleInvoicePaymentSucceeded() — use amount_paid, not unit_amount
+    // Initial amount: latest_invoice.amount_paid — matches handleInvoicePaymentSucceeded.
+    // Subsequent invoice.payment_succeeded writes overwrite this with the actual
+    // charged amount, so a 0 from a trial-only sub heals to the real amount on first bill.
     let amountCents = 0;
-    const latestInvoice = stripeSubscription.latest_invoice;
+    const latestInvoice = stripeSub.latest_invoice;
     if (latestInvoice && typeof latestInvoice === 'object') {
-      // latest_invoice is expanded — use amount_paid directly
       amountCents = latestInvoice.amount_paid;
     } else if (typeof latestInvoice === 'string') {
-      // latest_invoice is just an ID — retrieve the full invoice
       const invoice = await this.stripe.invoices.retrieve(latestInvoice);
       amountCents = invoice.amount_paid;
     }
-    // If latest_invoice is null (e.g. trial with no invoice yet), amountCents stays 0
 
-    const item = stripeSubscription.items.data[0];
+    const item = stripeSub.items.data[0];
     const billingInterval =
       item?.price?.recurring?.interval === 'year'
         ? BILLING_INTERVAL.YEAR
         : BILLING_INTERVAL.MONTH;
-
-    // Calculate revenue split using DB-configurable fees (Codex-m644n).
-    // FeeConfigService falls back to FEES.* constants when no fee row exists,
-    // preserving pre-m644n bit-for-bit behaviour on fresh installs.
-    const split = await this.computeSubscriptionSplit(orgId, amountCents);
-
-    // In Stripe v19+, period dates are on the subscription item, not the subscription
     const periodStart = item?.current_period_start ?? 0;
     const periodEnd = item?.current_period_end ?? 0;
 
-    // Atomic: subscription insert + follower upsert + membership upsert must
-    // all commit together. Partial state (e.g. subscription row exists but
-    // follower/membership missing) leaves the user in an inconsistent
-    // state that library queries and role-gated paths read incorrectly.
-    // The unique constraint on stripe_subscription_id still provides
-    // webhook-replay idempotency — the whole transaction rolls back on
-    // duplicate insert and we return normally.
+    const split = await this.computeSubscriptionSplit(orgId, amountCents);
+
     try {
       await (this.db as typeof import('@codex/database').dbWs).transaction(
         async (tx) => {
@@ -905,9 +958,9 @@ export class SubscriptionService extends BaseService {
             tierId,
             stripeSubscriptionId: stripeSubId,
             stripeCustomerId:
-              typeof stripeSubscription.customer === 'string'
-                ? stripeSubscription.customer
-                : stripeSubscription.customer.id,
+              typeof stripeSub.customer === 'string'
+                ? stripeSub.customer
+                : stripeSub.customer.id,
             status: SUBSCRIPTION_STATUS.ACTIVE,
             billingInterval,
             currentPeriodStart: new Date(periodStart * 1000),
@@ -926,9 +979,7 @@ export class SubscriptionService extends BaseService {
             .onConflictDoNothing();
 
           // BUG-016: Upsert membership with role=subscriber (backward compat).
-          // TODO(Phase 3): Remove once frontend no longer reads membership
-          // roles for library access badges. Preserve higher roles (owner/
-          // admin/creator) on conflict.
+          // Preserve higher roles (owner/admin/creator) on conflict.
           await tx
             .insert(organizationMemberships)
             .values({
@@ -950,24 +1001,130 @@ export class SubscriptionService extends BaseService {
             });
         }
       );
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        // Concurrent self-heal or create-event raced us to insert. Re-select
+        // and return justInserted=false so caller skips the "just inserted"
+        // log line — the row is now present either way.
+        const [raced] = await this.db
+          .select()
+          .from(subscriptions)
+          .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
+          .limit(1);
+        if (raced) {
+          return { subscription: raced, justInserted: false };
+        }
+        throw error;
+      }
+      throw error;
+    }
 
+    const [inserted] = await this.db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
+      .limit(1);
+    if (!inserted) {
+      // Should be unreachable — INSERT just succeeded. Defensive throw so a
+      // truly impossible state surfaces as 5xx (Stripe retry) instead of NPE.
+      throw new InternalServiceError(
+        'ensureSubscriptionDataPresent: row missing after successful insert',
+        { stripeSubscriptionId: stripeSubId }
+      );
+    }
+
+    if (context.knownStripeSub) {
       this.obs.info('Subscription created from webhook', {
         stripeSubscriptionId: stripeSubId,
         organizationId: orgId,
         tierId,
         amountCents,
       });
-    } catch (error) {
-      if (isUniqueViolation(error)) {
-        this.obs.info('Subscription already recorded (idempotent)', {
-          stripeSubscriptionId: stripeSubId,
-        });
-        return;
-      }
-      throw error;
+    } else {
+      // Self-heal path: the invoice handler (or similar) pre-inserted the row
+      // before the create event arrived. Distinct log line so it's
+      // greppable in production.
+      this.obs.info('Subscription self-healed from Stripe API', {
+        stripeSubscriptionId: stripeSubId,
+        organizationId: orgId,
+        tierId,
+        invoiceId: context.invoiceId,
+        eventType: context.eventType,
+      });
     }
 
-    // Build email notification data — look up tier name from DB
+    return { subscription: inserted, justInserted: true };
+  }
+
+  /**
+   * Handle customer.subscription.created.
+   * Ensures the subscription row exists (idempotent — honours prior
+   * self-heal pre-insert) and fires create-event side effects: welcome
+   * email + library/badge cache invalidation.
+   *
+   * Side effects ALWAYS fire on this event, even when the row pre-existed
+   * (Codex-t7psp regression prevention). The previous "swallow on unique
+   * violation" was incompatible with the self-heal pattern because it
+   * silently dropped the welcome email + cache bump when self-heal got
+   * here first. Cost: a Stripe redelivery of the create event will send
+   * the welcome email twice. Mitigated long-term by event-id dedupe
+   * (Codex-257ia, Layer D).
+   *
+   * @param stripeSubscription The Stripe subscription object
+   * @param webAppUrl The web app base URL for email links (optional)
+   */
+  async handleSubscriptionCreated(
+    stripeSubscription: Stripe.Subscription,
+    webAppUrl?: string
+  ): Promise<WebhookHandlerResult | void> {
+    const stripeSubId = stripeSubscription.id;
+    const metadata = stripeSubscription.metadata ?? {};
+    const userId = metadata.codex_user_id;
+    const orgId = metadata.codex_organization_id;
+    const tierId = metadata.codex_tier_id;
+
+    if (!userId || !orgId || !tierId) {
+      this.obs.warn('Subscription webhook missing metadata', {
+        stripeSubscriptionId: stripeSubId,
+        metadata,
+      });
+      return;
+    }
+
+    const result = await this.ensureSubscriptionDataPresent(stripeSubId, {
+      eventType: 'customer.subscription.created',
+      knownStripeSub: stripeSubscription,
+    });
+    if (!result) return;
+
+    if (!result.justInserted) {
+      // Row was pre-inserted by an earlier self-heal or a prior delivery
+      // attempt that 5xx'd after INSERT. Fire side effects anyway — the
+      // duplicate-email risk on redelivery is a known trade-off.
+      this.obs.info(
+        'Subscription already recorded, firing create-event side effects',
+        { stripeSubscriptionId: stripeSubId }
+      );
+    }
+
+    // Compute the amount actually charged for the welcome-email payload.
+    // Matches handleInvoicePaymentSucceeded — use amount_paid, not unit_amount,
+    // so trials/coupons/prorations show the correct figure.
+    let amountCents = 0;
+    const latestInvoice = stripeSubscription.latest_invoice;
+    if (latestInvoice && typeof latestInvoice === 'object') {
+      amountCents = latestInvoice.amount_paid;
+    } else if (typeof latestInvoice === 'string') {
+      const invoice = await this.stripe.invoices.retrieve(latestInvoice);
+      amountCents = invoice.amount_paid;
+    }
+
+    const item = stripeSubscription.items.data[0];
+    const billingInterval =
+      item?.price?.recurring?.interval === 'year'
+        ? BILLING_INTERVAL.YEAR
+        : BILLING_INTERVAL.MONTH;
+
     const email = await this.buildSubscriptionCreatedEmail(
       userId,
       tierId,
@@ -978,8 +1135,7 @@ export class SubscriptionService extends BaseService {
     );
 
     // Orchestrator hook: bump per-user library + per-org subscription
-    // version keys. Runs AFTER the DB writes above succeeded; a thrown
-    // error earlier in this method would bypass this call entirely.
+    // version keys. Runs AFTER the row is guaranteed present.
     this.invalidateIfConfigured(userId, orgId, 'subscription_created');
 
     return { userId, orgId, email: email ?? undefined };
@@ -1123,19 +1279,17 @@ export class SubscriptionService extends BaseService {
       return;
     }
 
-    // Find our subscription record
-    const [sub] = await this.db
-      .select()
-      .from(subscriptions)
-      .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
-      .limit(1);
-
-    if (!sub) {
-      this.obs.warn('Invoice for unknown subscription', {
-        stripeSubscriptionId: stripeSubId,
-      });
-      return;
-    }
+    // Self-heal: if the subscription row is missing, retrieve from Stripe
+    // and insert it (Codex-t7psp). Stripe does not guarantee webhook
+    // delivery order — invoice.payment_succeeded routinely arrives before
+    // customer.subscription.created on fresh subs. Without self-heal the
+    // first payout would be silently lost.
+    const presence = await this.ensureSubscriptionDataPresent(stripeSubId, {
+      eventType: 'invoice.payment_succeeded',
+      invoiceId: stripeInvoice.id,
+    });
+    if (!presence) return;
+    const { subscription: sub } = presence;
 
     // Fetch the Stripe subscription for period dates (v19+: on items)
     const stripeSub = await this.stripe.subscriptions.retrieve(stripeSubId);
@@ -1253,18 +1407,33 @@ export class SubscriptionService extends BaseService {
         ? subDetails.subscription
         : (subDetails?.subscription?.id ?? null);
 
+    // Self-heal: ensure the subscription row exists before flipping status.
+    // Same ordering race as race #1 — invoice.payment_failed can arrive
+    // before customer.subscription.created on first-bill failure.
+    let userId: string | undefined;
+    let orgId: string | undefined;
     if (stripeSubId) {
-      await this.db
-        .update(subscriptions)
-        .set({
-          status: SUBSCRIPTION_STATUS.PAST_DUE,
-          updatedAt: new Date(),
-        })
-        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId));
-
-      this.obs.info('Subscription status updated to past_due', {
-        stripeSubscriptionId: stripeSubId,
+      const presence = await this.ensureSubscriptionDataPresent(stripeSubId, {
+        eventType: 'invoice.payment_failed',
+        invoiceId: stripeInvoice.id,
       });
+      if (presence) {
+        const { subscription: sub } = presence;
+        userId = sub.userId;
+        orgId = sub.organizationId;
+
+        await this.db
+          .update(subscriptions)
+          .set({
+            status: SUBSCRIPTION_STATUS.PAST_DUE,
+            updatedAt: new Date(),
+          })
+          .where(eq(subscriptions.id, sub.id));
+
+        this.obs.info('Subscription status updated to past_due', {
+          stripeSubscriptionId: stripeSubId,
+        });
+      }
     }
 
     // Build payment-failed email
@@ -1287,24 +1456,6 @@ export class SubscriptionService extends BaseService {
           updatePaymentUrl: `${webAppUrl || ''}/account/subscriptions`,
         },
       };
-    }
-
-    // Look up userId + orgId from subscription record for cache invalidation.
-    // Both caches (COLLECTION_USER_LIBRARY and per-org COLLECTION_USER_SUBSCRIPTION)
-    // need to flip to 'past_due' for cross-device staleness detection.
-    let userId: string | undefined;
-    let orgId: string | undefined;
-    if (stripeSubId) {
-      const [sub] = await this.db
-        .select({
-          userId: subscriptions.userId,
-          organizationId: subscriptions.organizationId,
-        })
-        .from(subscriptions)
-        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
-        .limit(1);
-      userId = sub?.userId;
-      orgId = sub?.organizationId;
     }
 
     // Orchestrator hook: payment failure flips status to past_due → bump
@@ -2565,7 +2716,13 @@ export class SubscriptionService extends BaseService {
     options: {
       page: number;
       limit: number;
-      status?: 'all' | 'pending' | 'paid' | 'resolved' | 'failed' | 'needs_attention';
+      status?:
+        | 'all'
+        | 'pending'
+        | 'paid'
+        | 'resolved'
+        | 'failed'
+        | 'needs_attention';
       fromDate?: string;
       toDate?: string;
     }


### PR DESCRIPTION
## Summary

- Stripe webhooks arrive out-of-order on fresh subscriptions — `invoice.payment_succeeded` routinely beats `customer.subscription.created`. The invoice handler used to log `Invoice for unknown subscription` and silently drop the first payout.
- New `ensureSubscriptionDataPresent` helper retrieves the sub from the Stripe API when the local row is missing, then inserts `subscriptions` + `organizationFollowers` + `organizationMemberships` atomically. Wired into `handleSubscriptionCreated`, `handleInvoicePaymentSucceeded`, and `handleInvoicePaymentFailed`.
- Side effects (welcome email + cache invalidation) now fire unconditionally on the create event — the prior "swallow on unique violation" was incompatible with the self-heal pre-insert (would silently drop 5 side effects). Cost: rare Stripe redelivery may double-send welcome email; mitigated long-term by event-id dedupe (Codex-257ia, P2 follow-up).

## Race coverage

| # | Race | Today (before fix) | After |
|---|---|---|---|
| 1 | `invoice.payment_succeeded` before `customer.subscription.created` | WARN + first payout dropped | Self-heals, transfers fire ✓ |
| 2 | `invoice.payment_failed` before `customer.subscription.created` | Silent no-op UPDATE | Self-heals, status flipped to past_due ✓ |
| 3 | `customer.subscription.updated` before `customer.subscription.created` | WARN | **Follow-up: Codex-1hvda** |
| 4 | `charge.refunded` before `checkout.session.completed` | WARN | **Follow-up: Codex-aa08z** (PurchaseService) |

## Tests

7 new regression tests in `subscription-service.test.ts` (real PG + mocked Stripe):
1. Race #1: invoice arrives → self-heal inserts row + follower + membership, transfers fire with chargeId-derived idempotency keys
2. Race #2: invoice.payment_failed arrives → self-heal + flip to past_due
3. Stripe 404 on retrieve → handler returns cleanly, no row inserted, no transfer
4. Metadata missing on retrieved sub → helper returns null, no row inserted
5. Concurrent self-heal: two parallel invoice handlers → exactly one row inserted, both run transfers (Stripe dedupes via idempotency key)
6. **Regression guard**: `customer.subscription.created` lands AFTER self-heal pre-insert → side effects (email + cache bump) STILL fire
7. Stripe redelivers create event after 5xx-after-insert → side effects fire on redelivery (incidentally fixes "5xx-after-insert email lost" bug)

Full subscription suite: **349 passed**, 1 pre-existing unrelated JSDoc parse failure in `__denoise_proofs__`. Typecheck clean. Build clean.

## Test plan

- [x] `pnpm --filter @codex/subscription typecheck` ✓
- [x] `pnpm --filter @codex/subscription test` → 349 pass (342 before + 7 new) ✓
- [x] `pnpm --filter @codex/subscription build` ✓
- [x] Wrangler hot-reloaded all workers after dist rebuild ✓
- [ ] **Manual smoke-test (recommended)**: Subscribe a fresh test customer via `/pricing` on an org subdomain with `4242 4242 4242 4242`. Verify in `/tmp/pnpm-dev.log`: (a) NO `Invoice for unknown subscription` WARN, (b) `Subscription self-healed from Stripe API` INFO (if race hits) OR `Subscription created from webhook` INFO (if create event arrives first), (c) `/studio/payouts` shows the row within ~5s of checkout, (d) welcome email present in notifications-api log. Playwright struggled with Stripe Checkout's nested iframes, so this last step is human-verified.

## Follow-ups (already filed, blocked on this PR)

- **Codex-1hvda** (P1) — `handleSubscriptionUpdated` upsert on missing row (race #3)
- **Codex-aa08z** (P1) — `handleChargeRefunded` self-heal on missing purchase row (race #4)
- **Codex-257ia** (P2) — event-id dedupe table (Layer D) — removes the duplicate-email risk this PR accepts

## Reference

Builds on PR #201 (Codex-zdbhg) which established the "retrieve from Stripe API to recover missing data" precedent via `resolveInvoiceCharge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)