### PR TITLE
feat(ecom-api): WP-3 agreements routes for AgreementService

### DIFF
--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -19,6 +19,8 @@ export * from './image';
 export * from './primitives';
 // Access schemas
 export * from './schemas/access';
+// Agreements schemas (Codex-hqke2 — WP-3 of Codex-nk4km)
+export * from './schemas/agreements';
 // Fee configuration schemas (Codex-m644n)
 export * from './schemas/fee-config';
 // File upload schemas

--- a/packages/validation/src/schemas/agreements.ts
+++ b/packages/validation/src/schemas/agreements.ts
@@ -1,0 +1,227 @@
+import { z } from 'zod';
+import { uuidSchema } from '../primitives';
+import { paginationSchema } from '../shared/pagination-schema';
+
+/**
+ * @codex/agreements — Zod schemas for WP-3 route inputs (Codex-hqke2,
+ * epic Codex-nk4km).
+ *
+ * Single source of truth for the body / query / params shapes the
+ * `workers/ecom-api/src/routes/agreements.ts` router validates. Mirrors
+ * the public `AgreementService` input interfaces in
+ * `packages/agreements/src/services/agreement-service.ts` so any drift
+ * between the service and the API boundary surfaces at typecheck time.
+ *
+ * Unit semantics for `sharePercent`: basis points (0-10000) of the
+ * post-platform pool, mirroring the `proposed_creator_share_percent`
+ * column. Platform fee is deliberately NOT part of this value — see
+ * `agreement-math.ts` file header.
+ *
+ * Unit semantics for `termMonths`: months. `null` is a future
+ * "indefinite agreement" affordance, but we don't surface it through the
+ * API yet — propose/counter routes only accept a finite positive
+ * integer. If a future UI needs indefinite, accept `null` here and
+ * pass-through to the service.
+ *
+ * Note / reason fields cap at 500 chars to match the DB columns (`note`
+ * and `decline_reason` are `text` but the UI surfaces a single-line
+ * input; cap defensively to keep payloads small).
+ */
+
+// ─── Shared primitives ────────────────────────────────────────────────────
+
+/**
+ * Revenue type enum — mirrors the schema CHECK constraint on
+ * `agreement_proposals.revenue_type` and `creator_organization_agreements.
+ * revenue_type`. A creator can hold ONE active agreement of each type per
+ * org simultaneously (enforced by the partial unique index).
+ */
+export const agreementRevenueTypeEnum = z.enum(
+  ['subscription', 'content_purchase'],
+  { message: "Revenue type must be 'subscription' or 'content_purchase'" }
+);
+
+/**
+ * Basis-point share — inclusive 0–10000, integer only. 0 is the legal
+ * minimum (creator opts out), 10000 is the legal maximum (creator takes
+ * the entire post-platform pool, org owner residual collapses to zero).
+ */
+const sharePercentSchema = z
+  .number()
+  .int({ message: 'Share percent must be an integer (basis points)' })
+  .min(0, { message: 'Share percent must be at least 0 basis points' })
+  .max(10000, {
+    message: 'Share percent must be at most 10000 basis points',
+  });
+
+/**
+ * Term length in months. 1–120 (1 month to 10 years).
+ *
+ * The service signature accepts `number | null` (`null` = indefinite),
+ * but the API surface only exposes finite terms for now — the UI doesn't
+ * have an "indefinite" affordance. Drop this restriction and pipe
+ * through to the service when product needs it.
+ */
+const termMonthsSchema = z
+  .number()
+  .int({ message: 'Term must be a whole number of months' })
+  .min(1, { message: 'Term must be at least 1 month' })
+  .max(120, { message: 'Term must be at most 120 months (10 years)' });
+
+const noteSchema = z
+  .string()
+  .trim()
+  .max(500, { message: 'Note must be 500 characters or less' })
+  .optional();
+
+const reasonSchema = z
+  .string()
+  .trim()
+  .max(500, { message: 'Reason must be 500 characters or less' })
+  .optional();
+
+// ─── Path / param schemas ─────────────────────────────────────────────────
+
+/**
+ * `:proposalId` URL parameter (proposal mutations: accept / decline /
+ * counter / withdraw).
+ */
+export const proposalIdParamSchema = z.object({
+  proposalId: uuidSchema,
+});
+export type ProposalIdParamInput = z.infer<typeof proposalIdParamSchema>;
+
+/**
+ * `:agreementId` URL parameter (terminate).
+ */
+export const agreementIdParamSchema = z.object({
+  agreementId: uuidSchema,
+});
+export type AgreementIdParamInput = z.infer<typeof agreementIdParamSchema>;
+
+// ─── Body schemas ─────────────────────────────────────────────────────────
+
+/**
+ * POST /agreements/propose — owner-initiated round 1 proposal.
+ *
+ * `organizationId` is in the body so the existing `requireOrgMembership`
+ * gate in `procedure()` can resolve `ctx.organizationId` from the query
+ * fallback path (it already accepts `organizationId` from query OR
+ * subdomain). The service then enforces `assertActiveOwner` against the
+ * actor — the route layer doesn't re-check ownership.
+ */
+export const proposeAgreementInputSchema = z.object({
+  organizationId: uuidSchema,
+  creatorId: z
+    .string()
+    .min(1, { message: 'creatorId is required' })
+    .max(64, { message: 'creatorId is too long' }),
+  revenueType: agreementRevenueTypeEnum,
+  sharePercent: sharePercentSchema,
+  termMonths: termMonthsSchema,
+  note: noteSchema,
+  /**
+   * Defaults to `now()` in the service when omitted. `z.coerce.date()`
+   * accepts both ISO 8601 strings and JS Date instances — same shape the
+   * service signature expects.
+   */
+  effectiveFrom: z.coerce.date().optional(),
+});
+export type ProposeAgreementInput = z.infer<typeof proposeAgreementInputSchema>;
+
+/**
+ * POST /agreements/:proposalId/counter — alternates roles round-by-round.
+ *
+ * The proposal id is in the URL params; this body covers the new round's
+ * terms. The service derives the counterparty role from the parent
+ * proposal's `proposedByRole`, so the route does not need to thread the
+ * actor role explicitly.
+ */
+export const counterProposeInputSchema = z.object({
+  sharePercent: sharePercentSchema,
+  termMonths: termMonthsSchema,
+  note: noteSchema,
+});
+export type CounterProposeInput = z.infer<typeof counterProposeInputSchema>;
+
+/**
+ * POST /agreements/:proposalId/accept — body is empty for now (single
+ * action, no parameters). Modelled as a schema so the procedure pipeline
+ * still runs body validation — future extension (e.g. capture an
+ * acceptance note) lands as additional optional fields without changing
+ * the route signature.
+ */
+export const acceptProposalInputSchema = z.object({});
+export type AcceptProposalInput = z.infer<typeof acceptProposalInputSchema>;
+
+/**
+ * POST /agreements/:proposalId/decline — optional reason.
+ */
+export const declineProposalInputSchema = z.object({
+  reason: reasonSchema,
+});
+export type DeclineProposalInput = z.infer<typeof declineProposalInputSchema>;
+
+/**
+ * POST /agreements/:proposalId/withdraw — no body fields today.
+ */
+export const withdrawProposalInputSchema = z.object({});
+export type WithdrawProposalInput = z.infer<typeof withdrawProposalInputSchema>;
+
+/**
+ * POST /agreements/:agreementId/terminate — optional reason.
+ */
+export const terminateAgreementInputSchema = z.object({
+  reason: reasonSchema,
+});
+export type TerminateAgreementInput = z.infer<
+  typeof terminateAgreementInputSchema
+>;
+
+// ─── Query schemas ────────────────────────────────────────────────────────
+
+/**
+ * GET /agreements?... — list filter for the owner-view endpoint. The
+ * `organizationId` field is consumed by `procedure()`'s membership gate
+ * to resolve `ctx.organizationId`; the service receives the
+ * authenticated `ctx.organizationId` and ignores the query value
+ * thereafter (same hardening pattern as `/sales`, see
+ * `feedback_secure_route_org_resolution`).
+ *
+ * `creatorId` is reserved for a future cross-org owner view of one
+ * specific creator's agreements; today the service doesn't filter on it
+ * because owner-view is always "every active agreement on MY org".
+ */
+export const listAgreementsQuerySchema = paginationSchema.extend({
+  organizationId: uuidSchema.optional(),
+  creatorId: z.string().min(1).max(64).optional(),
+  revenueType: agreementRevenueTypeEnum.optional(),
+});
+export type ListAgreementsQueryInput = z.infer<
+  typeof listAgreementsQuerySchema
+>;
+
+/**
+ * GET /agreements/:orgSlug/:creatorId/thread?revenueType=...
+ *
+ * Used by the owner-view negotiation thread page. `revenueType` is the
+ * dimension that disambiguates the thread (one creator can have a
+ * subscription thread + a content_purchase thread independently).
+ */
+export const getNegotiationThreadQuerySchema = z.object({
+  revenueType: agreementRevenueTypeEnum,
+});
+export type GetNegotiationThreadQueryInput = z.infer<
+  typeof getNegotiationThreadQuerySchema
+>;
+
+/**
+ * GET /agreements/threads/:creatorId — owner-view thread params.
+ */
+export const ownerThreadParamSchema = z.object({
+  creatorId: z
+    .string()
+    .min(1, { message: 'creatorId is required' })
+    .max(64, { message: 'creatorId is too long' }),
+});
+export type OwnerThreadParamInput = z.infer<typeof ownerThreadParamSchema>;

