### PR TITLE
feat(agreements): WP-2 AgreementService state machine + math validation

### DIFF
--- a/packages/agreements/package.json
+++ b/packages/agreements/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@codex/agreements",
+  "version": "1.0.0",
+  "description": "Revenue-share agreement state machine for the Codex platform (Codex-nk4km WP-2)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./services": {
+      "types": "./dist/services/index.d.ts",
+      "default": "./dist/services/index.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "default": "./dist/errors.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    }
+  },
+  "scripts": {
+    "build": "vite build --config vite.config.agreements.ts",
+    "dev": "vite build --config vite.config.agreements.ts --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.agreements.ts",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "biome lint --write .",
+    "format": "biome format --write ."
+  },
+  "dependencies": {
+    "@codex/constants": "workspace:*",
+    "@codex/database": "workspace:*",
+    "@codex/observability": "workspace:*",
+    "@codex/purchase": "workspace:*",
+    "@codex/service-errors": "workspace:*",
+    "@codex/shared-types": "workspace:*",
+    "@codex/validation": "workspace:*",
+    "drizzle-orm": "0.44.7"
+  },
+  "devDependencies": {
+    "@codex/test-utils": "workspace:*",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.3",
+    "vite": "^7.2.2",
+    "vitest": "^4.0.2"
+  }
+}

--- a/packages/agreements/src/errors.ts
+++ b/packages/agreements/src/errors.ts
@@ -1,0 +1,93 @@
+/**
+ * @codex/agreements — Domain errors
+ *
+ * Typed `ServiceError` subclasses for the revenue-share state machine.
+ * `procedure()` maps these to HTTP via `mapErrorToResponse()`.
+ *
+ * Per memory `feedback_service_error_test_instanceof`, tests assert on
+ * either `toBeInstanceOf(...)` or `err.name === '...'` — NEVER on
+ * `err.constructor.name`, which Vite/esbuild collapse to single letters.
+ */
+
+import { BusinessLogicError, NotFoundError } from '@codex/service-errors';
+
+// Re-export base error classes for callers who only want the agreements barrel
+export {
+  BusinessLogicError,
+  ConflictError,
+  ForbiddenError,
+  InternalServiceError,
+  isServiceError as isAgreementServiceError,
+  NotFoundError,
+  ServiceError as AgreementServiceError,
+  ValidationError,
+  wrapError,
+} from '@codex/service-errors';
+
+/**
+ * Thrown when a proposal or active agreement is referenced by id but not
+ * found (or has been hard-pruned, which today is impossible — agreements
+ * are append-only). Context: the id we tried to resolve.
+ */
+export class AgreementNotFoundError extends NotFoundError {
+  constructor(
+    message: string,
+    context?: { proposalId?: string; agreementId?: string }
+  ) {
+    super(message, context);
+    this.name = 'AgreementNotFoundError';
+  }
+}
+
+/**
+ * Thrown when a state-machine transition is rejected:
+ *   - accepting/declining/withdrawing an already-terminal proposal
+ *   - countering a non-open proposal
+ *   - terminating an already-terminated agreement
+ *   - proposing into a thread that already has an open proposal
+ *
+ * Context carries the offending id + the observed status so the UI / API
+ * caller can render a meaningful "you can't do that now" message.
+ *
+ * Maps to 422 Unprocessable Entity (BusinessLogicError) — the request is
+ * well-formed but violates the lifecycle.
+ */
+export class InvalidProposalStateError extends BusinessLogicError {
+  constructor(
+    message: string,
+    context?: {
+      proposalId?: string;
+      agreementId?: string;
+      currentStatus?: string;
+      attemptedAction?: string;
+    }
+  ) {
+    super(message, context);
+    this.name = 'InvalidProposalStateError';
+  }
+}
+
+/**
+ * Thrown when a proposed creator share, combined with currently-active
+ * sibling agreements and the current platform fee, would exceed 100% of
+ * gross revenue. Surfaced at both `proposeAgreement` and `acceptProposal`
+ * — the world between propose and accept can shift, so we re-check at
+ * acceptance time per the WP-2 brief.
+ *
+ * Maps to 422 (BusinessLogicError). Context carries the numeric breakdown
+ * so the UI can render which slice would have to shrink.
+ */
+export class ShareExceedsAvailableError extends BusinessLogicError {
+  constructor(
+    message: string,
+    context?: {
+      proposedSharePercent?: number;
+      existingActiveSharePercent?: number;
+      platformFeePercent?: number;
+      maxAllowedSharePercent?: number;
+    }
+  ) {
+    super(message, context);
+    this.name = 'ShareExceedsAvailableError';
+  }
+}

--- a/packages/agreements/src/index.ts
+++ b/packages/agreements/src/index.ts
@@ -1,0 +1,76 @@
+/**
+ * @codex/agreements
+ *
+ * Revenue-share agreement state machine + validation math for the Codex
+ * platform. Operates on the schema landed in WP-1 (Codex-ppxtd, PR #207)
+ * and feeds the payout pipeline (WP-4 of epic Codex-nk4km).
+ *
+ * Quick start (route handler):
+ * ```ts
+ * const agreement = await ctx.services.agreements.acceptProposal({
+ *   proposalId: ctx.input.params.id,
+ *   acceptedByUserId: ctx.user.id,
+ * });
+ * ```
+ *
+ * Construction is normally via the worker service registry. For tests:
+ * ```ts
+ * const service = new AgreementService({
+ *   db, // setupTestDatabase() — dbWs supports transactions
+ *   environment: 'test',
+ *   feeConfig,
+ * });
+ * ```
+ */
+
+// ─── Services ─────────────────────────────────────────────────────────────
+
+export {
+  type AcceptProposalInput,
+  type ActiveAgreementShareView,
+  AgreementService,
+  type AgreementServiceConfig,
+  type CounterProposeInput,
+  type DeclineProposalInput,
+  legacyOrgFeeFromCreatorShare,
+  type ProposeAgreementInput,
+  sumActiveCreatorShares,
+  type TerminateAgreementInput,
+  type ValidateProposedShareInput,
+  validateProposedShare,
+  type WithdrawProposalInput,
+} from './services';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export type {
+  AgreementProposal,
+  AgreementStatus,
+  CreatorOrganizationAgreement,
+  NewAgreementProposal,
+  NewCreatorOrganizationAgreement,
+  ProposalStatus,
+  ProposedByRole,
+  RevenueType,
+} from './types';
+
+// ─── Errors ───────────────────────────────────────────────────────────────
+
+export {
+  AgreementNotFoundError,
+  AgreementServiceError,
+  BusinessLogicError,
+  ConflictError,
+  ForbiddenError,
+  InternalServiceError,
+  InvalidProposalStateError,
+  isAgreementServiceError,
+  NotFoundError,
+  ShareExceedsAvailableError,
+  ValidationError,
+  wrapError,
+} from './errors';
+
+// ─── Re-exports for convenience ───────────────────────────────────────────
+
+export type { ServiceConfig } from '@codex/service-errors';

--- a/packages/agreements/src/services/__tests__/agreement-math.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-math.test.ts
@@ -5,6 +5,8 @@
  *   - sumActiveCreatorShares counts only active rows
  *   - validateProposedShare boundary semantics (inclusive at remaining-pool)
  *   - validateProposedShare basis-point bounds
+ *   - dual-write inverse round-trip (creatorShareFromLegacyOrgFee ↔
+ *     legacyOrgFeeFromCreatorShare)
  *
  * Per `feedback_service_error_test_instanceof` memory: assertions use
  * `toBeInstanceOf` + `err.name`, never `err.constructor.name`.
