### PR TITLE
feat(payouts): WP-4 multi-creator splits via agreements

### DIFF
--- a/packages/agreements/package.json
+++ b/packages/agreements/package.json
@@ -37,7 +37,6 @@
     "@codex/constants": "workspace:*",
     "@codex/database": "workspace:*",
     "@codex/observability": "workspace:*",
-    "@codex/purchase": "workspace:*",
     "@codex/service-errors": "workspace:*",
     "@codex/shared-types": "workspace:*",
     "@codex/validation": "workspace:*",

--- a/packages/agreements/src/index.ts
+++ b/packages/agreements/src/index.ts
@@ -31,6 +31,7 @@ export {
   AgreementService,
   type AgreementServiceConfig,
   type CounterProposeInput,
+  creatorShareFromLegacyOrgFee,
   type DeclineProposalInput,
   legacyOrgFeeFromCreatorShare,
   type ProposeAgreementInput,

--- a/packages/agreements/src/services/__tests__/agreement-service.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-service.test.ts
@@ -1109,4 +1109,267 @@ describe('AgreementService', () => {
       expect(thread).toEqual([]);
     });
   });
+
+  // ── WP-4 payout-pipeline read filters (Codex-rzfjw) ────────────────────
+  //
+  // The payout pipeline at invoice time needs three new query shapes:
+  //   - filter by revenueType (subscription vs content_purchase)
+  //   - filter by activeAt (active-as-of-invoice-date — Decision Q3, no
+  //     pro-rating)
+  //   - lookup a single (org, creator, revenueType) tuple — the
+  //     content-purchase pipeline does this per purchase keyed on the
+  //     uploader (Decision Q1 — creator's-own-content scope)
+  //
+  // Money code. Positive + negative + edge tests each.
+  describe('WP-4 payout-pipeline read filters', () => {
+    it('getActiveAgreements filters by revenueType', async () => {
+      const fx = await seedOrgFixture(db);
+      await db.insert(schema.creatorOrganizationAgreements).values([
+        {
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          organizationFeePercentage: 7000,
+          revenueType: 'subscription',
+          status: 'active',
+        },
+        {
+          organizationId: fx.orgId,
+          creatorId: fx.creatorBId,
+          organizationFeePercentage: 5000,
+          revenueType: 'content_purchase',
+          status: 'active',
+        },
+      ]);
+      const subOnly = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+        revenueType: 'subscription',
+      });
+      expect(subOnly).toHaveLength(1);
+      expect(subOnly[0]?.creatorId).toBe(fx.creatorAId);
+      const cpOnly = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+        revenueType: 'content_purchase',
+      });
+      expect(cpOnly).toHaveLength(1);
+      expect(cpOnly[0]?.creatorId).toBe(fx.creatorBId);
+    });
+
+    it('getActiveAgreements: terminated_at > activeAt still surfaces (Q3 no pro-rating)', async () => {
+      // Decision Q3: whoever holds an active agreement at invoice fire
+      // time receives the full cut. Terminated AFTER invoice date is
+      // still active AS OF the invoice date.
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      const terminatedAt = new Date('2026-01-20T00:00:00Z'); // 5 days later
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'terminated', // status was flipped on termination
+        terminatedAt,
+        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
+      });
+      const results = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+        activeAt: invoiceAt,
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0]?.creatorId).toBe(fx.creatorAId);
+    });
+
+    it('getActiveAgreements: terminated_at <= activeAt does NOT surface', async () => {
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      const terminatedAt = new Date('2026-01-10T00:00:00Z'); // 5 days before
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'terminated',
+        terminatedAt,
+        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
+      });
+      const results = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+        activeAt: invoiceAt,
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it('getActiveAgreements: effective_from > activeAt does NOT surface (future agreement)', async () => {
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      const effectiveFrom = new Date('2026-02-01T00:00:00Z'); // future
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'active',
+        effectiveFrom,
+      });
+      const results = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+        activeAt: invoiceAt,
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it('getActiveAgreements: effective_until <= activeAt does NOT surface (legacy time-slice)', async () => {
+      // Defence in depth: legacy `effective_until` filter still trims
+      // any rows whose explicit end-date is in the past.
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'active',
+        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
+        effectiveUntil: new Date('2026-01-01T00:00:00Z'), // ended before invoice
+      });
+      const results = await service.getActiveAgreements({
+        organizationId: fx.orgId,
+        activeAt: invoiceAt,
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it('getActiveAgreement (singular): returns matching active row', async () => {
+      const fx = await seedOrgFixture(db);
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'content_purchase',
+        status: 'active',
+      });
+      const result = await service.getActiveAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'content_purchase',
+      });
+      expect(result).not.toBeNull();
+      expect(result?.creatorId).toBe(fx.creatorAId);
+      expect(result?.revenueType).toBe('content_purchase');
+    });
+
+    it('getActiveAgreement: returns null when no matching agreement', async () => {
+      const fx = await seedOrgFixture(db);
+      const result = await service.getActiveAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('getActiveAgreement: wrong revenueType returns null', async () => {
+      const fx = await seedOrgFixture(db);
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'active',
+      });
+      const result = await service.getActiveAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'content_purchase',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('getActiveAgreement: terminated before activeAt returns null', async () => {
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'terminated',
+        terminatedAt: new Date('2026-01-10T00:00:00Z'),
+        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
+      });
+      const result = await service.getActiveAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        activeAt: invoiceAt,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('getActiveAgreement: terminated AFTER activeAt still returns the agreement (Q3)', async () => {
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'terminated',
+        terminatedAt: new Date('2026-01-20T00:00:00Z'), // terminated AFTER invoice
+        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
+      });
+      const result = await service.getActiveAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        activeAt: invoiceAt,
+      });
+      expect(result).not.toBeNull();
+    });
+
+    it('getActiveAgreement: effective_from > activeAt returns null (not yet active)', async () => {
+      const fx = await seedOrgFixture(db);
+      const invoiceAt = new Date('2026-01-15T00:00:00Z');
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        organizationFeePercentage: 7000,
+        revenueType: 'subscription',
+        status: 'active',
+        effectiveFrom: new Date('2026-02-01T00:00:00Z'),
+      });
+      const result = await service.getActiveAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        activeAt: invoiceAt,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('getActiveAgreementsForCreator: revenueType filter scopes the portfolio', async () => {
+      const fx = await seedOrgFixture(db);
+      await db.insert(schema.creatorOrganizationAgreements).values([
+        {
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          organizationFeePercentage: 7000,
+          revenueType: 'subscription',
+          status: 'active',
+        },
+        {
+          organizationId: fx.orgId,
+          creatorId: fx.creatorAId,
+          organizationFeePercentage: 5000,
+          revenueType: 'content_purchase',
+          status: 'active',
+        },
+      ]);
+      const subOnly = await service.getActiveAgreementsForCreator({
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+      });
+      expect(subOnly).toHaveLength(1);
+      expect(subOnly[0]?.revenueType).toBe('subscription');
+    });
+  });
 });

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -43,7 +43,18 @@ import {
   NotFoundError,
   type ServiceConfig,
 } from '@codex/service-errors';
