### PR TITLE
feat(agreements): WP-6 RevenueSplitPie component

### DIFF
--- a/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte
+++ b/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte
@@ -1,0 +1,591 @@
+<!--
+  @component RevenueSplitPie
+
+  Stacked horizontal bar visualising revenue-share splits between the platform
+  fee, the org/owner residual, and any number of creator slices. Used in both
+  the owner surface (full visibility) and the creator surface (self-visible,
+  peers anonymised).
+
+  Despite the name (kept for parity with the epic plan), the component is a
+  stacked bar — better for many slices and far more accessible than a radial
+  pie. Each draggable boundary acts as a `role="slider"` widget. Numeric inputs
+  alongside each unlocked slice stay in sync with drag.
+
+  All values are basis points internally (0-10000) and displayed as percent.
+  Colors are CSS custom-property references — never hex literals — so org
+  branding flows through unchanged.
+
+  Props mirror the WP-6 spec in Codex-tg3p6.
+-->
+<script lang="ts">
+  import { tick } from 'svelte';
+  import {
+    BP_MAX,
+    BP_STEP,
+    BP_STEP_LARGE,
+    type RevenueSplitMode,
+    type RevenueSplitSlice,
+  } from './types';
+
+  interface Props {
+    /** `owner` = full visibility; `creator` = self + anonymised peers. */
+    mode: RevenueSplitMode;
+    /** Platform fee in basis points. Forms the locked first slice. */
+    platformFeePercent: number;
+    /** Ordered slices following the platform fee. */
+    slices: RevenueSplitSlice[];
+    /** Fires only when the user produces a value distinct from current props. */
+    onChange?: (next: RevenueSplitSlice[]) => void;
+    /** Read-only renders the bar without handles or inputs. */
+    readOnly?: boolean;
+    /** Optional class forwarded to the root element (composition seam per R13). */
+    class?: string;
+  }
+
+  const {
+    mode,
+    platformFeePercent,
+    slices,
+    onChange,
+    readOnly = false,
+    class: className,
+  }: Props = $props();
+
+  // -- Derived state ---------------------------------------------------------
+
+  /** Sum of creator/owner slice basis points (excludes platform fee). */
+  const sliceTotalBp = $derived(
+    slices.reduce((sum, s) => sum + s.percent, 0)
+  );
+
+  /** Maximum non-platform basis points available. */
+  const availableBp = $derived(BP_MAX - platformFeePercent);
+
+  /** True when slices over-allocate (sum > 100% minus platform fee). */
+  const isOverAllocated = $derived(sliceTotalBp > availableBp);
+
+  /** True when slices under-allocate (sum < 100% minus platform fee). */
+  const isUnderAllocated = $derived(sliceTotalBp < availableBp);
+
+  // -- SR live-region (debounced) -------------------------------------------
+
+  let liveMessage = $state('');
+  let liveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function announce(message: string) {
+    if (liveTimer) clearTimeout(liveTimer);
+    liveTimer = setTimeout(() => {
+      liveMessage = message;
+    }, 200);
+  }
+
+  $effect(() => {
+    return () => {
+      if (liveTimer) clearTimeout(liveTimer);
+    };
+  });
+
+  // -- Helpers ---------------------------------------------------------------
+
+  function bpToPercent(bp: number): number {
+    return bp / 100;
+  }
+
+  function formatPercent(bp: number): string {
+    const pct = bpToPercent(bp);
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  function displayLabel(slice: RevenueSplitSlice, index: number): string {
+    if (mode === 'creator' && slice.anonymous) {
+      return `Other creator ${index + 1}`;
+    }
+    return slice.label;
+  }
+
+  /**
+   * Replace one slice and emit. Idempotent: skips the callback when the next
+   * value equals the current one (per feedback_melt_controlled_components).
+   */
+  function emitSliceChange(sliceId: string, nextPercent: number) {
+    const current = slices.find((s) => s.id === sliceId);
+    if (!current) return;
+    if (current.percent === nextPercent) return;
+    const next = slices.map((s) =>
+      s.id === sliceId ? { ...s, percent: nextPercent } : s
+    );
+    onChange?.(next);
+    announce(
+      `${displayLabel(current, slices.indexOf(current))} now ${formatPercent(nextPercent)}`
+    );
+  }
+
+  /**
+   * Max a single slice can grow to without exceeding the available budget.
+   */
+  function maxForSlice(sliceId: string): number {
+    const others = slices
+      .filter((s) => s.id !== sliceId)
+      .reduce((sum, s) => sum + s.percent, 0);
+    return Math.max(0, availableBp - others);
+  }
+
+  // -- Keyboard handling -----------------------------------------------------
+
+  function onHandleKeyDown(event: KeyboardEvent, slice: RevenueSplitSlice) {
+    if (slice.locked || readOnly) return;
+    const isIncrement = event.key === 'ArrowRight' || event.key === 'ArrowUp';
+    const isDecrement = event.key === 'ArrowLeft' || event.key === 'ArrowDown';
+    const isHome = event.key === 'Home';
+    const isEnd = event.key === 'End';
+    if (!isIncrement && !isDecrement && !isHome && !isEnd) return;
+    event.preventDefault();
+    const step = event.shiftKey ? BP_STEP_LARGE : BP_STEP;
+    const max = maxForSlice(slice.id);
+    let next = slice.percent;
+    if (isIncrement) next = Math.min(max, slice.percent + step);
+    else if (isDecrement) next = Math.max(0, slice.percent - step);
+    else if (isHome) next = 0;
+    else if (isEnd) next = max;
+    emitSliceChange(slice.id, next);
+  }
+
+  // -- Pointer drag handling -------------------------------------------------
+
+  let barEl: HTMLDivElement | undefined = $state();
+  let activeDragId: string | null = $state(null);
+
+  function onHandlePointerDown(event: PointerEvent, slice: RevenueSplitSlice) {
+    if (slice.locked || readOnly || !barEl) return;
+    if (event.button !== 0) return;
+    activeDragId = slice.id;
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  }
+
+  function onHandlePointerMove(event: PointerEvent, slice: RevenueSplitSlice) {
+    if (activeDragId !== slice.id || !barEl) return;
+    const rect = barEl.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    const ratio = Math.min(
+      1,
+      Math.max(0, (event.clientX - rect.left) / rect.width)
+    );
+    // The handle sits at the trailing boundary of `slice`. Its new cumulative
+    // position controls the slice's value:
+    //   sliceBp = cumulativeBp - platformFee - sum(earlier slices)
+    const cumulativeBp = Math.round(ratio * BP_MAX);
+    const earlierSliceBp = slices
+      .slice(0, slices.indexOf(slice))
+      .reduce((sum, s) => sum + s.percent, 0);
+    const wantedSliceBp = cumulativeBp - platformFeePercent - earlierSliceBp;
+    const max = maxForSlice(slice.id);
+    const clamped = Math.min(max, Math.max(0, wantedSliceBp));
+    // Snap to nearest BP_STEP for predictable values.
+    const snapped = Math.round(clamped / BP_STEP) * BP_STEP;
+    emitSliceChange(slice.id, snapped);
+  }
+
+  function onHandlePointerUp(event: PointerEvent, slice: RevenueSplitSlice) {
+    if (activeDragId !== slice.id) return;
+    activeDragId = null;
+    try {
+      (event.currentTarget as HTMLElement).releasePointerCapture(
+        event.pointerId
+      );
+    } catch {
+      // Pointer may already be released; ignore.
+    }
+  }
+
+  // -- Numeric input handling -----------------------------------------------
+
+  async function onPercentInput(
+    event: Event,
+    slice: RevenueSplitSlice
+  ) {
+    if (slice.locked || readOnly) return;
+    const target = event.currentTarget as HTMLInputElement;
+    const raw = Number(target.value);
+    if (!Number.isFinite(raw)) return;
+    const clampedPct = Math.min(100, Math.max(0, raw));
+    const bp = Math.round(clampedPct * 100);
+    const max = maxForSlice(slice.id);
+    const next = Math.min(max, bp);
+    emitSliceChange(slice.id, next);
+    if (next !== bp) {
+      await tick();
+      target.value = String(bpToPercent(next));
+    }
+  }
+
+  // -- Platform-fee slice (always first, always locked) ---------------------
+
+  const platformSlice = $derived<RevenueSplitSlice>({
+    id: '__platform__',
+    label: 'Platform fee',
+    percent: platformFeePercent,
+    color: 'var(--color-text-muted)',
+    locked: true,
+    anonymous: false,
+  });
+
+  const renderedSlices = $derived([platformSlice, ...slices]);
+</script>
+
+<div
+  class="revenue-split-pie {className ?? ''}"
+  data-mode={mode}
+  data-state={isOverAllocated ? 'over' : isUnderAllocated ? 'under' : 'balanced'}
+>
+  <div
+    class="revenue-split-pie__bar"
+    role="presentation"
+    bind:this={barEl}
+  >
+    {#each renderedSlices as slice, index (slice.id)}
+      {@const widthPct = bpToPercent(slice.percent)}
+      <div
+        class="revenue-split-pie__slice"
+        data-locked={slice.locked ? 'true' : 'false'}
+        style="--slice-width: {widthPct}%; --slice-color: {slice.color};"
+        title="{displayLabel(slice, index - 1)}: {formatPercent(slice.percent)}"
+      >
+        <span class="revenue-split-pie__slice-fill"></span>
+      </div>
+    {/each}
+
+    <!--
+      Handles sit at the trailing boundary of each non-platform slice. The
+      platform fee is locked and does not get a handle.
+    -->
+    {#each slices as slice, index (`handle-${slice.id}`)}
+      {@const cumulativeBp =
+        platformFeePercent +
+        slices.slice(0, index + 1).reduce((sum, s) => sum + s.percent, 0)}
+      {@const handlePct = bpToPercent(cumulativeBp)}
+      {@const max = maxForSlice(slice.id)}
+      {@const interactive = !slice.locked && !readOnly}
+      <div
+        class="revenue-split-pie__handle"
+        data-interactive={interactive ? 'true' : 'false'}
+        data-dragging={activeDragId === slice.id ? 'true' : 'false'}
+        style="--handle-pos: {handlePct}%;"
+        role="slider"
+        tabindex={interactive ? 0 : -1}
+        aria-label="{displayLabel(slice, index)} share"
+        aria-valuemin="0"
+        aria-valuemax={bpToPercent(max)}
+        aria-valuenow={bpToPercent(slice.percent)}
+        aria-valuetext={formatPercent(slice.percent)}
+        aria-disabled={interactive ? undefined : 'true'}
+        onkeydown={(e) => onHandleKeyDown(e, slice)}
+        onpointerdown={(e) => onHandlePointerDown(e, slice)}
+        onpointermove={(e) => onHandlePointerMove(e, slice)}
+        onpointerup={(e) => onHandlePointerUp(e, slice)}
+        onpointercancel={(e) => onHandlePointerUp(e, slice)}
+      >
+        <span class="revenue-split-pie__handle-grip" aria-hidden="true"></span>
+      </div>
+    {/each}
+  </div>
+
+  <ul class="revenue-split-pie__legend">
+    {#each renderedSlices as slice, index (slice.id)}
+      {@const isPlatform = slice.id === '__platform__'}
+      {@const sliceIndex = index - 1}
+      <li
+        class="revenue-split-pie__legend-item"
+        data-locked={slice.locked ? 'true' : 'false'}
+      >
+        <span
+          class="revenue-split-pie__legend-swatch"
+          style="--swatch-color: {slice.color};"
+          aria-hidden="true"
+        ></span>
+        <span class="revenue-split-pie__legend-label">
+          {displayLabel(slice, sliceIndex)}
+        </span>
+        {#if readOnly || slice.locked}
+          <span class="revenue-split-pie__legend-value">
+            {formatPercent(slice.percent)}
+          </span>
+        {:else}
+          <label
+            class="revenue-split-pie__legend-input"
+            aria-label="{displayLabel(slice, sliceIndex)} share percent"
+          >
+            <input
+              type="number"
+              min="0"
+              max={bpToPercent(maxForSlice(slice.id))}
+              step="1"
+              value={bpToPercent(slice.percent)}
+              oninput={(e) => onPercentInput(e, slice)}
+              disabled={isPlatform}
+            />
+            <span aria-hidden="true">%</span>
+          </label>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+
+  {#if isOverAllocated}
+    <p class="revenue-split-pie__warning" role="status">
+      Splits exceed available budget by
+      {formatPercent(sliceTotalBp - availableBp)}. Reduce one or more shares.
+    </p>
+  {/if}
+
+  <span
+    class="revenue-split-pie__sr-live"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    {liveMessage}
+  </span>
+</div>
+
+<style>
+  .revenue-split-pie {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    container-type: inline-size;
+    container-name: revenue-split-pie;
+  }
+
+  /* -- Bar ---------------------------------------------------------------- */
+
+  .revenue-split-pie__bar {
+    position: relative;
+    display: flex;
+    width: 100%;
+    height: var(--space-8);
+    background: var(--color-surface-secondary);
+    border: var(--border-width) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    touch-action: none;
+  }
+
+  .revenue-split-pie[data-state='over'] .revenue-split-pie__bar {
+    border-color: var(--color-error);
+    box-shadow: 0 0 0 var(--border-width) var(--color-error-200);
+  }
+
+  .revenue-split-pie__slice {
+    position: relative;
+    height: 100%;
+    width: var(--slice-width, 0%);
+    min-width: 0;
+    flex-shrink: 0;
+  }
+
+  .revenue-split-pie__slice-fill {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--slice-color, var(--color-surface-tertiary));
+    transition: background-color var(--transition-colors, 180ms ease);
+  }
+
+  .revenue-split-pie__slice[data-locked='true'] .revenue-split-pie__slice-fill {
+    /* Locked slices read as system-set, not user-owned. */
+    background-image: linear-gradient(
+      135deg,
+      var(--slice-color, var(--color-text-muted)) 0%,
+      var(--slice-color, var(--color-text-muted)) 50%,
+      oklch(from var(--slice-color, var(--color-text-muted)) calc(l + 0.05) c h) 50%,
+      oklch(from var(--slice-color, var(--color-text-muted)) calc(l + 0.05) c h) 100%
+    );
+    background-size: var(--space-3) var(--space-3);
+  }
+
+  /* -- Handles ------------------------------------------------------------ */
+
+  .revenue-split-pie__handle {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: var(--handle-pos, 0%);
+    transform: translateX(-50%);
+    width: var(--space-4);
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: none;
+    padding: 0;
+  }
+
+  .revenue-split-pie__handle[data-interactive='true'] {
+    cursor: ew-resize;
+  }
+
+  .revenue-split-pie__handle[data-interactive='false'] {
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  .revenue-split-pie__handle-grip {
+    display: block;
+    width: var(--border-width-thick, 2px);
+    height: 60%;
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border-strong);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    transition:
+      transform var(--transition-colors, 180ms ease),
+      background-color var(--transition-colors, 180ms ease);
+  }
+
+  .revenue-split-pie__handle[data-interactive='true']:hover
+    .revenue-split-pie__handle-grip,
+  .revenue-split-pie__handle[data-dragging='true']
+    .revenue-split-pie__handle-grip {
+    background: var(--color-interactive);
+    transform: scaleY(1.05);
+  }
+
+  .revenue-split-pie__handle:focus-visible {
+    outline: none;
+  }
+
+  .revenue-split-pie__handle:focus-visible .revenue-split-pie__handle-grip {
+    outline: var(--border-width-thick, 2px) solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  /* -- Legend ------------------------------------------------------------- */
+
+  .revenue-split-pie__legend {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  @container revenue-split-pie (min-width: 32rem) {
+    .revenue-split-pie__legend {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-3);
+    }
+  }
+
+  @container revenue-split-pie (min-width: 48rem) {
+    .revenue-split-pie__legend {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .revenue-split-pie__legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border-subtle);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .revenue-split-pie__legend-item[data-locked='true'] {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-split-pie__legend-swatch {
+    flex-shrink: 0;
+    width: var(--space-3);
+    height: var(--space-3);
+    border-radius: var(--radius-sm);
+    background: var(--swatch-color, var(--color-surface-tertiary));
+    border: var(--border-width) solid var(--color-border-subtle);
+  }
+
+  .revenue-split-pie__legend-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .revenue-split-pie__legend-value {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-split-pie__legend-input {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-split-pie__legend-input input {
+    width: var(--space-12);
+    padding: var(--space-1) var(--space-2);
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-text);
+    font: inherit;
+    text-align: end;
+  }
+
+  .revenue-split-pie__legend-input input:focus-visible {
+    outline: var(--border-width-thick, 2px) solid var(--color-focus);
+    outline-offset: 2px;
+    border-color: var(--color-border-focus);
+  }
+
+  .revenue-split-pie__legend-input input:disabled {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+  }
+
+  /* -- Warning state ------------------------------------------------------ */
+
+  .revenue-split-pie__warning {
+    margin: 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-error-50);
+    color: var(--color-error-700);
+    border: var(--border-width) solid var(--color-error-200);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+  }
+
+  /* -- Screen-reader live region ----------------------------------------- */
+
+  .revenue-split-pie__sr-live {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* -- Reduced motion ----------------------------------------------------- */
+
+  @media (prefers-reduced-motion: reduce) {
+    .revenue-split-pie__slice-fill,
+    .revenue-split-pie__handle-grip {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte.test.ts
@@ -1,0 +1,493 @@
+/**
+ * RevenueSplitPie unit tests.
+ *
+ * Verifies prop-driven rendering, keyboard nudge, numeric input clamping,
+ * over-allocation warning, mode-driven anonymisation, and idempotent onChange.
+ *
+ * Pointer-drag and full axe sweeps run in Playwright (see e2e).
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import RevenueSplitPie from './RevenueSplitPie.svelte';
+import type { RevenueSplitSlice } from './types';
+
+function makeSlices(): RevenueSplitSlice[] {
+  return [
+    {
+      id: 'owner',
+      label: 'Org owner',
+      percent: 3000,
+      color: 'var(--color-info-600)',
+      locked: false,
+      anonymous: false,
+    },
+    {
+      id: 'creator-1',
+      label: 'Alex Rivera',
+      percent: 6000,
+      color: 'var(--color-primary-500)',
+      locked: false,
+      anonymous: false,
+    },
+  ];
+}
+
+describe('RevenueSplitPie', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('renders platform fee slice + each provided slice', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const slices = document.body.querySelectorAll('.revenue-split-pie__slice');
+    // platform + 2 supplied
+    expect(slices.length).toBe(3);
+  });
+
+  test('renders one slider handle per non-platform slice', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const handles = document.body.querySelectorAll('[role="slider"]');
+    expect(handles.length).toBe(2);
+  });
+
+  test('handle exposes correct aria-valuenow as percent', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const handles = document.body.querySelectorAll('[role="slider"]');
+    // First non-platform = owner @ 3000bp = 30
+    expect(handles[0]?.getAttribute('aria-valuenow')).toBe('30');
+    // Second = creator-1 @ 6000bp = 60
+    expect(handles[1]?.getAttribute('aria-valuenow')).toBe('60');
+  });
+
+  test('ArrowRight nudges a slice by 100 basis points (1 %)', () => {
+    const onChange = vi.fn();
+    // Owner @ 2000bp, creator @ 5000bp, platform @ 1000bp → 2000bp headroom.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Org owner',
+        percent: 2000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'creator-1',
+        label: 'Alex Rivera',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices,
+        onChange,
+      },
+    });
+    const ownerHandle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      bubbles: true,
+      cancelable: true,
+    });
+    ownerHandle.dispatchEvent(event);
+    flushSync();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as RevenueSplitSlice[];
+    const owner = next.find((s) => s.id === 'owner');
+    expect(owner?.percent).toBe(2100);
+  });
+
+  test('Shift+ArrowRight nudges by 1000 basis points (10 %)', () => {
+    const onChange = vi.fn();
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Owner',
+        percent: 2000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'c1',
+        label: 'C1',
+        percent: 1000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices, onChange },
+    });
+    const ownerHandle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    ownerHandle.dispatchEvent(event);
+    flushSync();
+    const owner = (onChange.mock.calls[0][0] as RevenueSplitSlice[]).find(
+      (s) => s.id === 'owner'
+    );
+    expect(owner?.percent).toBe(3000);
+  });
+
+  test('ArrowLeft cannot drop below zero', () => {
+    const onChange = vi.fn();
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Owner',
+        percent: 0,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices, onChange },
+    });
+    const handle = document.body.querySelector(
+      '[role="slider"]'
+    ) as HTMLElement;
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', cancelable: true })
+    );
+    flushSync();
+    // Already at zero — idempotent guard suppresses callback.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('ArrowRight cannot exceed available budget', () => {
+    const onChange = vi.fn();
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'a',
+        label: 'A',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'b',
+        label: 'B',
+        percent: 4000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    // platform 10 % + 50 % + 40 % = 100 %. No room for "a" to grow.
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices, onChange },
+    });
+    const handle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true })
+    );
+    flushSync();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('warning state appears when slices over-allocate', () => {
+    // 10 % platform + 60 % + 60 % = 130 % total → over by 30 %.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'a',
+        label: 'A',
+        percent: 6000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'b',
+        label: 'B',
+        percent: 6000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices },
+    });
+    const root = document.body.querySelector('.revenue-split-pie');
+    expect(root?.getAttribute('data-state')).toBe('over');
+    const warning = document.body.querySelector('.revenue-split-pie__warning');
+    expect(warning).toBeTruthy();
+  });
+
+  test('creator mode anonymises peers but keeps the owning slice visible', () => {
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'me',
+        label: 'Me',
+        percent: 4000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'peer-1',
+        label: 'Hidden Peer',
+        percent: 3000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: true,
+      },
+      {
+        id: 'peer-2',
+        label: 'Other Hidden',
+        percent: 2000,
+        color: 'var(--color-success-600)',
+        locked: false,
+        anonymous: true,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'creator', platformFeePercent: 1000, slices },
+    });
+    const labels = Array.from(
+      document.body.querySelectorAll('.revenue-split-pie__legend-label')
+    ).map((el) => el.textContent?.trim());
+    expect(labels).toContain('Me');
+    expect(labels).not.toContain('Hidden Peer');
+    expect(labels).not.toContain('Other Hidden');
+    // Anonymised replacements present
+    expect(labels.some((l) => l?.startsWith('Other creator'))).toBe(true);
+  });
+
+  test('readOnly mode hides numeric inputs', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        readOnly: true,
+      },
+    });
+    const numericInputs = document.body.querySelectorAll(
+      '.revenue-split-pie__legend-input input'
+    );
+    expect(numericInputs.length).toBe(0);
+  });
+
+  test('readOnly mode disables handle interactivity', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        readOnly: true,
+      },
+    });
+    const handle = document.body.querySelector(
+      '[role="slider"]'
+    ) as HTMLElement;
+    expect(handle.getAttribute('data-interactive')).toBe('false');
+    expect(handle.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('numeric input dispatches onChange with clamped basis points', () => {
+    const onChange = vi.fn();
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        onChange,
+      },
+    });
+    const ownerInput = document.body.querySelectorAll(
+      '.revenue-split-pie__legend-input input'
+    )[0] as HTMLInputElement;
+    ownerInput.value = '25';
+    ownerInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const owner = (onChange.mock.calls[0][0] as RevenueSplitSlice[]).find(
+      (s) => s.id === 'owner'
+    );
+    expect(owner?.percent).toBe(2500);
+  });
+
+  test('numeric input over the budget is clamped to available max', () => {
+    const onChange = vi.fn();
+    // Owner=2000, creator=5000, platform=1000 → max for owner = 10000-1000-5000 = 4000bp = 40%.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Org owner',
+        percent: 2000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'creator-1',
+        label: 'Alex Rivera',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices,
+        onChange,
+      },
+    });
+    const ownerInput = document.body.querySelectorAll(
+      '.revenue-split-pie__legend-input input'
+    )[0] as HTMLInputElement;
+    ownerInput.value = '95';
+    ownerInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const owner = (onChange.mock.calls[0][0] as RevenueSplitSlice[]).find(
+      (s) => s.id === 'owner'
+    );
+    // 95% requested, but only 40% available → clamps to 4000bp.
+    expect(owner?.percent).toBe(4000);
+  });
+
+  test('onChange is idempotent when next value equals current', () => {
+    const onChange = vi.fn();
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        onChange,
+      },
+    });
+    // Owner is at 30, hitting End jumps to its max (which is 30 because the rest fills available).
+    const handle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', cancelable: true })
+    );
+    flushSync();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('locked slices render with pattern marker and no handle interactivity', () => {
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'fixed',
+        label: 'System reserve',
+        percent: 2000,
+        color: 'var(--color-text-muted)',
+        locked: true,
+        anonymous: false,
+      },
+      {
+        id: 'a',
+        label: 'A',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices },
+    });
+    const handles = document.body.querySelectorAll('[role="slider"]');
+    // First handle follows the locked 'fixed' slice — non-interactive.
+    expect(handles[0]?.getAttribute('data-interactive')).toBe('false');
+    expect(handles[1]?.getAttribute('data-interactive')).toBe('true');
+  });
+
+  test('forwards optional class to root', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        class: 'agreements-pie',
+      },
+    });
+    const root = document.body.querySelector('.revenue-split-pie');
+    expect(root?.classList.contains('agreements-pie')).toBe(true);
+  });
+
+  test('omitting class does NOT stringify undefined into class attribute (R13)', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const root = document.body.querySelector(
+      '.revenue-split-pie'
+    ) as HTMLElement;
+    expect(root.className.includes('undefined')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/components/agreements/types.ts
+++ b/apps/web/src/lib/components/agreements/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared types for revenue-share agreement UI components.
+ *
+ * Lives in a sibling `.ts` because SvelteKit's ambient `*.svelte` module
+ * declaration only exposes the default export — named exports from
+ * `<script module>` aren't surfaced to TypeScript consumers.
+ */
+
+/** Render mode for {@link RevenueSplitSlice} consumers. */
+export type RevenueSplitMode = 'owner' | 'creator';
+
+/**
+ * One slice of the stacked-bar revenue split. Percent values are basis points
+ * (0–10_000) internally; the component renders them as decimal percent.
+ */
+export interface RevenueSplitSlice {
+  /** Stable identity for keyed iteration + onChange diffing. */
+  id: string;
+  /** Human-readable label (e.g. 'Platform Fee', 'Org owner', 'Alex Rivera'). */
+  label: string;
+  /** Share in basis points (0–10_000). 100 bp = 1 %. */
+  percent: number;
+  /**
+   * CSS custom-property reference (e.g. `var(--color-info-600)`). MUST be a
+   * token reference, NEVER a hex literal — keeps the org-branding chain intact.
+   */
+  color: string;
+  /**
+   * Locked slices cannot be dragged (e.g. platform fee, computed residual).
+   * The boundary AFTER a locked slice is not focusable.
+   */
+  locked: boolean;
+  /**
+   * In creator mode, anonymous slices render with a generic label and no peer
+   * identity. The owning slice (`anonymous: false`) renders normally.
+   */
+  anonymous: boolean;
+}
+
+/** Basis-points ceiling (100 %). */
+export const BP_MAX = 10_000;
+/** Single-step nudge in basis points (1 %). */
+export const BP_STEP = 100;
+/** Shift-modifier nudge in basis points (10 %). */
+export const BP_STEP_LARGE = 1_000;


### PR DESCRIPTION
## Summary
- Adds `apps/web/src/lib/components/agreements/RevenueSplitPie.svelte` — stacked-bar revenue-split visualisation used by both the owner and creator surfaces of the upcoming Revenue-Share Agreements epic (Codex-nk4km, WP-6 = Codex-tg3p6). Parallel to WP-1/WP-2 BE work; no dependencies.
- Draggable handles between slices (`role="slider"`), arrow-key nudging (1% / 10% with Shift, Home/End jumps to ends), numeric percent inputs synced bidirectionally with drag, and a visible warning when slices over-allocate against `100% - platformFeePercent`.
- Mode-aware rendering — `mode="creator"` anonymises peer slices and keeps the owning slice visible. `readOnly` strips handle interactivity and numeric inputs.
- All values are basis points (0–10000) internally; colours are design-token references (`var(--color-*)`), legend layout is container-query driven, locked slices use OKLCH-derived diagonal hatching, reduced-motion is honoured.
- Sibling `types.ts` carries shared `RevenueSplitSlice` / `RevenueSplitMode` because SvelteKit's ambient `*.svelte` module declaration only exposes the default export.

## Test plan
- [x] `pnpm --filter web exec vitest run src/lib/components/agreements/RevenueSplitPie.svelte.test.ts` — 17/17 pass (render, keyboard ±1%/±10%, Home/End, idempotent emit, numeric clamping, over-allocation warning, mode anonymisation, readOnly disable, locked slices, R13 class forwarding)
- [x] `pnpm --filter web typecheck` — 0 new errors introduced (5 pre-existing on main)
- [x] `pnpm build --filter='./packages/*' --filter=web` — clean (R16 build gate)
- [x] `svelte-autofixer` — no issues; only stylistic suggestions (clearTimeout-in-$effect is the documented debounce cleanup, `bind:this` is needed for pointer-relative drag math)
- [ ] Playwright visual regression — deferred to WP-10 (end-to-end suite for the agreements epic)

## Notes
- File-bleed note: agent-worktree paths in this repo resolve to the main worktree; files were created at the main worktree path, copied into the agent worktree, removed from main, and committed from the worktree. No content left on `main` HEAD.
- Component is composition-only and has no remote-data dependencies — safe to land before WP-7/WP-8 consume it.

Refs Codex-tg3p6, epic Codex-nk4km.

🤖 Generated with [Claude Code](https://claude.com/claude-code)