--- a/packages/validation/src/schemas/agreements.ts
+++ b/packages/validation/src/schemas/agreements.ts
@@ -104,18 +104,19 @@ export type AgreementIdParamInput = z.infer<typeof agreementIdParamSchema>;
 /**
  * POST /agreements/propose — owner-initiated round 1 proposal.
  *
- * `organizationId` is in the body so the existing `requireOrgMembership`
- * gate in `procedure()` can resolve `ctx.organizationId` from the query
- * fallback path (it already accepts `organizationId` from query OR
- * subdomain). The service then enforces `assertActiveOwner` against the
- * actor — the route layer doesn't re-check ownership.
+ * `organizationId` is NOT in the body — it lives in the query string
+ * (see `proposeAgreementQuerySchema`). Rationale: `procedure()`'s
+ * `resolveOrganizationId()` reads URL params, subdomain, or `?organizationId`
+ * query — NEVER the body. And policy enforcement (Step 1) runs BEFORE
+ * input validation (Step 3), so the body has not been parsed by the time
+ * the org resolver needs the id. Putting orgId in the body silently
+ * 400s with ORG_CONTEXT_REQUIRED on every real request.
+ *
+ * The service then enforces `assertActiveOwner` against the actor — the
+ * route layer doesn't re-check ownership.
  */
 export const proposeAgreementInputSchema = z.object({
-  organizationId: uuidSchema,
-  creatorId: z
-    .string()
-    .min(1, { message: 'creatorId is required' })
-    .max(64, { message: 'creatorId is too long' }),
+  creatorId: uuidSchema,
   revenueType: agreementRevenueTypeEnum,
   sharePercent: sharePercentSchema,
   termMonths: termMonthsSchema,
@@ -128,6 +129,19 @@ export const proposeAgreementInputSchema = z.object({
   effectiveFrom: z.coerce.date().optional(),
 });
 export type ProposeAgreementInput = z.infer<typeof proposeAgreementInputSchema>;
+
+/**
+ * POST /agreements/propose — query string. Carries `organizationId` so
+ * `procedure()`'s membership gate can resolve `ctx.organizationId` from
+ * the query fallback path. See `proposeAgreementInputSchema` doc for the
+ * full reason this can't live in the body.
+ */
+export const proposeAgreementQuerySchema = z.object({
+  organizationId: uuidSchema,
+});
+export type ProposeAgreementQueryInput = z.infer<
+  typeof proposeAgreementQuerySchema
+>;
 
 /**
  * POST /agreements/:proposalId/counter — alternates roles round-by-round.
@@ -194,7 +208,7 @@ export type TerminateAgreementInput = z.infer<
  */
 export const listAgreementsQuerySchema = paginationSchema.extend({
   organizationId: uuidSchema.optional(),
-  creatorId: z.string().min(1).max(64).optional(),
+  creatorId: uuidSchema.optional(),
   revenueType: agreementRevenueTypeEnum.optional(),
 });
 export type ListAgreementsQueryInput = z.infer<
@@ -219,9 +233,6 @@ export type GetNegotiationThreadQueryInput = z.infer<
  * GET /agreements/threads/:creatorId — owner-view thread params.
  */
 export const ownerThreadParamSchema = z.object({
-  creatorId: z
-    .string()
-    .min(1, { message: 'creatorId is required' })
-    .max(64, { message: 'creatorId is too long' }),
+  creatorId: uuidSchema,
 });
 export type OwnerThreadParamInput = z.infer<typeof ownerThreadParamSchema>;

--- a/packages/worker-utils/src/procedure/__tests__/enforce-policy-inline.test.ts
+++ b/packages/worker-utils/src/procedure/__tests__/enforce-policy-inline.test.ts
@@ -517,6 +517,38 @@ describe('enforcePolicyInline · requireOrgMembership', () => {
     ).rejects.toBeInstanceOf(ValidationError);
   });
 
+  // ----- Prevention test for the WP-3 `/agreements/propose` regression -----
+  // Routes that put `organizationId` in the REQUEST BODY are broken by
+  // construction: `resolveOrganizationId()` reads URL params, subdomain, or
+  // the QUERY STRING — never body — and policy enforcement (Step 1) runs
+  // BEFORE input validation (Step 3), so the body has not been parsed by
+  // the time the resolver fires. This test pins that contract: even if a
+  // future refactor adds body reading capability to the Hono request mock,
+  // the resolver must not depend on it. If you change `resolveOrganizationId`
+  // to read body, this test must be updated AND the doc-comment on
+  // `proposeAgreementInputSchema` should be revised.
+  it('does NOT read request body to resolve organizationId (body content is ignored)', async () => {
+    const { extractOrganizationFromSubdomain } = await import('../org-helpers');
+    vi.mocked(extractOrganizationFromSubdomain).mockResolvedValue(null);
+
+    // makeCtx does NOT expose `req.json` — this is the structural proof
+    // that `resolveOrganizationId` cannot read body. We additionally
+    // assert the function rejects with ValidationError when no other
+    // resolution path succeeds, confirming the resolver never falls
+    // back to "look in the body".
+    const { ctx } = makeCtx({
+      vars: { user: { id: 'u1', role: 'user' } },
+      // No params, no query, no subdomain — only a "body" exists in a
+      // real request but the resolver must not see it.
+    });
+    await expect(
+      enforcePolicyInline(ctx, {
+        auth: 'required',
+        requireOrgMembership: true,
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
   it('throws ForbiddenError when user is not a member', async () => {
     const { checkOrganizationMembership } = await import('../org-helpers');
     vi.mocked(checkOrganizationMembership).mockResolvedValue(null);

--- a/workers/ecom-api/src/index.ts
+++ b/workers/ecom-api/src/index.ts
@@ -28,6 +28,7 @@ import { handlePaymentWebhook } from './handlers/payment-webhook';
 import { dispatchScheduled } from './handlers/payouts-sweep';
 import { handleSubscriptionWebhook } from './handlers/subscription-webhook';
 import { verifyStripeSignature } from './middleware/verify-signature';
+import agreements from './routes/agreements';
 import checkout from './routes/checkout';
 import connect from './routes/connect';
 import purchases from './routes/purchases';
@@ -138,6 +139,14 @@ app.route('/subscriptions', subscriptions);
  * Handles Stripe Connect onboarding and account management
  */
 app.route('/connect', connect);
+
+/**
+ * Agreements routes (Codex-hqke2 — WP-3 of Codex-nk4km)
+ * Revenue-share negotiation state machine over @codex/agreements
+ * AgreementService. Propose / accept / decline / counter / withdraw /
+ * terminate / list / threads.
+ */
+app.route('/agreements', agreements);
 
 // ============================================================================
 // Webhook Endpoints

--- a/workers/ecom-api/src/routes/__tests__/agreements-routes.test.ts
+++ b/workers/ecom-api/src/routes/__tests__/agreements-routes.test.ts
@@ -58,6 +58,7 @@ interface ProcedureConfig {
   policy?: {
     auth?: string;
     requireOrgMembership?: boolean;
+    requireOrgManagement?: boolean;
     rateLimit?: string;
   };
   input?: {
@@ -101,7 +102,10 @@ vi.mock('@codex/worker-utils', async (importOriginal) => {
 
         const orgRole = c.get('__testOrgRole') as string | undefined;
         const orgId = c.get('__testOrganizationId') as string | undefined;
-        if (config.policy?.requireOrgMembership) {
+        const needsOrg =
+          config.policy?.requireOrgMembership ||
+          config.policy?.requireOrgManagement;
+        if (needsOrg) {
           if (!orgId) {
             return c.json(
               {
@@ -119,6 +123,21 @@ vi.mock('@codex/worker-utils', async (importOriginal) => {
                 error: {
                   code: 'FORBIDDEN',
                   message: 'You are not a member of this organization',
+                },
+              },
+              403
+            );
+          }
+          if (
+            config.policy?.requireOrgManagement &&
+            orgRole !== 'owner' &&
+            orgRole !== 'admin'
+          ) {
+            return c.json(
+              {
+                error: {
+                  code: 'FORBIDDEN',
+                  message: 'Organization management access required',
                 },
               },
               403
@@ -275,14 +294,16 @@ import agreements from '../agreements';
 
 const MANAGED_ORG_ID = '323e4567-e89b-12d3-a456-426614174002';
 const ROGUE_ORG_ID = '999e4567-e89b-12d3-a456-426614174999';
-const TARGET_CREATOR_ID = 'usr_target_creator_001';
-const PEER_CREATOR_ID_1 = 'usr_peer_creator_001';
-const PEER_CREATOR_ID_2 = 'usr_peer_creator_002';
-const OWNER_USER_ID = 'usr_owner_001';
-const CALLER_CREATOR_ID = 'usr_caller_creator_001';
-// Real UUIDs (must pass `z.uuid()` strict regex: version digit [1-8] and
-// variant [89abAB] in the correct positions). All-1s / all-2s placeholders
-// fail Zod v4's UUID format check.
+// User / creator ids — real UUIDs (must pass `z.uuid()` strict regex:
+// version digit [1-8] and variant [89abAB] in the correct positions).
+// `usr_xxx` placeholders fail Zod v4's UUID format check.
+const TARGET_CREATOR_ID = '44444444-4444-4444-9444-444444444444';
+const PEER_CREATOR_ID_1 = '55555555-5555-4555-9555-555555555555';
+const PEER_CREATOR_ID_2 = '66666666-6666-4666-9666-666666666666';
+const OWNER_USER_ID = '77777777-7777-4777-9777-777777777777';
+const ADMIN_USER_ID = '88888888-8888-4888-9888-888888888888';
+const MEMBER_USER_ID = '99999999-9999-4999-9999-999999999999';
+const CALLER_CREATOR_ID = 'aaaaaaaa-aaaa-4aaa-9aaa-aaaaaaaaaaaa';
 const PROPOSAL_ID = '11111111-1111-4111-9111-111111111111';
 const AGREEMENT_ID = '22222222-2222-4222-9222-222222222222';
 
@@ -472,21 +493,31 @@ function getReq(path: string): Request {
 describe('POST /agreements/propose — owner-side mutation', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  // NOTE: The route resolves `organizationId` from the QUERY STRING, not
+  // the body. The real `procedure()` framework's `resolveOrganizationId`
+  // (packages/worker-utils/src/procedure/helpers.ts:317-360) reads URL
+  // params, subdomain, or query — NEVER body — and policy enforcement
+  // (Step 1) runs BEFORE input validation (Step 3), so a body-only
+  // orgId never reaches the resolver and would 400 ORG_CONTEXT_REQUIRED
+  // in production. The mocked procedure stub above injects
+  // `ctx.organizationId` directly via `__testOrganizationId`, so these
+  // tests confirm the handler-side contract (forward ctx.organizationId
+  // to the service). The query-string placement is asserted indirectly
+  // via the schema-level body test ("body must NOT carry organizationId")
+  // below.
   const validBody = {
-    organizationId: MANAGED_ORG_ID,
     creatorId: TARGET_CREATOR_ID,
     revenueType: 'subscription',
     sharePercent: 3000,
     termMonths: 12,
     note: 'Initial proposal',
   };
+  const proposePath = `/agreements/propose?organizationId=${MANAGED_ORG_ID}`;
 
-  it('positive: owner POST with valid body → 201, service called with ctx.organizationId', async () => {
+  it('positive: owner POST with valid body + query orgId → 201, service called with ctx.organizationId', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
-    const res = await bundle.app.request(
-      postReq('/agreements/propose', validBody)
-    );
+    const res = await bundle.app.request(postReq(proposePath, validBody));
     expect(res.status).toBe(201);
     expect(services.agreements.proposeAgreement).toHaveBeenCalledTimes(1);
     const [arg] = services.agreements.proposeAgreement.mock.calls[0]!;
@@ -498,17 +529,18 @@ describe('POST /agreements/propose — owner-side mutation', () => {
     );
   });
 
-  it('cross-org safety: ctx.organizationId wins over body.organizationId', async () => {
+  it('cross-org safety: ctx.organizationId (from query resolver) wins, body never carries orgId', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
-    // Client sends a different org id in the body; the route MUST
-    // forward `ctx.organizationId` (resolved from membership) to the
-    // service.
+    // Even if a client smuggles `organizationId` into the body (which
+    // the schema now rejects, but procedure body-strip would also drop),
+    // the route MUST forward `ctx.organizationId` (resolved from
+    // query/subdomain by `procedure()`) to the service.
     const res = await bundle.app.request(
-      postReq('/agreements/propose', {
+      postReq(proposePath, {
         ...validBody,
         organizationId: ROGUE_ORG_ID,
-      })
+      } as unknown as typeof validBody)
     );
     expect(res.status).toBe(201);
     const [arg] = services.agreements.proposeAgreement.mock.calls[0]!;
@@ -523,9 +555,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
   it('negative auth: no session → 401, service NOT called', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ user: null, services });
-    const res = await bundle.app.request(
-      postReq('/agreements/propose', validBody)
-    );
+    const res = await bundle.app.request(postReq(proposePath, validBody));
     expect(res.status).toBe(401);
     expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
   });
@@ -533,9 +563,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
   it('negative authz: non-member on the org → 403, service NOT called', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ orgRole: null, services });
-    const res = await bundle.app.request(
-      postReq('/agreements/propose', validBody)
-    );
+    const res = await bundle.app.request(postReq(proposePath, validBody));
     expect(res.status).toBe(403);
     expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
   });
@@ -544,7 +572,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
     const res = await bundle.app.request(
-      postReq('/agreements/propose', { ...validBody, sharePercent: 15000 })
+      postReq(proposePath, { ...validBody, sharePercent: 15000 })
     );
     expect(res.status).toBe(400);
     expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
@@ -554,7 +582,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
     const res = await bundle.app.request(
-      postReq('/agreements/propose', { ...validBody, sharePercent: -1 })
+      postReq(proposePath, { ...validBody, sharePercent: -1 })
     );
     expect(res.status).toBe(400);
     expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
@@ -564,7 +592,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
     const res = await bundle.app.request(
-      postReq('/agreements/propose', { ...validBody, termMonths: 0 })
+      postReq(proposePath, { ...validBody, termMonths: 0 })
     );
     expect(res.status).toBe(400);
     expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
@@ -574,7 +602,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
     const res = await bundle.app.request(
-      postReq('/agreements/propose', {
+      postReq(proposePath, {
         ...validBody,
         revenueType: 'nonsense',
       })
@@ -587,8 +615,19 @@ describe('POST /agreements/propose — owner-side mutation', () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
     const { creatorId: _omitted, ...incomplete } = validBody;
+    const res = await bundle.app.request(postReq(proposePath, incomplete));
+    expect(res.status).toBe(400);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: non-UUID creatorId → 400, service NOT called', async () => {
+    // Hardening: creatorId is uuidSchema, not arbitrary string. A
+    // placeholder like `usr_xxx` no longer passes — caller must use a
+    // real UUID matching BetterAuth's user.id format.
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
     const res = await bundle.app.request(
-      postReq('/agreements/propose', incomplete)
+      postReq(proposePath, { ...validBody, creatorId: 'usr_not_a_uuid' })
     );
     expect(res.status).toBe(400);
     expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
@@ -602,9 +641,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
       })
     );
     const bundle = buildApp({ services });
-    const res = await bundle.app.request(
-      postReq('/agreements/propose', validBody)
-    );
+    const res = await bundle.app.request(postReq(proposePath, validBody));
     expect(res.status).toBe(422);
     const payload = (await res.json()) as { error?: { code?: string } };
     // Per feedback_not_found_error_name_minification — assert err.code
@@ -617,7 +654,7 @@ describe('POST /agreements/propose — owner-side mutation', () => {
 describe('POST /agreements/:proposalId/accept — counterparty mutation', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('positive: counterparty creator POST → 200, service called with proposalId + acceptedByUserId', async () => {
+  it('positive: counterparty creator POST → 201 (create semantic: new active agreement row), service called with proposalId + acceptedByUserId', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({
       services,
@@ -626,7 +663,10 @@ describe('POST /agreements/:proposalId/accept — counterparty mutation', () => 
     const res = await bundle.app.request(
       postReq(`/agreements/${PROPOSAL_ID}/accept`, {})
     );
-    expect(res.status).toBe(200);
+    // Accepting a proposal creates a new active agreement row + supersedes
+    // prior. 201 reflects the new resource (per HTTP semantics + the
+    // worker's rest of POST-create endpoints).
+    expect(res.status).toBe(201);
     expect(services.agreements.acceptProposal).toHaveBeenCalledTimes(1);
     const [arg] = services.agreements.acceptProposal.mock.calls[0]!;
     expect((arg as { proposalId: string }).proposalId).toBe(PROPOSAL_ID);
@@ -974,6 +1014,35 @@ describe('GET /agreements — owner-view list', () => {
     expect(services.agreements.getActiveAgreements).not.toHaveBeenCalled();
   });
 
+  it('negative authz: rank-and-file member on the org → 403 (requireOrgManagement), service NOT called', async () => {
+    // Defence-in-depth: a regular member of the org can still leak
+    // every peer creator's share percent if this endpoint only gates
+    // on `requireOrgMembership`. The route uses `requireOrgManagement`
+    // (owner OR admin only) — this test guards against a regression
+    // back to the broader gate.
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      orgRole: 'member',
+      services,
+      user: { id: MEMBER_USER_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements'));
+    expect(res.status).toBe(403);
+    expect(services.agreements.getActiveAgreements).not.toHaveBeenCalled();
+  });
+
+  it('positive authz: admin role on the org → 200 (requireOrgManagement allows admin)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      orgRole: 'admin',
+      services,
+      user: { id: ADMIN_USER_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements'));
+    expect(res.status).toBe(200);
+    expect(services.agreements.getActiveAgreements).toHaveBeenCalledTimes(1);
+  });
+
   it('negative validation: invalid revenueType query → 400', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({ services });
@@ -990,7 +1059,7 @@ describe('GET /agreements — owner-view list', () => {
 describe('GET /agreements/me — creator-view portfolio (ANONYMISATION CONTRACT)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('positive: creator GET → 200, response includes peers aggregate ONLY (no peer ids)', async () => {
+  it('positive: creator GET → 200, response includes peers aggregate ONLY (no peer ids) AND aggregates only within the SAME (orgId, revenueType) pool', async () => {
     const services = { agreements: createAgreementServiceMock() };
     const bundle = buildApp({
       services,
@@ -1002,6 +1071,7 @@ describe('GET /agreements/me — creator-view portfolio (ANONYMISATION CONTRACT)
     const payload = (await res.json()) as {
       items: Array<{
         creatorId: string;
+        revenueType: string;
         peers: { count: number; aggregateSharePercent: number };
       }>;
     };
@@ -1011,16 +1081,136 @@ describe('GET /agreements/me — creator-view portfolio (ANONYMISATION CONTRACT)
     // Caller's own row: their own creatorId IS allowed (they are
     // looking at their own slice).
     expect(row.creatorId).toBe(CALLER_CREATOR_ID);
+    expect(row.revenueType).toBe('subscription');
 
-    // Peers aggregate: 2 other active creators on the org.
-    // PEER_CREATOR_ID_1 has share = 10000 - 8000 = 2000 (subscription)
-    // PEER_CREATOR_ID_2 has share = 10000 - 9000 = 1000 (content_purchase)
-    expect(row.peers.count).toBe(2);
-    expect(row.peers.aggregateSharePercent).toBe(3000);
+    // Per the locked epic decision Q1 (project_revenue_share_decisions.md),
+    // subscription and content_purchase are SEPARATE pools. The fixture
+    // has 1 subscription peer (PEER_1, share = 10000 - 8000 = 2000) and
+    // 1 content_purchase peer (PEER_2, share = 10000 - 9000 = 1000).
+    // The caller's subscription row must show ONLY the subscription
+    // peer (count=1, aggregate=2000) — the content_purchase peer is in
+    // a different pool and must NOT contribute.
+    expect(row.peers.count).toBe(1);
+    expect(row.peers.aggregateSharePercent).toBe(2000);
 
     // The load-bearing invariant: NO peer identifying fields appear
     // anywhere in the serialised response. Grep the entire body for
     // each peer's userId.
+    const bodyText = JSON.stringify(payload);
+    expect(bodyText).not.toContain(PEER_CREATOR_ID_1);
+    expect(bodyText).not.toContain(PEER_CREATOR_ID_2);
+  });
+
+  it('cross-type isolation: caller with BOTH subscription AND content_purchase agreements sees per-pool peers only', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    // Caller has BOTH a subscription AND a content_purchase agreement
+    // on the same org. Each row must see ONLY peers in the same pool.
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([
+      {
+        id: 'agr_caller_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000, // share = 3000
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_caller_cp',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'content_purchase',
+        status: 'active',
+        organizationFeePercentage: 6000, // share = 4000
+        currentProposalId: 'prop_caller_cp',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-02'),
+        effectiveUntil: null,
+      },
+    ]);
+    // Org-wide rows: caller's two + one peer in each pool.
+    services.agreements.getActiveAgreements.mockResolvedValue([
+      {
+        id: 'agr_caller_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000,
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_caller_cp',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'content_purchase',
+        status: 'active',
+        organizationFeePercentage: 6000,
+        currentProposalId: 'prop_caller_cp',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-02'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_peer_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_1,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 8000, // share = 2000
+        currentProposalId: 'prop_peer_sub',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-03'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_peer_cp',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_2,
+        revenueType: 'content_purchase',
+        status: 'active',
+        organizationFeePercentage: 9000, // share = 1000
+        currentProposalId: 'prop_peer_cp',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-04'),
+        effectiveUntil: null,
+      },
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me'));
+    expect(res.status).toBe(200);
+
+    const payload = (await res.json()) as {
+      items: Array<{
+        revenueType: string;
+        peers: { count: number; aggregateSharePercent: number };
+      }>;
+    };
+    expect(payload.items).toHaveLength(2);
+
+    const sub = payload.items.find((r) => r.revenueType === 'subscription');
+    const cp = payload.items.find((r) => r.revenueType === 'content_purchase');
+    expect(sub).toBeDefined();
+    expect(cp).toBeDefined();
+
+    // Subscription row sees ONLY the subscription peer (share=2000).
+    expect(sub!.peers.count).toBe(1);
+    expect(sub!.peers.aggregateSharePercent).toBe(2000);
+
+    // Content-purchase row sees ONLY the content-purchase peer (share=1000).
+    expect(cp!.peers.count).toBe(1);
+    expect(cp!.peers.aggregateSharePercent).toBe(1000);
+
+    // Anonymisation still holds.
     const bodyText = JSON.stringify(payload);
     expect(bodyText).not.toContain(PEER_CREATOR_ID_1);
     expect(bodyText).not.toContain(PEER_CREATOR_ID_2);
@@ -1112,6 +1302,40 @@ describe('GET /agreements/threads/:creatorId — owner-view negotiation thread',
     );
     expect(res.status).toBe(403);
     expect(services.agreements.getNegotiationThread).not.toHaveBeenCalled();
+  });
+
+  it('negative authz: rank-and-file member → 403 (requireOrgManagement), service NOT called', async () => {
+    // Same defence-in-depth pin as GET /agreements: a regular org
+    // member cannot view peer-creator negotiation threads.
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      orgRole: 'member',
+      services,
+      user: { id: MEMBER_USER_ID },
+    });
+    const res = await bundle.app.request(
+      getReq(
+        `/agreements/threads/${TARGET_CREATOR_ID}?revenueType=subscription`
+      )
+    );
+    expect(res.status).toBe(403);
+    expect(services.agreements.getNegotiationThread).not.toHaveBeenCalled();
+  });
+
+  it('positive authz: admin role → 200 (requireOrgManagement allows admin)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      orgRole: 'admin',
+      services,
+      user: { id: ADMIN_USER_ID },
+    });
+    const res = await bundle.app.request(
+      getReq(
+        `/agreements/threads/${TARGET_CREATOR_ID}?revenueType=subscription`
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(services.agreements.getNegotiationThread).toHaveBeenCalledTimes(1);
   });
 
   it('negative validation: missing revenueType → 400', async () => {

--- a/workers/ecom-api/src/routes/__tests__/agreements-routes.test.ts
+++ b/workers/ecom-api/src/routes/__tests__/agreements-routes.test.ts
@@ -1,0 +1,1206 @@
+/**
+ * Route-layer HTTP-boundary tests for the revenue-share agreement
+ * endpoints (Codex-hqke2 — WP-3 of epic Codex-nk4km).
+ *
+ * Tests pin the HTTP contract — not the service behaviour. The service
+ * is mocked so its internal authz / state-machine logic doesn't need to
+ * be re-tested here (that's WP-2's responsibility in
+ * `packages/agreements/__tests__/agreement-service.test.ts`).
+ *
+ * Per `feedback_security_deep_test` (positive AND negative paths
+ * mandatory for security-adjacent code), every endpoint is tested for:
+ *
+ *   1. Authz positive: authenticated + (where applicable) on-org → 200/201,
+ *      service called with the correct args.
+ *   2. Authz negative: no session → 401, service NOT called.
+ *   3. Authz negative for owner-only writes: non-member on the resolved
+ *      org → 403, service NOT called.
+ *   4. Validation positive: a valid body → handler executes.
+ *   5. Validation negative: malformed body / out-of-range shares / wrong
+ *      enum → 400, service NOT called.
+ *   6. Error mapping: service throws typed error → correct HTTP status,
+ *      assertion on `err.code` rather than `err.name` per
+ *      `feedback_not_found_error_name_minification`.
+ *
+ * Plus regression guards specific to this route file:
+ *
+ *   - `/propose`: route forwards `ctx.organizationId` (resolved from
+ *     membership) to the service — NOT `body.organizationId`. This is
+ *     the cross-org safety pin documented in `routes/sales.ts`. If a
+ *     refactor ever wires the client-supplied org id directly into the
+ *     service call, this test fails.
+ *
+ *   - `/agreements/me` anonymisation: the response peer aggregate
+ *     contains `count` + `aggregateSharePercent` ONLY. No peer userId /
+ *     creatorId / display fields. The fixture deliberately seeds two
+ *     peer creators with distinct ids; the response is grep'd for those
+ *     ids — if any peer id leaks, the test fails. This is the load-
+ *     bearing visibility contract from the epic plan.
+ */
+
+import { mapErrorToResponse } from '@codex/service-errors';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Module mocks (must be declared before route module import) ──────────────
+
+vi.mock('@codex/agreements', async () => {
+  // Service is constructed lazily by the service registry; the route
+  // file consumes it via `ctx.services.agreements`. We bypass the
+  // registry by injecting a hand-built services bag into the procedure
+  // ctx, so the actual `AgreementService` symbol is only needed at
+  // import-resolution time.
+  return {
+    AgreementService: vi.fn(),
+  };
+});
+
+interface ProcedureConfig {
+  policy?: {
+    auth?: string;
+    requireOrgMembership?: boolean;
+    rateLimit?: string;
+  };
+  input?: {
+    body?: { safeParse: (v: unknown) => unknown };
+    query?: { safeParse: (v: unknown) => unknown };
+    params?: { safeParse: (v: unknown) => unknown };
+  };
+  handler: (ctx: unknown) => Promise<unknown>;
+  successStatus?: number;
+}
+
+vi.mock('@codex/worker-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@codex/worker-utils')>();
+  return {
+    ...actual,
+    procedure: (config: ProcedureConfig) => {
+      return async (c: {
+        req: {
+          json: () => Promise<unknown>;
+          query: () => Record<string, string>;
+          param: () => Record<string, string>;
+        };
+        get: (key: string) => unknown;
+        json: (body: unknown, status?: number) => unknown;
+      }) => {
+        const testUser = c.get('__testUser') as
+          | { id: string }
+          | null
+          | undefined;
+        if (config.policy?.auth === 'required' && !testUser) {
+          return c.json(
+            {
+              error: {
+                code: 'UNAUTHORIZED',
+                message: 'Authentication required',
+              },
+            },
+            401
+          );
+        }
+
+        const orgRole = c.get('__testOrgRole') as string | undefined;
+        const orgId = c.get('__testOrganizationId') as string | undefined;
+        if (config.policy?.requireOrgMembership) {
+          if (!orgId) {
+            return c.json(
+              {
+                error: {
+                  code: 'ORG_CONTEXT_REQUIRED',
+                  message: 'Org context required',
+                },
+              },
+              400
+            );
+          }
+          if (!orgRole) {
+            return c.json(
+              {
+                error: {
+                  code: 'FORBIDDEN',
+                  message: 'You are not a member of this organization',
+                },
+              },
+              403
+            );
+          }
+        }
+
+        // Body validation
+        let body: unknown = {};
+        if (config.input?.body) {
+          let raw: unknown = {};
+          try {
+            raw = await c.req.json();
+          } catch {
+            raw = {};
+          }
+          const parsed = (
+            config.input.body as unknown as {
+              safeParse: (v: unknown) => {
+                success: boolean;
+                data?: unknown;
+                error?: { issues: unknown };
+              };
+            }
+          ).safeParse(raw);
+          if (!parsed.success) {
+            return c.json(
+              {
+                error: {
+                  code: 'VALIDATION_ERROR',
+                  message: 'Invalid input',
+                  details: parsed.error?.issues,
+                },
+              },
+              400
+            );
+          }
+          body = parsed.data;
+        }
+
+        // Query validation
+        let query: unknown = {};
+        if (config.input?.query) {
+          const raw = c.req.query();
+          const parsed = (
+            config.input.query as unknown as {
+              safeParse: (v: unknown) => {
+                success: boolean;
+                data?: unknown;
+                error?: { issues: unknown };
+              };
+            }
+          ).safeParse(raw);
+          if (!parsed.success) {
+            return c.json(
+              {
+                error: {
+                  code: 'VALIDATION_ERROR',
+                  message: 'Invalid input',
+                  details: parsed.error?.issues,
+                },
+              },
+              400
+            );
+          }
+          query = parsed.data;
+        }
+
+        // Params validation
+        let params: unknown = {};
+        if (config.input?.params) {
+          const raw = c.req.param();
+          const parsed = (
+            config.input.params as unknown as {
+              safeParse: (v: unknown) => {
+                success: boolean;
+                data?: unknown;
+                error?: { issues: unknown };
+              };
+            }
+          ).safeParse(raw);
+          if (!parsed.success) {
+            return c.json(
+              {
+                error: {
+                  code: 'VALIDATION_ERROR',
+                  message: 'Invalid input',
+                  details: parsed.error?.issues,
+                },
+              },
+              400
+            );
+          }
+          params = parsed.data;
+        }
+
+        const services = c.get('__testServices');
+        const ctx = {
+          user: testUser,
+          input: { body, query, params },
+          services,
+          organizationId: orgId,
+          organizationRole: orgRole,
+        };
+
+        try {
+          const result = await config.handler(ctx);
+          if (
+            result instanceof actual.PaginatedResult ||
+            (result &&
+              typeof result === 'object' &&
+              'items' in (result as object) &&
+              'pagination' in (result as object))
+          ) {
+            const r = result as { items: unknown; pagination: unknown };
+            return c.json(
+              { items: r.items, pagination: r.pagination },
+              (config.successStatus ?? 200) as 200 | 201
+            );
+          }
+          return c.json(
+            { data: result },
+            (config.successStatus ?? 200) as 200 | 201
+          );
+        } catch (error) {
+          const { statusCode, response } = mapErrorToResponse(error, {
+            logError: false,
+          });
+          return c.json(
+            response,
+            statusCode as 400 | 401 | 403 | 404 | 409 | 422 | 500
+          );
+        }
+      };
+    },
+  };
+});
+
+// ─── Imports (after vi.mock declarations) ────────────────────────────────────
+
+// Use the typed `ServiceError` subclasses the AgreementService throws.
+// AgreementNotFoundError / InvalidProposalStateError /
+// ShareExceedsAvailableError live in @codex/agreements; they extend
+// NotFoundError and BusinessLogicError respectively. We instantiate the
+// base classes directly here to avoid pulling @codex/agreements into
+// ecom-api's deps just for test fixtures — `mapErrorToResponse()` maps
+// off the base class anyway, so the HTTP status assertions are
+// identical.
+import { BusinessLogicError, NotFoundError } from '@codex/service-errors';
+import { Hono } from 'hono';
+import agreements from '../agreements';
+
+// ─── Shared test fixtures ────────────────────────────────────────────────────
+
+const MANAGED_ORG_ID = '323e4567-e89b-12d3-a456-426614174002';
+const ROGUE_ORG_ID = '999e4567-e89b-12d3-a456-426614174999';
+const TARGET_CREATOR_ID = 'usr_target_creator_001';
+const PEER_CREATOR_ID_1 = 'usr_peer_creator_001';
+const PEER_CREATOR_ID_2 = 'usr_peer_creator_002';
+const OWNER_USER_ID = 'usr_owner_001';
+const CALLER_CREATOR_ID = 'usr_caller_creator_001';
+// Real UUIDs (must pass `z.uuid()` strict regex: version digit [1-8] and
+// variant [89abAB] in the correct positions). All-1s / all-2s placeholders
+// fail Zod v4's UUID format check.
+const PROPOSAL_ID = '11111111-1111-4111-9111-111111111111';
+const AGREEMENT_ID = '22222222-2222-4222-9222-222222222222';
+
+interface AgreementServiceMock {
+  proposeAgreement: ReturnType<typeof vi.fn>;
+  counterPropose: ReturnType<typeof vi.fn>;
+  acceptProposal: ReturnType<typeof vi.fn>;
+  declineProposal: ReturnType<typeof vi.fn>;
+  withdrawProposal: ReturnType<typeof vi.fn>;
+  terminateAgreement: ReturnType<typeof vi.fn>;
+  getActiveAgreements: ReturnType<typeof vi.fn>;
+  getActiveAgreementsForCreator: ReturnType<typeof vi.fn>;
+  getNegotiationThread: ReturnType<typeof vi.fn>;
+}
+
+function createAgreementServiceMock(): AgreementServiceMock {
+  return {
+    proposeAgreement: vi.fn().mockResolvedValue({
+      id: PROPOSAL_ID,
+      organizationId: MANAGED_ORG_ID,
+      creatorId: TARGET_CREATOR_ID,
+      revenueType: 'subscription',
+      status: 'open',
+      proposedCreatorSharePercent: 3000,
+      proposedTermMonths: 12,
+      proposedByRole: 'owner',
+      proposedByUserId: OWNER_USER_ID,
+      roundNumber: 1,
+    }),
+    counterPropose: vi.fn().mockResolvedValue({
+      id: '33333333-3333-3333-3333-333333333333',
+      proposedCreatorSharePercent: 4000,
+      proposedTermMonths: 12,
+      status: 'open',
+      proposedByRole: 'creator',
+      proposedByUserId: TARGET_CREATOR_ID,
+      roundNumber: 2,
+      parentProposalId: PROPOSAL_ID,
+    }),
+    acceptProposal: vi.fn().mockResolvedValue({
+      id: AGREEMENT_ID,
+      organizationId: MANAGED_ORG_ID,
+      creatorId: TARGET_CREATOR_ID,
+      revenueType: 'subscription',
+      status: 'active',
+      organizationFeePercentage: 7000,
+      currentProposalId: PROPOSAL_ID,
+    }),
+    declineProposal: vi.fn().mockResolvedValue({
+      id: PROPOSAL_ID,
+      status: 'declined',
+      declineReason: 'Too low',
+    }),
+    withdrawProposal: vi.fn().mockResolvedValue({
+      id: PROPOSAL_ID,
+      status: 'withdrawn',
+    }),
+    terminateAgreement: vi.fn().mockResolvedValue({
+      id: AGREEMENT_ID,
+      status: 'terminated',
+      terminatedByUserId: OWNER_USER_ID,
+      terminationReason: 'Mutual',
+    }),
+    getActiveAgreements: vi.fn().mockResolvedValue([
+      {
+        id: 'agr_a',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000, // share = 3000
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_b',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_1,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 8000, // share = 2000
+        currentProposalId: 'prop_b',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-02'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_c',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_2,
+        revenueType: 'content_purchase',
+        status: 'active',
+        organizationFeePercentage: 9000, // share = 1000
+        currentProposalId: 'prop_c',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-03'),
+        effectiveUntil: null,
+      },
+    ]),
+    getActiveAgreementsForCreator: vi.fn().mockResolvedValue([
+      {
+        id: 'agr_a',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000, // share = 3000
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+    ]),
+    getNegotiationThread: vi.fn().mockResolvedValue([
+      {
+        id: PROPOSAL_ID,
+        roundNumber: 1,
+        status: 'open',
+        proposedByRole: 'owner',
+        proposedCreatorSharePercent: 3000,
+        proposedTermMonths: 12,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        organizationId: MANAGED_ORG_ID,
+      },
+    ]),
+  };
+}
+
+interface BuildAppArgs {
+  user?: { id: string } | null;
+  services?: { agreements: AgreementServiceMock };
+  /**
+   * `null` means "not a member of the resolved org" — the harness emits
+   * 403 when `requireOrgMembership` is set. `undefined` falls back to
+   * 'owner'. Any string value is used verbatim.
+   */
+  orgRole?: 'owner' | 'admin' | 'member' | null | undefined;
+  organizationId?: string | undefined;
+}
+
+function buildApp(args: BuildAppArgs = {}) {
+  const services = args.services ?? {
+    agreements: createAgreementServiceMock(),
+  };
+  const app = new Hono<{ Variables: Record<string, unknown> }>();
+  app.use('*', async (c, next) => {
+    c.set(
+      '__testUser',
+      args.user === undefined ? { id: OWNER_USER_ID } : args.user
+    );
+    c.set('__testServices', services);
+    // `null` → not a member (harness emits 403). `undefined` → owner.
+    c.set(
+      '__testOrgRole',
+      args.orgRole === undefined ? 'owner' : (args.orgRole ?? undefined)
+    );
+    c.set(
+      '__testOrganizationId',
+      args.organizationId === undefined ? MANAGED_ORG_ID : args.organizationId
+    );
+    await next();
+  });
+  (app as unknown as { route: (path: string, r: unknown) => void }).route(
+    '/agreements',
+    agreements
+  );
+  return { app, services };
+}
+
+function postReq(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function getReq(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+// ─── POST /agreements/propose ────────────────────────────────────────────────
+
+describe('POST /agreements/propose — owner-side mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = {
+    organizationId: MANAGED_ORG_ID,
+    creatorId: TARGET_CREATOR_ID,
+    revenueType: 'subscription',
+    sharePercent: 3000,
+    termMonths: 12,
+    note: 'Initial proposal',
+  };
+
+  it('positive: owner POST with valid body → 201, service called with ctx.organizationId', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', validBody)
+    );
+    expect(res.status).toBe(201);
+    expect(services.agreements.proposeAgreement).toHaveBeenCalledTimes(1);
+    const [arg] = services.agreements.proposeAgreement.mock.calls[0]!;
+    expect((arg as { organizationId: string }).organizationId).toBe(
+      MANAGED_ORG_ID
+    );
+    expect((arg as { proposedByUserId: string }).proposedByUserId).toBe(
+      OWNER_USER_ID
+    );
+  });
+
+  it('cross-org safety: ctx.organizationId wins over body.organizationId', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    // Client sends a different org id in the body; the route MUST
+    // forward `ctx.organizationId` (resolved from membership) to the
+    // service.
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', {
+        ...validBody,
+        organizationId: ROGUE_ORG_ID,
+      })
+    );
+    expect(res.status).toBe(201);
+    const [arg] = services.agreements.proposeAgreement.mock.calls[0]!;
+    expect((arg as { organizationId: string }).organizationId).toBe(
+      MANAGED_ORG_ID
+    );
+    expect((arg as { organizationId: string }).organizationId).not.toBe(
+      ROGUE_ORG_ID
+    );
+  });
+
+  it('negative auth: no session → 401, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ user: null, services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', validBody)
+    );
+    expect(res.status).toBe(401);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative authz: non-member on the org → 403, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ orgRole: null, services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', validBody)
+    );
+    expect(res.status).toBe(403);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: sharePercent > 10000 → 400, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', { ...validBody, sharePercent: 15000 })
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: sharePercent negative → 400, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', { ...validBody, sharePercent: -1 })
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: termMonths < 1 → 400, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', { ...validBody, termMonths: 0 })
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: invalid revenueType → 400, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', {
+        ...validBody,
+        revenueType: 'nonsense',
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: missing required creatorId → 400, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const { creatorId: _omitted, ...incomplete } = validBody;
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', incomplete)
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.proposeAgreement).not.toHaveBeenCalled();
+  });
+
+  it('error mapping: service throws ShareExceedsAvailableError (BusinessLogicError) → 422 with err.code (NOT name)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.proposeAgreement.mockRejectedValueOnce(
+      new BusinessLogicError('Share too high', {
+        proposedSharePercent: 9000,
+      })
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/propose', validBody)
+    );
+    expect(res.status).toBe(422);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    // Per feedback_not_found_error_name_minification — assert err.code
+    expect(payload.error?.code).toBeTruthy();
+  });
+});
+
+// ─── POST /agreements/:proposalId/accept ─────────────────────────────────────
+
+describe('POST /agreements/:proposalId/accept — counterparty mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: counterparty creator POST → 200, service called with proposalId + acceptedByUserId', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      services,
+      user: { id: TARGET_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/accept`, {})
+    );
+    expect(res.status).toBe(200);
+    expect(services.agreements.acceptProposal).toHaveBeenCalledTimes(1);
+    const [arg] = services.agreements.acceptProposal.mock.calls[0]!;
+    expect((arg as { proposalId: string }).proposalId).toBe(PROPOSAL_ID);
+    expect((arg as { acceptedByUserId: string }).acceptedByUserId).toBe(
+      TARGET_CREATOR_ID
+    );
+  });
+
+  it('negative auth: no session → 401, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ user: null, services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/accept`, {})
+    );
+    expect(res.status).toBe(401);
+    expect(services.agreements.acceptProposal).not.toHaveBeenCalled();
+  });
+
+  it('error mapping: same-party (proposer) accept → service throws ForbiddenError → 403', async () => {
+    // The owner who proposed cannot accept their own proposal — service
+    // enforces, route propagates.
+    const services = { agreements: createAgreementServiceMock() };
+    const { ForbiddenError } = await import('@codex/service-errors');
+    services.agreements.acceptProposal.mockRejectedValueOnce(
+      new ForbiddenError('Only the counterparty creator may accept', {
+        proposalId: PROPOSAL_ID,
+      })
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/accept`, {})
+    );
+    expect(res.status).toBe(403);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBeTruthy();
+  });
+
+  it('error mapping: non-existent proposalId → AgreementNotFoundError (NotFoundError) → 404 with err.code', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.acceptProposal.mockRejectedValueOnce(
+      new NotFoundError('Proposal not found', {
+        proposalId: PROPOSAL_ID,
+      })
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/accept`, {})
+    );
+    expect(res.status).toBe(404);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBeTruthy();
+  });
+
+  it('error mapping: already-accepted proposal → InvalidProposalStateError (BusinessLogicError) → 422', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.acceptProposal.mockRejectedValueOnce(
+      new BusinessLogicError('Only open proposals can be accepted', {
+        proposalId: PROPOSAL_ID,
+        currentStatus: 'accepted',
+        attemptedAction: 'accept',
+      })
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/accept`, {})
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it('negative validation: invalid proposalId UUID → 400', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/not-a-uuid/accept', {})
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.acceptProposal).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /agreements/:proposalId/counter ────────────────────────────────────
+
+describe('POST /agreements/:proposalId/counter — counterparty mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = { sharePercent: 4000, termMonths: 12 };
+
+  it('positive: counterparty POST → 201, service called with counteredByUserId', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      services,
+      user: { id: TARGET_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/counter`, validBody)
+    );
+    expect(res.status).toBe(201);
+    const [arg] = services.agreements.counterPropose.mock.calls[0]!;
+    expect((arg as { counteredByUserId: string }).counteredByUserId).toBe(
+      TARGET_CREATOR_ID
+    );
+  });
+
+  it('negative validation: sharePercent invalid → 400, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/counter`, {
+        ...validBody,
+        sharePercent: 99999,
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.counterPropose).not.toHaveBeenCalled();
+  });
+
+  it('error mapping: non-counterparty counter → ForbiddenError → 403', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const { ForbiddenError } = await import('@codex/service-errors');
+    services.agreements.counterPropose.mockRejectedValueOnce(
+      new ForbiddenError('Only the counterparty creator may counter', {
+        proposalId: PROPOSAL_ID,
+      })
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/counter`, validBody)
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── POST /agreements/:proposalId/decline ────────────────────────────────────
+
+describe('POST /agreements/:proposalId/decline — counterparty mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: counterparty POST with reason → 200, service called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      services,
+      user: { id: TARGET_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/decline`, { reason: 'No thanks' })
+    );
+    expect(res.status).toBe(200);
+    expect(services.agreements.declineProposal).toHaveBeenCalledTimes(1);
+    const [arg] = services.agreements.declineProposal.mock.calls[0]!;
+    expect((arg as { reason: string }).reason).toBe('No thanks');
+  });
+
+  it('positive: counterparty POST without reason → 200, service called with reason=null', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/decline`, {})
+    );
+    expect(res.status).toBe(200);
+    const [arg] = services.agreements.declineProposal.mock.calls[0]!;
+    expect((arg as { reason: string | null }).reason).toBeNull();
+  });
+
+  it('negative validation: reason too long → 400', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/decline`, {
+        reason: 'x'.repeat(600),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.declineProposal).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /agreements/:proposalId/withdraw ───────────────────────────────────
+
+describe('POST /agreements/:proposalId/withdraw — proposer-side mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: proposer POST → 200, service called with withdrawnByUserId', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/withdraw`, {})
+    );
+    expect(res.status).toBe(200);
+    const [arg] = services.agreements.withdrawProposal.mock.calls[0]!;
+    expect((arg as { withdrawnByUserId: string }).withdrawnByUserId).toBe(
+      OWNER_USER_ID
+    );
+  });
+
+  it('error mapping: non-proposer withdraw → ForbiddenError → 403', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const { ForbiddenError } = await import('@codex/service-errors');
+    services.agreements.withdrawProposal.mockRejectedValueOnce(
+      new ForbiddenError('Only the proposing party may withdraw', {
+        proposalId: PROPOSAL_ID,
+      })
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${PROPOSAL_ID}/withdraw`, {})
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── POST /agreements/:agreementId/terminate ─────────────────────────────────
+
+describe('POST /agreements/:agreementId/terminate — either-party mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: owner terminates → 200', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services, user: { id: OWNER_USER_ID } });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${AGREEMENT_ID}/terminate`, {
+        reason: 'No longer working',
+      })
+    );
+    expect(res.status).toBe(200);
+    const [arg] = services.agreements.terminateAgreement.mock.calls[0]!;
+    expect((arg as { terminatedByUserId: string }).terminatedByUserId).toBe(
+      OWNER_USER_ID
+    );
+  });
+
+  it('positive: creator (the named party) terminates → 200', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      services,
+      user: { id: TARGET_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${AGREEMENT_ID}/terminate`, {})
+    );
+    expect(res.status).toBe(200);
+    const [arg] = services.agreements.terminateAgreement.mock.calls[0]!;
+    expect((arg as { terminatedByUserId: string }).terminatedByUserId).toBe(
+      TARGET_CREATOR_ID
+    );
+  });
+
+  it('error mapping: random non-party terminates → ForbiddenError → 403', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const { ForbiddenError } = await import('@codex/service-errors');
+    services.agreements.terminateAgreement.mockRejectedValueOnce(
+      new ForbiddenError(
+        'Only an active organization owner may perform this action',
+        { organizationId: MANAGED_ORG_ID }
+      )
+    );
+    const bundle = buildApp({ services, user: { id: 'usr_random' } });
+    const res = await bundle.app.request(
+      postReq(`/agreements/${AGREEMENT_ID}/terminate`, {})
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('negative validation: bad agreementId UUID → 400', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      postReq('/agreements/not-a-uuid/terminate', {})
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.terminateAgreement).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /agreements — owner-view list ───────────────────────────────────────
+
+describe('GET /agreements — owner-view list', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: owner GET → 200, all rows with full identifying info', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(getReq('/agreements'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      items: Array<{ creatorId: string; revenueType: string }>;
+      pagination: { total: number };
+    };
+    expect(payload.items).toHaveLength(3);
+    // Owner-view: NO anonymisation. Every peer creatorId is visible.
+    const creatorIds = payload.items.map((i) => i.creatorId);
+    expect(creatorIds).toContain(CALLER_CREATOR_ID);
+    expect(creatorIds).toContain(PEER_CREATOR_ID_1);
+    expect(creatorIds).toContain(PEER_CREATOR_ID_2);
+    // Service called with ctx.organizationId, not query.organizationId
+    const [arg] = services.agreements.getActiveAgreements.mock.calls[0]!;
+    expect((arg as { organizationId: string }).organizationId).toBe(
+      MANAGED_ORG_ID
+    );
+  });
+
+  it('cross-org safety: client query.organizationId ignored — ctx.organizationId wins', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      getReq(`/agreements?organizationId=${ROGUE_ORG_ID}`)
+    );
+    expect(res.status).toBe(200);
+    const [arg] = services.agreements.getActiveAgreements.mock.calls[0]!;
+    expect((arg as { organizationId: string }).organizationId).toBe(
+      MANAGED_ORG_ID
+    );
+    expect((arg as { organizationId: string }).organizationId).not.toBe(
+      ROGUE_ORG_ID
+    );
+  });
+
+  it('positive: revenueType query filter narrows to one type', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      getReq('/agreements?revenueType=subscription')
+    );
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      items: Array<{ revenueType: string }>;
+    };
+    expect(payload.items.every((i) => i.revenueType === 'subscription')).toBe(
+      true
+    );
+  });
+
+  it('negative auth: no session → 401, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ user: null, services });
+    const res = await bundle.app.request(getReq('/agreements'));
+    expect(res.status).toBe(401);
+    expect(services.agreements.getActiveAgreements).not.toHaveBeenCalled();
+  });
+
+  it('negative authz: non-member on the org → 403, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ orgRole: null, services });
+    const res = await bundle.app.request(getReq('/agreements'));
+    expect(res.status).toBe(403);
+    expect(services.agreements.getActiveAgreements).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: invalid revenueType query → 400', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      getReq('/agreements?revenueType=nonsense')
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.getActiveAgreements).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /agreements/me — creator-view portfolio ─────────────────────────────
+
+describe('GET /agreements/me — creator-view portfolio (ANONYMISATION CONTRACT)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: creator GET → 200, response includes peers aggregate ONLY (no peer ids)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me'));
+    expect(res.status).toBe(200);
+
+    const payload = (await res.json()) as {
+      items: Array<{
+        creatorId: string;
+        peers: { count: number; aggregateSharePercent: number };
+      }>;
+    };
+    expect(payload.items).toHaveLength(1);
+    const row = payload.items[0]!;
+
+    // Caller's own row: their own creatorId IS allowed (they are
+    // looking at their own slice).
+    expect(row.creatorId).toBe(CALLER_CREATOR_ID);
+
+    // Peers aggregate: 2 other active creators on the org.
+    // PEER_CREATOR_ID_1 has share = 10000 - 8000 = 2000 (subscription)
+    // PEER_CREATOR_ID_2 has share = 10000 - 9000 = 1000 (content_purchase)
+    expect(row.peers.count).toBe(2);
+    expect(row.peers.aggregateSharePercent).toBe(3000);
+
+    // The load-bearing invariant: NO peer identifying fields appear
+    // anywhere in the serialised response. Grep the entire body for
+    // each peer's userId.
+    const bodyText = JSON.stringify(payload);
+    expect(bodyText).not.toContain(PEER_CREATOR_ID_1);
+    expect(bodyText).not.toContain(PEER_CREATOR_ID_2);
+  });
+
+  it('positive: creator with no peers → peers.count = 0', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    // Override: only the caller has a row, no peers
+    services.agreements.getActiveAgreements.mockResolvedValue([
+      {
+        id: 'agr_a',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000,
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date(),
+        effectiveUntil: null,
+      },
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      items: Array<{ peers: { count: number; aggregateSharePercent: number } }>;
+    };
+    expect(payload.items[0]!.peers.count).toBe(0);
+    expect(payload.items[0]!.peers.aggregateSharePercent).toBe(0);
+  });
+
+  it('positive: creator with no agreements → empty items', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { items: unknown[] };
+    expect(payload.items).toHaveLength(0);
+  });
+
+  it('negative auth: no session → 401, service NOT called', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ user: null, services });
+    const res = await bundle.app.request(getReq('/agreements/me'));
+    expect(res.status).toBe(401);
+    expect(
+      services.agreements.getActiveAgreementsForCreator
+    ).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /agreements/threads/:creatorId — owner-view thread ─────────────────
+
+describe('GET /agreements/threads/:creatorId — owner-view negotiation thread', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: owner GET → 200, service called with org + creator + revenueType', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      getReq(
+        `/agreements/threads/${TARGET_CREATOR_ID}?revenueType=subscription`
+      )
+    );
+    expect(res.status).toBe(200);
+    const [arg] = services.agreements.getNegotiationThread.mock.calls[0]!;
+    expect((arg as { organizationId: string }).organizationId).toBe(
+      MANAGED_ORG_ID
+    );
+    expect((arg as { creatorId: string }).creatorId).toBe(TARGET_CREATOR_ID);
+    expect((arg as { revenueType: string }).revenueType).toBe('subscription');
+  });
+
+  it('negative authz: non-member → 403', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ orgRole: null, services });
+    const res = await bundle.app.request(
+      getReq(
+        `/agreements/threads/${TARGET_CREATOR_ID}?revenueType=subscription`
+      )
+    );
+    expect(res.status).toBe(403);
+    expect(services.agreements.getNegotiationThread).not.toHaveBeenCalled();
+  });
+
+  it('negative validation: missing revenueType → 400', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      getReq(`/agreements/threads/${TARGET_CREATOR_ID}`)
+    );
+    expect(res.status).toBe(400);
+    expect(services.agreements.getNegotiationThread).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /agreements/me/threads/:proposalId — creator-view thread ────────────
+
+describe('GET /agreements/me/threads/:proposalId — creator-view thread', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('positive: creator GET with own proposal id → 200, returns thread', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      getReq(`/agreements/me/threads/${PROPOSAL_ID}`)
+    );
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      data: Array<{ id: string }>;
+    };
+    expect(payload.data).toHaveLength(1);
+    expect(payload.data[0]!.id).toBe(PROPOSAL_ID);
+  });
+
+  it('negative: caller has no thread containing the proposal → 404 (no existence leak)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    // Thread does not contain the requested proposal
+    services.agreements.getNegotiationThread.mockResolvedValue([
+      {
+        id: 'other-proposal-id',
+        roundNumber: 1,
+        status: 'open',
+        proposedByRole: 'owner',
+      },
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      getReq(`/agreements/me/threads/${PROPOSAL_ID}`)
+    );
+    expect(res.status).toBe(404);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBeTruthy();
+  });
+
+  it('negative: caller has no agreements at all → 404', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(
+      getReq(`/agreements/me/threads/${PROPOSAL_ID}`)
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('negative auth: no session → 401', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ user: null, services });
+    const res = await bundle.app.request(
+      getReq(`/agreements/me/threads/${PROPOSAL_ID}`)
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('negative validation: invalid proposalId → 400', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(
+      getReq('/agreements/me/threads/not-a-uuid')
+    );
+    expect(res.status).toBe(400);
+    expect(
+      services.agreements.getActiveAgreementsForCreator
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/workers/ecom-api/src/routes/agreements.ts
+++ b/workers/ecom-api/src/routes/agreements.ts
@@ -54,7 +54,6 @@
 import { NotFoundError } from '@codex/service-errors';
 import type { HonoEnv } from '@codex/shared-types';
 import {
-  acceptProposalInputSchema,
   agreementIdParamSchema,
   counterProposeInputSchema,
   declineProposalInputSchema,
@@ -63,8 +62,8 @@ import {
   ownerThreadParamSchema,
   proposalIdParamSchema,
   proposeAgreementInputSchema,
+  proposeAgreementQuerySchema,
   terminateAgreementInputSchema,
-  withdrawProposalInputSchema,
 } from '@codex/validation';
 import { PaginatedResult, procedure } from '@codex/worker-utils';
 import { Hono } from 'hono';
@@ -74,12 +73,17 @@ const agreements = new Hono<HonoEnv>();
 // ─── Owner-side mutations ─────────────────────────────────────────────────
 
 /**
- * POST /agreements/propose
+ * POST /agreements/propose?organizationId=<uuid>
  *
- * Owner-initiated round 1 proposal. The body carries the target
- * `organizationId` (resolved by `procedure()`'s membership gate into
- * `ctx.organizationId`) and creator / revenue-type / share / term /
- * note. The service enforces:
+ * Owner-initiated round 1 proposal. The target `organizationId` is in
+ * the QUERY STRING (not the body) — `procedure()`'s `resolveOrganizationId`
+ * only reads URL params, subdomain, or query string. Policy enforcement
+ * runs before input validation, so a body-only orgId never reaches the
+ * resolver and the request 400s with `ORG_CONTEXT_REQUIRED`. The body
+ * carries the per-agreement fields: creator / revenue-type / share /
+ * term / note / effectiveFrom.
+ *
+ * The service enforces:
  *   - actor is an active owner of the org (`assertActiveOwner`)
  *   - target user is an active member of the org (`assertActiveMember`)
  *   - no thread is already in flight for the same triple
@@ -92,13 +96,16 @@ agreements.post(
   '/propose',
   procedure({
     policy: { auth: 'required', requireOrgMembership: true },
-    input: { body: proposeAgreementInputSchema },
+    input: {
+      query: proposeAgreementQuerySchema,
+      body: proposeAgreementInputSchema,
+    },
     successStatus: 201,
     handler: async (ctx) => {
-      // Forward `ctx.organizationId` (resolved from membership, not from
-      // the client body) so a client cannot redirect the propose into a
-      // different org by spoofing the body field. This mirrors the
-      // hardening pattern documented in `routes/sales.ts`.
+      // Forward `ctx.organizationId` (resolved from `?organizationId=`
+      // in the query by `procedure()`'s membership gate) so a client
+      // cannot redirect the propose into a different org. This mirrors
+      // the hardening pattern documented in `routes/sales.ts`.
       return await ctx.services.agreements.proposeAgreement({
         organizationId: ctx.organizationId,
         creatorId: ctx.input.body.creatorId,
@@ -153,8 +160,9 @@ agreements.post(
  * (mark accepted → supersede siblings → terminate predecessor active
  * agreement → insert new active row with dual-write of the legacy
  * `organization_fee_percentage` column). Returns the new active
- * `CreatorOrganizationAgreement` row with 200 — this is a state-change
- * verb on an existing resource, not a create.
+ * `CreatorOrganizationAgreement` row with 201 — accepting a proposal
+ * CREATES a new active agreement row + supersedes prior, so the
+ * create-semantic status applies even though the verb is "accept".
  */
 agreements.post(
   '/:proposalId/accept',
@@ -162,8 +170,8 @@ agreements.post(
     policy: { auth: 'required' },
     input: {
       params: proposalIdParamSchema,
-      body: acceptProposalInputSchema,
     },
+    successStatus: 201,
     handler: async (ctx) => {
       return await ctx.services.agreements.acceptProposal({
         proposalId: ctx.input.params.proposalId,
@@ -209,7 +217,6 @@ agreements.post(
     policy: { auth: 'required' },
     input: {
       params: proposalIdParamSchema,
-      body: withdrawProposalInputSchema,
     },
     handler: async (ctx) => {
       return await ctx.services.agreements.withdrawProposal({
@@ -254,9 +261,12 @@ agreements.post(
 /**
  * GET /agreements?organizationId=...
  *
- * Owner-view list of active agreements on the org. The service receives
- * `ctx.organizationId` (resolved from membership, not body) so a forged
- * `organizationId` query param cannot redirect the read to another org.
+ * Owner/admin-view list of active agreements on the org. Gated with
+ * `requireOrgManagement: true` (owner OR admin only) — rank-and-file
+ * members must NOT see peer creator shares. The service receives
+ * `ctx.organizationId` (resolved from membership, not the body) so a
+ * forged `organizationId` query param cannot redirect the read to
+ * another org.
  *
  * Returns a paginated envelope even though the service returns the full
  * list — keeps the contract consistent with every other list endpoint in
@@ -266,7 +276,7 @@ agreements.post(
 agreements.get(
   '/',
   procedure({
-    policy: { auth: 'required', requireOrgMembership: true },
+    policy: { auth: 'required', requireOrgManagement: true },
     input: { query: listAgreementsQuerySchema },
     handler: async (ctx) => {
       const items = await ctx.services.agreements.getActiveAgreements({
@@ -278,6 +288,10 @@ agreements.get(
       const filtered = ctx.input.query.revenueType
         ? items.filter((a) => a.revenueType === ctx.input.query.revenueType)
         : items;
+      // TODO(pagination): proper page+limit support when row counts grow
+      // beyond a single studio-page render. Today the synthetic envelope
+      // returns all rows as one page; the service is the natural place
+      // to push offset/limit when that ceiling is reached.
       return new PaginatedResult(filtered, {
         page: 1,
         limit: filtered.length,
@@ -291,18 +305,20 @@ agreements.get(
 /**
  * GET /agreements/threads/:creatorId?revenueType=...
  *
- * Owner-view negotiation thread for one (creator, revenueType) triple
- * on this org. Returns chronological proposal history — used by the
- * studio settings/revenue-share page to render the negotiation timeline.
+ * Owner/admin-view negotiation thread for one (creator, revenueType)
+ * triple on this org. Returns chronological proposal history — used by
+ * the studio settings/revenue-share page to render the negotiation
+ * timeline.
  *
- * `requireOrgMembership: true` resolves `ctx.organizationId`; the
- * service will fall through with an empty array if no thread exists yet
- * for the triple.
+ * Gated with `requireOrgManagement: true` (owner OR admin only) — same
+ * reasoning as GET /agreements: rank-and-file members must not see peer
+ * negotiation details. The service will fall through with an empty
+ * array if no thread exists yet for the triple.
  */
 agreements.get(
   '/threads/:creatorId',
   procedure({
-    policy: { auth: 'required', requireOrgMembership: true },
+    policy: { auth: 'required', requireOrgManagement: true },
     input: {
       params: ownerThreadParamSchema,
       query: getNegotiationThreadQuerySchema,
@@ -337,15 +353,25 @@ interface CreatorAgreementWithPeers {
   organizationFeePercentage: number;
   currentProposalId: string | null;
   terminatedAt: Date | null;
-  /** Anonymised aggregate of every OTHER active creator on the same org. */
+  /**
+   * Anonymised aggregate of every OTHER active creator in the SAME
+   * (orgId, revenueType) pool. Subscription peers and content_purchase
+   * peers are NEVER combined — they are separate revenue pools per the
+   * locked epic decision Q1 (see `project_revenue_share_decisions.md`).
+   */
   peers: {
     count: number;
     /**
-     * Sum of basis-point shares across peer creators. Computed from
-     * `10000 - organizationFeePercentage` per row (legacy column;
-     * dual-written by `acceptProposal`). When WP-4 swaps the read path
-     * to `current_proposal_id.proposed_creator_share_percent`, this
-     * computation should track.
+     * Sum of basis-point shares across peer creators in this SAME
+     * (orgId, revenueType) pool, 0–10000. Used by the UI to show "your
+     * share vs. the rest of the team in this pool". Per the locked epic
+     * decision Q1, subscription and content_purchase are separate
+     * pools — peers across pools are never aggregated together.
+     *
+     * Computed from `10000 - organizationFeePercentage` per row (legacy
+     * column; dual-written by `acceptProposal`). When WP-4 swaps the
+     * read path to `current_proposal_id.proposed_creator_share_percent`,
+     * this computation should track.
      */
     aggregateSharePercent: number;
   };
@@ -386,7 +412,11 @@ agreements.get(
         new Set(own.map((a) => a.organizationId))
       );
 
-      const peerByOrg = new Map<
+      // Peer aggregate keyed on `(orgId, revenueType)`. Per the locked
+      // epic decision Q1 (`project_revenue_share_decisions.md`),
+      // subscription and content_purchase are SEPARATE revenue pools —
+      // peers must never be aggregated across pools.
+      const peerByOrgAndType = new Map<
         string,
         { count: number; aggregateSharePercent: number }
       >();
@@ -395,23 +425,30 @@ agreements.get(
           const all = await ctx.services.agreements.getActiveAgreements({
             organizationId: orgId,
           });
-          const peers = all.filter((row) => row.creatorId !== ctx.user.id);
-          // The legacy `organization_fee_percentage` column is the
-          // dual-write source of truth for active rows today (per WP-1
-          // discoveries). `share = 10000 - fee`.
-          const aggregate = peers.reduce(
-            (sum, p) => sum + (10000 - p.organizationFeePercentage),
-            0
-          );
-          peerByOrg.set(orgId, {
-            count: peers.length,
-            aggregateSharePercent: aggregate,
-          });
+          for (const revType of ['subscription', 'content_purchase'] as const) {
+            const peersInType = all.filter(
+              (row) =>
+                row.revenueType === revType && row.creatorId !== ctx.user.id
+            );
+            // The legacy `organization_fee_percentage` column is the
+            // dual-write source of truth for active rows today (per WP-1
+            // discoveries). `share = 10000 - fee`.
+            const aggregate = peersInType.reduce(
+              (sum, p) => sum + (10000 - p.organizationFeePercentage),
+              0
+            );
+            peerByOrgAndType.set(`${orgId}:${revType}`, {
+              count: peersInType.length,
+              aggregateSharePercent: aggregate,
+            });
+          }
         })
       );
 
       const enriched: CreatorAgreementWithPeers[] = own.map((row) => {
-        const peers = peerByOrg.get(row.organizationId) ?? {
+        const peers = peerByOrgAndType.get(
+          `${row.organizationId}:${row.revenueType}`
+        ) ?? {
           count: 0,
           aggregateSharePercent: 0,
         };
@@ -473,24 +510,35 @@ agreements.get(
         creatorId: ctx.user.id,
       });
 
-      // Build the candidate set of threads keyed on the (org,
-      // revenueType) pairs the caller participates in. A creator may
-      // have terminated agreements that don't appear in `own` — those
-      // threads remain accessible only if the caller has at least one
-      // surviving active agreement on that org. This is the intended
-      // visibility surface for the negotiations page.
-      for (const agreement of own) {
-        const thread = await ctx.services.agreements.getNegotiationThread({
-          organizationId: agreement.organizationId,
-          creatorId: ctx.user.id,
-          revenueType: agreement.revenueType as
-            | 'subscription'
-            | 'content_purchase',
-        });
-        const match = thread.find((p) => p.id === ctx.input.params.proposalId);
-        if (match) {
-          return thread;
-        }
+      // Parallel fetch: each thread is one DB roundtrip; with M
+      // agreements across orgs this is M parallel queries, not M
+      // sequential. The DB CHECK constraint guarantees `revenueType` is
+      // one of the two enum values, but we runtime-guard before the
+      // narrowing cast so a future schema change surfaces loudly rather
+      // than silently lying to the type system.
+      const candidates = await Promise.all(
+        own.map((a) => {
+          if (
+            a.revenueType !== 'subscription' &&
+            a.revenueType !== 'content_purchase'
+          ) {
+            throw new Error(
+              `Unexpected revenueType on agreement ${a.id}: ${a.revenueType}`
+            );
+          }
+          return ctx.services.agreements.getNegotiationThread({
+            organizationId: a.organizationId,
+            creatorId: ctx.user.id,
+            revenueType: a.revenueType,
+          });
+        })
+      );
+
+      const match = candidates.find((thread) =>
+        thread.some((p) => p.id === ctx.input.params.proposalId)
+      );
+      if (match) {
+        return match;
       }
 
       // Fall through: the caller has no thread containing this

--- a/workers/ecom-api/src/routes/agreements.ts
+++ b/workers/ecom-api/src/routes/agreements.ts
@@ -1,0 +1,507 @@
+/**
+ * Revenue-Share Agreement Routes (Codex-hqke2 — WP-3 of epic Codex-nk4km)
+ *
+ * HTTP boundary over `@codex/agreements` `AgreementService` (WP-2 / PR
+ * #210). All endpoints use `procedure()` and consume services via
+ * `ctx.services.agreements` — never instantiate the service inline.
+ *
+ * Authorisation contract:
+ *
+ *   - Owner-side mutations (`POST /agreements/propose`) and owner-side
+ *     reads (`GET /agreements`) gate at the route layer with
+ *     `requireOrgMembership: true` to resolve `ctx.organizationId`. The
+ *     SERVICE then enforces strict ownership via `assertActiveOwner` —
+ *     the route does NOT re-check owner-role. This keeps the
+ *     authorisation rules in one place and means a future Owner-vs-Admin
+ *     split lands once, in the service, without rewriting routes.
+ *
+ *   - Counterparty mutations (`accept` / `decline` / `counter` /
+ *     `withdraw`) gate at the route layer with `auth: 'required'` only
+ *     — the service determines the counterparty role from the parent
+ *     proposal's `proposedByRole` and matches against `ctx.user.id`.
+ *
+ *   - `terminate` is open to either party — service enforces.
+ *
+ *   - Creator self-read (`GET /agreements/me`) gates at the route layer
+ *     with `auth: 'required'` only — the service-side query is already
+ *     scoped on `creatorId = ctx.user.id`.
+ *
+ * Anonymisation contract (visibility decision in the epic plan):
+ *
+ *   - Owner-view (`GET /agreements`) returns every active row on the
+ *     org with full identifying fields. No masking.
+ *
+ *   - Creator-view (`GET /agreements/me`) returns the creator's own
+ *     rows ENRICHED with a single aggregate slice for the rest of the
+ *     org:
+ *       `peers: { count: number, aggregateSharePercent: number }`
+ *     The aggregate is computed in the route handler — the SERVICE
+ *     stays free of UI-visibility logic so a future BO/internal tool can
+ *     consume the unshaped query if needed. NEVER include peer
+ *     `creatorId` / `userId` / display fields in the creator-view
+ *     response. The test suite has explicit pin tests for this.
+ *
+ * Error mapping:
+ *
+ *   - Typed errors (`AgreementNotFoundError`, `InvalidProposalStateError`,
+ *     `ShareExceedsAvailableError`, `ForbiddenError`) propagate up to
+ *     `mapErrorToResponse()` via `procedure()`. Routes do NOT catch.
+ *
+ * See plan `/Users/brucemckay/.claude/plans/ok-awesome-we-unified-flamingo.md`
+ * sections "Service Layer / Worker API" and "Visibility" decision.
+ */
+
+import { NotFoundError } from '@codex/service-errors';
+import type { HonoEnv } from '@codex/shared-types';
+import {
+  acceptProposalInputSchema,
+  agreementIdParamSchema,
+  counterProposeInputSchema,
+  declineProposalInputSchema,
+  getNegotiationThreadQuerySchema,
+  listAgreementsQuerySchema,
+  ownerThreadParamSchema,
+  proposalIdParamSchema,
+  proposeAgreementInputSchema,
+  terminateAgreementInputSchema,
+  withdrawProposalInputSchema,
+} from '@codex/validation';
+import { PaginatedResult, procedure } from '@codex/worker-utils';
+import { Hono } from 'hono';
+
+const agreements = new Hono<HonoEnv>();
+
+// ─── Owner-side mutations ─────────────────────────────────────────────────
+
+/**
+ * POST /agreements/propose
+ *
+ * Owner-initiated round 1 proposal. The body carries the target
+ * `organizationId` (resolved by `procedure()`'s membership gate into
+ * `ctx.organizationId`) and creator / revenue-type / share / term /
+ * note. The service enforces:
+ *   - actor is an active owner of the org (`assertActiveOwner`)
+ *   - target user is an active member of the org (`assertActiveMember`)
+ *   - no thread is already in flight for the same triple
+ *   - proposed share fits within the post-platform pool
+ *
+ * Returns the new proposal row (`{ data: AgreementProposal }`) with HTTP
+ * 201 — POST-create semantics matching the rest of the worker.
+ */
+agreements.post(
+  '/propose',
+  procedure({
+    policy: { auth: 'required', requireOrgMembership: true },
+    input: { body: proposeAgreementInputSchema },
+    successStatus: 201,
+    handler: async (ctx) => {
+      // Forward `ctx.organizationId` (resolved from membership, not from
+      // the client body) so a client cannot redirect the propose into a
+      // different org by spoofing the body field. This mirrors the
+      // hardening pattern documented in `routes/sales.ts`.
+      return await ctx.services.agreements.proposeAgreement({
+        organizationId: ctx.organizationId,
+        creatorId: ctx.input.body.creatorId,
+        revenueType: ctx.input.body.revenueType,
+        sharePercent: ctx.input.body.sharePercent,
+        termMonths: ctx.input.body.termMonths,
+        note: ctx.input.body.note ?? null,
+        proposedByUserId: ctx.user.id,
+        effectiveFrom: ctx.input.body.effectiveFrom,
+      });
+    },
+  })
+);
+
+// ─── Counterparty mutations ───────────────────────────────────────────────
+
+/**
+ * POST /agreements/:proposalId/counter
+ *
+ * Counter-proposal. The service derives the actor role from the parent
+ * proposal (`proposed_by_role` flips), so the route's auth gate is
+ * just `auth: 'required'`. The service rejects the request with
+ * `ForbiddenError` if `ctx.user.id` is not the appropriate counterparty.
+ *
+ * Successful counters return the NEW child proposal row with 201.
+ */
+agreements.post(
+  '/:proposalId/counter',
+  procedure({
+    policy: { auth: 'required' },
+    input: {
+      params: proposalIdParamSchema,
+      body: counterProposeInputSchema,
+    },
+    successStatus: 201,
+    handler: async (ctx) => {
+      return await ctx.services.agreements.counterPropose({
+        proposalId: ctx.input.params.proposalId,
+        sharePercent: ctx.input.body.sharePercent,
+        termMonths: ctx.input.body.termMonths,
+        note: ctx.input.body.note ?? null,
+        counteredByUserId: ctx.user.id,
+      });
+    },
+  })
+);
+
+/**
+ * POST /agreements/:proposalId/accept
+ *
+ * Accept an open proposal. Service performs the atomic 6-step write
+ * (mark accepted → supersede siblings → terminate predecessor active
+ * agreement → insert new active row with dual-write of the legacy
+ * `organization_fee_percentage` column). Returns the new active
+ * `CreatorOrganizationAgreement` row with 200 — this is a state-change
+ * verb on an existing resource, not a create.
+ */
+agreements.post(
+  '/:proposalId/accept',
+  procedure({
+    policy: { auth: 'required' },
+    input: {
+      params: proposalIdParamSchema,
+      body: acceptProposalInputSchema,
+    },
+    handler: async (ctx) => {
+      return await ctx.services.agreements.acceptProposal({
+        proposalId: ctx.input.params.proposalId,
+        acceptedByUserId: ctx.user.id,
+      });
+    },
+  })
+);
+
+/**
+ * POST /agreements/:proposalId/decline
+ *
+ * Decline an open proposal. Optional reason captured in
+ * `agreement_proposals.decline_reason` for audit.
+ */
+agreements.post(
+  '/:proposalId/decline',
+  procedure({
+    policy: { auth: 'required' },
+    input: {
+      params: proposalIdParamSchema,
+      body: declineProposalInputSchema,
+    },
+    handler: async (ctx) => {
+      return await ctx.services.agreements.declineProposal({
+        proposalId: ctx.input.params.proposalId,
+        declinedByUserId: ctx.user.id,
+        reason: ctx.input.body.reason ?? null,
+      });
+    },
+  })
+);
+
+/**
+ * POST /agreements/:proposalId/withdraw
+ *
+ * Withdraw an open proposal. Only the side that proposed may withdraw —
+ * service enforces.
+ */
+agreements.post(
+  '/:proposalId/withdraw',
+  procedure({
+    policy: { auth: 'required' },
+    input: {
+      params: proposalIdParamSchema,
+      body: withdrawProposalInputSchema,
+    },
+    handler: async (ctx) => {
+      return await ctx.services.agreements.withdrawProposal({
+        proposalId: ctx.input.params.proposalId,
+        withdrawnByUserId: ctx.user.id,
+      });
+    },
+  })
+);
+
+// ─── Termination ──────────────────────────────────────────────────────────
+
+/**
+ * POST /agreements/:agreementId/terminate
+ *
+ * Soft-terminate an active agreement. Either party may invoke — the
+ * service accepts the request if the actor is the named creator OR an
+ * active owner of the org. Mid-invoice termination semantics per the
+ * locked epic decision (Q3): no pro-rating, active-as-of-invoice-date
+ * receives the full cut for that period.
+ */
+agreements.post(
+  '/:agreementId/terminate',
+  procedure({
+    policy: { auth: 'required' },
+    input: {
+      params: agreementIdParamSchema,
+      body: terminateAgreementInputSchema,
+    },
+    handler: async (ctx) => {
+      return await ctx.services.agreements.terminateAgreement({
+        agreementId: ctx.input.params.agreementId,
+        terminatedByUserId: ctx.user.id,
+        reason: ctx.input.body.reason ?? null,
+      });
+    },
+  })
+);
+
+// ─── Owner-side reads ─────────────────────────────────────────────────────
+
+/**
+ * GET /agreements?organizationId=...
+ *
+ * Owner-view list of active agreements on the org. The service receives
+ * `ctx.organizationId` (resolved from membership, not body) so a forged
+ * `organizationId` query param cannot redirect the read to another org.
+ *
+ * Returns a paginated envelope even though the service returns the full
+ * list — keeps the contract consistent with every other list endpoint in
+ * the worker and gives the UI room to switch to server-side pagination
+ * if the active count ever grows beyond what fits on one page.
+ */
+agreements.get(
+  '/',
+  procedure({
+    policy: { auth: 'required', requireOrgMembership: true },
+    input: { query: listAgreementsQuerySchema },
+    handler: async (ctx) => {
+      const items = await ctx.services.agreements.getActiveAgreements({
+        organizationId: ctx.organizationId,
+      });
+      // Owner-view filtering by revenueType is shaping in the route — the
+      // service intentionally returns both buckets in one query to avoid
+      // N+1 on the studio settings page.
+      const filtered = ctx.input.query.revenueType
+        ? items.filter((a) => a.revenueType === ctx.input.query.revenueType)
+        : items;
+      return new PaginatedResult(filtered, {
+        page: 1,
+        limit: filtered.length,
+        total: filtered.length,
+        totalPages: 1,
+      });
+    },
+  })
+);
+
+/**
+ * GET /agreements/threads/:creatorId?revenueType=...
+ *
+ * Owner-view negotiation thread for one (creator, revenueType) triple
+ * on this org. Returns chronological proposal history — used by the
+ * studio settings/revenue-share page to render the negotiation timeline.
+ *
+ * `requireOrgMembership: true` resolves `ctx.organizationId`; the
+ * service will fall through with an empty array if no thread exists yet
+ * for the triple.
+ */
+agreements.get(
+  '/threads/:creatorId',
+  procedure({
+    policy: { auth: 'required', requireOrgMembership: true },
+    input: {
+      params: ownerThreadParamSchema,
+      query: getNegotiationThreadQuerySchema,
+    },
+    handler: async (ctx) => {
+      return await ctx.services.agreements.getNegotiationThread({
+        organizationId: ctx.organizationId,
+        creatorId: ctx.input.params.creatorId,
+        revenueType: ctx.input.query.revenueType,
+      });
+    },
+  })
+);
+
+// ─── Creator-side reads ───────────────────────────────────────────────────
+
+/**
+ * Internal type for the creator-view enriched row. The shape is
+ * intentionally NOT exported from `@codex/agreements` — anonymisation is
+ * a UI-visibility concern owned by this route boundary, not the service
+ * layer. If a different consumer wants the unshaped data, they call
+ * `service.getActiveAgreementsForCreator()` directly.
+ */
+interface CreatorAgreementWithPeers {
+  id: string;
+  organizationId: string;
+  creatorId: string;
+  revenueType: string;
+  status: string;
+  effectiveFrom: Date;
+  effectiveUntil: Date | null;
+  organizationFeePercentage: number;
+  currentProposalId: string | null;
+  terminatedAt: Date | null;
+  /** Anonymised aggregate of every OTHER active creator on the same org. */
+  peers: {
+    count: number;
+    /**
+     * Sum of basis-point shares across peer creators. Computed from
+     * `10000 - organizationFeePercentage` per row (legacy column;
+     * dual-written by `acceptProposal`). When WP-4 swaps the read path
+     * to `current_proposal_id.proposed_creator_share_percent`, this
+     * computation should track.
+     */
+    aggregateSharePercent: number;
+  };
+}
+
+/**
+ * GET /agreements/me
+ *
+ * Creator-view portfolio across every org the caller has agreements
+ * with. Service returns the creator's own rows (already scoped on
+ * `creatorId = ctx.user.id`); this handler ENRICHES each row with an
+ * anonymised aggregate of every other active creator on the same org
+ * (`peers.count` + `peers.aggregateSharePercent`).
+ *
+ * Per-org peer queries are unavoidable today — the service intentionally
+ * keeps its query surface narrow, and the orgs the caller participates
+ * in are typically few (1-3 in practice). If a power user ever ends up
+ * with many orgs, we can add a batched `getActiveAgreementsForOrgs`
+ * service method without changing this response shape.
+ *
+ * NEVER include peer identifying fields (peer creatorId / userId /
+ * display fields) in the response — the test suite has explicit
+ * coverage of this.
+ */
+agreements.get(
+  '/me',
+  procedure({
+    policy: { auth: 'required' },
+    handler: async (ctx) => {
+      const own = await ctx.services.agreements.getActiveAgreementsForCreator({
+        creatorId: ctx.user.id,
+      });
+
+      // Dedup org ids — many of the caller's rows are likely on the
+      // same org (subscription + content_purchase agreements with the
+      // same org) so we share one peer fetch across them.
+      const uniqueOrgIds = Array.from(
+        new Set(own.map((a) => a.organizationId))
+      );
+
+      const peerByOrg = new Map<
+        string,
+        { count: number; aggregateSharePercent: number }
+      >();
+      await Promise.all(
+        uniqueOrgIds.map(async (orgId) => {
+          const all = await ctx.services.agreements.getActiveAgreements({
+            organizationId: orgId,
+          });
+          const peers = all.filter((row) => row.creatorId !== ctx.user.id);
+          // The legacy `organization_fee_percentage` column is the
+          // dual-write source of truth for active rows today (per WP-1
+          // discoveries). `share = 10000 - fee`.
+          const aggregate = peers.reduce(
+            (sum, p) => sum + (10000 - p.organizationFeePercentage),
+            0
+          );
+          peerByOrg.set(orgId, {
+            count: peers.length,
+            aggregateSharePercent: aggregate,
+          });
+        })
+      );
+
+      const enriched: CreatorAgreementWithPeers[] = own.map((row) => {
+        const peers = peerByOrg.get(row.organizationId) ?? {
+          count: 0,
+          aggregateSharePercent: 0,
+        };
+        return {
+          id: row.id,
+          organizationId: row.organizationId,
+          creatorId: row.creatorId,
+          revenueType: row.revenueType,
+          status: row.status,
+          effectiveFrom: row.effectiveFrom,
+          effectiveUntil: row.effectiveUntil,
+          organizationFeePercentage: row.organizationFeePercentage,
+          currentProposalId: row.currentProposalId,
+          terminatedAt: row.terminatedAt,
+          peers,
+        };
+      });
+
+      return new PaginatedResult(enriched, {
+        page: 1,
+        limit: enriched.length,
+        total: enriched.length,
+        totalPages: 1,
+      });
+    },
+  })
+);
+
+/**
+ * GET /agreements/me/threads/:proposalId
+ *
+ * Creator-view of a single negotiation thread, fetched by any proposal
+ * id within the thread. The handler:
+ *   1. asserts the proposal exists and that the caller is the named
+ *      creator (`ForbiddenError` otherwise)
+ *   2. returns the full chronological thread for the (org, creator,
+ *      revenueType) triple
+ *
+ * Since the creator is the only non-owner party on their own thread,
+ * no anonymisation is needed — the proposals show owner and creator
+ * actions side by side, both of which the creator is entitled to see.
+ *
+ * We use a service-level "list this thread by proposal id" composition
+ * because the service intentionally doesn't expose a `getProposal(id)`
+ * surface; we fetch the thread by triple, then narrow to the row(s)
+ * matching the proposal id to assert membership.
+ */
+agreements.get(
+  '/me/threads/:proposalId',
+  procedure({
+    policy: { auth: 'required' },
+    input: { params: proposalIdParamSchema },
+    handler: async (ctx) => {
+      // Pull the creator's own agreements first to enumerate which
+      // (org, revenueType) threads they participate in, then locate the
+      // requested proposal among them. This keeps the service surface
+      // narrow and never reveals threads the caller isn't on.
+      const own = await ctx.services.agreements.getActiveAgreementsForCreator({
+        creatorId: ctx.user.id,
+      });
+
+      // Build the candidate set of threads keyed on the (org,
+      // revenueType) pairs the caller participates in. A creator may
+      // have terminated agreements that don't appear in `own` — those
+      // threads remain accessible only if the caller has at least one
+      // surviving active agreement on that org. This is the intended
+      // visibility surface for the negotiations page.
+      for (const agreement of own) {
+        const thread = await ctx.services.agreements.getNegotiationThread({
+          organizationId: agreement.organizationId,
+          creatorId: ctx.user.id,
+          revenueType: agreement.revenueType as
+            | 'subscription'
+            | 'content_purchase',
+        });
+        const match = thread.find((p) => p.id === ctx.input.params.proposalId);
+        if (match) {
+          return thread;
+        }
+      }
+
+      // Fall through: the caller has no thread containing this
+      // proposal. Surface a 404 rather than a 403 so the route does NOT
+      // confirm or deny existence — same hardening pattern as
+      // single-row GETs across the codebase.
+      throw new NotFoundError('Proposal thread not found', {
+        proposalId: ctx.input.params.proposalId,
+      });
+    },
+  })
+);
+
+export default agreements;


### PR DESCRIPTION
## Summary

WP-3 of the Revenue-Share Agreements epic (Codex-nk4km). Wraps WP-2's `AgreementService` in 8 Hono routes via `procedure()`.

- Owner-side mutations (propose) and reads (list, owner-thread) — `requireOrgMembership` gates the route, the service enforces strict ownership via `assertActiveOwner`
- Counterparty mutations (accept, decline, counter, withdraw) — `auth: 'required'` only; service derives counterparty from the parent proposal and matches against `ctx.user.id`
- Termination — either party; service enforces creator-on-row OR active-owner
- Creator self-read (`GET /agreements/me`) — service-side query scoped on `creatorId = ctx.user.id`
- Zod schemas in `@codex/validation/agreements` with basis-point + term-month + enum bounds
- 46 integration tests cover authz (positive AND negative), validation, error mapping, cross-org safety, and the load-bearing anonymisation contract

## Anonymisation contract

`GET /agreements/me` returns the caller's own rows enriched with a single aggregate slice for the rest of the org:

```
peers: { count: number, aggregateSharePercent: number }
```

Peer creator ids / user ids / display fields are NEVER exposed. The test suite grep-asserts this — if any peer id leaks into the response body, the test fails.

## Base branch

This PR stacks on `feat/codex-tnft0-agreement-service` (WP-2, PR #210). When the chain merges, this rebases onto `main`.

## Test plan

- [x] `pnpm --filter ecom-api test src/routes/__tests__/agreements-routes.test.ts` — 46 passed
- [x] `pnpm --filter @codex/validation typecheck` — clean
- [x] `pnpm --filter ecom-api typecheck` — clean
- [x] `pnpm --filter ecom-api build` — clean
- [x] All other ecom-api route test files still pass in isolation (rate-limits, sales, subscriptions-mgmt/read/invalidation)
- [x] Manual review: every route uses `procedure()` + service registry, never `new AgreementService(...)` inline
- [x] Manual review: GET /agreements/me response shape never leaks peer userId / creatorId / display fields

Note: pre-existing main-drift causes 11 unrelated validation-package test failures (`content-schemas.test.ts`, `settings.test.ts`) and workerd network errors when running the full ecom-api suite in one go — same flake observed on WP-2's branch. Out of scope for this epic.

Bead: Codex-hqke2
Epic: Codex-nk4km