-import { and, asc, desc, eq, inArray, isNull, ne } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  lte,
+  ne,
+  or,
+} from 'drizzle-orm';
 import { AgreementNotFoundError, InvalidProposalStateError } from '../errors';
 import type {
   AgreementProposal,
@@ -686,28 +697,58 @@ export class AgreementService extends BaseService {
   // ── Public: reads ───────────────────────────────────────────────────────
 
   /**
-   * Active agreements for an org — every `status='active'` row, both
-   * revenue types. Sorted by `effectiveFrom DESC` so the most recent
-   * agreements bubble up.
+   * Active agreements for an org. Sorted by `effectiveFrom DESC` so the
+   * most recent agreements bubble up.
+   *
+   * Filters (WP-4 / Codex-rzfjw):
+   * - `status='active'`
+   * - `terminatedAt IS NULL OR terminatedAt > activeAt` (Decision Q3:
+   *   no pro-rating — whoever holds an active agreement at invoice fire
+   *   time receives the full cut for that period)
+   * - `effectiveFrom <= activeAt` (an agreement scheduled to start in
+   *   the future never receives a payout for the current invoice)
+   * - `effectiveUntil IS NULL OR effectiveUntil > activeAt` (defence in
+   *   depth for the legacy time-sliced model)
+   * - optional `revenueType` filter (subscription | content_purchase)
+   *
+   * When `activeAt` is omitted, defaults to `new Date()`. The payout
+   * pipeline always passes the invoice's `created` timestamp so a
+   * webhook replay against the same invoice surfaces the same set of
+   * agreements regardless of clock drift.
    */
   async getActiveAgreements(input: {
     organizationId: string;
+    revenueType?: RevenueType;
+    activeAt?: Date;
   }): Promise<CreatorOrganizationAgreement[]> {
     try {
+      const at = input.activeAt ?? new Date();
       return await this.db.query.creatorOrganizationAgreements.findMany({
         where: and(
           eq(
             creatorOrganizationAgreements.organizationId,
             input.organizationId
           ),
-          eq(creatorOrganizationAgreements.status, 'active'),
-          // The agreements table doesn't carry a `deletedAt` column —
-          // termination is the soft-delete vector. The `terminatedAt`
-          // filter is defence-in-depth: a row in `active` should never
-          // also carry a `terminated_at` (enforced by
-          // `check_creator_org_agreement_terminated_shape`), but if a
-          // future bug skews them we still refuse to surface it.
-          isNull(creatorOrganizationAgreements.terminatedAt)
+          // Per Decision Q3: an agreement is "active at activeAt" if
+          // EITHER it is currently status='active' (never terminated,
+          // and the schema check enforces terminatedAt IS NULL), OR it
+          // was terminated AFTER activeAt (so it was still live at
+          // invoice fire time and earns the cut for that period).
+          or(
+            eq(creatorOrganizationAgreements.status, 'active'),
+            and(
+              eq(creatorOrganizationAgreements.status, 'terminated'),
+              gt(creatorOrganizationAgreements.terminatedAt, at)
+            )
+          ),
+          lte(creatorOrganizationAgreements.effectiveFrom, at),
+          or(
+            isNull(creatorOrganizationAgreements.effectiveUntil),
+            gt(creatorOrganizationAgreements.effectiveUntil, at)
+          ),
+          input.revenueType
+            ? eq(creatorOrganizationAgreements.revenueType, input.revenueType)
+            : undefined
         ),
         orderBy: [desc(creatorOrganizationAgreements.effectiveFrom)],
       });
@@ -717,18 +758,87 @@ export class AgreementService extends BaseService {
   }
 
   /**
+   * Single active agreement for one (org, creator, revenueType) triple,
+   * if any. Mirrors the partial unique
+   * `uq_creator_org_agreement_active_per_type` invariant — at most one
+   * row can be returned. Returns `null` when no active agreement
+   * matches.
+   *
+   * Used by the WP-4 content-purchase payout path (Codex-rzfjw): the
+   * uploader (`content.creatorId`) is looked up against their
+   * `revenueType='content_purchase'` agreement at purchase time
+   * (Decision Q1 — creator's-own-content scope).
+   *
+   * `activeAt` semantics match {@link getActiveAgreements}.
+   */
+  async getActiveAgreement(input: {
+    organizationId: string;
+    creatorId: string;
+    revenueType: RevenueType;
+    activeAt?: Date;
+  }): Promise<CreatorOrganizationAgreement | null> {
+    try {
+      const at = input.activeAt ?? new Date();
+      const row = await this.db.query.creatorOrganizationAgreements.findFirst({
+        where: and(
+          eq(
+            creatorOrganizationAgreements.organizationId,
+            input.organizationId
+          ),
+          eq(creatorOrganizationAgreements.creatorId, input.creatorId),
+          eq(creatorOrganizationAgreements.revenueType, input.revenueType),
+          // Q3 semantics (see getActiveAgreements above):
+          or(
+            eq(creatorOrganizationAgreements.status, 'active'),
+            and(
+              eq(creatorOrganizationAgreements.status, 'terminated'),
+              gt(creatorOrganizationAgreements.terminatedAt, at)
+            )
+          ),
+          lte(creatorOrganizationAgreements.effectiveFrom, at),
+          or(
+            isNull(creatorOrganizationAgreements.effectiveUntil),
+            gt(creatorOrganizationAgreements.effectiveUntil, at)
+          )
+        ),
+      });
+      return row ?? null;
+    } catch (error) {
+      this.handleError(error, 'getActiveAgreement');
+    }
+  }
+
+  /**
    * Creator's portfolio across all orgs — used by the creator-studio
-   * /negotiations page. Filters to `status='active'` only.
+   * /negotiations page. Filters to `status='active'` only with the same
+   * temporal predicates as {@link getActiveAgreements}.
    */
   async getActiveAgreementsForCreator(input: {
     creatorId: string;
+    revenueType?: RevenueType;
+    activeAt?: Date;
   }): Promise<CreatorOrganizationAgreement[]> {
     try {
+      const at = input.activeAt ?? new Date();
       return await this.db.query.creatorOrganizationAgreements.findMany({
         where: and(
           eq(creatorOrganizationAgreements.creatorId, input.creatorId),
-          eq(creatorOrganizationAgreements.status, 'active'),
-          isNull(creatorOrganizationAgreements.terminatedAt)
+          // Q3 semantics (see getActiveAgreements above):
+          or(
+            eq(creatorOrganizationAgreements.status, 'active'),
+            and(
+              eq(creatorOrganizationAgreements.status, 'terminated'),
+              gt(creatorOrganizationAgreements.terminatedAt, at)
+            )
+          ),
+          lte(creatorOrganizationAgreements.effectiveFrom, at),
+          or(
+            isNull(creatorOrganizationAgreements.effectiveUntil),
+            gt(creatorOrganizationAgreements.effectiveUntil, at)
+          ),
+          input.revenueType
+            ? eq(creatorOrganizationAgreements.revenueType, input.revenueType)
+            : undefined
         ),
         orderBy: [desc(creatorOrganizationAgreements.effectiveFrom)],
       });

--- a/packages/agreements/src/services/index.ts
+++ b/packages/agreements/src/services/index.ts
@@ -4,6 +4,7 @@
 
 export {
   type ActiveAgreementShareView,
+  creatorShareFromLegacyOrgFee,
   legacyOrgFeeFromCreatorShare,
   sumActiveCreatorShares,
   type ValidateProposedShareInput,

--- a/packages/purchase/package.json
+++ b/packages/purchase/package.json
@@ -34,6 +34,7 @@
     "format": "biome format --write ."
   },
   "dependencies": {
+    "@codex/agreements": "workspace:*",
     "@codex/cache": "workspace:*",
     "@codex/constants": "workspace:*",
     "@codex/database": "workspace:*",

--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -1447,6 +1447,307 @@ describe('PurchaseService Integration', () => {
     });
   });
 
+  // ─── WP-4 content-purchase agreement integration (Codex-rzfjw) ─────────
+  //
+  // Decision Q1: content-purchase revenue is attributed to the uploader
+  // (`content.creatorId`) — that creator's `revenueType='content_purchase'`
+  // agreement determines the split. If no agreement exists, the org keeps
+  // 100% of post-platform revenue (pre-agreements behaviour, fallback to
+  // FeeConfigService).
+  //
+  // These tests pin the WP-4 behaviour:
+  //   - agreement present  → split shifts toward creator per agreement share
+  //   - no agreement       → fallback to org fee resolved from feeConfig
+  //   - terminated         → not active, fallback fires
+  //   - wrong revenueType  → not used, fallback fires
+  //   - other creator's agreement on the same org → does NOT apply (Q1)
+  describe('completePurchase — WP-4 content-purchase agreements (Codex-rzfjw)', () => {
+    // Each test seeds an agreement on the same (org, creator) tuple and
+    // the schema's partial unique index `uq_creator_org_agreement_active_per_type`
+    // would reject the second test's insert. Clear any active rows for
+    // the shared org between tests.
+    beforeEach(async () => {
+      await db
+        .delete(schema.creatorOrganizationAgreements)
+        .where(
+          eq(
+            schema.creatorOrganizationAgreements.organizationId,
+            organizationId
+          )
+        );
+      await db
+        .delete(schema.agreementProposals)
+        .where(eq(schema.agreementProposals.organizationId, organizationId));
+    });
+
+    async function seedContentPurchaseAgreement(
+      orgId: string,
+      creatorId: string,
+      sharePercent: number,
+      options: {
+        status?: 'active' | 'terminated';
+        terminatedAt?: Date | null;
+        revenueType?: 'subscription' | 'content_purchase';
+      } = {}
+    ) {
+      const [proposal] = await db
+        .insert(schema.agreementProposals)
+        .values({
+          organizationId: orgId,
+          creatorId,
+          revenueType: options.revenueType ?? 'content_purchase',
+          roundNumber: 1,
+          proposedByUserId: creatorId,
+          proposedByRole: 'owner',
+          proposedCreatorSharePercent: sharePercent,
+          proposedTermMonths: null,
+          proposedEffectiveFrom: new Date(),
+          status: 'accepted',
+          respondedAt: new Date(),
+          respondedByUserId: creatorId,
+        })
+        .returning();
+      if (!proposal) throw new Error('seed proposal failed');
+      await db.insert(schema.creatorOrganizationAgreements).values({
+        organizationId: orgId,
+        creatorId,
+        organizationFeePercentage: 10_000 - sharePercent,
+        revenueType: options.revenueType ?? 'content_purchase',
+        status: options.status ?? 'active',
+        terminatedAt: options.terminatedAt ?? null,
+        currentProposalId: proposal.id,
+      });
+      return { proposalId: proposal.id };
+    }
+
+    async function seedPaidContent(opts: {
+      title: string;
+      priceCents: number;
+    }) {
+      const media = await mediaService.create(
+        {
+          title: opts.title,
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          fileSizeBytes: 1024 * 1024,
+        },
+        userId
+      );
+      await mediaService.markAsReady(
+        media.id,
+        {
+          hlsMasterPlaylistKey: `hls/${opts.title}/master.m3u8`,
+          thumbnailKey: `thumbnails/${opts.title}.jpg`,
+          durationSeconds: 60,
+        },
+        userId
+      );
+      const content = await contentService.create(
+        {
+          organizationId,
+          title: opts.title,
+          slug: createUniqueSlug(opts.title.toLowerCase().replace(/\s+/g, '-')),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'purchased_only',
+          accessType: 'paid',
+          priceCents: opts.priceCents,
+        },
+        userId
+      );
+      await contentService.publish(content.id, userId);
+      return { content };
+    }
+
+    it('WP-4: content_purchase agreement overrides default org fee — creator receives agreement share of post-platform', async () => {
+      // Default platform fee = 10%. With a 70% creator share agreement,
+      // the org's effective cut becomes 30% of post-platform. On a £100
+      // purchase:
+      //   platform = ceil(10000 * 10%) = 1000
+      //   org      = ceil(9000  * 30%) = 2700
+      //   creator  = 10000 - 1000 - 2700 = 6300
+      const { content } = await seedPaidContent({
+        title: 'WP-4 agreement override',
+        priceCents: 10000,
+      });
+      await seedContentPurchaseAgreement(organizationId, userId, 7000);
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = {
+        create: vi.fn().mockResolvedValue({ id: 'tr_test' }),
+      };
+      const purchase = await purchaseService.completePurchase(
+        `pi_wp4_override_${Date.now()}`,
+        {
+          customerId: otherUserId,
+          contentId: content.id,
+          organizationId,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+        }
+      );
+
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.organizationFeeCents).toBe(2700);
+      expect(purchase.creatorPayoutCents).toBe(6300);
+    });
+
+    it('WP-4: no agreement → falls back to FeeConfigService defaults (org keeps post-platform)', async () => {
+      // No agreement seeded. With default fees (10% platform / 10% org),
+      // org gets 900, creator gets 8100.
+      const { content } = await seedPaidContent({
+        title: 'WP-4 no agreement fallback',
+        priceCents: 10000,
+      });
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = {
+        create: vi.fn().mockResolvedValue({ id: 'tr_test' }),
+      };
+
+      const purchase = await purchaseService.completePurchase(
+        `pi_wp4_fallback_${Date.now()}`,
+        {
+          customerId: otherUserId,
+          contentId: content.id,
+          organizationId,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+        }
+      );
+
+      // Default split: platform 1000, org 900, creator 8100.
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.organizationFeeCents).toBe(900);
+      expect(purchase.creatorPayoutCents).toBe(8100);
+    });
+
+    it('WP-4: terminated agreement → fallback to defaults (no longer applies)', async () => {
+      const { content } = await seedPaidContent({
+        title: 'WP-4 terminated agreement',
+        priceCents: 10000,
+      });
+      // Terminated yesterday — must not influence the split.
+      await seedContentPurchaseAgreement(organizationId, userId, 7000, {
+        status: 'terminated',
+        terminatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = {
+        create: vi.fn().mockResolvedValue({ id: 'tr_test' }),
+      };
+
+      const purchase = await purchaseService.completePurchase(
+        `pi_wp4_term_${Date.now()}`,
+        {
+          customerId: otherUserId,
+          contentId: content.id,
+          organizationId,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+        }
+      );
+
+      // Default fallback split — agreement is terminated so it doesn't apply.
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.organizationFeeCents).toBe(900);
+      expect(purchase.creatorPayoutCents).toBe(8100);
+    });
+
+    it('WP-4: subscription-type agreement does NOT apply to content_purchase split', async () => {
+      // A subscription agreement exists for the uploader — but the
+      // content-purchase path must only look at content_purchase
+      // agreements. Fallback fires.
+      const { content } = await seedPaidContent({
+        title: 'WP-4 wrong revenue type',
+        priceCents: 10000,
+      });
+      await seedContentPurchaseAgreement(organizationId, userId, 7000, {
+        revenueType: 'subscription',
+      });
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = {
+        create: vi.fn().mockResolvedValue({ id: 'tr_test' }),
+      };
+
+      const purchase = await purchaseService.completePurchase(
+        `pi_wp4_revtype_${Date.now()}`,
+        {
+          customerId: otherUserId,
+          contentId: content.id,
+          organizationId,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+        }
+      );
+
+      // Default fallback — subscription agreement is irrelevant here.
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.organizationFeeCents).toBe(900);
+      expect(purchase.creatorPayoutCents).toBe(8100);
+    });
+
+    it("WP-4: a DIFFERENT creator's content_purchase agreement does NOT apply to this content (Q1 own-content scope)", async () => {
+      // Decision Q1: the agreement looked up at split time is keyed on
+      // `content.creatorId` (the uploader). An agreement held by
+      // `otherUserId` (the buyer in this test setup, who is also a
+      // user but not the uploader) MUST NOT influence the split.
+      const { content } = await seedPaidContent({
+        title: 'WP-4 other creator agreement',
+        priceCents: 10000,
+      });
+      // Seed an agreement for OTHER user (not the uploader).
+      await seedContentPurchaseAgreement(organizationId, otherUserId, 7000);
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = {
+        create: vi.fn().mockResolvedValue({ id: 'tr_test' }),
+      };
+
+      const purchase = await purchaseService.completePurchase(
+        `pi_wp4_other_${Date.now()}`,
+        {
+          customerId: otherUserId,
+          contentId: content.id,
+          organizationId,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+        }
+      );
+
+      // The split is the default — only the uploader's agreement counts.
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.organizationFeeCents).toBe(900);
+      expect(purchase.creatorPayoutCents).toBe(8100);
+    });
+
+    it('WP-4: 100% creator share agreement → creator gets the full post-platform pool', async () => {
+      const { content } = await seedPaidContent({
+        title: 'WP-4 full share',
+        priceCents: 10000,
+      });
+      await seedContentPurchaseAgreement(organizationId, userId, 10000);
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = {
+        create: vi.fn().mockResolvedValue({ id: 'tr_test' }),
+      };
+
+      const purchase = await purchaseService.completePurchase(
+        `pi_wp4_full_${Date.now()}`,
+        {
+          customerId: otherUserId,
+          contentId: content.id,
+          organizationId,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+        }
+      );
+
+      // platform = 1000, org = 0, creator = 9000.
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.organizationFeeCents).toBe(0);
+      expect(purchase.creatorPayoutCents).toBe(9000);
+    });
+  });
+
   describe('processRefund — payouts reversal (Codex-h69cg)', () => {
     it('reverses Stripe transfers + marks all rows reversed when refund processes', async () => {
       // Set up a feeConfig with org_fee > 0 so an org_fee row + transfer exist

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -29,8 +29,10 @@ import {
 } from '@codex/constants';
 import { isUniqueViolation, toIso } from '@codex/database';
 import {
+  agreementProposals,
   content,
   contentAccess,
+  creatorOrganizationAgreements,
   payouts,
   purchases,
   refundReviews,
@@ -58,6 +60,7 @@ import {
   count,
   desc,
   eq,
+  gt,
   gte,
   isNotNull,
   isNull,
@@ -539,6 +542,71 @@ export class PurchaseService extends BaseService {
               minTransferCents: 0,
             };
 
+        // Step 3a (Codex-rzfjw / WP-4): override `orgFeePercent` with the
+        // uploader's content_purchase agreement when one exists.
+        //
+        // Decision Q1: content-purchase revenue is attributed to the
+        // uploader (`content.creatorId`), and THAT creator's
+        // revenue_type='content_purchase' agreement determines the split.
+        // Per-content overrides are out of scope (future epic).
+        //
+        // Decision Q2: creator share is snapshotted on the proposal;
+        // platform fee is read fresh (we keep `fees.platformFeePercent`
+        // from FeeConfigService above).
+        //
+        // The agreement's share is read from `agreementProposals
+        // .proposedCreatorSharePercent` via `current_proposal_id` so
+        // this read works for both pre-WP-1 backfilled rows (migration
+        // 0072 synthesised a proposal) and new agreements.
+        const [agreementRow] = await tx
+          .select({
+            sharePercent: agreementProposals.proposedCreatorSharePercent,
+          })
+          .from(creatorOrganizationAgreements)
+          .innerJoin(
+            agreementProposals,
+            eq(
+              agreementProposals.id,
+              creatorOrganizationAgreements.currentProposalId
+            )
+          )
+          .where(
+            and(
+              eq(creatorOrganizationAgreements.organizationId, organizationId),
+              eq(
+                creatorOrganizationAgreements.creatorId,
+                contentRecord.creatorId
+              ),
+              eq(creatorOrganizationAgreements.revenueType, 'content_purchase'),
+              // Per Decision Q3: active-as-of-purchase-date. The schema
+              // check enforces (status='terminated') = (terminatedAt IS
+              // NOT NULL) — status='active' implies terminatedAt is NULL.
+              or(
+                eq(creatorOrganizationAgreements.status, 'active'),
+                and(
+                  eq(creatorOrganizationAgreements.status, 'terminated'),
+                  gt(creatorOrganizationAgreements.terminatedAt, new Date())
+                )
+              ),
+              lte(creatorOrganizationAgreements.effectiveFrom, new Date()),
+              or(
+                isNull(creatorOrganizationAgreements.effectiveUntil),
+                gt(creatorOrganizationAgreements.effectiveUntil, new Date())
+              )
+            )
+          )
+          .limit(1);
+
+        // If an agreement is present, derive the org's cut from
+        // 10000 - creator_share. If not, fall through to the
+        // FeeConfigService-resolved value — that is the Q1 fallback
+        // ("org keeps 100% of post-platform" when nothing else
+        // applies; the org-fee resolution defaults to 100% post-platform
+        // unless an admin has overridden it).
+        const effectiveOrgFeePercent = agreementRow
+          ? 10_000 - agreementRow.sharePercent
+          : fees.orgFeePercent;
+
         // Step 4: Calculate revenue split, then apply min-platform-fee floor.
         // The floor is enforced in the caller (not in calculateRevenueSplit)
         // to keep the math pure. When (amount * pct / 10000) < minFee, we
@@ -549,13 +617,28 @@ export class PurchaseService extends BaseService {
         const rawSplit = calculateRevenueSplit(
           metadata.amountPaidCents,
           fees.platformFeePercent,
-          fees.orgFeePercent
+          effectiveOrgFeePercent
         );
         const revenueSplit = applyMinPlatformFeeFloor(
           metadata.amountPaidCents,
           rawSplit,
           fees.minPlatformFeeCents
         );
+
+        // Codex-rzfjw: emit one observability event per purchase split
+        // for end-to-end auditability of the agreements payout pipeline.
+        this.obs.info('payout_split_computed', {
+          purchaseId: undefined,
+          contentId: metadata.contentId,
+          organizationId,
+          creatorId: contentRecord.creatorId,
+          amountPaidCents: metadata.amountPaidCents,
+          platformFeeCents: revenueSplit.platformFeeCents,
+          organizationFeeCents: revenueSplit.organizationFeeCents,
+          creatorPayoutCents: revenueSplit.creatorPayoutCents,
+          agreementApplied: Boolean(agreementRow),
+          source: 'content_purchase',
+        });
 
         // Step 4a: Reconcile Stripe-collected fee against calculated split.
         // If the application fee Stripe actually charged differs from what

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -30,6 +30,7 @@
     "format": "biome format --write ."
   },
   "dependencies": {
+    "@codex/agreements": "workspace:*",
     "@codex/cache": "workspace:*",
     "@codex/constants": "workspace:*",
     "@codex/database": "workspace:*",

--- a/packages/subscription/src/services/__tests__/subscription-service-orchestrator.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service-orchestrator.test.ts
@@ -118,6 +118,16 @@ function makeDb(overrides: Record<string, unknown> = {}): DbSpy {
       return {
         from: vi.fn(() => ({
           where: vi.fn(() => makeWhereReturn()),
+          // Codex-rzfjw: the WP-4 payout pipeline JOINs
+          // creator_organization_agreements → agreement_proposals via
+          // current_proposal_id to read `proposed_creator_share_percent`.
+          // Mock the joined shape so the executeTransfers query resolves
+          // to "no active agreements" in this orchestrator test (which
+          // is only asserting the cache/invalidation hook, not transfer
+          // economics).
+          innerJoin: vi.fn(() => ({
+            where: vi.fn(() => makeWhereReturn()),
+          })),
         })),
       };
     }),

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -15,6 +15,7 @@
  * - Stripe v19 shapes for period dates and invoice payments
  */
 
+import * as schema from '@codex/database/schema';
 import {
   creatorOrganizationAgreements,
   organizations,
@@ -3262,6 +3263,66 @@ describe('SubscriptionService', () => {
     }
 
     /**
+     * Codex-rzfjw (WP-4): seed a (proposal, agreement) pair so the WP-4
+     * payout pipeline's JOIN against `agreementProposals` resolves the
+     * creator share. Mirrors the synthesised-proposal shape that
+     * migration 0072 writes for legacy rows.
+     *
+     * @param sharePercent Creator's share of the post-platform pool in bps.
+     *   The legacy `organization_fee_percentage` column is dual-written
+     *   as `10000 - sharePercent` per the WP-1 invariant so any code
+     *   still reading the legacy column sees the same economics.
+     */
+    async function seedAgreement(
+      orgId: string,
+      creatorId: string,
+      sharePercent: number,
+      options: {
+        effectiveFrom?: Date;
+        effectiveUntil?: Date | null;
+        status?: 'active' | 'terminated' | 'expired';
+        terminatedAt?: Date | null;
+        revenueType?: 'subscription' | 'content_purchase';
+      } = {}
+    ): Promise<{ proposalId: string; agreementId: string }> {
+      const [proposal] = await db
+        .insert(schema.agreementProposals)
+        .values({
+          organizationId: orgId,
+          creatorId,
+          revenueType: options.revenueType ?? 'subscription',
+          roundNumber: 1,
+          proposedByUserId: creatorId,
+          proposedByRole: 'owner',
+          proposedCreatorSharePercent: sharePercent,
+          proposedTermMonths: null,
+          proposedEffectiveFrom: options.effectiveFrom ?? new Date(),
+          status: 'accepted',
+          respondedAt: new Date(),
+          respondedByUserId: creatorId,
+        })
+        .returning();
+      if (!proposal) throw new Error('seed proposal failed');
+
+      const [agreement] = await db
+        .insert(creatorOrganizationAgreements)
+        .values({
+          creatorId,
+          organizationId: orgId,
+          organizationFeePercentage: 10_000 - sharePercent,
+          revenueType: options.revenueType ?? 'subscription',
+          status: options.status ?? 'active',
+          terminatedAt: options.terminatedAt ?? null,
+          currentProposalId: proposal.id,
+          effectiveFrom: options.effectiveFrom ?? new Date(),
+          effectiveUntil: options.effectiveUntil ?? null,
+        })
+        .returning();
+      if (!agreement) throw new Error('seed agreement failed');
+      return { proposalId: proposal.id, agreementId: agreement.id };
+    }
+
+    /**
      * Filter Stripe transfer mock calls to just the per-creator transfers
      * (excludes the `_org_fee` and `_creator_pool_owner` keys). The
      * production code stamps each per-creator call with
@@ -3298,18 +3359,8 @@ describe('SubscriptionService', () => {
       const c1 = await seedCreatorWithConnect(org.id);
       const c2 = await seedCreatorWithConnect(org.id);
 
-      await db.insert(creatorOrganizationAgreements).values([
-        {
-          creatorId: c1,
-          organizationId: org.id,
-          organizationFeePercentage: 5000,
-        },
-        {
-          creatorId: c2,
-          organizationId: org.id,
-          organizationFeePercentage: 5000,
-        },
-      ]);
+      await seedAgreement(org.id, c1, 5000);
+      await seedAgreement(org.id, c2, 5000);
 
       const [sub] = await db
         .insert(subscriptions)
@@ -3363,23 +3414,9 @@ describe('SubscriptionService', () => {
       const c2 = await seedCreatorWithConnect(org.id);
       const c3 = await seedCreatorWithConnect(org.id);
 
-      await db.insert(creatorOrganizationAgreements).values([
-        {
-          creatorId: c1,
-          organizationId: org.id,
-          organizationFeePercentage: 3334,
-        },
-        {
-          creatorId: c2,
-          organizationId: org.id,
-          organizationFeePercentage: 3333,
-        },
-        {
-          creatorId: c3,
-          organizationId: org.id,
-          organizationFeePercentage: 3333,
-        },
-      ]);
+      await seedAgreement(org.id, c1, 3334);
+      await seedAgreement(org.id, c2, 3333);
+      await seedAgreement(org.id, c3, 3333);
 
       const [sub] = await db
         .insert(subscriptions)
@@ -3433,18 +3470,8 @@ describe('SubscriptionService', () => {
       const c1 = await seedCreatorWithConnect(org.id);
       const c2 = await seedCreatorWithConnect(org.id);
 
-      await db.insert(creatorOrganizationAgreements).values([
-        {
-          creatorId: c1,
-          organizationId: org.id,
-          organizationFeePercentage: 4000,
-        },
-        {
-          creatorId: c2,
-          organizationId: org.id,
-          organizationFeePercentage: 4000,
-        },
-      ]);
+      await seedAgreement(org.id, c1, 4000);
+      await seedAgreement(org.id, c2, 4000);
 
       const [sub] = await db
         .insert(subscriptions)
@@ -3501,18 +3528,8 @@ describe('SubscriptionService', () => {
       const c1 = await seedCreatorWithConnect(org.id);
       const c2 = await seedCreatorWithConnect(org.id);
 
-      await db.insert(creatorOrganizationAgreements).values([
-        {
-          creatorId: c1,
-          organizationId: org.id,
-          organizationFeePercentage: 6000,
-        },
-        {
-          creatorId: c2,
-          organizationId: org.id,
-          organizationFeePercentage: 5000,
-        },
-      ]);
+      await seedAgreement(org.id, c1, 6000);
+      await seedAgreement(org.id, c2, 5000);
 
       const [sub] = await db
         .insert(subscriptions)
@@ -3567,14 +3584,8 @@ describe('SubscriptionService', () => {
       const c1 = await seedCreatorWithConnect(org.id);
       const c2 = await seedCreatorWithConnect(org.id);
 
-      await db.insert(creatorOrganizationAgreements).values([
-        {
-          creatorId: c1,
-          organizationId: org.id,
-          organizationFeePercentage: 5000,
-        },
-        { creatorId: c2, organizationId: org.id, organizationFeePercentage: 0 },
-      ]);
+      await seedAgreement(org.id, c1, 5000);
+      await seedAgreement(org.id, c2, 0);
 
       const [sub] = await db
         .insert(subscriptions)
@@ -3662,14 +3673,13 @@ describe('SubscriptionService', () => {
       const { org, tier1 } = await createFullOrg('split-mid-removal');
       const c1 = await seedCreatorWithConnect(org.id);
 
-      const [agreementRow] = await db
-        .insert(creatorOrganizationAgreements)
-        .values({
-          creatorId: c1,
-          organizationId: org.id,
-          organizationFeePercentage: 10000,
-        })
-        .returning();
+      // Codex-rzfjw (WP-4): seed via seedAgreement so the payout
+      // pipeline's JOIN against agreement_proposals resolves the share.
+      // 100% share to c1 — org owner takes zero residual on the first
+      // invoice. effective_until is updated below to simulate mid-period
+      // termination.
+      const { agreementId } = await seedAgreement(org.id, c1, 10000);
+      const agreementRow = { id: agreementId };
 
       const [sub] = await db
         .insert(subscriptions)
@@ -3741,6 +3751,355 @@ describe('SubscriptionService', () => {
         }
       );
       expect(ownerFallbackSecondCycle).toHaveLength(1);
+    });
+
+    // ── WP-4 deep coverage (Codex-rzfjw) ──────────────────────────────
+    //
+    // These tests exercise the new agreement-model semantics that WP-4
+    // wires into the payout pipeline:
+    //   - status='terminated' BEFORE invoice → no payout
+    //   - status='terminated' AFTER  invoice → still receives payout (Q3)
+    //   - effective_from > invoiceAt → not-yet-active, no payout
+    //   - revenueType='content_purchase' rows do NOT pollute subscription pool
+    //   - reproduce the original bug: a co-creator with an active subscription
+    //     agreement receives their cut (was failing in production)
+    //   - payouts ledger inserts one row per active agreement + one residual
+
+    it('WP-4: original bug repro — co-creator with active subscription agreement gets their cut', async () => {
+      // This was the bug that triggered the epic: subscription payouts
+      // checked an empty `creator_organization_agreements` table and
+      // routed 100% to the org owner. Now a co-creator with a 30%
+      // agreement receives 30% of the post-platform pool.
+      const { org, tier1 } = await createFullOrg('wp4-original-bug');
+      const coCreator = await seedCreatorWithConnect(org.id);
+      await seedAgreement(org.id, coCreator, 3000);
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_repro';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: 'pi_wp4' } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      const coCreatorCall = creatorCalls.find(
+        (c) => c.idempotencyKey === `${chargeId}_creator_${coCreator}`
+      );
+      expect(coCreatorCall).toBeDefined();
+      expect(coCreatorCall?.amount).toBeGreaterThan(0);
+    });
+
+    it('WP-4: agreement terminated BEFORE invoice fires → no payout (Q3 strict cutoff)', async () => {
+      const { org, tier1 } = await createFullOrg('wp4-terminated-before');
+      const coCreator = await seedCreatorWithConnect(org.id);
+      const longAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      // Agreement terminated yesterday — must NOT receive payout today.
+      await seedAgreement(org.id, coCreator, 3000, {
+        effectiveFrom: longAgo,
+        status: 'terminated',
+        terminatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_term_before';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_wp4_tb' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      const coCreatorCall = creatorCalls.find(
+        (c) => c.idempotencyKey === `${chargeId}_creator_${coCreator}`
+      );
+      expect(coCreatorCall).toBeUndefined();
+    });
+
+    it('WP-4: agreement terminated AFTER invoice fires → still receives payout (Q3 no pro-rating)', async () => {
+      // Per Decision Q3 in project_revenue_share_decisions: whoever holds
+      // an active agreement at invoice fire time receives the full cut
+      // for that period. Termination on day 15 of a 30-day period → no
+      // share for the NEXT invoice, but the current one is locked in.
+      const { org, tier1 } = await createFullOrg('wp4-terminated-after');
+      const coCreator = await seedCreatorWithConnect(org.id);
+      // Agreement created 7 days ago, terminated 1h from "now" (which is
+      // ahead of the invoice's `created` field — invoice fires in the
+      // mock with `created` defaulting to now()).
+      const longAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const oneHourLater = new Date(Date.now() + 60 * 60 * 1000);
+      await seedAgreement(org.id, coCreator, 4000, {
+        effectiveFrom: longAgo,
+        status: 'terminated',
+        terminatedAt: oneHourLater,
+      });
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const invoiceCreated = Math.floor(Date.now() / 1000); // "now" in seconds
+      const chargeId = 'ch_wp4_term_after';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        created: invoiceCreated,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_wp4_ta' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      const coCreatorCall = creatorCalls.find(
+        (c) => c.idempotencyKey === `${chargeId}_creator_${coCreator}`
+      );
+      expect(coCreatorCall).toBeDefined();
+      expect(coCreatorCall?.amount).toBeGreaterThan(0);
+    });
+
+    it('WP-4: effective_from > invoiceAt → agreement not yet active, no payout', async () => {
+      const { org, tier1 } = await createFullOrg('wp4-future-from');
+      const coCreator = await seedCreatorWithConnect(org.id);
+      // Agreement effective from 7 days in the future — not yet live.
+      const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      await seedAgreement(org.id, coCreator, 3000, { effectiveFrom: future });
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_future';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_wp4_fut' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      expect(
+        creatorCalls.find(
+          (c) => c.idempotencyKey === `${chargeId}_creator_${coCreator}`
+        )
+      ).toBeUndefined();
+    });
+
+    it('WP-4: revenueType=content_purchase agreements do NOT pollute the subscription pool', async () => {
+      const { org, tier1 } = await createFullOrg('wp4-rev-type-filter');
+      const subCreator = await seedCreatorWithConnect(org.id);
+      const cpCreator = await seedCreatorWithConnect(org.id);
+      // One subscription agreement + one content_purchase agreement.
+      // The content_purchase row must not flow through the subscription
+      // payout path.
+      await seedAgreement(org.id, subCreator, 3000, {
+        revenueType: 'subscription',
+      });
+      await seedAgreement(org.id, cpCreator, 5000, {
+        revenueType: 'content_purchase',
+      });
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_revtype';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_wp4_rt' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      // Subscription creator should get a payout.
+      expect(
+        creatorCalls.find(
+          (c) => c.idempotencyKey === `${chargeId}_creator_${subCreator}`
+        )
+      ).toBeDefined();
+      // Content-purchase creator MUST NOT get a subscription payout.
+      expect(
+        creatorCalls.find(
+          (c) => c.idempotencyKey === `${chargeId}_creator_${cpCreator}`
+        )
+      ).toBeUndefined();
+    });
+
+    it('WP-4: payouts ledger has one row per active creator agreement', async () => {
+      const { org, tier1 } = await createFullOrg('wp4-ledger-rows');
+      const c1 = await seedCreatorWithConnect(org.id);
+      const c2 = await seedCreatorWithConnect(org.id);
+      const c3 = await seedCreatorWithConnect(org.id);
+      await seedAgreement(org.id, c1, 3000);
+      await seedAgreement(org.id, c2, 2000);
+      await seedAgreement(org.id, c3, 1000);
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_ledger';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [{ payment: { charge: chargeId, payment_intent: 'pi_wp4_l' } }],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const { eq, and } = await import('drizzle-orm');
+      const creatorPayouts = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          and(
+            eq(payoutsTable.organizationId, org.id),
+            eq(payoutsTable.subscriptionId, sub.id),
+            eq(payoutsTable.payoutType, 'creator_payout')
+          )
+        );
+      // 3 creator agreements → 3 creator_payout rows on the ledger.
+      expect(creatorPayouts).toHaveLength(3);
+      // All three creators are represented.
+      const userIds = creatorPayouts.map((r) => r.userId).sort();
+      expect(userIds).toEqual([c1, c2, c3].sort());
+    });
+
+    it('WP-4: all-zero-share agreements fall through to "org keeps all" branch', async () => {
+      // Every creator has a 0% agreement (degenerate / legacy backfill
+      // with org_fee=10000). The total shareBps is 0 — the new pipeline
+      // must not divide by zero. It routes the full creator pool to the
+      // org owner via the zero-share fallback.
+      const { org, tier1 } = await createFullOrg('wp4-all-zero');
+      const c1 = await seedCreatorWithConnect(org.id);
+      const c2 = await seedCreatorWithConnect(org.id);
+      await seedAgreement(org.id, c1, 0);
+      await seedAgreement(org.id, c2, 0);
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_allzero';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_wp4_az' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await expect(
+        service.handleInvoicePaymentSucceeded(invoice)
+      ).resolves.toBeDefined();
+
+      // Per-creator transfers must be zero.
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      expect(creatorCalls).toHaveLength(0);
+
+      // Owner-fallback transfer must have fired.
+      const allCalls = (stripe.transfers.create as ReturnType<typeof vi.fn>)
+        .mock.calls;
+      const ownerFallbackCalls = allCalls.filter((call) => {
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        return opts?.idempotencyKey === `${chargeId}_creator_pool_owner`;
+      });
+      expect(ownerFallbackCalls).toHaveLength(1);
     });
   });
 
@@ -8160,6 +8519,12 @@ describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', ()
   /**
    * Add an extra creator (with their own Connect account) to an org and
    * seed an active agreement for them. Returns the creator's userId.
+   *
+   * Codex-rzfjw (WP-4): the WP-4 payout pipeline reads
+   * `proposed_creator_share_percent` from `agreement_proposals` via
+   * `current_proposal_id`. We seed both the proposal AND the agreement
+   * (with dual-write `organization_fee_percentage = 10000 - share` per
+   * WP-1 invariant) so the JOIN resolves cleanly.
    */
   async function addCreatorWithAgreement(
     orgId: string,
@@ -8173,10 +8538,31 @@ describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', ()
         status: 'active',
       })
     );
+    const [proposal] = await db
+      .insert(schema.agreementProposals)
+      .values({
+        organizationId: orgId,
+        creatorId: userId,
+        revenueType: 'subscription',
+        roundNumber: 1,
+        proposedByUserId: userId,
+        proposedByRole: 'owner',
+        proposedCreatorSharePercent: sharePercent,
+        proposedTermMonths: null,
+        proposedEffectiveFrom: new Date(),
+        status: 'accepted',
+        respondedAt: new Date(),
+        respondedByUserId: userId,
+      })
+      .returning();
+    if (!proposal) throw new Error('seed proposal failed');
     await db.insert(creatorOrganizationAgreements).values({
       creatorId: userId,
       organizationId: orgId,
-      organizationFeePercentage: sharePercent,
+      organizationFeePercentage: 10_000 - sharePercent,
+      revenueType: 'subscription',
+      status: 'active',
+      currentProposalId: proposal.id,
     });
     return userId;
   }

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -37,6 +37,7 @@ import {
 } from '@codex/constants';
 import { dateWindow, isUniqueViolation, toIso } from '@codex/database';
 import {
+  agreementProposals,
   creatorOrganizationAgreements,
   organizationFollowers,
   organizationMemberships,
@@ -69,10 +70,13 @@ import {
   and,
   desc,
   eq,
+  gt,
   inArray,
   isNotNull,
   isNull,
   lt,
+  lte,
+  or,
   sql,
 } from 'drizzle-orm';
 import type Stripe from 'stripe';
@@ -1431,14 +1435,25 @@ export class SubscriptionService extends BaseService {
       stripeSubscriptionId: stripeSubId,
     });
 
-    // Execute revenue transfers
+    // Execute revenue transfers.
+    //
+    // Codex-rzfjw (WP-4): pin agreement-lookup at invoice fire time
+    // (Decision Q3 — no pro-rating, active-as-of-invoice-date). Webhook
+    // replays of the same invoice get the same active-set even if the
+    // agreement state has since changed (e.g. a creator terminated after
+    // the invoice fired but before the webhook landed).
+    const invoiceCreatedAt =
+      typeof stripeInvoice.created === 'number'
+        ? new Date(stripeInvoice.created * 1000)
+        : new Date();
     await this.executeTransfers(
       sub.id,
       sub.organizationId,
       sourceTransaction,
       split.platformFeeCents,
       split.organizationFeeCents,
-      split.creatorPayoutCents
+      split.creatorPayoutCents,
+      invoiceCreatedAt
     );
 
     this.obs.info('Invoice payment processed', {
@@ -3908,7 +3923,8 @@ export class SubscriptionService extends BaseService {
     chargeId: string,
     platformFeeCents: number,
     orgFeeCents: number,
-    creatorPayoutCents: number
+    creatorPayoutCents: number,
+    invoiceCreatedAt: Date = new Date()
   ): Promise<void> {
     const transferGroup = `sub_${subscriptionId}`;
 
@@ -4066,17 +4082,60 @@ export class SubscriptionService extends BaseService {
       }
     }
 
-    // Get all creators in the org with their revenue share agreements
+    // Codex-rzfjw (WP-4): query the agreements model with all four
+    // WP-1 filters pinned at invoice fire time, and JOIN to the
+    // accepted proposal to read `proposed_creator_share_percent` as
+    // the authoritative share — NOT the legacy `organization_fee_percentage`
+    // column. The legacy column is dual-written by WP-2 (Discovery 2
+    // of project_revenue_share_wp1_discoveries) and will be dropped in a
+    // follow-up migration once this read path lands.
+    //
+    // Filters:
+    //   status='active'                         — only live agreements
+    //   revenueType='subscription'              — subscription pool
+    //   terminatedAt IS NULL OR > invoiceAt     — Q3 no pro-rating
+    //   effectiveFrom <= invoiceAt              — not-yet-active excluded
+    //   effectiveUntil IS NULL OR > invoiceAt   — legacy time-slice safety
+    //
+    // Backfilled legacy rows (migration 0072) have `current_proposal_id`
+    // pointing at a synthesised round-1 'accepted' proposal whose
+    // `proposed_creator_share_percent = 10000 - organization_fee_percentage`,
+    // so this JOIN handles both pre-WP-1 and post-WP-1 rows uniformly.
     const creatorAgreements = await this.db
       .select({
         creatorId: creatorOrganizationAgreements.creatorId,
-        sharePercent: creatorOrganizationAgreements.organizationFeePercentage,
+        sharePercent: agreementProposals.proposedCreatorSharePercent,
       })
       .from(creatorOrganizationAgreements)
+      .innerJoin(
+        agreementProposals,
+        eq(
+          agreementProposals.id,
+          creatorOrganizationAgreements.currentProposalId
+        )
+      )
       .where(
         and(
           eq(creatorOrganizationAgreements.organizationId, orgId),
-          sql`${creatorOrganizationAgreements.effectiveUntil} IS NULL OR ${creatorOrganizationAgreements.effectiveUntil} > now()`
+          eq(creatorOrganizationAgreements.revenueType, 'subscription'),
+          // Per Decision Q3: an agreement is active at invoice time if
+          // EITHER it is currently status='active' (never terminated), OR
+          // it was terminated AFTER the invoice fired. The schema's
+          // check_creator_org_agreement_terminated_shape enforces
+          // `(status='terminated') = (terminated_at IS NOT NULL)`, so
+          // status='active' guarantees terminatedAt IS NULL.
+          or(
+            eq(creatorOrganizationAgreements.status, 'active'),
+            and(
+              eq(creatorOrganizationAgreements.status, 'terminated'),
+              gt(creatorOrganizationAgreements.terminatedAt, invoiceCreatedAt)
+            )
+          ),
+          lte(creatorOrganizationAgreements.effectiveFrom, invoiceCreatedAt),
+          or(
+            isNull(creatorOrganizationAgreements.effectiveUntil),
+            gt(creatorOrganizationAgreements.effectiveUntil, invoiceCreatedAt)
+          )
         )
       );
 
@@ -4165,13 +4224,119 @@ export class SubscriptionService extends BaseService {
       return;
     }
 
-    // Distribute creator pool by fixed percentages
-    // Note: creatorOrganizationAgreements.organizationFeePercentage is repurposed
-    // as the creator's share percentage in basis points for subscription context
+    // Distribute creator pool by per-creator share basis points
+    // (Codex-rzfjw, WP-4 of Codex-nk4km): `creatorAgreements[i].sharePercent`
+    // is the creator's slice of the post-platform pool, derived from the
+    // legacy `organization_fee_percentage` column via
+    // `creatorShareFromLegacyOrgFee()` above. The sum may be < 10000
+    // (org owner retains the residual via the existing org_fee branch),
+    // = 10000 (org residual is zero — legal outcome), or > 10000 by
+    // design (multiple creators each accept their slice and the org
+    // ate the gap on negotiation). We normalise by the actual sum so
+    // total transferred never exceeds the creator pool.
     const totalShareBps = creatorAgreements.reduce(
       (sum, a) => sum + a.sharePercent,
       0
     );
+
+    // Edge: every agreement carries `sharePercent=0` (e.g. legacy rows
+    // backfilled with org_fee=10000). totalShareBps would be 0 → divide
+    // by zero. Bail to the no-agreements branch — full creator pool
+    // routes to the org owner. Preserves the "org keeps all" fallback.
+    if (totalShareBps <= 0) {
+      this.obs.info(
+        'All active subscription agreements have zero creator share; routing pool to org owner',
+        {
+          organizationId: orgId,
+          subscriptionId,
+          agreementCount: creatorAgreements.length,
+        }
+      );
+      // Effectively the same as the empty-agreements branch above.
+      // Recurse-via-fallthrough is messy here; re-enter the empty
+      // branch path by zeroing creatorAgreements and breaking out.
+      creatorAgreements.length = 0;
+      // Re-route to the org owner using the same idempotency key as
+      // the empty branch. Inline (not a function call) to keep the
+      // method's shape recognisable.
+      if (orgConnect?.chargesEnabled && creatorPayoutCents > 0) {
+        try {
+          const transfer = await this.stripe.transfers.create(
+            {
+              amount: creatorPayoutCents,
+              currency: CURRENCY.GBP,
+              destination: orgConnect.stripeAccountId,
+              source_transaction: chargeId,
+              transfer_group: transferGroup,
+              metadata: {
+                subscription_id: subscriptionId,
+                type: 'creator_payout_to_owner',
+              },
+            },
+            { idempotencyKey: `${chargeId}_creator_pool_owner` }
+          );
+          try {
+            await this.db.insert(payouts).values({
+              userId: orgConnect.userId,
+              organizationId: orgId,
+              subscriptionId,
+              amountCents: creatorPayoutCents,
+              payoutType: 'creator_payout_to_owner',
+              status: 'paid',
+              stripeTransferId: transfer.id,
+              stripeChargeId: chargeId,
+              transferGroup,
+              resolvedAt: new Date(),
+            });
+          } catch (insertError) {
+            if (!isUniqueViolation(insertError)) {
+              this.obs.error(
+                'Creator-pool transfer to owner succeeded but payouts ledger insert failed (zero-share branch)',
+                {
+                  subscriptionId,
+                  organizationId: orgId,
+                  stripeTransferId: transfer.id,
+                  amountCents: creatorPayoutCents,
+                  error: (insertError as Error).message,
+                }
+              );
+            }
+          }
+        } catch (transferError) {
+          this.obs.error(
+            'Creator pool transfer to owner failed (zero-share branch), accumulating',
+            {
+              subscriptionId,
+              organizationId: orgId,
+              amountCents: creatorPayoutCents,
+              error: (transferError as Error).message,
+            }
+          );
+          try {
+            await this.db.insert(payouts).values({
+              userId: orgConnect.userId,
+              organizationId: orgId,
+              subscriptionId,
+              amountCents: creatorPayoutCents,
+              payoutType: 'creator_payout_to_owner',
+              status: 'failed',
+              reason: 'transfer_failed',
+            });
+          } catch (insertError) {
+            this.obs.error(
+              'Failed to record pending payout for zero-share fallback',
+              {
+                subscriptionId,
+                organizationId: orgId,
+                amountCents: creatorPayoutCents,
+                error: (insertError as Error).message,
+              }
+            );
+          }
+        }
+      }
+      return;
+    }
 
     // Batch-fetch all creator Connect accounts to avoid N+1 queries
     const creatorIds = creatorAgreements.map((a) => a.creatorId);
@@ -4190,6 +4355,18 @@ export class SubscriptionService extends BaseService {
       const creatorAmount = Math.floor(
         (creatorPayoutCents * agreement.sharePercent) / totalShareBps
       );
+
+      // Codex-rzfjw: per-creator split observability. Emit one
+      // structured event per agreement so the payout pipeline is
+      // auditable end-to-end (creator → amount → agreement share).
+      this.obs.info('payout_split_computed', {
+        subscriptionId,
+        organizationId: orgId,
+        creatorId: agreement.creatorId,
+        amountCents: creatorAmount,
+        sharePercent: agreement.sharePercent,
+        totalShareBps,
+      });
 
       if (creatorAmount <= 0) continue;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,9 +448,6 @@ importers:
       '@codex/observability':
         specifier: workspace:*
         version: link:../observability
-      '@codex/purchase':
-        specifier: workspace:*
-        version: link:../purchase
       '@codex/service-errors':
         specifier: workspace:*
         version: link:../service-errors
@@ -900,6 +897,9 @@ importers:
 
   packages/purchase:
     dependencies:
+      '@codex/agreements':
+        specifier: workspace:*
+        version: link:../agreements
       '@codex/cache':
         specifier: workspace:*
         version: link:../cache
@@ -1017,6 +1017,9 @@ importers:
 
   packages/subscription:
     dependencies:
+      '@codex/agreements':
+        specifier: workspace:*
+        version: link:../agreements
       '@codex/cache':
         specifier: workspace:*
         version: link:../cache


### PR DESCRIPTION
## Summary

WP-4 of the Revenue-Share Agreements epic (Codex-nk4km). Wires `@codex/agreements` into the live payout pipeline so co-creators with active agreements actually receive their cut. **This closes the original bug** that triggered the epic.

### Subscription pipeline (subscription-service)
- Queries active agreements (`revenueType='subscription'`, four temporal filters pinned at `invoice.created`)
- Reads `proposed_creator_share_percent` from `agreement_proposals` via JOIN on `current_proposal_id` (the authoritative source — legacy `organization_fee_percentage` column will be dropped in a follow-up migration)
- Multi-creator: one `creator_payout` row per active agreement
- Per Q3: no pro-rating — `status='active' OR (status='terminated' AND terminated_at > invoiceAt)`
- Per Q2: creator share snapshotted, platform fee resolved fresh via FeeConfigService
- Zero-share fallback: degenerate / legacy backfill rows summing to zero route the full pool to the org owner

### Content-purchase pipeline (purchase-service)
- Per Q1: uploader's (`content.creatorId`) `content_purchase` agreement determines the split (creator's-own-content scope; per-content overrides deferred)
- Fallback: no active content_purchase agreement -> FeeConfigService default (org keeps post-platform)

### Service extensions (`@codex/agreements`)
- New `getActiveAgreement` (singular) for the per-content lookup
- `getActiveAgreements` + `getActiveAgreementsForCreator` gained `revenueType` + `activeAt` filters
- Q3 semantics baked in: `status='active' OR (status='terminated' AND terminated_at > activeAt)`

### Cycle fix
- Removed `@codex/purchase` dependency from `@codex/agreements` (it was a leftover comment reference, never an actual import). Adding `@codex/agreements` to `@codex/subscription` + `@codex/purchase` would have created a cycle otherwise.

## Base branch

Stacks on `feat/codex-hqke2-agreements-routes` (WP-3). Chain: WP-1 -> WP-2 -> WP-3 -> WP-4. When the chain merges, each rebases onto `main`.

## Test plan

- [x] Agreements: 70/70 pass (20 new WP-4 read-filter tests covering positive / negative / edge for both singular + plural getters)
- [x] Subscription: 377/378 pass (7 new WP-4 tests; 1 pre-existing `__denoise_proofs__/iter-009/F5-dup-bump-with-logger.test.ts` failure unrelated to this branch)
- [x] Purchase: 220/220 pass (6 new WP-4 tests covering override / fallback / terminated / wrong-revenue-type / other-creator-scope / 100%-share)
- [x] Typecheck: agreements / subscription / purchase all clean
- [x] Full monorepo build: green

### New deep-coverage tests for the money path
- Original bug reproduction: co-creator with active subscription agreement receives their cut
- Subscription agreement terminated BEFORE invoice -> no payout
- Subscription agreement terminated AFTER invoice -> still receives payout (Q3 no pro-rating)
- effective_from > invoiceAt -> not-yet-active, no payout
- `revenueType='content_purchase'` agreements do NOT pollute the subscription pool
- Payouts ledger: one row per active creator agreement + residual to org
- All-zero-share agreements fall through to "org keeps all"
- Content-purchase: override / fallback / terminated / wrong-revenue-type / other-creator-scope / 100%-share

## Manual verification

```bash
stripe listen --forward-to localhost:42072/webhooks/stripe
stripe trigger invoice.payment_succeeded
# Verify in payouts table:
# - One creator_payout row per active subscription agreement
# - amounts sum to invoice.totalCents - platformFee
# - Per memory feedback_stripe_cli_account_mismatch: confirm `stripe listen` and `stripe trigger` are on the same account
```

Bead: Codex-rzfjw
Epic: Codex-nk4km