@@ -13,6 +15,7 @@
 import { describe, expect, it } from 'vitest';
 import { ShareExceedsAvailableError } from '../../errors';
 import {
+  creatorShareFromLegacyOrgFee,
   legacyOrgFeeFromCreatorShare,
   sumActiveCreatorShares,
   validateProposedShare,
@@ -68,13 +71,11 @@ describe('agreement-math.sumActiveCreatorShares', () => {
 });
 
 describe('agreement-math.validateProposedShare', () => {
-  it('passes when proposed + existing + platform fee = 100% (inclusive boundary)', () => {
-    // 10% platform + 60% existing + 30% proposed = 100%
+  it('passes at the inclusive boundary — 70% existing + 30% proposed = 100% of post-platform pool', () => {
     expect(() =>
       validateProposedShare({
         proposedSharePercent: 3000,
-        existingActiveShares: [6000],
-        platformFeePercent: 1000,
+        existingActiveShares: [7000],
       })
     ).not.toThrow();
   });
@@ -84,49 +85,33 @@ describe('agreement-math.validateProposedShare', () => {
       validateProposedShare({
         proposedSharePercent: 2000,
         existingActiveShares: [3000, 1000],
-        platformFeePercent: 1000,
       })
     ).not.toThrow();
   });
 
-  it('passes with zero existing shares', () => {
+  it('passes with zero existing shares (proposal can take the whole pool)', () => {
     expect(() =>
       validateProposedShare({
-        proposedSharePercent: 9000,
+        proposedSharePercent: 10000,
         existingActiveShares: [],
-        platformFeePercent: 1000,
       })
     ).not.toThrow();
   });
 
-  it('passes with zero platform fee', () => {
+  it('passes with multiple existing siblings summing to most of the pool', () => {
     expect(() =>
       validateProposedShare({
-        proposedSharePercent: 5000,
-        existingActiveShares: [3000, 2000],
-        platformFeePercent: 0,
+        proposedSharePercent: 1000,
+        existingActiveShares: [3000, 3000, 3000],
       })
     ).not.toThrow();
   });
 
-  it('passes with high (30%) platform fee', () => {
-    // 30% platform + 50% existing + 20% proposed = 100%
-    expect(() =>
-      validateProposedShare({
-        proposedSharePercent: 2000,
-        existingActiveShares: [5000],
-        platformFeePercent: 3000,
-      })
-    ).not.toThrow();
-  });
-
-  it('throws ShareExceedsAvailableError when proposed + existing + platform fee > 100%', () => {
-    // 10% platform + 60% existing + 31% proposed = 101%
+  it('throws when proposed + existing > 100% of the post-platform pool', () => {
     try {
       validateProposedShare({
-        proposedSharePercent: 3100,
+        proposedSharePercent: 4001,
         existingActiveShares: [6000],
-        platformFeePercent: 1000,
       });
       expect.fail('Expected ShareExceedsAvailableError');
     } catch (err) {
@@ -135,12 +120,23 @@ describe('agreement-math.validateProposedShare', () => {
     }
   });
 
+  it('throws when a single existing share already fills the pool and proposal is non-zero', () => {
+    try {
+      validateProposedShare({
+        proposedSharePercent: 1,
+        existingActiveShares: [10000],
+      });
+      expect.fail('Expected ShareExceedsAvailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+    }
+  });
+
   it('throws when proposed share exceeds 10000 basis points', () => {
     try {
       validateProposedShare({
         proposedSharePercent: 11000,
         existingActiveShares: [],
-        platformFeePercent: 1000,
       });
       expect.fail('Expected ShareExceedsAvailableError');
     } catch (err) {
@@ -153,7 +149,6 @@ describe('agreement-math.validateProposedShare', () => {
       validateProposedShare({
         proposedSharePercent: -1,
         existingActiveShares: [],
-        platformFeePercent: 1000,
       });
       expect.fail('Expected ShareExceedsAvailableError');
     } catch (err) {
@@ -166,7 +161,6 @@ describe('agreement-math.validateProposedShare', () => {
       validateProposedShare({
         proposedSharePercent: 1500.5,
         existingActiveShares: [],
-        platformFeePercent: 1000,
       });
       expect.fail('Expected ShareExceedsAvailableError');
     } catch (err) {
@@ -174,25 +168,42 @@ describe('agreement-math.validateProposedShare', () => {
     }
   });
 
-  it('throws when platform fee is out of range', () => {
+  it('throws when an existing share is out of basis-point range', () => {
     try {
       validateProposedShare({
         proposedSharePercent: 1000,
-        existingActiveShares: [],
-        platformFeePercent: 12000,
+        existingActiveShares: [-100],
       });
       expect.fail('Expected ShareExceedsAvailableError');
     } catch (err) {
       expect(err).toBeInstanceOf(ShareExceedsAvailableError);
     }
+  });
+
+  it('is independent of platform fee — same shares, no platform-fee param, same result (regression guard for C1)', () => {
+    // Pre-C1 the validator subtracted platform fee from the pool, which
+    // double-counted (platform fee is already outside the post-platform
+    // pool). After C1 the signature has no `platformFeePercent` field
+    // and the function reasons purely about the post-platform pool.
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 5000,
+        existingActiveShares: [5000],
+      })
+    ).not.toThrow();
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 5001,
+        existingActiveShares: [5000],
+      })
+    ).toThrow(ShareExceedsAvailableError);
   });
 
   it('error context includes max allowed share', () => {
     try {
       validateProposedShare({
         proposedSharePercent: 5000,
-        existingActiveShares: [4000],
-        platformFeePercent: 2000,
+        existingActiveShares: [6000],
       });
       expect.fail('Expected throw');
     } catch (err) {
@@ -201,9 +212,8 @@ describe('agreement-math.validateProposedShare', () => {
         string,
         unknown
       >;
-      expect(ctx.maxAllowedSharePercent).toBe(4000); // 10000 - 2000 - 4000
-      expect(ctx.existingActiveSharePercent).toBe(4000);
-      expect(ctx.platformFeePercent).toBe(2000);
+      expect(ctx.maxAllowedSharePercent).toBe(4000); // 10000 - 6000
+      expect(ctx.existingActiveSharePercent).toBe(6000);
       expect(ctx.proposedSharePercent).toBe(5000);
     }
   });
@@ -214,5 +224,21 @@ describe('agreement-math.legacyOrgFeeFromCreatorShare', () => {
     expect(legacyOrgFeeFromCreatorShare(0)).toBe(10000);
     expect(legacyOrgFeeFromCreatorShare(3000)).toBe(7000);
     expect(legacyOrgFeeFromCreatorShare(10000)).toBe(0);
+  });
+});
+
+describe('agreement-math.creatorShareFromLegacyOrgFee', () => {
+  it('returns 10000 - orgFee (inverse direction)', () => {
+    expect(creatorShareFromLegacyOrgFee(0)).toBe(10000);
+    expect(creatorShareFromLegacyOrgFee(7000)).toBe(3000);
+    expect(creatorShareFromLegacyOrgFee(10000)).toBe(0);
+  });
+
+  it('round-trips through legacyOrgFeeFromCreatorShare', () => {
+    for (const share of [0, 100, 2500, 5000, 7500, 10000]) {
+      expect(
+        creatorShareFromLegacyOrgFee(legacyOrgFeeFromCreatorShare(share))
+      ).toBe(share);
+    }
   });
 });

--- a/packages/agreements/src/services/__tests__/agreement-math.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-math.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @codex/agreements — agreement-math unit tests
+ *
+ * Pure-function tests; no DB. Asserts:
+ *   - sumActiveCreatorShares counts only active rows
+ *   - validateProposedShare boundary semantics (inclusive at remaining-pool)
+ *   - validateProposedShare basis-point bounds
+ *
+ * Per `feedback_service_error_test_instanceof` memory: assertions use
+ * `toBeInstanceOf` + `err.name`, never `err.constructor.name`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ShareExceedsAvailableError } from '../../errors';
+import {
+  legacyOrgFeeFromCreatorShare,
+  sumActiveCreatorShares,
+  validateProposedShare,
+} from '../agreement-math';
+
+describe('agreement-math.sumActiveCreatorShares', () => {
+  it('returns 0 for empty array', () => {
+    expect(sumActiveCreatorShares([])).toBe(0);
+  });
+
+  it('sums a single active row', () => {
+    expect(
+      sumActiveCreatorShares([{ sharePercent: 3000, status: 'active' }])
+    ).toBe(3000);
+  });
+
+  it('sums multiple active rows', () => {
+    expect(
+      sumActiveCreatorShares([
+        { sharePercent: 3000, status: 'active' },
+        { sharePercent: 2000, status: 'active' },
+        { sharePercent: 1500, status: 'active' },
+      ])
+    ).toBe(6500);
+  });
+
+  it('ignores terminated rows', () => {
+    expect(
+      sumActiveCreatorShares([
+        { sharePercent: 3000, status: 'active' },
+        { sharePercent: 4000, status: 'terminated' },
+      ])
+    ).toBe(3000);
+  });
+
+  it('ignores expired rows', () => {
+    expect(
+      sumActiveCreatorShares([
+        { sharePercent: 1000, status: 'active' },
+        { sharePercent: 5000, status: 'expired' },
+      ])
+    ).toBe(1000);
+  });
+
+  it('ignores unknown statuses defensively', () => {
+    expect(
+      sumActiveCreatorShares([
+        { sharePercent: 2000, status: 'pending' },
+        { sharePercent: 3000, status: 'active' },
+      ])
+    ).toBe(3000);
+  });
+});
+
+describe('agreement-math.validateProposedShare', () => {
+  it('passes when proposed + existing + platform fee = 100% (inclusive boundary)', () => {
+    // 10% platform + 60% existing + 30% proposed = 100%
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 3000,
+        existingActiveShares: [6000],
+        platformFeePercent: 1000,
+      })
+    ).not.toThrow();
+  });
+
+  it('passes when proposed leaves room for the org residual', () => {
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 2000,
+        existingActiveShares: [3000, 1000],
+        platformFeePercent: 1000,
+      })
+    ).not.toThrow();
+  });
+
+  it('passes with zero existing shares', () => {
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 9000,
+        existingActiveShares: [],
+        platformFeePercent: 1000,
+      })
+    ).not.toThrow();
+  });
+
+  it('passes with zero platform fee', () => {
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 5000,
+        existingActiveShares: [3000, 2000],
+        platformFeePercent: 0,
+      })
+    ).not.toThrow();
+  });
+
+  it('passes with high (30%) platform fee', () => {
+    // 30% platform + 50% existing + 20% proposed = 100%
+    expect(() =>
+      validateProposedShare({
+        proposedSharePercent: 2000,
+        existingActiveShares: [5000],
+        platformFeePercent: 3000,
+      })
+    ).not.toThrow();
+  });
+
+  it('throws ShareExceedsAvailableError when proposed + existing + platform fee > 100%', () => {
+    // 10% platform + 60% existing + 31% proposed = 101%
+    try {
+      validateProposedShare({
+        proposedSharePercent: 3100,
+        existingActiveShares: [6000],
+        platformFeePercent: 1000,
+      });
+      expect.fail('Expected ShareExceedsAvailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+      expect((err as Error).name).toBe('ShareExceedsAvailableError');
+    }
+  });
+
+  it('throws when proposed share exceeds 10000 basis points', () => {
+    try {
+      validateProposedShare({
+        proposedSharePercent: 11000,
+        existingActiveShares: [],
+        platformFeePercent: 1000,
+      });
+      expect.fail('Expected ShareExceedsAvailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+    }
+  });
+
+  it('throws when proposed share is negative', () => {
+    try {
+      validateProposedShare({
+        proposedSharePercent: -1,
+        existingActiveShares: [],
+        platformFeePercent: 1000,
+      });
+      expect.fail('Expected ShareExceedsAvailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+    }
+  });
+
+  it('throws when proposed share is non-integer', () => {
+    try {
+      validateProposedShare({
+        proposedSharePercent: 1500.5,
+        existingActiveShares: [],
+        platformFeePercent: 1000,
+      });
+      expect.fail('Expected ShareExceedsAvailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+    }
+  });
+
+  it('throws when platform fee is out of range', () => {
+    try {
+      validateProposedShare({
+        proposedSharePercent: 1000,
+        existingActiveShares: [],
+        platformFeePercent: 12000,
+      });
+      expect.fail('Expected ShareExceedsAvailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+    }
+  });
+
+  it('error context includes max allowed share', () => {
+    try {
+      validateProposedShare({
+        proposedSharePercent: 5000,
+        existingActiveShares: [4000],
+        platformFeePercent: 2000,
+      });
+      expect.fail('Expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+      const ctx = (err as ShareExceedsAvailableError).context as Record<
+        string,
+        unknown
+      >;
+      expect(ctx.maxAllowedSharePercent).toBe(4000); // 10000 - 2000 - 4000
+      expect(ctx.existingActiveSharePercent).toBe(4000);
+      expect(ctx.platformFeePercent).toBe(2000);
+      expect(ctx.proposedSharePercent).toBe(5000);
+    }
+  });
+});
+
+describe('agreement-math.legacyOrgFeeFromCreatorShare', () => {
+  it('returns 10000 - share', () => {
+    expect(legacyOrgFeeFromCreatorShare(0)).toBe(10000);
+    expect(legacyOrgFeeFromCreatorShare(3000)).toBe(7000);
+    expect(legacyOrgFeeFromCreatorShare(10000)).toBe(0);
+  });
+});

--- a/packages/agreements/src/services/__tests__/agreement-service.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-service.test.ts
@@ -16,9 +16,9 @@
  * letters and the assertion will silently pass on the wrong type.
  */
 
+import { randomUUID } from 'node:crypto';
 import * as schema from '@codex/database/schema';
-import { FeeConfigService } from '@codex/purchase';
-import { ForbiddenError } from '@codex/service-errors';
+import { ForbiddenError, NotFoundError } from '@codex/service-errors';
 import {
   cleanupDatabase,
   createUniqueSlug,
@@ -111,7 +111,6 @@ async function seedOrgFixture(
 describe('AgreementService', () => {
   let db: Database;
   let service: AgreementService;
-  let feeConfig: FeeConfigService;
 
   beforeAll(async () => {
     db = setupTestDatabase();
@@ -125,11 +124,13 @@ describe('AgreementService', () => {
       throw error;
     }
 
-    feeConfig = new FeeConfigService({ db, environment: 'test' });
+    // Per PR #210 review, AgreementService no longer threads
+    // FeeConfigService — share-validation reasons purely about the
+    // post-platform pool. WP-4's payout pipeline reads the platform
+    // fee fresh at invoice time elsewhere.
     service = new AgreementService({
       db,
       environment: 'test',
-      feeConfig,
     });
   });
 
@@ -140,8 +141,15 @@ describe('AgreementService', () => {
   // Each test starts with a clean slate. We use the shared cleanupDatabase
   // helper because it already orders FK deletions correctly (purchases
   // and contentAccess reference organizations with onDelete: 'restrict',
-  // so they must go first). Memberships cascade with organizations.
-  // Users are preserved across tests for cheapness.
+  // so they must go first). Users are preserved across tests for cheapness.
+  //
+  // Note: `cleanupDatabase` does NOT delete `organizationMemberships` —
+  // the schema declares those FKs as `onDelete: 'cascade'` from
+  // organizations, so the membership rows are wiped automatically when
+  // the org rows go. The explicit delete here is defence-in-depth in
+  // case a prior test happened to seed memberships against an org that
+  // got rolled back; cheap insurance against test-ordering side effects
+  // ([[feedback-test-cleanup-fk-ordering]]).
   beforeEach(async () => {
     await cleanupDatabase(db);
     await db.delete(schema.organizationMemberships);
@@ -208,24 +216,23 @@ describe('AgreementService', () => {
       }
     });
 
-    it('throws ShareExceedsAvailableError when proposal + active + fee > 100%', async () => {
+    it('throws ShareExceedsAvailableError when proposal + active > 100% of post-platform pool', async () => {
       const fx = await seedOrgFixture(db);
-      // Active 50% subscription agreement to creator B already.
+      // Active 70% subscription agreement to creator B (orgFee=3000).
       await db.insert(schema.creatorOrganizationAgreements).values({
         organizationId: fx.orgId,
         creatorId: fx.creatorBId,
-        organizationFeePercentage: 5000, // creator B has 50% share
+        organizationFeePercentage: 3000, // creator B has 70% share
         revenueType: 'subscription',
         status: 'active',
       });
-      // Default platform fee = FEES.PLATFORM_PERCENT = 1000. 50% existing
-      // + 10% fee = 60% taken. A 50% proposal would total 110%.
+      // 70% existing + 31% proposed = 101% of post-platform pool → fail.
       try {
         await service.proposeAgreement({
           organizationId: fx.orgId,
           creatorId: fx.creatorAId,
           revenueType: 'subscription',
-          sharePercent: 5000,
+          sharePercent: 3100,
           termMonths: 6,
           proposedByUserId: fx.ownerId,
         });
@@ -278,6 +285,137 @@ describe('AgreementService', () => {
         expect((err as Error).name).toBe('InvalidProposalStateError');
       }
     });
+
+    it('throws NotFoundError when organization id does not exist (I2)', async () => {
+      // Per PR #210 review, missing-org throws the shared `NotFoundError`
+      // with `{ resource: 'organization', organizationId }`. Previously
+      // this leaked through `AgreementNotFoundError` with the wrong
+      // context key (`agreementId`).
+      // Note: shared NotFoundError doesn't set `this.name` so Vite/esbuild
+      // minification collapses err.name to single letters under build.
+      // We use `toBeInstanceOf` + the error CODE for type discrimination,
+      // not err.name. ([[feedback-service-error-test-instanceof]])
+      const bogusOrgId = randomUUID();
+      try {
+        await service.proposeAgreement({
+          organizationId: bogusOrgId,
+          creatorId: 'whatever',
+          revenueType: 'subscription',
+          sharePercent: 3000,
+          termMonths: 6,
+          proposedByUserId: 'whatever',
+        });
+        expect.fail('Expected NotFoundError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotFoundError);
+        const e = err as NotFoundError;
+        expect(e.code).toBe('NOT_FOUND');
+        const ctx = e.context as Record<string, unknown>;
+        expect(ctx.resource).toBe('organization');
+        expect(ctx.organizationId).toBe(bogusOrgId);
+      }
+    });
+
+    // I4: re-opening a thread after every fully-terminal end state.
+    // The implementation comment on `assertNoOpenThread` documents that
+    // after declined/withdrawn/superseded/accepted (all terminal),
+    // the bucket is free for a fresh round-1 proposal. Locking in
+    // tests so a future refactor can't silently break the UX.
+
+    it('allows re-opening a fully-terminal thread (after decline) — I4', async () => {
+      const fx = await seedOrgFixture(db);
+      const first = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      await service.declineProposal({
+        proposalId: first.id,
+        declinedByUserId: fx.creatorAId,
+      });
+      const second = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 2500,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      expect(second.status).toBe('open');
+      expect(second.roundNumber).toBe(1);
+      expect(second.parentProposalId).toBeNull();
+    });
+
+    it('allows re-opening after a withdraw — I4', async () => {
+      const fx = await seedOrgFixture(db);
+      const first = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      await service.withdrawProposal({
+        proposalId: first.id,
+        withdrawnByUserId: fx.ownerId,
+      });
+      const second = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 2500,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      expect(second.status).toBe('open');
+      expect(second.roundNumber).toBe(1);
+      expect(second.parentProposalId).toBeNull();
+    });
+
+    it('allows re-opening after terminating an active agreement — I4', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const agreement = await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      await service.terminateAgreement({
+        agreementId: agreement.id,
+        terminatedByUserId: fx.ownerId,
+      });
+      // Accepted proposal is terminal; thread is fully terminal once
+      // the active agreement is terminated. Bucket is free.
+      const second = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 2000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      expect(second.status).toBe('open');
+      expect(second.roundNumber).toBe(1);
+      expect(second.parentProposalId).toBeNull();
+    });
+
+    // I1: concurrency. A deterministic test would need controlled
+    // scheduling we don't have here — locking in `it.todo` as a
+    // tracking point. The implementation uses `SELECT ... FOR UPDATE`
+    // on every status-mutating proposal/agreement lookup.
+    it.todo(
+      'locks proposal row to prevent concurrent accept/decline race — I1'
+    );
   });
 
   // ── counterPropose ────────────────────────────────────────────────────
@@ -391,7 +529,7 @@ describe('AgreementService', () => {
 
     it('rejects when share exceeds available pool', async () => {
       const fx = await seedOrgFixture(db);
-      // Active 80% subscription agreement to creator B.
+      // Active 80% subscription agreement to creator B (orgFee=2000).
       await db.insert(schema.creatorOrganizationAgreements).values({
         organizationId: fx.orgId,
         creatorId: fx.creatorBId,
@@ -407,11 +545,11 @@ describe('AgreementService', () => {
         termMonths: 6,
         proposedByUserId: fx.ownerId,
       });
-      // 10% platform + 80% B + 11% creator A counter = 101%.
+      // 80% B + 21% creator A counter = 101% of post-platform pool → fail.
       try {
         await service.counterPropose({
           proposalId: r1.id,
-          sharePercent: 1100,
+          sharePercent: 2100,
           termMonths: 6,
           counteredByUserId: fx.creatorAId,
         });
@@ -571,17 +709,18 @@ describe('AgreementService', () => {
 
     it('re-validates share at accept-time → throws if siblings have moved', async () => {
       const fx = await seedOrgFixture(db);
-      // Propose 50% to creator A.
+      // Propose 60% to creator A.
       const r1 = await service.proposeAgreement({
         organizationId: fx.orgId,
         creatorId: fx.creatorAId,
         revenueType: 'subscription',
-        sharePercent: 5000,
+        sharePercent: 6000,
         termMonths: 6,
         proposedByUserId: fx.ownerId,
       });
-      // Between propose and accept, a 50% agreement lands for creator B.
-      // That eats the remaining headroom (10% platform fee + 50% B + 50% A = 110%).
+      // Between propose and accept, a 50% agreement lands for creator B
+      // (orgFee=5000 → share=5000). Now 50% B + 60% A = 110% of the
+      // post-platform pool — accept-time re-validation must reject.
       await db.insert(schema.creatorOrganizationAgreements).values({
         organizationId: fx.orgId,
         creatorId: fx.creatorBId,

--- a/packages/agreements/src/services/__tests__/agreement-service.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-service.test.ts
@@ -1,0 +1,973 @@
+/**
+ * @codex/agreements — AgreementService integration tests
+ *
+ * Covers the full state machine with BOTH positive AND negative paths
+ * per the `feedback_security_deep_test` memory: money-touching and
+ * authorisation code MUST have rejection tests, not just happy paths.
+ *
+ * Schema fixtures: created inline via the test-utils factories so each
+ * test owns its data. The neon-testing CI plugin gives this file an
+ * ephemeral branch; locally we share the LOCAL_PROXY DB across tests
+ * but every test uses unique slugs to avoid collisions.
+ *
+ * Per `feedback_service_error_test_instanceof`: assertions use
+ * `toBeInstanceOf(Class)` and `err.name === 'ClassName'`. NEVER use
+ * `err.constructor.name` — Vite/esbuild minify class names to single
+ * letters and the assertion will silently pass on the wrong type.
+ */
+
+import * as schema from '@codex/database/schema';
+import { FeeConfigService } from '@codex/purchase';
+import { ForbiddenError } from '@codex/service-errors';
+import {
+  cleanupDatabase,
+  createUniqueSlug,
+  type Database,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+  validateDatabaseConnection,
+} from '@codex/test-utils';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AgreementNotFoundError,
+  InvalidProposalStateError,
+  ShareExceedsAvailableError,
+} from '../../errors';
+import { AgreementService } from '../agreement-service';
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────
+
+interface OrgFixture {
+  orgId: string;
+  ownerId: string;
+  creatorAId: string;
+  creatorBId: string;
+  outsiderId: string;
+}
+
+/**
+ * Seed an org with one owner + two creators + one outsider (not a member).
+ *
+ * Returns the IDs the test cases use. We deliberately do NOT set
+ * `organizations.owner_id` — that column doesn't exist (per WP-1
+ * discovery #1); ownership comes from the membership row with
+ * `role='owner', status='active'`.
+ */
+async function seedOrgFixture(
+  db: Database,
+  options: { ownerActive?: boolean } = {}
+): Promise<OrgFixture> {
+  const [ownerId, creatorAId, creatorBId, outsiderId] = await seedTestUsers(
+    db,
+    4
+  );
+
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({
+      name: 'Test Org',
+      slug: createUniqueSlug('agree-org'),
+    })
+    .returning();
+  if (!org) throw new Error('Failed to seed test organization');
+
+  // Owner membership (active by default; tests can mark inactive via
+  // ownerActive=false to exercise the no-active-owner path).
+  await db.insert(schema.organizationMemberships).values({
+    organizationId: org.id,
+    userId: ownerId,
+    role: 'owner',
+    status: options.ownerActive === false ? 'inactive' : 'active',
+  });
+  // Two creator memberships — for sibling-share and multi-creator paths.
+  await db.insert(schema.organizationMemberships).values([
+    {
+      organizationId: org.id,
+      userId: creatorAId,
+      role: 'creator',
+      status: 'active',
+    },
+    {
+      organizationId: org.id,
+      userId: creatorBId,
+      role: 'creator',
+      status: 'active',
+    },
+  ]);
+
+  return {
+    orgId: org.id,
+    ownerId,
+    creatorAId,
+    creatorBId,
+    outsiderId,
+  };
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────
+
+describe('AgreementService', () => {
+  let db: Database;
+  let service: AgreementService;
+  let feeConfig: FeeConfigService;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    try {
+      await validateDatabaseConnection(db);
+    } catch (error) {
+      console.warn(
+        'Database connection failed - tests will be skipped:',
+        (error as Error).message
+      );
+      throw error;
+    }
+
+    feeConfig = new FeeConfigService({ db, environment: 'test' });
+    service = new AgreementService({
+      db,
+      environment: 'test',
+      feeConfig,
+    });
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  // Each test starts with a clean slate. We use the shared cleanupDatabase
+  // helper because it already orders FK deletions correctly (purchases
+  // and contentAccess reference organizations with onDelete: 'restrict',
+  // so they must go first). Memberships cascade with organizations.
+  // Users are preserved across tests for cheapness.
+  beforeEach(async () => {
+    await cleanupDatabase(db);
+    await db.delete(schema.organizationMemberships);
+  });
+
+  // ── proposeAgreement ──────────────────────────────────────────────────
+
+  describe('proposeAgreement', () => {
+    it('owner can propose to existing creator member', async () => {
+      const fx = await seedOrgFixture(db);
+      const proposal = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        note: 'Hello',
+        proposedByUserId: fx.ownerId,
+      });
+      expect(proposal.id).toBeDefined();
+      expect(proposal.organizationId).toBe(fx.orgId);
+      expect(proposal.creatorId).toBe(fx.creatorAId);
+      expect(proposal.revenueType).toBe('subscription');
+      expect(proposal.proposedCreatorSharePercent).toBe(3000);
+      expect(proposal.proposedTermMonths).toBe(6);
+      expect(proposal.note).toBe('Hello');
+      expect(proposal.status).toBe('open');
+      expect(proposal.proposedByRole).toBe('owner');
+      expect(proposal.roundNumber).toBe(1);
+      expect(proposal.parentProposalId).toBeNull();
+    });
+
+    it('non-owner cannot propose (Forbidden)', async () => {
+      const fx = await seedOrgFixture(db);
+      try {
+        await service.proposeAgreement({
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          revenueType: 'subscription',
+          sharePercent: 3000,
+          termMonths: 6,
+          proposedByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('cannot propose when target user is not an active member', async () => {
+      const fx = await seedOrgFixture(db);
+      try {
+        await service.proposeAgreement({
+          organizationId: fx.orgId,
+          creatorId: fx.outsiderId,
+          revenueType: 'subscription',
+          sharePercent: 3000,
+          termMonths: 6,
+          proposedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('throws ShareExceedsAvailableError when proposal + active + fee > 100%', async () => {
+      const fx = await seedOrgFixture(db);
+      // Active 50% subscription agreement to creator B already.
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorBId,
+        organizationFeePercentage: 5000, // creator B has 50% share
+        revenueType: 'subscription',
+        status: 'active',
+      });
+      // Default platform fee = FEES.PLATFORM_PERCENT = 1000. 50% existing
+      // + 10% fee = 60% taken. A 50% proposal would total 110%.
+      try {
+        await service.proposeAgreement({
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          revenueType: 'subscription',
+          sharePercent: 5000,
+          termMonths: 6,
+          proposedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected ShareExceedsAvailableError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+        expect((err as Error).name).toBe('ShareExceedsAvailableError');
+      }
+    });
+
+    it('throws ForbiddenError when org has no active owner', async () => {
+      const fx = await seedOrgFixture(db, { ownerActive: false });
+      try {
+        await service.proposeAgreement({
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          revenueType: 'subscription',
+          sharePercent: 3000,
+          termMonths: 6,
+          proposedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('throws InvalidProposalStateError when an open proposal already exists for the triple', async () => {
+      const fx = await seedOrgFixture(db);
+      await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      try {
+        await service.proposeAgreement({
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          revenueType: 'subscription',
+          sharePercent: 2500,
+          termMonths: 6,
+          proposedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected InvalidProposalStateError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidProposalStateError);
+        expect((err as Error).name).toBe('InvalidProposalStateError');
+      }
+    });
+  });
+
+  // ── counterPropose ────────────────────────────────────────────────────
+
+  describe('counterPropose', () => {
+    it('creator can counter owner-proposed round-1', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const r2 = await service.counterPropose({
+        proposalId: r1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fx.creatorAId,
+      });
+      expect(r2.roundNumber).toBe(2);
+      expect(r2.parentProposalId).toBe(r1.id);
+      expect(r2.proposedByRole).toBe('creator');
+      expect(r2.proposedCreatorSharePercent).toBe(4000);
+      expect(r2.status).toBe('open');
+
+      // Parent is now countered.
+      const parentAfter = await db.query.agreementProposals.findFirst({
+        where: eq(schema.agreementProposals.id, r1.id),
+      });
+      expect(parentAfter?.status).toBe('countered');
+      expect(parentAfter?.respondedByUserId).toBe(fx.creatorAId);
+    });
+
+    it('owner can counter creator-counter (round 3, flipped role)', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const r2 = await service.counterPropose({
+        proposalId: r1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fx.creatorAId,
+      });
+      const r3 = await service.counterPropose({
+        proposalId: r2.id,
+        sharePercent: 3500,
+        termMonths: 6,
+        counteredByUserId: fx.ownerId,
+      });
+      expect(r3.roundNumber).toBe(3);
+      expect(r3.proposedByRole).toBe('owner');
+    });
+
+    it('cannot counter an accepted proposal', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      try {
+        await service.counterPropose({
+          proposalId: r1.id,
+          sharePercent: 2000,
+          termMonths: 6,
+          counteredByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected InvalidProposalStateError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidProposalStateError);
+      }
+    });
+
+    it('same-party cannot counter their own proposal (owner cannot counter owner-proposed)', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      try {
+        await service.counterPropose({
+          proposalId: r1.id,
+          sharePercent: 2500,
+          termMonths: 6,
+          counteredByUserId: fx.ownerId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('rejects when share exceeds available pool', async () => {
+      const fx = await seedOrgFixture(db);
+      // Active 80% subscription agreement to creator B.
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorBId,
+        organizationFeePercentage: 2000,
+        revenueType: 'subscription',
+        status: 'active',
+      });
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 1000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      // 10% platform + 80% B + 11% creator A counter = 101%.
+      try {
+        await service.counterPropose({
+          proposalId: r1.id,
+          sharePercent: 1100,
+          termMonths: 6,
+          counteredByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected ShareExceedsAvailableError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+      }
+    });
+  });
+
+  // ── acceptProposal ────────────────────────────────────────────────────
+
+  describe('acceptProposal', () => {
+    it('counterparty accepts owner-proposed → active agreement + dual-write', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const agreement = await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      expect(agreement.status).toBe('active');
+      expect(agreement.revenueType).toBe('subscription');
+      expect(agreement.currentProposalId).toBe(r1.id);
+      // Dual-write invariant: organization_fee_percentage = 10000 - share.
+      expect(agreement.organizationFeePercentage).toBe(7000);
+
+      // The proposal is now accepted.
+      const proposalAfter = await db.query.agreementProposals.findFirst({
+        where: eq(schema.agreementProposals.id, r1.id),
+      });
+      expect(proposalAfter?.status).toBe('accepted');
+      expect(proposalAfter?.respondedByUserId).toBe(fx.creatorAId);
+    });
+
+    it('accepting supersedes any open/countered sibling proposals in the thread', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      // Round 2 — creator counters.
+      const r2 = await service.counterPropose({
+        proposalId: r1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fx.creatorAId,
+      });
+      // Owner accepts the counter.
+      await service.acceptProposal({
+        proposalId: r2.id,
+        acceptedByUserId: fx.ownerId,
+      });
+      const r1After = await db.query.agreementProposals.findFirst({
+        where: eq(schema.agreementProposals.id, r1.id),
+      });
+      // r1 was already 'countered' from r2's insertion; it stays
+      // 'countered' (terminal for the round-1 row — supersede only
+      // touches open+countered SIBLINGS not the accepted row itself).
+      // Our query for siblings excluded r1's status='countered' status —
+      // but per our service it transitions sibling open/countered to
+      // 'superseded'. So r1 should be 'superseded' after acceptance.
+      expect(r1After?.status).toBe('superseded');
+    });
+
+    it('accepting terminates the predecessor active agreement (auto-supersede)', async () => {
+      const fx = await seedOrgFixture(db);
+      // Pre-existing active agreement at 30%.
+      const [previous] = await db
+        .insert(schema.creatorOrganizationAgreements)
+        .values({
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          organizationFeePercentage: 7000,
+          revenueType: 'subscription',
+          status: 'active',
+        })
+        .returning();
+      if (!previous) throw new Error('seed failed');
+      // Propose a new 40% agreement.
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 4000,
+        termMonths: 12,
+        proposedByUserId: fx.ownerId,
+      });
+      await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      // Previous row terminated.
+      const previousAfter =
+        await db.query.creatorOrganizationAgreements.findFirst({
+          where: eq(schema.creatorOrganizationAgreements.id, previous.id),
+        });
+      expect(previousAfter?.status).toBe('terminated');
+      expect(previousAfter?.terminatedByUserId).toBe(fx.creatorAId);
+    });
+
+    it('same-party cannot accept own proposal (owner cannot self-accept)', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      try {
+        await service.acceptProposal({
+          proposalId: r1.id,
+          acceptedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('cannot accept an already-accepted proposal', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      try {
+        await service.acceptProposal({
+          proposalId: r1.id,
+          acceptedByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected InvalidProposalStateError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidProposalStateError);
+      }
+    });
+
+    it('re-validates share at accept-time → throws if siblings have moved', async () => {
+      const fx = await seedOrgFixture(db);
+      // Propose 50% to creator A.
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 5000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      // Between propose and accept, a 50% agreement lands for creator B.
+      // That eats the remaining headroom (10% platform fee + 50% B + 50% A = 110%).
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorBId,
+        organizationFeePercentage: 5000,
+        revenueType: 'subscription',
+        status: 'active',
+      });
+      try {
+        await service.acceptProposal({
+          proposalId: r1.id,
+          acceptedByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected ShareExceedsAvailableError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ShareExceedsAvailableError);
+      }
+    });
+  });
+
+  // ── declineProposal ──────────────────────────────────────────────────
+
+  describe('declineProposal', () => {
+    it('counterparty declines open owner-proposed', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const declined = await service.declineProposal({
+        proposalId: r1.id,
+        declinedByUserId: fx.creatorAId,
+        reason: 'Not enough share',
+      });
+      expect(declined.status).toBe('declined');
+      expect(declined.declineReason).toBe('Not enough share');
+      expect(declined.respondedByUserId).toBe(fx.creatorAId);
+    });
+
+    it('same-party cannot decline own proposal', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      try {
+        await service.declineProposal({
+          proposalId: r1.id,
+          declinedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('cannot decline an already-terminal proposal', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      await service.declineProposal({
+        proposalId: r1.id,
+        declinedByUserId: fx.creatorAId,
+      });
+      try {
+        await service.declineProposal({
+          proposalId: r1.id,
+          declinedByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected InvalidProposalStateError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidProposalStateError);
+      }
+    });
+  });
+
+  // ── withdrawProposal ─────────────────────────────────────────────────
+
+  describe('withdrawProposal', () => {
+    it('proposing party (owner) can withdraw own owner-proposed', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const withdrawn = await service.withdrawProposal({
+        proposalId: r1.id,
+        withdrawnByUserId: fx.ownerId,
+      });
+      expect(withdrawn.status).toBe('withdrawn');
+      expect(withdrawn.respondedByUserId).toBe(fx.ownerId);
+    });
+
+    it("counterparty cannot withdraw the proposing party's proposal", async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      try {
+        await service.withdrawProposal({
+          proposalId: r1.id,
+          withdrawnByUserId: fx.creatorAId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('proposing creator can withdraw their counter-proposal', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const r2 = await service.counterPropose({
+        proposalId: r1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fx.creatorAId,
+      });
+      const withdrawn = await service.withdrawProposal({
+        proposalId: r2.id,
+        withdrawnByUserId: fx.creatorAId,
+      });
+      expect(withdrawn.status).toBe('withdrawn');
+    });
+  });
+
+  // ── terminateAgreement ───────────────────────────────────────────────
+
+  describe('terminateAgreement', () => {
+    it('owner can terminate an active agreement', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const agreement = await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      const terminated = await service.terminateAgreement({
+        agreementId: agreement.id,
+        terminatedByUserId: fx.ownerId,
+        reason: 'Business reasons',
+      });
+      expect(terminated.status).toBe('terminated');
+      expect(terminated.terminationReason).toBe('Business reasons');
+      expect(terminated.terminatedByUserId).toBe(fx.ownerId);
+      expect(terminated.terminatedAt).toBeInstanceOf(Date);
+    });
+
+    it('the named creator can terminate their own agreement', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const agreement = await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      const terminated = await service.terminateAgreement({
+        agreementId: agreement.id,
+        terminatedByUserId: fx.creatorAId,
+      });
+      expect(terminated.status).toBe('terminated');
+      expect(terminated.terminatedByUserId).toBe(fx.creatorAId);
+    });
+
+    it("outsider cannot terminate someone else's agreement", async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const agreement = await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      try {
+        await service.terminateAgreement({
+          agreementId: agreement.id,
+          terminatedByUserId: fx.outsiderId,
+        });
+        expect.fail('Expected ForbiddenError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenError);
+      }
+    });
+
+    it('cannot terminate an already-terminated agreement', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const agreement = await service.acceptProposal({
+        proposalId: r1.id,
+        acceptedByUserId: fx.creatorAId,
+      });
+      await service.terminateAgreement({
+        agreementId: agreement.id,
+        terminatedByUserId: fx.ownerId,
+      });
+      try {
+        await service.terminateAgreement({
+          agreementId: agreement.id,
+          terminatedByUserId: fx.ownerId,
+        });
+        expect.fail('Expected InvalidProposalStateError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidProposalStateError);
+      }
+    });
+
+    it('throws AgreementNotFoundError for non-existent agreement id', async () => {
+      try {
+        await service.terminateAgreement({
+          agreementId: '00000000-0000-0000-0000-000000000000',
+          terminatedByUserId: 'some-user',
+        });
+        expect.fail('Expected AgreementNotFoundError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AgreementNotFoundError);
+      }
+    });
+  });
+
+  // ── getActiveAgreements / getActiveAgreementsForCreator ───────────────
+
+  describe('read queries', () => {
+    it('getActiveAgreements returns only active rows', async () => {
+      const fx = await seedOrgFixture(db);
+      // Create two: one active, one terminated.
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 6000,
+        revenueType: 'subscription',
+        status: 'active',
+      });
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorBId,
+        organizationFeePercentage: 5000,
+        revenueType: 'subscription',
+        status: 'terminated',
+        terminatedAt: new Date(),
+      });
+      const results = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+      });
+      expect(results.length).toBe(1);
+      expect(results[0]?.creatorId).toBe(fx.creatorAId);
+    });
+
+    it('getActiveAgreementsForCreator is multi-org isolated', async () => {
+      const fx1 = await seedOrgFixture(db);
+      const fx2 = await seedOrgFixture(db);
+      // Creator A from fx1 also signed an agreement in fx2 via direct
+      // seed (no need to wire memberships for this read test — the
+      // read filters on creatorId, not on org membership).
+      await db.insert(schema.creatorOrganizationAgreements).values([
+        {
+          organizationId: fx1.orgId,
+          creatorId: fx1.creatorAId,
+          organizationFeePercentage: 6000,
+          revenueType: 'subscription',
+          status: 'active',
+        },
+        {
+          organizationId: fx2.orgId,
+          // Use a NEW user not on fx2's team yet — the read service
+          // doesn't enforce membership, just returns active rows where
+          // creatorId matches. We deliberately reuse fx1.creatorAId here
+          // to assert cross-org visibility.
+          creatorId: fx1.creatorAId,
+          organizationFeePercentage: 7000,
+          revenueType: 'subscription',
+          status: 'active',
+        },
+      ]);
+      const results = await service.getActiveAgreementsForCreator({
+        creatorId: fx1.creatorAId,
+      });
+      expect(results.length).toBe(2);
+      const orgs = results.map((r) => r.organizationId).sort();
+      expect(orgs).toEqual([fx1.orgId, fx2.orgId].sort());
+    });
+
+    it('getActiveAgreements excludes terminated rows', async () => {
+      const fx = await seedOrgFixture(db);
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 5000,
+        revenueType: 'subscription',
+        status: 'terminated',
+        terminatedAt: new Date(),
+      });
+      const results = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+      });
+      expect(results.length).toBe(0);
+    });
+
+    it('getNegotiationThread returns proposals in chronological order', async () => {
+      const fx = await seedOrgFixture(db);
+      const r1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const r2 = await service.counterPropose({
+        proposalId: r1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fx.creatorAId,
+      });
+      const thread = await service.getNegotiationThread({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+      });
+      expect(thread.length).toBe(2);
+      expect(thread[0]?.id).toBe(r1.id);
+      expect(thread[0]?.roundNumber).toBe(1);
+      expect(thread[1]?.id).toBe(r2.id);
+      expect(thread[1]?.roundNumber).toBe(2);
+    });
+
+    it('getNegotiationThread returns empty array when no thread exists', async () => {
+      const fx = await seedOrgFixture(db);
+      const thread = await service.getNegotiationThread({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+      });
+      expect(thread).toEqual([]);
+    });
+  });
+});

--- a/packages/agreements/src/services/agreement-math.ts
+++ b/packages/agreements/src/services/agreement-math.ts
@@ -1,0 +1,159 @@
+/**
+ * @codex/agreements — Share validation math
+ *
+ * Pure functions, no DB access. Used by `AgreementService` at propose-time
+ * and re-checked at accept-time. Lives in its own module so the math can
+ * be unit-tested without a database fixture and so the worker can re-use
+ * the same predicate at API boundary (e.g. POST /agreements/preview).
+ *
+ * Units: all percentages are basis points (0–10000), matching the
+ * `proposed_creator_share_percent` and `organization_fee_percentage`
+ * columns. NEVER pass floats here.
+ */
+
+import { ShareExceedsAvailableError } from '../errors';
+
+/**
+ * Bounds for a single basis-point percentage value.
+ *
+ * Mirrors the `check_agreement_proposals_share_bps` and
+ * `check_org_fee_percentage` constraints. We validate locally so the
+ * service throws a domain error instead of letting Postgres throw a
+ * less-actionable constraint violation.
+ */
+const BPS_MIN = 0;
+const BPS_MAX = 10_000;
+
+/**
+ * Slim view of an agreement row that `sumActiveCreatorShares` cares about.
+ *
+ * Anything carrying `sharePercent` and a `status` we can narrow to
+ * `'active'` works — keeps callers from having to pluck and rename
+ * fields off the Drizzle row.
+ */
+export interface ActiveAgreementShareView {
+  sharePercent: number;
+  status: string;
+}
+
+/**
+ * Sum the creator-share basis points across the supplied agreements that
+ * are currently `status='active'`. Non-active rows are ignored — they
+ * are kept in the table for audit (terminated / expired) but contribute
+ * nothing to the live pool.
+ *
+ * @returns Total basis points (sum of all `sharePercent` where status='active').
+ */
+export function sumActiveCreatorShares(
+  agreements: readonly ActiveAgreementShareView[]
+): number {
+  let total = 0;
+  for (const a of agreements) {
+    if (a.status === 'active') {
+      total += a.sharePercent;
+    }
+  }
+  return total;
+}
+
+/**
+ * Inputs to `validateProposedShare` — names mirror the math, not any
+ * specific DB column, so callers can re-use the function in any
+ * context (propose, counter, accept, preview API).
+ */
+export interface ValidateProposedShareInput {
+  /** Basis points the new proposal would lock in. */
+  proposedSharePercent: number;
+  /**
+   * Basis-point shares from *other* currently-active agreements on the
+   * same (org, revenue_type) bucket. The caller filters out any
+   * agreement being replaced/superseded by this proposal — passing the
+   * full active set without that filter would double-count.
+   */
+  existingActiveShares: readonly number[];
+  /**
+   * Current platform fee for this org/revenue-type at validation time,
+   * resolved by the caller via `FeeConfigService.getFeesForOrg()`. Per
+   * decision #2 in the epic ("platform fee current, not snapshotted"),
+   * this is read fresh and never cached on the agreement row.
+   */
+  platformFeePercent: number;
+}
+
+/**
+ * Throws `ShareExceedsAvailableError` when the proposed creator share
+ * would overflow the remaining pool. The remaining pool is
+ *
+ *   10000 - platformFeePercent - sum(existingActiveShares)
+ *
+ * The boundary is inclusive — a proposal that exactly fills the
+ * remaining pool is accepted (the org owner residual goes to zero,
+ * which is a legal outcome).
+ *
+ * Also enforces that the proposed share is within the basis-point range
+ * [0, 10000]. We surface this as the same domain error so the API
+ * caller doesn't have to discriminate between "out of range" and
+ * "exceeds remaining pool" — they're both "fix the slider" at the UI.
+ *
+ * Pure function, no DB access. Safe to call inside transactions.
+ */
+export function validateProposedShare(input: ValidateProposedShareInput): void {
+  const { proposedSharePercent, existingActiveShares, platformFeePercent } =
+    input;
+
+  // Per-field bounds. Doing it here rather than relying solely on the DB
+  // CHECK gives the API a 422 with a meaningful message before a write.
+  if (
+    !Number.isInteger(proposedSharePercent) ||
+    proposedSharePercent < BPS_MIN ||
+    proposedSharePercent > BPS_MAX
+  ) {
+    throw new ShareExceedsAvailableError(
+      'Proposed creator share must be an integer basis-point value between 0 and 10000',
+      { proposedSharePercent }
+    );
+  }
+  if (
+    !Number.isInteger(platformFeePercent) ||
+    platformFeePercent < BPS_MIN ||
+    platformFeePercent > BPS_MAX
+  ) {
+    throw new ShareExceedsAvailableError(
+      'Platform fee percent must be an integer basis-point value between 0 and 10000',
+      { platformFeePercent }
+    );
+  }
+
+  const existingSum = existingActiveShares.reduce(
+    (acc, n) => acc + (Number.isFinite(n) ? n : 0),
+    0
+  );
+  const maxAllowed = BPS_MAX - platformFeePercent - existingSum;
+
+  if (proposedSharePercent > maxAllowed) {
+    throw new ShareExceedsAvailableError(
+      'Proposed creator share would exceed the available pool',
+      {
+        proposedSharePercent,
+        existingActiveSharePercent: existingSum,
+        platformFeePercent,
+        maxAllowedSharePercent: Math.max(0, maxAllowed),
+      }
+    );
+  }
+}
+
+/**
+ * Convenience: the dual-write invariant from WP-1 discoveries.
+ *
+ *   organization_fee_percentage = 10000 - proposed_creator_share_percent
+ *
+ * Keeps the legacy payout pipeline happy until WP-4 swaps the read path.
+ * Centralising the formula here means every writer in `AgreementService`
+ * uses the same expression and a future grep finds them all.
+ */
+export function legacyOrgFeeFromCreatorShare(
+  creatorSharePercent: number
+): number {
+  return BPS_MAX - creatorSharePercent;
+}

--- a/packages/agreements/src/services/agreement-math.ts
+++ b/packages/agreements/src/services/agreement-math.ts
@@ -1,4 +1,20 @@
 /**
+ * Unit semantics (load-bearing for WP-4 payout pipeline):
+ *
+ * `proposed_creator_share_percent` is the creator's slice of the
+ * POST-PLATFORM pool, in basis points (0-10000). This matches the
+ * schema column comment in `ecommerce.ts` and the legacy
+ * `calculateRevenueSplit` in @codex/purchase, which treats
+ * `organization_fee_percentage` as a fraction of (gross - platform_fee).
+ *
+ * Therefore: dual-write `organization_fee_percentage = 10000 - share`
+ * (both quantities in the same post-platform unit), and validation
+ * checks `sum(active creator shares) <= 10000` — the platform fee is
+ * already accounted for upstream of this pool and does NOT enter share
+ * validation.
+ */
+
+/**
  * @codex/agreements — Share validation math
  *
  * Pure functions, no DB access. Used by `AgreementService` at propose-time
@@ -6,9 +22,9 @@
  * be unit-tested without a database fixture and so the worker can re-use
  * the same predicate at API boundary (e.g. POST /agreements/preview).
  *
- * Units: all percentages are basis points (0–10000), matching the
- * `proposed_creator_share_percent` and `organization_fee_percentage`
- * columns. NEVER pass floats here.
+ * Units: all percentages are basis points (0–10000) of the post-platform
+ * pool, matching the `proposed_creator_share_percent` and
+ * `organization_fee_percentage` columns. NEVER pass floats here.
  */
 
 import { ShareExceedsAvailableError } from '../errors';
@@ -60,6 +76,9 @@ export function sumActiveCreatorShares(
  * Inputs to `validateProposedShare` — names mirror the math, not any
  * specific DB column, so callers can re-use the function in any
  * context (propose, counter, accept, preview API).
+ *
+ * Platform fee is deliberately NOT a parameter — see the file header.
+ * The post-platform pool is the only unit this function reasons about.
  */
 export interface ValidateProposedShareInput {
   /** Basis points the new proposal would lock in. */
@@ -71,20 +90,13 @@ export interface ValidateProposedShareInput {
    * full active set without that filter would double-count.
    */
   existingActiveShares: readonly number[];
-  /**
-   * Current platform fee for this org/revenue-type at validation time,
-   * resolved by the caller via `FeeConfigService.getFeesForOrg()`. Per
-   * decision #2 in the epic ("platform fee current, not snapshotted"),
-   * this is read fresh and never cached on the agreement row.
-   */
-  platformFeePercent: number;
 }
 
 /**
  * Throws `ShareExceedsAvailableError` when the proposed creator share
- * would overflow the remaining pool. The remaining pool is
+ * would overflow the post-platform pool. The remaining pool is
  *
- *   10000 - platformFeePercent - sum(existingActiveShares)
+ *   10000 - sum(existingActiveShares)
  *
  * The boundary is inclusive — a proposal that exactly fills the
  * remaining pool is accepted (the org owner residual goes to zero,
@@ -98,8 +110,7 @@ export interface ValidateProposedShareInput {
  * Pure function, no DB access. Safe to call inside transactions.
  */
 export function validateProposedShare(input: ValidateProposedShareInput): void {
-  const { proposedSharePercent, existingActiveShares, platformFeePercent } =
-    input;
+  const { proposedSharePercent, existingActiveShares } = input;
 
   // Per-field bounds. Doing it here rather than relying solely on the DB
   // CHECK gives the API a 422 with a meaningful message before a write.
@@ -113,22 +124,21 @@ export function validateProposedShare(input: ValidateProposedShareInput): void {
       { proposedSharePercent }
     );
   }
-  if (
-    !Number.isInteger(platformFeePercent) ||
-    platformFeePercent < BPS_MIN ||
-    platformFeePercent > BPS_MAX
-  ) {
-    throw new ShareExceedsAvailableError(
-      'Platform fee percent must be an integer basis-point value between 0 and 10000',
-      { platformFeePercent }
-    );
+
+  // Validate each existing share is within bounds — if a caller passes a
+  // negative or out-of-range value here, we want a meaningful error, not
+  // a silent arithmetic skew.
+  for (const n of existingActiveShares) {
+    if (!Number.isInteger(n) || n < BPS_MIN || n > BPS_MAX) {
+      throw new ShareExceedsAvailableError(
+        'Existing active share basis-points must each be integers between 0 and 10000',
+        { existingActiveSharePercent: n }
+      );
+    }
   }
 
-  const existingSum = existingActiveShares.reduce(
-    (acc, n) => acc + (Number.isFinite(n) ? n : 0),
-    0
-  );
-  const maxAllowed = BPS_MAX - platformFeePercent - existingSum;
+  const existingSum = existingActiveShares.reduce((acc, n) => acc + n, 0);
+  const maxAllowed = BPS_MAX - existingSum;
 
   if (proposedSharePercent > maxAllowed) {
     throw new ShareExceedsAvailableError(
@@ -136,7 +146,6 @@ export function validateProposedShare(input: ValidateProposedShareInput): void {
       {
         proposedSharePercent,
         existingActiveSharePercent: existingSum,
-        platformFeePercent,
         maxAllowedSharePercent: Math.max(0, maxAllowed),
       }
     );
@@ -156,4 +165,15 @@ export function legacyOrgFeeFromCreatorShare(
   creatorSharePercent: number
 ): number {
   return BPS_MAX - creatorSharePercent;
+}
+
+/**
+ * Inverse of {@link legacyOrgFeeFromCreatorShare}: derive a creator's
+ * post-platform share from the legacy `organization_fee_percentage`
+ * column. Same arithmetic (10000 - x is its own inverse) but the
+ * function name documents the direction at the call site — important
+ * for WP-4 when the read path swaps off the legacy column entirely.
+ */
+export function creatorShareFromLegacyOrgFee(orgFeePercent: number): number {
+  return BPS_MAX - orgFeePercent;
 }

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -1,0 +1,1016 @@
+/**
+ * @codex/agreements — AgreementService
+ *
+ * State machine for revenue-share negotiations + lifecycle of the
+ * resulting `creator_organization_agreements` rows. Drives the schema
+ * landed in WP-1 (PR #207) and feeds the payout pipeline WP-4 will
+ * rewire.
+ *
+ * Reference reading before editing:
+ *   - `packages/database/src/schema/ecommerce.ts` (agreementProposals,
+ *     creatorOrganizationAgreements, *Relations)
+ *   - `~/.claude/projects/.../memory/project_revenue_share_wp1_discoveries.md`
+ *     (three load-bearing constraints below — owner-resolution via
+ *     memberships, dual-write legacy fee column, Drizzle relationName).
+ *   - `~/.claude/projects/.../memory/project_revenue_share_decisions.md`
+ *     (creator share snapshotted; platform fee read fresh).
+ *
+ * Every multi-step write goes through `this.db.transaction()` so the
+ * database is never left in a half-applied state — agreement acceptance
+ * in particular touches three tables (proposal, prior active agreement,
+ * new active agreement) plus marks siblings superseded.
+ */
+
+import { FEES } from '@codex/constants';
+import { whereNotDeleted } from '@codex/database';
+import {
+  agreementProposals,
+  creatorOrganizationAgreements,
+  organizationMemberships,
+  organizations,
+} from '@codex/database/schema';
+import type { FeeConfigService, FeeContext } from '@codex/purchase';
+import {
+  BaseService,
+  ForbiddenError,
+  InternalServiceError,
+  type ServiceConfig,
+} from '@codex/service-errors';
+import { and, asc, desc, eq, inArray, isNull, ne } from 'drizzle-orm';
+import { AgreementNotFoundError, InvalidProposalStateError } from '../errors';
+import type {
+  AgreementProposal,
+  CreatorOrganizationAgreement,
+  RevenueType,
+} from '../types';
+import {
+  legacyOrgFeeFromCreatorShare,
+  validateProposedShare,
+} from './agreement-math';
+
+// ─── Public input shapes ──────────────────────────────────────────────────
+
+export interface ProposeAgreementInput {
+  organizationId: string;
+  creatorId: string;
+  revenueType: RevenueType;
+  /** Basis points 0–10000. */
+  sharePercent: number;
+  /** Soft-lock review window in months. `null` = indefinite. */
+  termMonths: number | null;
+  note?: string | null;
+  /** User initiating the propose; must be an active owner of the org. */
+  proposedByUserId: string;
+  /** Defaults to `new Date()` if omitted. */
+  effectiveFrom?: Date;
+}
+
+export interface CounterProposeInput {
+  /** The proposal being countered. Must currently be `status='open'`. */
+  proposalId: string;
+  sharePercent: number;
+  termMonths: number | null;
+  note?: string | null;
+  /** Must be the counterparty of the proposal being countered. */
+  counteredByUserId: string;
+}
+
+export interface AcceptProposalInput {
+  proposalId: string;
+  /** Must be the counterparty of the proposal being accepted. */
+  acceptedByUserId: string;
+}
+
+export interface DeclineProposalInput {
+  proposalId: string;
+  /** Must be the counterparty of the proposal being declined. */
+  declinedByUserId: string;
+  reason?: string | null;
+}
+
+export interface WithdrawProposalInput {
+  proposalId: string;
+  /** Must be the *proposing* party. */
+  withdrawnByUserId: string;
+}
+
+export interface TerminateAgreementInput {
+  agreementId: string;
+  /** Must be the org owner or the creator named on the agreement. */
+  terminatedByUserId: string;
+  reason?: string | null;
+}
+
+// ─── Service config ───────────────────────────────────────────────────────
+
+/**
+ * Constructor config. `feeConfig` is required because validateProposedShare
+ * needs the *current* platform fee (per epic decision #2 — fee is read
+ * fresh at propose/accept time, never snapshotted on the agreement row).
+ *
+ * Workers wire this through `service-registry.ts`; tests inject a minimal
+ * stub or the real `FeeConfigService` with a stub `cache`.
+ */
+export interface AgreementServiceConfig extends ServiceConfig {
+  feeConfig: FeeConfigService;
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────
+
+export class AgreementService extends BaseService {
+  private readonly feeConfig: FeeConfigService;
+
+  constructor(config: AgreementServiceConfig) {
+    super(config);
+    this.feeConfig = config.feeConfig;
+  }
+
+  // ── Public: propose ─────────────────────────────────────────────────────
+
+  /**
+   * Owner-initiated initial proposal (round 1). Per the plan, only the
+   * organization owner can open a negotiation. Subsequent rounds are
+   * created via `counterPropose`.
+   *
+   * Validates:
+   *   1. proposer is an active owner of the org
+   *   2. creator is an active member of the org (any role; org may have
+   *      promoted a member to "creator" or kept them as "member" — we
+   *      gate on membership, not on role, to allow paying any team
+   *      member out of pooled revenue)
+   *   3. no other proposal in this (org, creator, revenue_type) thread
+   *      is currently `open` or `countered` (one negotiation at a time
+   *      per bucket — keeps the UI sane)
+   *   4. proposed share + active sibling shares + current platform fee
+   *      ≤ 100%
+   */
+  async proposeAgreement(
+    input: ProposeAgreementInput
+  ): Promise<AgreementProposal> {
+    try {
+      // Resolve platform fee outside the transaction — the FeeConfig
+      // service can hit KV cache and has its own DB pool semantics; we
+      // want to keep this transaction tight to the write set.
+      const platformFee = await this.resolvePlatformFee(
+        input.organizationId,
+        input.revenueType
+      );
+
+      return await this.db.transaction(async (tx) => {
+        await this.assertActiveOwner(
+          tx,
+          input.organizationId,
+          input.proposedByUserId
+        );
+        await this.assertActiveMember(
+          tx,
+          input.organizationId,
+          input.creatorId
+        );
+        await this.assertNoOpenThread(
+          tx,
+          input.organizationId,
+          input.creatorId,
+          input.revenueType
+        );
+
+        // Existing active shares ELSEWHERE in the org for this revenue
+        // type — these reduce the headroom. We deliberately exclude
+        // (org, creator, revenue_type) because no active agreement
+        // for that triple can exist (partial unique index) and the
+        // payout splitter sums per-creator, not per-row.
+        const existingActiveShares = await this.fetchExistingActiveShares(
+          tx,
+          input.organizationId,
+          input.revenueType,
+          { excludeCreatorId: input.creatorId }
+        );
+
+        validateProposedShare({
+          proposedSharePercent: input.sharePercent,
+          existingActiveShares,
+          platformFeePercent: platformFee,
+        });
+
+        const [row] = await tx
+          .insert(agreementProposals)
+          .values({
+            organizationId: input.organizationId,
+            creatorId: input.creatorId,
+            revenueType: input.revenueType,
+            parentProposalId: null,
+            roundNumber: 1,
+            proposedByUserId: input.proposedByUserId,
+            proposedByRole: 'owner',
+            proposedCreatorSharePercent: input.sharePercent,
+            proposedTermMonths: input.termMonths,
+            proposedEffectiveFrom: input.effectiveFrom ?? new Date(),
+            note: input.note ?? null,
+            status: 'open',
+          })
+          .returning();
+
+        if (!row) {
+          throw new InternalServiceError('Failed to insert agreement proposal');
+        }
+        return row;
+      });
+    } catch (error) {
+      this.handleError(error, 'proposeAgreement');
+    }
+  }
+
+  // ── Public: counter ─────────────────────────────────────────────────────
+
+  /**
+   * Counter-proposal — same negotiation thread, next round, flipped role.
+   *
+   * The parent proposal must currently be `status='open'`. The actor must
+   * be the *counterparty* — if the parent was proposed by an owner, the
+   * actor must be the creator named on the proposal (and vice versa for
+   * owner-counters-creator). The parent transitions to `'countered'` in
+   * the same transaction so the read-side never observes two `open`
+   * rows in a thread.
+   */
+  async counterPropose(input: CounterProposeInput): Promise<AgreementProposal> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        const parent = await this.findProposalOrThrow(tx, input.proposalId);
+
+        if (parent.status !== 'open') {
+          throw new InvalidProposalStateError(
+            'Only open proposals can be countered',
+            {
+              proposalId: parent.id,
+              currentStatus: parent.status,
+              attemptedAction: 'counter',
+            }
+          );
+        }
+
+        // Counter-party check. If the parent was owner-proposed, only
+        // the named creator may counter. If creator-proposed, only an
+        // active owner of the org may counter.
+        const counteringRole: 'owner' | 'creator' =
+          parent.proposedByRole === 'owner' ? 'creator' : 'owner';
+
+        if (counteringRole === 'creator') {
+          if (parent.creatorId !== input.counteredByUserId) {
+            throw new ForbiddenError(
+              'Only the counterparty creator may counter this proposal',
+              { proposalId: parent.id }
+            );
+          }
+        } else {
+          await this.assertActiveOwner(
+            tx,
+            parent.organizationId,
+            input.counteredByUserId
+          );
+        }
+
+        // Re-check share against current world. The counter may land
+        // months after the parent — sibling agreements may have shifted.
+        const platformFee = await this.resolvePlatformFee(
+          parent.organizationId,
+          parent.revenueType as RevenueType
+        );
+        const existingActiveShares = await this.fetchExistingActiveShares(
+          tx,
+          parent.organizationId,
+          parent.revenueType as RevenueType,
+          { excludeCreatorId: parent.creatorId }
+        );
+        validateProposedShare({
+          proposedSharePercent: input.sharePercent,
+          existingActiveShares,
+          platformFeePercent: platformFee,
+        });
+
+        // Parent → countered. responded_* captures who closed the parent
+        // row out, separate from who created the new child row.
+        await tx
+          .update(agreementProposals)
+          .set({
+            status: 'countered',
+            respondedAt: new Date(),
+            respondedByUserId: input.counteredByUserId,
+            updatedAt: new Date(),
+          })
+          .where(eq(agreementProposals.id, parent.id));
+
+        const [child] = await tx
+          .insert(agreementProposals)
+          .values({
+            organizationId: parent.organizationId,
+            creatorId: parent.creatorId,
+            revenueType: parent.revenueType,
+            parentProposalId: parent.id,
+            roundNumber: parent.roundNumber + 1,
+            proposedByUserId: input.counteredByUserId,
+            proposedByRole: counteringRole,
+            proposedCreatorSharePercent: input.sharePercent,
+            proposedTermMonths: input.termMonths,
+            // Counter-proposals inherit the parent's effective_from —
+            // the negotiation is about the same contract window, not a
+            // new start date.
+            proposedEffectiveFrom: parent.proposedEffectiveFrom,
+            note: input.note ?? null,
+            status: 'open',
+          })
+          .returning();
+
+        if (!child) {
+          throw new InternalServiceError('Failed to insert counter proposal');
+        }
+        return child;
+      });
+    } catch (error) {
+      this.handleError(error, 'counterPropose');
+    }
+  }
+
+  // ── Public: accept ──────────────────────────────────────────────────────
+
+  /**
+   * Accept an open proposal. Atomically:
+   *   1. validates the actor is the counterparty
+   *   2. re-validates the share against the current world
+   *   3. marks the accepted proposal `status='accepted'`
+   *   4. marks any sibling `open|countered` proposals in the thread
+   *      `status='superseded'` (defence in depth — the partial unique
+   *      index alone would not catch a stranded open row in the same
+   *      thread because that index is on the AGREEMENT table, not the
+   *      proposal table)
+   *   5. marks any prior `active` agreement for the triple
+   *      `status='terminated'` (auto-terminate the predecessor; the
+   *      partial unique index enforces this anyway, but explicit
+   *      gives a clean audit trail with `terminationReason` set)
+   *   6. inserts the new `creator_organization_agreements` row with
+   *      `status='active'`, links it back via `current_proposal_id`,
+   *      and dual-writes the legacy `organization_fee_percentage`
+   *      column per WP-1 discovery.
+   */
+  async acceptProposal(
+    input: AcceptProposalInput
+  ): Promise<CreatorOrganizationAgreement> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        const proposal = await this.findProposalOrThrow(tx, input.proposalId);
+
+        if (proposal.status !== 'open') {
+          throw new InvalidProposalStateError(
+            'Only open proposals can be accepted',
+            {
+              proposalId: proposal.id,
+              currentStatus: proposal.status,
+              attemptedAction: 'accept',
+            }
+          );
+        }
+
+        // Counter-party authorisation: the side that did NOT propose
+        // is the one allowed to accept. Defensive: if a future bug ever
+        // creates a proposal whose `proposed_by_user_id` equals the
+        // creator slot AND `proposed_by_role='owner'`, this check still
+        // does the right thing because we look at the role, not the
+        // user-id.
+        if (proposal.proposedByRole === 'owner') {
+          if (proposal.creatorId !== input.acceptedByUserId) {
+            throw new ForbiddenError(
+              'Only the counterparty creator may accept this proposal',
+              { proposalId: proposal.id }
+            );
+          }
+        } else {
+          await this.assertActiveOwner(
+            tx,
+            proposal.organizationId,
+            input.acceptedByUserId
+          );
+        }
+
+        // Re-validate share at accept time — siblings may have moved.
+        const platformFee = await this.resolvePlatformFee(
+          proposal.organizationId,
+          proposal.revenueType as RevenueType
+        );
+        const existingActiveShares = await this.fetchExistingActiveShares(
+          tx,
+          proposal.organizationId,
+          proposal.revenueType as RevenueType,
+          { excludeCreatorId: proposal.creatorId }
+        );
+        validateProposedShare({
+          proposedSharePercent: proposal.proposedCreatorSharePercent,
+          existingActiveShares,
+          platformFeePercent: platformFee,
+        });
+
+        const now = new Date();
+
+        // (3) Mark the proposal accepted.
+        await tx
+          .update(agreementProposals)
+          .set({
+            status: 'accepted',
+            respondedAt: now,
+            respondedByUserId: input.acceptedByUserId,
+            updatedAt: now,
+          })
+          .where(eq(agreementProposals.id, proposal.id));
+
+        // (4) Supersede sibling open/countered proposals in the thread.
+        await tx
+          .update(agreementProposals)
+          .set({ status: 'superseded', updatedAt: now })
+          .where(
+            and(
+              eq(agreementProposals.organizationId, proposal.organizationId),
+              eq(agreementProposals.creatorId, proposal.creatorId),
+              eq(agreementProposals.revenueType, proposal.revenueType),
+              ne(agreementProposals.id, proposal.id),
+              inArray(agreementProposals.status, ['open', 'countered'])
+            )
+          );
+
+        // (5) Terminate the predecessor active agreement, if any.
+        await tx
+          .update(creatorOrganizationAgreements)
+          .set({
+            status: 'terminated',
+            terminatedAt: now,
+            terminatedByUserId: input.acceptedByUserId,
+            terminationReason: 'Superseded by accepted proposal',
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(
+                creatorOrganizationAgreements.organizationId,
+                proposal.organizationId
+              ),
+              eq(creatorOrganizationAgreements.creatorId, proposal.creatorId),
+              eq(
+                creatorOrganizationAgreements.revenueType,
+                proposal.revenueType
+              ),
+              eq(creatorOrganizationAgreements.status, 'active')
+            )
+          );
+
+        // (6) Insert the new active agreement.
+        // Dual-write invariant (WP-1 discovery): the legacy
+        // `organization_fee_percentage` column is NOT NULL and the
+        // payout pipeline still reads it. Until WP-4 swaps the read
+        // path, every write to `proposed_creator_share_percent` must
+        // be paired with `organization_fee_percentage = 10000 - share`
+        // in the SAME transaction. Centralised in
+        // `legacyOrgFeeFromCreatorShare()`.
+        const [agreement] = await tx
+          .insert(creatorOrganizationAgreements)
+          .values({
+            creatorId: proposal.creatorId,
+            organizationId: proposal.organizationId,
+            organizationFeePercentage: legacyOrgFeeFromCreatorShare(
+              proposal.proposedCreatorSharePercent
+            ),
+            revenueType: proposal.revenueType,
+            status: 'active',
+            currentProposalId: proposal.id,
+            effectiveFrom: proposal.proposedEffectiveFrom,
+            effectiveUntil: this.computeEffectiveUntil(
+              proposal.proposedEffectiveFrom,
+              proposal.proposedTermMonths
+            ),
+          })
+          .returning();
+
+        if (!agreement) {
+          throw new InternalServiceError(
+            'Failed to insert creator organization agreement'
+          );
+        }
+        return agreement;
+      });
+    } catch (error) {
+      this.handleError(error, 'acceptProposal');
+    }
+  }
+
+  // ── Public: decline ─────────────────────────────────────────────────────
+
+  async declineProposal(
+    input: DeclineProposalInput
+  ): Promise<AgreementProposal> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        const proposal = await this.findProposalOrThrow(tx, input.proposalId);
+
+        if (proposal.status !== 'open') {
+          throw new InvalidProposalStateError(
+            'Only open proposals can be declined',
+            {
+              proposalId: proposal.id,
+              currentStatus: proposal.status,
+              attemptedAction: 'decline',
+            }
+          );
+        }
+
+        if (proposal.proposedByRole === 'owner') {
+          if (proposal.creatorId !== input.declinedByUserId) {
+            throw new ForbiddenError(
+              'Only the counterparty creator may decline this proposal',
+              { proposalId: proposal.id }
+            );
+          }
+        } else {
+          await this.assertActiveOwner(
+            tx,
+            proposal.organizationId,
+            input.declinedByUserId
+          );
+        }
+
+        const now = new Date();
+        const [updated] = await tx
+          .update(agreementProposals)
+          .set({
+            status: 'declined',
+            respondedAt: now,
+            respondedByUserId: input.declinedByUserId,
+            declineReason: input.reason ?? null,
+            updatedAt: now,
+          })
+          .where(eq(agreementProposals.id, proposal.id))
+          .returning();
+        if (!updated) {
+          throw new InternalServiceError(
+            'Failed to update proposal to declined'
+          );
+        }
+        return updated;
+      });
+    } catch (error) {
+      this.handleError(error, 'declineProposal');
+    }
+  }
+
+  // ── Public: withdraw ────────────────────────────────────────────────────
+
+  async withdrawProposal(
+    input: WithdrawProposalInput
+  ): Promise<AgreementProposal> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        const proposal = await this.findProposalOrThrow(tx, input.proposalId);
+
+        if (proposal.status !== 'open') {
+          throw new InvalidProposalStateError(
+            'Only open proposals can be withdrawn',
+            {
+              proposalId: proposal.id,
+              currentStatus: proposal.status,
+              attemptedAction: 'withdraw',
+            }
+          );
+        }
+
+        // Withdraw is "the side that PROPOSED rescinds the offer". For
+        // owner-proposed rows, the actor must be an active owner of the
+        // org (allows co-owners to clean up after each other). For
+        // creator-proposed counters, the actor must be the named
+        // creator.
+        if (proposal.proposedByRole === 'creator') {
+          if (proposal.creatorId !== input.withdrawnByUserId) {
+            throw new ForbiddenError(
+              'Only the proposing creator may withdraw this proposal',
+              { proposalId: proposal.id }
+            );
+          }
+        } else {
+          await this.assertActiveOwner(
+            tx,
+            proposal.organizationId,
+            input.withdrawnByUserId
+          );
+        }
+
+        const now = new Date();
+        const [updated] = await tx
+          .update(agreementProposals)
+          .set({
+            status: 'withdrawn',
+            respondedAt: now,
+            respondedByUserId: input.withdrawnByUserId,
+            updatedAt: now,
+          })
+          .where(eq(agreementProposals.id, proposal.id))
+          .returning();
+        if (!updated) {
+          throw new InternalServiceError(
+            'Failed to update proposal to withdrawn'
+          );
+        }
+        return updated;
+      });
+    } catch (error) {
+      this.handleError(error, 'withdrawProposal');
+    }
+  }
+
+  // ── Public: terminate active agreement ──────────────────────────────────
+
+  async terminateAgreement(
+    input: TerminateAgreementInput
+  ): Promise<CreatorOrganizationAgreement> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        const agreement = await this.findAgreementOrThrow(
+          tx,
+          input.agreementId
+        );
+
+        if (agreement.status !== 'active') {
+          throw new InvalidProposalStateError(
+            'Only active agreements can be terminated',
+            {
+              agreementId: agreement.id,
+              currentStatus: agreement.status,
+              attemptedAction: 'terminate',
+            }
+          );
+        }
+
+        // Either party may terminate — the creator named on the row, or
+        // any active owner of the org. We check creator first because
+        // it's a single equality compare; the membership lookup falls
+        // through only when needed.
+        if (agreement.creatorId !== input.terminatedByUserId) {
+          await this.assertActiveOwner(
+            tx,
+            agreement.organizationId,
+            input.terminatedByUserId
+          );
+        }
+
+        const now = new Date();
+        const [updated] = await tx
+          .update(creatorOrganizationAgreements)
+          .set({
+            status: 'terminated',
+            terminatedAt: now,
+            terminatedByUserId: input.terminatedByUserId,
+            terminationReason: input.reason ?? null,
+            updatedAt: now,
+          })
+          .where(eq(creatorOrganizationAgreements.id, agreement.id))
+          .returning();
+        if (!updated) {
+          throw new InternalServiceError(
+            'Failed to update agreement to terminated'
+          );
+        }
+        return updated;
+      });
+    } catch (error) {
+      this.handleError(error, 'terminateAgreement');
+    }
+  }
+
+  // ── Public: reads ───────────────────────────────────────────────────────
+
+  /**
+   * Active agreements for an org — every `status='active'` row, both
+   * revenue types. Sorted by `effectiveFrom DESC` so the most recent
+   * agreements bubble up.
+   */
+  async getActiveAgreements(input: {
+    organizationId: string;
+  }): Promise<CreatorOrganizationAgreement[]> {
+    try {
+      return await this.db.query.creatorOrganizationAgreements.findMany({
+        where: and(
+          eq(
+            creatorOrganizationAgreements.organizationId,
+            input.organizationId
+          ),
+          eq(creatorOrganizationAgreements.status, 'active'),
+          // The agreements table doesn't carry a `deletedAt` column —
+          // termination is the soft-delete vector. The `terminatedAt`
+          // filter is defence-in-depth: a row in `active` should never
+          // also carry a `terminated_at` (enforced by
+          // `check_creator_org_agreement_terminated_shape`), but if a
+          // future bug skews them we still refuse to surface it.
+          isNull(creatorOrganizationAgreements.terminatedAt)
+        ),
+        orderBy: [desc(creatorOrganizationAgreements.effectiveFrom)],
+      });
+    } catch (error) {
+      this.handleError(error, 'getActiveAgreements');
+    }
+  }
+
+  /**
+   * Creator's portfolio across all orgs — used by the creator-studio
+   * /negotiations page. Filters to `status='active'` only.
+   */
+  async getActiveAgreementsForCreator(input: {
+    creatorId: string;
+  }): Promise<CreatorOrganizationAgreement[]> {
+    try {
+      return await this.db.query.creatorOrganizationAgreements.findMany({
+        where: and(
+          eq(creatorOrganizationAgreements.creatorId, input.creatorId),
+          eq(creatorOrganizationAgreements.status, 'active'),
+          isNull(creatorOrganizationAgreements.terminatedAt)
+        ),
+        orderBy: [desc(creatorOrganizationAgreements.effectiveFrom)],
+      });
+    } catch (error) {
+      this.handleError(error, 'getActiveAgreementsForCreator');
+    }
+  }
+
+  /**
+   * Full negotiation thread for a (org, creator, revenue_type) triple,
+   * chronological. Empty array if no thread exists yet.
+   *
+   * The UI uses this to render the proposal history alongside the
+   * accept/counter/decline controls. Round numbers are monotonic per
+   * thread so the order is unambiguous.
+   */
+  async getNegotiationThread(input: {
+    organizationId: string;
+    creatorId: string;
+    revenueType: RevenueType;
+  }): Promise<AgreementProposal[]> {
+    try {
+      return await this.db.query.agreementProposals.findMany({
+        where: and(
+          eq(agreementProposals.organizationId, input.organizationId),
+          eq(agreementProposals.creatorId, input.creatorId),
+          eq(agreementProposals.revenueType, input.revenueType)
+        ),
+        orderBy: [
+          asc(agreementProposals.roundNumber),
+          asc(agreementProposals.createdAt),
+        ],
+      });
+    } catch (error) {
+      this.handleError(error, 'getNegotiationThread');
+    }
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────────────
+
+  /**
+   * Resolve "is this user an active owner of this org?".
+   *
+   * Per WP-1 discovery, `organizations.owner_id` does NOT exist —
+   * ownership is encoded by `organization_memberships.role='owner' AND
+   * status='active'`. There may be 0 or many such rows.
+   *
+   * Throws `ForbiddenError` when the user is not an active owner, or
+   * when the org has no active owner at all (orphaned organisations).
+   * Documented choice: we don't silently fall through to "no owner = no
+   * agreement possible" — the call site asked for an owner check, the
+   * service refuses rather than guess.
+   */
+  private async assertActiveOwner(
+    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    organizationId: string,
+    userId: string
+  ): Promise<void> {
+    // Quick existence check on the org first — gives a more precise
+    // error than "no active owner" when the org id is bogus.
+    const org = await tx.query.organizations.findFirst({
+      where: and(
+        eq(organizations.id, organizationId),
+        whereNotDeleted(organizations)
+      ),
+      columns: { id: true },
+    });
+    if (!org) {
+      throw new AgreementNotFoundError('Organization not found', {
+        agreementId: organizationId,
+      });
+    }
+
+    const owners = await tx
+      .select({ userId: organizationMemberships.userId })
+      .from(organizationMemberships)
+      .where(
+        and(
+          eq(organizationMemberships.organizationId, organizationId),
+          eq(organizationMemberships.role, 'owner'),
+          eq(organizationMemberships.status, 'active')
+        )
+      )
+      .orderBy(asc(organizationMemberships.createdAt));
+
+    if (owners.length === 0) {
+      throw new ForbiddenError('Organization has no active owner', {
+        organizationId,
+      });
+    }
+    if (!owners.some((o) => o.userId === userId)) {
+      throw new ForbiddenError(
+        'Only an active organization owner may perform this action',
+        { organizationId, userId }
+      );
+    }
+  }
+
+  /**
+   * Membership existence check — the creator must be on the team. Any
+   * active role qualifies; we don't gate on `role='creator'` so an
+   * owner can propose to themselves (single-creator-orgs do this to
+   * pre-empt the org-keeps-100% fallback path).
+   */
+  private async assertActiveMember(
+    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    organizationId: string,
+    userId: string
+  ): Promise<void> {
+    const membership = await tx.query.organizationMemberships.findFirst({
+      where: and(
+        eq(organizationMemberships.organizationId, organizationId),
+        eq(organizationMemberships.userId, userId),
+        eq(organizationMemberships.status, 'active')
+      ),
+      columns: { id: true },
+    });
+    if (!membership) {
+      throw new ForbiddenError(
+        'Target user is not an active member of this organization',
+        { organizationId, userId }
+      );
+    }
+  }
+
+  /**
+   * Refuse to open a new round-1 proposal when a thread is already in
+   * flight for the same (org, creator, revenue_type) triple. The
+   * "in flight" set is `status IN ('open', 'countered')` — any
+   * terminal status frees the bucket.
+   *
+   * If the caller wants to re-open after a decline/withdraw, they
+   * call `proposeAgreement` again, which lands in this guard and
+   * passes because the previous thread is fully terminal.
+   */
+  private async assertNoOpenThread(
+    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    organizationId: string,
+    creatorId: string,
+    revenueType: RevenueType
+  ): Promise<void> {
+    const inflight = await tx.query.agreementProposals.findFirst({
+      where: and(
+        eq(agreementProposals.organizationId, organizationId),
+        eq(agreementProposals.creatorId, creatorId),
+        eq(agreementProposals.revenueType, revenueType),
+        inArray(agreementProposals.status, ['open', 'countered'])
+      ),
+      columns: { id: true, status: true },
+    });
+    if (inflight) {
+      throw new InvalidProposalStateError(
+        'A proposal is already open for this creator + revenue type — counter or decline it first',
+        {
+          proposalId: inflight.id,
+          currentStatus: inflight.status,
+          attemptedAction: 'propose',
+        }
+      );
+    }
+  }
+
+  /**
+   * Existing active creator shares for this (org, revenue_type) bucket.
+   *
+   * We reconstruct each share via the legacy `organization_fee_percentage`
+   * column on the agreement (`share = 10000 - fee`). That column is:
+   *
+   *   - NOT NULL (schema constraint),
+   *   - dual-written by `acceptProposal()` here in this service, and
+   *   - backfilled by migration 0072 for pre-existing rows.
+   *
+   * Reading it directly avoids a JOIN to `agreement_proposals` on a hot
+   * validation path. When WP-4 swaps the read path to query
+   * `proposed_creator_share_percent` via `current_proposal_id`, this
+   * helper can be flipped over too — the public signature is stable.
+   *
+   * Returns an array (not the sum) so the caller can include the
+   * breakdown in `ShareExceedsAvailableError.context.existingActiveShares`.
+   */
+  private async fetchExistingActiveShares(
+    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    organizationId: string,
+    revenueType: RevenueType,
+    options: { excludeCreatorId?: string } = {}
+  ): Promise<number[]> {
+    const conditions = [
+      eq(creatorOrganizationAgreements.organizationId, organizationId),
+      eq(creatorOrganizationAgreements.revenueType, revenueType),
+      eq(creatorOrganizationAgreements.status, 'active'),
+      isNull(creatorOrganizationAgreements.terminatedAt),
+    ];
+    if (options.excludeCreatorId) {
+      conditions.push(
+        ne(creatorOrganizationAgreements.creatorId, options.excludeCreatorId)
+      );
+    }
+    const rows = await tx
+      .select({
+        orgFee: creatorOrganizationAgreements.organizationFeePercentage,
+      })
+      .from(creatorOrganizationAgreements)
+      .where(and(...conditions));
+
+    return rows.map((r) => legacyOrgFeeFromCreatorShare(r.orgFee));
+  }
+
+  /**
+   * Read platform fee for (org, revenueType) at the current moment.
+   *
+   * Per decision #2, platform fee is NEVER snapshotted on the
+   * agreement — it's read fresh at propose/accept time. The
+   * `feeConfig.getFeesForOrg(...)` call walks the 3-tier fallback
+   * chain (creator-override → org → platform → constants).
+   *
+   * Note: `FeeConfig` uses `'subscription' | 'one_off'` for its
+   * context label, while our domain uses
+   * `'subscription' | 'content_purchase'`. Translate at the boundary
+   * so we don't leak FeeConfig's vocabulary into the agreement API.
+   */
+  private async resolvePlatformFee(
+    organizationId: string,
+    revenueType: RevenueType
+  ): Promise<number> {
+    const ctx: FeeContext =
+      revenueType === 'subscription' ? 'subscription' : 'one_off';
+    try {
+      const fees = await this.feeConfig.getFeesForOrg(organizationId, ctx);
+      return fees.platformFeePercent;
+    } catch (error) {
+      // Don't let a fee-config blip kill an agreement read — fall back
+      // to the platform-level default constant. We log so the failure
+      // is visible; the propose / accept flow degrades to a strict but
+      // not-org-tuned validation.
+      this.obs.warn(
+        'Falling back to default platform fee for share validation',
+        {
+          organizationId,
+          revenueType,
+          errorName: error instanceof Error ? error.name : 'unknown',
+        }
+      );
+      return FEES.PLATFORM_PERCENT;
+    }
+  }
+
+  /**
+   * Walks `proposed_term_months` into a concrete `effective_until`
+   * timestamp. `null` term = indefinite agreement, so we leave
+   * `effective_until` null. Months are added by walking the date
+   * components — DST-safe within the resolution this column needs
+   * (monthly).
+   */
+  private computeEffectiveUntil(
+    effectiveFrom: Date,
+    termMonths: number | null
+  ): Date | null {
+    if (termMonths == null) return null;
+    const d = new Date(effectiveFrom.getTime());
+    d.setUTCMonth(d.getUTCMonth() + termMonths);
+    return d;
+  }
+
+  private async findProposalOrThrow(
+    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    proposalId: string
+  ): Promise<AgreementProposal> {
+    const row = await tx.query.agreementProposals.findFirst({
+      where: eq(agreementProposals.id, proposalId),
+    });
+    if (!row) {
+      throw new AgreementNotFoundError('Proposal not found', { proposalId });
+    }
+    return row;
+  }
+
+  private async findAgreementOrThrow(
+    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    agreementId: string
+  ): Promise<CreatorOrganizationAgreement> {
+    const row = await tx.query.creatorOrganizationAgreements.findFirst({
+      where: eq(creatorOrganizationAgreements.id, agreementId),
+    });
+    if (!row) {
+      throw new AgreementNotFoundError('Agreement not found', { agreementId });
+    }
+    return row;
+  }
+}

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -13,15 +13,22 @@
  *     (three load-bearing constraints below — owner-resolution via
  *     memberships, dual-write legacy fee column, Drizzle relationName).
  *   - `~/.claude/projects/.../memory/project_revenue_share_decisions.md`
- *     (creator share snapshotted; platform fee read fresh).
+ *     (creator share snapshotted; platform fee read fresh in the payout
+ *     pipeline — but NOT in share-validation, see `agreement-math.ts`).
  *
  * Every multi-step write goes through `this.db.transaction()` so the
  * database is never left in a half-applied state — agreement acceptance
  * in particular touches three tables (proposal, prior active agreement,
  * new active agreement) plus marks siblings superseded.
+ *
+ * Concurrency: all five mutation methods (propose/counter/accept/
+ * decline/withdraw + terminate) acquire row-level `SELECT FOR UPDATE`
+ * locks on the target proposal / agreement row inside the transaction
+ * before the status check, closing the READ COMMITTED window in which
+ * two concurrent callers could both observe `status='open'` and both
+ * proceed.
  */
 
-import { FEES } from '@codex/constants';
 import { whereNotDeleted } from '@codex/database';
 import {
   agreementProposals,
@@ -29,11 +36,11 @@ import {
   organizationMemberships,
   organizations,
 } from '@codex/database/schema';
-import type { FeeConfigService, FeeContext } from '@codex/purchase';
 import {
   BaseService,
   ForbiddenError,
   InternalServiceError,
+  NotFoundError,
   type ServiceConfig,
 } from '@codex/service-errors';
 import { and, asc, desc, eq, inArray, isNull, ne } from 'drizzle-orm';
@@ -44,6 +51,7 @@ import type {
   RevenueType,
 } from '../types';
 import {
+  creatorShareFromLegacyOrgFee,
   legacyOrgFeeFromCreatorShare,
   validateProposedShare,
 } from './agreement-math';
@@ -104,25 +112,27 @@ export interface TerminateAgreementInput {
 // ─── Service config ───────────────────────────────────────────────────────
 
 /**
- * Constructor config. `feeConfig` is required because validateProposedShare
- * needs the *current* platform fee (per epic decision #2 — fee is read
- * fresh at propose/accept time, never snapshotted on the agreement row).
- *
- * Workers wire this through `service-registry.ts`; tests inject a minimal
- * stub or the real `FeeConfigService` with a stub `cache`.
+ * Constructor config. As of the PR #210 review, the service no longer
+ * threads `FeeConfigService` through share validation — `agreement-math`
+ * reasons purely about the post-platform pool. Platform fee is still
+ * read fresh in the WP-4 payout pipeline; if a future feature needs it
+ * inside this service (e.g. a /preview endpoint that breaks down org
+ * residual after platform fee), re-add the dep at that point.
  */
-export interface AgreementServiceConfig extends ServiceConfig {
-  feeConfig: FeeConfigService;
-}
+export type AgreementServiceConfig = ServiceConfig;
 
 // ─── Service ──────────────────────────────────────────────────────────────
 
-export class AgreementService extends BaseService {
-  private readonly feeConfig: FeeConfigService;
+/**
+ * Transaction handle type — the parameter the callback receives from
+ * `db.transaction()`. Extracted once here so the helper signatures don't
+ * each repeat the nested `Parameters<Parameters<...>[0]>[0]` chain.
+ */
+type Tx = Parameters<Parameters<AgreementService['db']['transaction']>[0]>[0];
 
+export class AgreementService extends BaseService {
   constructor(config: AgreementServiceConfig) {
     super(config);
-    this.feeConfig = config.feeConfig;
   }
 
   // ── Public: propose ─────────────────────────────────────────────────────
@@ -141,21 +151,14 @@ export class AgreementService extends BaseService {
    *   3. no other proposal in this (org, creator, revenue_type) thread
    *      is currently `open` or `countered` (one negotiation at a time
    *      per bucket — keeps the UI sane)
-   *   4. proposed share + active sibling shares + current platform fee
-   *      ≤ 100%
+   *   4. proposed share + active sibling shares ≤ 100% of the
+   *      post-platform pool (see `agreement-math.ts` header for the
+   *      unit semantics)
    */
   async proposeAgreement(
     input: ProposeAgreementInput
   ): Promise<AgreementProposal> {
     try {
-      // Resolve platform fee outside the transaction — the FeeConfig
-      // service can hit KV cache and has its own DB pool semantics; we
-      // want to keep this transaction tight to the write set.
-      const platformFee = await this.resolvePlatformFee(
-        input.organizationId,
-        input.revenueType
-      );
-
       return await this.db.transaction(async (tx) => {
         await this.assertActiveOwner(
           tx,
@@ -189,7 +192,6 @@ export class AgreementService extends BaseService {
         validateProposedShare({
           proposedSharePercent: input.sharePercent,
           existingActiveShares,
-          platformFeePercent: platformFee,
         });
 
         const [row] = await tx
@@ -235,7 +237,10 @@ export class AgreementService extends BaseService {
   async counterPropose(input: CounterProposeInput): Promise<AgreementProposal> {
     try {
       return await this.db.transaction(async (tx) => {
-        const parent = await this.findProposalOrThrow(tx, input.proposalId);
+        const parent = await this.findProposalForUpdateOrThrow(
+          tx,
+          input.proposalId
+        );
 
         if (parent.status !== 'open') {
           throw new InvalidProposalStateError(
@@ -271,10 +276,6 @@ export class AgreementService extends BaseService {
 
         // Re-check share against current world. The counter may land
         // months after the parent — sibling agreements may have shifted.
-        const platformFee = await this.resolvePlatformFee(
-          parent.organizationId,
-          parent.revenueType as RevenueType
-        );
         const existingActiveShares = await this.fetchExistingActiveShares(
           tx,
           parent.organizationId,
@@ -284,7 +285,6 @@ export class AgreementService extends BaseService {
         validateProposedShare({
           proposedSharePercent: input.sharePercent,
           existingActiveShares,
-          platformFeePercent: platformFee,
         });
 
         // Parent → countered. responded_* captures who closed the parent
@@ -356,7 +356,10 @@ export class AgreementService extends BaseService {
   ): Promise<CreatorOrganizationAgreement> {
     try {
       return await this.db.transaction(async (tx) => {
-        const proposal = await this.findProposalOrThrow(tx, input.proposalId);
+        const proposal = await this.findProposalForUpdateOrThrow(
+          tx,
+          input.proposalId
+        );
 
         if (proposal.status !== 'open') {
           throw new InvalidProposalStateError(
@@ -391,10 +394,6 @@ export class AgreementService extends BaseService {
         }
 
         // Re-validate share at accept time — siblings may have moved.
-        const platformFee = await this.resolvePlatformFee(
-          proposal.organizationId,
-          proposal.revenueType as RevenueType
-        );
         const existingActiveShares = await this.fetchExistingActiveShares(
           tx,
           proposal.organizationId,
@@ -404,7 +403,6 @@ export class AgreementService extends BaseService {
         validateProposedShare({
           proposedSharePercent: proposal.proposedCreatorSharePercent,
           existingActiveShares,
-          platformFeePercent: platformFee,
         });
 
         const now = new Date();
@@ -505,7 +503,10 @@ export class AgreementService extends BaseService {
   ): Promise<AgreementProposal> {
     try {
       return await this.db.transaction(async (tx) => {
-        const proposal = await this.findProposalOrThrow(tx, input.proposalId);
+        const proposal = await this.findProposalForUpdateOrThrow(
+          tx,
+          input.proposalId
+        );
 
         if (proposal.status !== 'open') {
           throw new InvalidProposalStateError(
@@ -564,7 +565,10 @@ export class AgreementService extends BaseService {
   ): Promise<AgreementProposal> {
     try {
       return await this.db.transaction(async (tx) => {
-        const proposal = await this.findProposalOrThrow(tx, input.proposalId);
+        const proposal = await this.findProposalForUpdateOrThrow(
+          tx,
+          input.proposalId
+        );
 
         if (proposal.status !== 'open') {
           throw new InvalidProposalStateError(
@@ -627,7 +631,7 @@ export class AgreementService extends BaseService {
   ): Promise<CreatorOrganizationAgreement> {
     try {
       return await this.db.transaction(async (tx) => {
-        const agreement = await this.findAgreementOrThrow(
+        const agreement = await this.findAgreementForUpdateOrThrow(
           tx,
           input.agreementId
         );
@@ -772,14 +776,17 @@ export class AgreementService extends BaseService {
    * ownership is encoded by `organization_memberships.role='owner' AND
    * status='active'`. There may be 0 or many such rows.
    *
+   * Implementation: two targeted queries. The first asks "is THIS user
+   * an active owner?" and short-circuits the happy path. If no, we
+   * issue a second query to distinguish "you are not an owner" (some
+   * owner exists, just not you) from "no owner exists at all" (orphan
+   * org) — useful telemetry and a precise error message for the UI.
+   *
    * Throws `ForbiddenError` when the user is not an active owner, or
    * when the org has no active owner at all (orphaned organisations).
-   * Documented choice: we don't silently fall through to "no owner = no
-   * agreement possible" — the call site asked for an owner check, the
-   * service refuses rather than guess.
    */
   private async assertActiveOwner(
-    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    tx: Tx,
     organizationId: string,
     userId: string
   ): Promise<void> {
@@ -793,34 +800,44 @@ export class AgreementService extends BaseService {
       columns: { id: true },
     });
     if (!org) {
-      throw new AgreementNotFoundError('Organization not found', {
-        agreementId: organizationId,
+      throw new NotFoundError('Organization not found', {
+        resource: 'organization',
+        organizationId,
       });
     }
 
-    const owners = await tx
-      .select({ userId: organizationMemberships.userId })
-      .from(organizationMemberships)
-      .where(
-        and(
-          eq(organizationMemberships.organizationId, organizationId),
-          eq(organizationMemberships.role, 'owner'),
-          eq(organizationMemberships.status, 'active')
-        )
-      )
-      .orderBy(asc(organizationMemberships.createdAt));
+    // Targeted lookup: is THIS user an active owner? Single-row hit.
+    const myOwnership = await tx.query.organizationMemberships.findFirst({
+      where: and(
+        eq(organizationMemberships.organizationId, organizationId),
+        eq(organizationMemberships.userId, userId),
+        eq(organizationMemberships.role, 'owner'),
+        eq(organizationMemberships.status, 'active')
+      ),
+      columns: { id: true },
+    });
+    if (myOwnership) return;
 
-    if (owners.length === 0) {
+    // Not this user — distinguish "no owner exists" from "you aren't
+    // the owner". Both are 403; the message + context differ so the UI
+    // can render the right next step.
+    const anyOwner = await tx.query.organizationMemberships.findFirst({
+      where: and(
+        eq(organizationMemberships.organizationId, organizationId),
+        eq(organizationMemberships.role, 'owner'),
+        eq(organizationMemberships.status, 'active')
+      ),
+      columns: { id: true },
+    });
+    if (!anyOwner) {
       throw new ForbiddenError('Organization has no active owner', {
         organizationId,
       });
     }
-    if (!owners.some((o) => o.userId === userId)) {
-      throw new ForbiddenError(
-        'Only an active organization owner may perform this action',
-        { organizationId, userId }
-      );
-    }
+    throw new ForbiddenError(
+      'Only an active organization owner may perform this action',
+      { organizationId, userId }
+    );
   }
 
   /**
@@ -830,7 +847,7 @@ export class AgreementService extends BaseService {
    * pre-empt the org-keeps-100% fallback path).
    */
   private async assertActiveMember(
-    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    tx: Tx,
     organizationId: string,
     userId: string
   ): Promise<void> {
@@ -861,7 +878,7 @@ export class AgreementService extends BaseService {
    * passes because the previous thread is fully terminal.
    */
   private async assertNoOpenThread(
-    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    tx: Tx,
     organizationId: string,
     creatorId: string,
     revenueType: RevenueType
@@ -906,7 +923,7 @@ export class AgreementService extends BaseService {
    * breakdown in `ShareExceedsAvailableError.context.existingActiveShares`.
    */
   private async fetchExistingActiveShares(
-    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+    tx: Tx,
     organizationId: string,
     revenueType: RevenueType,
     options: { excludeCreatorId?: string } = {}
@@ -929,46 +946,12 @@ export class AgreementService extends BaseService {
       .from(creatorOrganizationAgreements)
       .where(and(...conditions));
 
-    return rows.map((r) => legacyOrgFeeFromCreatorShare(r.orgFee));
-  }
-
-  /**
-   * Read platform fee for (org, revenueType) at the current moment.
-   *
-   * Per decision #2, platform fee is NEVER snapshotted on the
-   * agreement — it's read fresh at propose/accept time. The
-   * `feeConfig.getFeesForOrg(...)` call walks the 3-tier fallback
-   * chain (creator-override → org → platform → constants).
-   *
-   * Note: `FeeConfig` uses `'subscription' | 'one_off'` for its
-   * context label, while our domain uses
-   * `'subscription' | 'content_purchase'`. Translate at the boundary
-   * so we don't leak FeeConfig's vocabulary into the agreement API.
-   */
-  private async resolvePlatformFee(
-    organizationId: string,
-    revenueType: RevenueType
-  ): Promise<number> {
-    const ctx: FeeContext =
-      revenueType === 'subscription' ? 'subscription' : 'one_off';
-    try {
-      const fees = await this.feeConfig.getFeesForOrg(organizationId, ctx);
-      return fees.platformFeePercent;
-    } catch (error) {
-      // Don't let a fee-config blip kill an agreement read — fall back
-      // to the platform-level default constant. We log so the failure
-      // is visible; the propose / accept flow degrades to a strict but
-      // not-org-tuned validation.
-      this.obs.warn(
-        'Falling back to default platform fee for share validation',
-        {
-          organizationId,
-          revenueType,
-          errorName: error instanceof Error ? error.name : 'unknown',
-        }
-      );
-      return FEES.PLATFORM_PERCENT;
-    }
+    // Inverse of the dual-write invariant: org fee → creator share.
+    // Same arithmetic as `legacyOrgFeeFromCreatorShare` (10000 - x is
+    // its own inverse), but the helper-name documents the direction at
+    // the call site — important for WP-4 when the read path swaps off
+    // the legacy column entirely.
+    return rows.map((r) => creatorShareFromLegacyOrgFee(r.orgFee));
   }
 
   /**
@@ -988,26 +971,51 @@ export class AgreementService extends BaseService {
     return d;
   }
 
-  private async findProposalOrThrow(
-    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+  /**
+   * Locked proposal lookup — `SELECT ... FOR UPDATE` on the proposal
+   * row inside the calling transaction. Closes the READ COMMITTED race
+   * window where two concurrent callers could both observe
+   * `status='open'`, both proceed, and corrupt the audit trail.
+   *
+   * Used by all five proposal-mutating methods (counter / accept /
+   * decline / withdraw + the agreement counterpart `terminate`). The
+   * unlocked read path (`findProposalOrThrow`) is reserved for the
+   * non-mutating endpoints we don't yet have but might add (e.g. a
+   * /preview surface).
+   */
+  private async findProposalForUpdateOrThrow(
+    tx: Tx,
     proposalId: string
   ): Promise<AgreementProposal> {
-    const row = await tx.query.agreementProposals.findFirst({
-      where: eq(agreementProposals.id, proposalId),
-    });
+    const rows = await tx
+      .select()
+      .from(agreementProposals)
+      .where(eq(agreementProposals.id, proposalId))
+      .for('update');
+    const row = rows[0];
     if (!row) {
       throw new AgreementNotFoundError('Proposal not found', { proposalId });
     }
     return row;
   }
 
-  private async findAgreementOrThrow(
-    tx: Parameters<Parameters<typeof this.db.transaction>[0]>[0],
+  /**
+   * Locked agreement lookup — counterpart of
+   * {@link findProposalForUpdateOrThrow} for the
+   * `creator_organization_agreements` table. Called by
+   * `terminateAgreement` so the active → terminated transition is
+   * serialised against any concurrent caller.
+   */
+  private async findAgreementForUpdateOrThrow(
+    tx: Tx,
     agreementId: string
   ): Promise<CreatorOrganizationAgreement> {
-    const row = await tx.query.creatorOrganizationAgreements.findFirst({
-      where: eq(creatorOrganizationAgreements.id, agreementId),
-    });
+    const rows = await tx
+      .select()
+      .from(creatorOrganizationAgreements)
+      .where(eq(creatorOrganizationAgreements.id, agreementId))
+      .for('update');
+    const row = rows[0];
     if (!row) {
       throw new AgreementNotFoundError('Agreement not found', { agreementId });
     }

--- a/packages/agreements/src/services/index.ts
+++ b/packages/agreements/src/services/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @codex/agreements/services — barrel
+ */
+
+export {
+  type ActiveAgreementShareView,
+  legacyOrgFeeFromCreatorShare,
+  sumActiveCreatorShares,
+  type ValidateProposedShareInput,
+  validateProposedShare,
+} from './agreement-math';
+export {
+  type AcceptProposalInput,
+  AgreementService,
+  type AgreementServiceConfig,
+  type CounterProposeInput,
+  type DeclineProposalInput,
+  type ProposeAgreementInput,
+  type TerminateAgreementInput,
+  type WithdrawProposalInput,
+} from './agreement-service';

--- a/packages/agreements/src/types.ts
+++ b/packages/agreements/src/types.ts
@@ -1,0 +1,74 @@
+/**
+ * @codex/agreements — Domain types
+ *
+ * Literal unions modelling the agreement-proposal state machine and the
+ * read-side payloads the service exposes. Mirrors the CHECK constraints
+ * declared on `agreement_proposals` and `creator_organization_agreements`
+ * in `packages/database/src/schema/ecommerce.ts` (WP-1, Codex-ppxtd).
+ *
+ * Why literal unions over enums:
+ *   - The schema uses CHECK constraints, not native PG enums, so the
+ *     DB layer already stores `varchar`. Drizzle returns these as `string`,
+ *     and we use these unions to narrow them in the service layer.
+ *   - Avoids the dual-emit / barrel-import quirks of TS enums.
+ */
+
+import type {
+  AgreementProposal as DbAgreementProposal,
+  CreatorOrganizationAgreement as DbCreatorOrganizationAgreement,
+  NewAgreementProposal as DbNewAgreementProposal,
+  NewCreatorOrganizationAgreement as DbNewCreatorOrganizationAgreement,
+} from '@codex/database/schema';
+
+// ─── Literal unions ────────────────────────────────────────────────────────
+
+/**
+ * Revenue stream that an agreement governs.
+ *
+ * A creator can simultaneously hold an `active` agreement of each kind with
+ * the same org — enforced by the partial unique index
+ * `uq_creator_org_agreement_active_per_type`.
+ */
+export type RevenueType = 'subscription' | 'content_purchase';
+
+/**
+ * Lifecycle of a single negotiation proposal row.
+ *
+ * Transitions (see `AgreementService` for the gate):
+ *   open      → accepted | declined | countered | withdrawn | superseded
+ *   countered → superseded
+ *   any terminal → throw InvalidProposalStateError
+ */
+export type ProposalStatus =
+  | 'open'
+  | 'accepted'
+  | 'declined'
+  | 'countered'
+  | 'withdrawn'
+  | 'superseded';
+
+/**
+ * Lifecycle of the canonical "active row" agreement.
+ *
+ * `expired` transitions are reserved for a future cron job (WP-?? in the
+ * epic plan) — WP-2 only handles termination by an actor.
+ */
+export type AgreementStatus = 'active' | 'terminated' | 'expired';
+
+/**
+ * Which side initiated a proposal. Round 1 is always `'owner'`; counters
+ * alternate as the negotiation walks down the parent chain.
+ */
+export type ProposedByRole = 'owner' | 'creator';
+
+// ─── Re-exports from the database schema ──────────────────────────────────
+
+/**
+ * Row shape returned by Drizzle `select` on `agreement_proposals`. The
+ * `status`/`proposedByRole`/`revenueType` columns come back as `string`
+ * from the driver — service callers should narrow with the unions above.
+ */
+export type AgreementProposal = DbAgreementProposal;
+export type NewAgreementProposal = DbNewAgreementProposal;
+export type CreatorOrganizationAgreement = DbCreatorOrganizationAgreement;
+export type NewCreatorOrganizationAgreement = DbNewCreatorOrganizationAgreement;

--- a/packages/agreements/tsconfig.json
+++ b/packages/agreements/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../config/tsconfig/package.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/agreements/vite.config.agreements.ts
+++ b/packages/agreements/vite.config.agreements.ts
@@ -1,0 +1,6 @@
+import { createPackageConfig } from '../../config/vite/package.config';
+
+export default createPackageConfig({
+  packageName: 'agreements',
+  additionalExternals: ['drizzle-orm'],
+});

--- a/packages/agreements/vitest.config.agreements.ts
+++ b/packages/agreements/vitest.config.agreements.ts
@@ -1,0 +1,20 @@
+import { packageVitestConfig } from '../../config/vitest/package.config';
+
+// Environment variables are loaded by root vitest.setup.ts
+// Neon Testing plugin will provision ephemeral branches for each test file
+//
+// Sequential mode: tests in agreement-service.test.ts share the same DB and
+// create orgs/proposals with overlapping (org, creator, revenue_type) triples;
+// the partial unique index `uq_creator_org_agreement_active_per_type` would
+// trip with concurrent test execution. The unit-only math suite is
+// pure-function and would run in parallel safely, but the global flag is
+// per-file so the cheaper safer path is to mark the whole package sequential.
+
+export default packageVitestConfig({
+  packageName: 'agreements',
+  setupFiles: ['../../vitest.setup.ts'],
+  testTimeout: 60000,
+  hookTimeout: 60000,
+  enableNeonTesting: true,
+  sequentialTests: true,
+});

--- a/packages/test-utils/src/database.ts
+++ b/packages/test-utils/src/database.ts
@@ -186,21 +186,36 @@ export function setupTestDatabase(): Database {
  *
  * Deletion order (respects foreign keys):
  * 1. video_playback (references content, users)
- * 2. purchases (references content, users, organizations)
- * 3. content_access (references content, users, organizations)
- * 4. creator_organization_agreements (references users, organizations)
- * 5. organization_platform_agreements (references organizations)
- * 6. content (references media_items, organizations, users)
- * 7. media_items (references users)
- * 8. organizations (no foreign keys from other content tables)
+ * 2. refund_reviews (references purchases AND payouts with onDelete: 'restrict')
+ * 3. payouts (referenced by refund_reviews)
+ * 4. purchases (references content, users, organizations; referenced by refund_reviews)
+ * 5. content_access (references content, users, organizations)
+ * 6. agreement_proposals (references organizations, users; self-FK)
+ * 7. creator_organization_agreements (references users, organizations, proposals)
+ * 8. organization_platform_agreements (references organizations)
+ * 9. content (references media_items, organizations, users)
+ * 10. media_items (references users)
+ * 11. organizations (no foreign keys from other content tables)
  *
  * @param db - Database client
  */
 export async function cleanupDatabase(db: Database): Promise<void> {
   // Delete in order that respects foreign key constraints
   await db.delete(schema.videoPlayback);
+  // refund_reviews references purchases AND payouts with onDelete: 'restrict' —
+  // must go before either. Was previously missed in cleanup and caused FK
+  // failures whenever a prior subscription test left rows behind.
+  await db.delete(schema.refundReviews);
+  await db.delete(schema.payouts);
   await db.delete(schema.purchases);
   await db.delete(schema.contentAccess);
+  // Codex-tnft0 (WP-2 of Codex-nk4km): agreement_proposals is referenced by
+  // creator_organization_agreements.current_proposal_id (onDelete: 'set null')
+  // and references organizations/users (onDelete: 'cascade'). Deleting
+  // proposals first is not strictly required (the SET NULL would resolve
+  // cleanly), but it keeps the cleanup explicit and FK-ordering audit-safe
+  // per the test-cleanup-fk-ordering feedback memory.
+  await db.delete(schema.agreementProposals);
   await db.delete(schema.creatorOrganizationAgreements);
   await db.delete(schema.organizationPlatformAgreements);
   await db.delete(schema.content);
@@ -220,8 +235,17 @@ export async function cleanupDatabase(db: Database): Promise<void> {
 export async function cleanupDatabaseComplete(db: Database): Promise<void> {
   // Delete in order that respects foreign key constraints
   await db.delete(schema.videoPlayback);
+  await db.delete(schema.refundReviews);
+  await db.delete(schema.payouts);
   await db.delete(schema.purchases);
   await db.delete(schema.contentAccess);
+  // Codex-tnft0 (WP-2 of Codex-nk4km): agreement_proposals is referenced by
+  // creator_organization_agreements.current_proposal_id (onDelete: 'set null')
+  // and references organizations/users (onDelete: 'cascade'). Deleting
+  // proposals first is not strictly required (the SET NULL would resolve
+  // cleanly), but it keeps the cleanup explicit and FK-ordering audit-safe
+  // per the test-cleanup-fk-ordering feedback memory.
+  await db.delete(schema.agreementProposals);
   await db.delete(schema.creatorOrganizationAgreements);
   await db.delete(schema.organizationPlatformAgreements);
   await db.delete(schema.content);

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@codex/access": "workspace:*",
     "@codex/admin": "workspace:*",
+    "@codex/agreements": "workspace:*",
     "@codex/cache": "workspace:*",
     "@codex/cloudflare-clients": "workspace:*",
     "@codex/constants": "workspace:*",

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -418,18 +418,18 @@ export function createServiceRegistry(
 
     /**
      * Codex-tnft0 (WP-2 of Codex-nk4km): revenue-share AgreementService.
-     * Depends on FeeConfigService for the current platform fee (per
-     * decision #2: platform fee read fresh at propose/accept time, never
-     * snapshotted on the agreement row). Uses the shared per-request
-     * WebSocket client so accept/terminate transactions reuse the
-     * existing connection.
+     * Uses the shared per-request WebSocket client so accept/terminate
+     * transactions reuse the existing connection. Per the PR #210
+     * review, share-validation is platform-fee-independent (it reasons
+     * purely about the post-platform pool — see `agreement-math.ts`),
+     * so no `feeConfig` dep is threaded through here. WP-4 reads the
+     * platform fee fresh in the payout pipeline.
      */
     get agreements() {
       if (!_agreements) {
         _agreements = new AgreementService({
           db: getSharedDb(),
           environment: getEnvironment(),
-          feeConfig: registry.feeConfig,
         });
       }
       return _agreements;

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -12,6 +12,7 @@ import {
   AdminContentManagementService,
   AdminCustomerManagementService,
 } from '@codex/admin';
+import { AgreementService } from '@codex/agreements';
 import { VersionedCache } from '@codex/cache';
 import { R2Service, type R2SigningConfig } from '@codex/cloudflare-clients';
 // Service imports
@@ -107,6 +108,7 @@ export function createServiceRegistry(
   let _subscription: SubscriptionService | undefined;
   let _tier: TierService | undefined;
   let _connectAccount: ConnectAccountService | undefined;
+  let _agreements: AgreementService | undefined;
 
   // Shared per-request DB client (for services needing transactions)
   let _sharedDbClient: ReturnType<typeof createPerRequestDbClient> | undefined;
@@ -412,6 +414,25 @@ export function createServiceRegistry(
         );
       }
       return _purchase;
+    },
+
+    /**
+     * Codex-tnft0 (WP-2 of Codex-nk4km): revenue-share AgreementService.
+     * Depends on FeeConfigService for the current platform fee (per
+     * decision #2: platform fee read fresh at propose/accept time, never
+     * snapshotted on the agreement row). Uses the shared per-request
+     * WebSocket client so accept/terminate transactions reuse the
+     * existing connection.
+     */
+    get agreements() {
+      if (!_agreements) {
+        _agreements = new AgreementService({
+          db: getSharedDb(),
+          environment: getEnvironment(),
+          feeConfig: registry.feeConfig,
+        });
+      }
+      return _agreements;
     },
 
     // ========================================================================

--- a/packages/worker-utils/src/procedure/types.ts
+++ b/packages/worker-utils/src/procedure/types.ts
@@ -14,6 +14,7 @@ import type {
   AdminContentManagementService,
   AdminCustomerManagementService,
 } from '@codex/admin';
+import type { AgreementService } from '@codex/agreements';
 // Service type imports (for typing only)
 import type { ContentService, MediaItemService } from '@codex/content';
 import type { IdentityService } from '@codex/identity';
@@ -132,6 +133,13 @@ export interface ServiceRegistry {
    * version-cache invalidation. Lazily read by purchase + subscription.
    */
   feeConfig: FeeConfigService;
+  /**
+   * Revenue-share agreements (Codex-tnft0, WP-2 of Codex-nk4km). State
+   * machine for propose / counter / accept / decline / withdraw +
+   * agreement termination. Reads platform fee fresh from feeConfig at
+   * propose/accept time (per epic decision #2).
+   */
+  agreements: AgreementService;
 
   // Subscription domain
   subscription: SubscriptionService;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,49 @@ importers:
         specifier: ^4.0.2
         version: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@22.13.0)(@vitest/ui@4.0.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0)(tsx@4.20.6)(yaml@2.8.1)
 
+  packages/agreements:
+    dependencies:
+      '@codex/constants':
+        specifier: workspace:*
+        version: link:../constants
+      '@codex/database':
+        specifier: workspace:*
+        version: link:../database
+      '@codex/observability':
+        specifier: workspace:*
+        version: link:../observability
+      '@codex/purchase':
+        specifier: workspace:*
+        version: link:../purchase
+      '@codex/service-errors':
+        specifier: workspace:*
+        version: link:../service-errors
+      '@codex/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+      '@codex/validation':
+        specifier: workspace:*
+        version: link:../validation
+      drizzle-orm:
+        specifier: 0.44.7
+        version: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.15.6)(better-sqlite3@12.4.6)(kysely@0.28.8)(mysql2@3.15.3)(pg@8.16.3)(prisma@5.22.0)
+    devDependencies:
+      '@codex/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.13.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.2.2
+        version: 7.2.4(@types/node@22.13.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest:
+        specifier: ^4.0.2
+        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@22.13.0)(@vitest/ui@4.0.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0)(tsx@4.20.6)(yaml@2.8.1)
+
   packages/cache:
     dependencies:
       '@codex/observability':
@@ -1134,6 +1177,9 @@ importers:
       '@codex/admin':
         specifier: workspace:*
         version: link:../admin
+      '@codex/agreements':
+        specifier: workspace:*
+        version: link:../agreements
       '@codex/cache':
         specifier: workspace:*
         version: link:../cache


### PR DESCRIPTION
## Summary

WP-2 of the Revenue-Share Agreements epic (Codex-nk4km). Builds the `@codex/agreements` service-layer state machine on top of WP-1's schema (PR #207).

- New package `@codex/agreements` with `AgreementService` covering full proposal lifecycle (propose, counter, accept, decline, withdraw, terminate) + agreement termination + read queries
- `agreement-math` pure functions for share validation, platform-fee-aware
- Service registry lazy getter in `@codex/worker-utils` so route handlers never construct ad-hoc instances
- Drizzle relational queries use explicit `relationName` on every multi-FK target (per WP-1 discovery)
- Owner resolution via `organization_memberships` table (`organizations.owner_id` does not exist)
- Dual-writes `organization_fee_percentage = 10000 - sharePercent` in the same transaction as `proposed_creator_share_percent` until WP-4 swaps the payout read path
- Test-utils `cleanupDatabase` now deletes `refund_reviews` + `payouts` in correct FK order (pre-existing gap surfaced by this work — broke whenever any prior subscription test left rows behind)

## Base branch

This PR targets `feat/codex-ppxtd-agreement-schema` (WP-1, PR #207) — when WP-1 merges, this rebases onto `main`.

## Test plan

- [x] `pnpm --filter @codex/agreements test` — 51 tests passing (18 math + 33 service-integration)
- [x] `pnpm --filter @codex/agreements typecheck` clean
- [x] `pnpm --filter @codex/agreements build` clean
- [x] `pnpm --filter @codex/worker-utils typecheck` clean (service registry compiles with new `agreements` lazy getter)
- [x] `pnpm --filter @codex/worker-utils build` clean
- [x] Manual review: every method writing `proposed_creator_share_percent` also writes `organization_fee_percentage` in same tx via `legacyOrgFeeFromCreatorShare()` helper
- [x] Manual review: every authorisation check resolves owner via `organization_memberships` (role='owner', status='active'), not `organizations.owner_id`
- [x] Manual review: all class-name assertions in tests use `toBeInstanceOf(Class)` + `err.name`, never `err.constructor.name` (per feedback-memory)

### Test coverage breakdown (positive AND negative paths per money-code policy)

- `proposeAgreement` — 6 tests (owner can / non-owner can't / non-member target / share-exceeds / no-active-owner / open-thread-conflict)
- `counterPropose` — 5 tests (r1→r2 / r2→r3 alternation / can't counter accepted / same-party can't counter own / share-exceeds)
- `acceptProposal` — 6 tests (counterparty accept + dual-write / sibling supersede / predecessor terminate / same-party can't self-accept / can't accept terminal / re-validates at accept-time)
- `declineProposal` — 3 tests (counterparty can / same-party can't / can't decline terminal)
- `withdrawProposal` — 3 tests (proposing party can / counterparty can't / creator-counter withdraw)
- `terminateAgreement` — 5 tests (owner / creator / outsider can't / can't terminate terminated / not-found)
- read queries — 5 tests (active-only / multi-org isolation / excludes terminated / thread chronological / empty thread)

## Notes

Bead: Codex-tnft0
Epic: Codex-nk4km