### PR TITLE
fix(payouts): align subscription share semantics with post-platform pool ADR

### DIFF
--- a/packages/database/src/__tests__/agreement-schema.test.ts
+++ b/packages/database/src/__tests__/agreement-schema.test.ts
@@ -663,7 +663,9 @@ describe.skipIf(!HAS_DB)('Agreement Schema (Codex-ppxtd)', () => {
       expect(sqlText).toMatch(
         /NOT EXISTS\s*\(\s*SELECT 1\s+FROM "agreement_proposals" p/i
       );
-      expect(sqlText).toMatch(/p\."organization_id"\s*=\s*a\."organization_id"/);
+      expect(sqlText).toMatch(
+        /p\."organization_id"\s*=\s*a\."organization_id"/
+      );
       expect(sqlText).toMatch(/p\."creator_id"\s*=\s*a\."creator_id"/);
       expect(sqlText).toMatch(/p\."revenue_type"\s*=\s*a\."revenue_type"/);
     });

--- a/packages/subscription/src/services/__tests__/subscription-service-orchestrator.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service-orchestrator.test.ts
@@ -125,7 +125,13 @@ function makeDb(overrides: Record<string, unknown> = {}): DbSpy {
           // to "no active agreements" in this orchestrator test (which
           // is only asserting the cache/invalidation hook, not transfer
           // economics).
-          innerJoin: vi.fn(() => ({
+          //
+          // Codex-ez3tl (I3): the pipeline switched innerJoin → leftJoin
+          // so a NULL current_proposal_id surfaces (with a warn) instead
+          // of silently dropping the row. The orchestrator-test mocks the
+          // empty-agreements case, so leftJoin and innerJoin behave the
+          // same here — both yield the empty `makeWhereReturn` result.
+          leftJoin: vi.fn(() => ({
             where: vi.fn(() => makeWhereReturn()),
           })),
         })),

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -3460,12 +3460,16 @@ describe('SubscriptionService', () => {
       expect(a1 + a2 + a3).toBeGreaterThan(0);
     });
 
-    it('share-sum UNDER 10000 bps (4000+4000=8000): production normalises by totalShareBps, so creators split the full pool', async () => {
-      // Production code at subscription-service.ts:2972-2974 divides by
-      // totalShareBps (the SUM of share rows), not by 10000. Locking in
-      // that contract: undersum does NOT route a remainder to the org
-      // owner. The creators receive the full creator pool, split by
-      // their relative weights.
+    it('share-sum UNDER 10000 bps (4000+4000=8000): creators get absolute shares of post-platform, org gets residual', async () => {
+      // Codex-ez3tl (C1): `proposed_creator_share_percent` is the
+      // ABSOLUTE fraction of the post-platform pool. With shares
+      // 4000+4000, totalShareBps=8000 → effectiveOrgFeePercent=2000.
+      // For gross=1000, platform=10%=100, post=900:
+      //   org gets floor(900*2000/10000) = 180
+      //   each creator gets floor(900*4000/10000) = 360
+      //   sum: 100 + 180 + 360 + 360 = 1000 ✓
+      // The org receives its residual via the existing `${chargeId}_org_fee`
+      // transfer, NOT the `${chargeId}_creator_pool_owner` fallback.
       const { org, tier1 } = await createFullOrg('split-undersum');
       const c1 = await seedCreatorWithConnect(org.id);
       const c2 = await seedCreatorWithConnect(org.id);
@@ -3503,9 +3507,8 @@ describe('SubscriptionService', () => {
       // Both creators receive a transfer.
       expect(creatorCalls).toHaveLength(2);
 
-      // With shares 4000+4000, totalShareBps = 8000. Each creator gets
-      // floor(payout * 4000/8000) = floor(payout/2). The agreements
-      // present branch is taken (no `creator_payout_to_owner` transfer):
+      // The agreements branch is taken (no `creator_payout_to_owner`
+      // fallback). The org's residual rides the existing org_fee key.
       const allCalls = (stripe.transfers.create as ReturnType<typeof vi.fn>)
         .mock.calls;
       const ownerFallbackCalls = allCalls.filter((call) => {
@@ -3514,16 +3517,34 @@ describe('SubscriptionService', () => {
       });
       expect(ownerFallbackCalls).toHaveLength(0);
 
-      // Equal split because shares are equal.
-      const [first, second] = creatorCalls;
-      expect(first.amount).toBe(second.amount);
+      // Exact-amount assertions (Codex-ez3tl I1): each creator gets 360,
+      // sum < creator pool of 900 (org keeps residual 180).
+      const byKey = new Map(
+        creatorCalls.map((c) => [c.idempotencyKey, c.amount])
+      );
+      expect(byKey.get(`${chargeId}_creator_${c1}`)).toBe(360);
+      expect(byKey.get(`${chargeId}_creator_${c2}`)).toBe(360);
+
+      // Org residual lands on the `${chargeId}_org_fee` key.
+      const orgFeeCalls = allCalls.filter((call) => {
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        return opts?.idempotencyKey === `${chargeId}_org_fee`;
+      });
+      expect(orgFeeCalls).toHaveLength(1);
+      const orgFeeParams = orgFeeCalls[0][0] as { amount: number };
+      expect(orgFeeParams.amount).toBe(180);
     });
 
-    it('share-sum OVER 10000 bps (6000+5000=11000): production silently clamps via normalisation, no throw', async () => {
-      // Production normalises by totalShareBps = 11000, so each creator
-      // receives floor(payout * share / 11000) — the sum is ≤ payout. No
-      // error is thrown; the service does not currently enforce a
-      // 10000-bps ceiling. This test pins that behaviour.
+    it('share-sum OVER 10000 bps (6000+5000=11000): clamp by max(totalShareBps,10000), no over-pay, no throw', async () => {
+      // Codex-ez3tl (C1): `validateProposedShare` enforces sum ≤ 10000,
+      // but the payout pipeline defends against an oversum config by
+      // dividing per-creator by `max(totalShareBps, 10000)`. Creators
+      // jointly take ≤ 100% of post-platform; org gets 0 residual.
+      // For gross=1000, platform=10%=100, post=900, divisor=11000:
+      //   c1 = floor(900*6000/11000) = 490
+      //   c2 = floor(900*5000/11000) = 409
+      //   org_fee = 0 (effectiveOrgFeePercent = max(0, 10000-11000) = 0)
+      //   sum: 100 + 0 + 490 + 409 = 999 ≤ 1000 ✓ (1¢ float-rounding loss)
       const { org, tier1 } = await createFullOrg('split-oversum');
       const c1 = await seedCreatorWithConnect(org.id);
       const c2 = await seedCreatorWithConnect(org.id);
@@ -3572,11 +3593,12 @@ describe('SubscriptionService', () => {
       // c1 (6000) > c2 (5000), so a1 > a2 (strict — different shares).
       expect(a1).toBeGreaterThan(a2);
 
-      // Clamp invariant: a1 = floor(payout * 6000/11000), a2 = floor(payout * 5000/11000).
-      // The ratio a1/a2 ≈ 6000/5000 = 1.2 (within rounding tolerance).
-      // The key contract is: total ≤ creator pool — which we can verify
-      // by checking no transfer exceeds the input amount_paid (=1000).
-      expect(a1 + a2).toBeLessThanOrEqual(1000);
+      // Exact-amount assertions (Codex-ez3tl I1): clamp via max-divisor.
+      expect(a1).toBe(490);
+      expect(a2).toBe(409);
+
+      // Critical invariant: total per-creator transfer ≤ post-platform pool.
+      expect(a1 + a2).toBeLessThanOrEqual(900);
     });
 
     it('zero-share agreement: creator with 0 bps receives no transfer, share holder gets full pool', async () => {
@@ -3770,6 +3792,16 @@ describe('SubscriptionService', () => {
       // checked an empty `creator_organization_agreements` table and
       // routed 100% to the org owner. Now a co-creator with a 30%
       // agreement receives 30% of the post-platform pool.
+      //
+      // Codex-ez3tl (I1): exact-amount assertion. Pre-fix, the
+      // co-creator received 85% of post-platform (765 cents) because
+      // the divisor was the sum-of-shares (3000) not 10000. Post-fix,
+      // they receive their ABSOLUTE share of post-platform per the
+      // ADR (agreement-math.ts header). For gross=1000, platform=10%
+      // (100 cents), post-platform=900, the 30%-share co-creator gets
+      // floor(900 * 3000 / 10000) = 270 cents. The org keeps the 70%
+      // residual = 630 cents via the existing `${chargeId}_org_fee`
+      // transfer — NO `creator_pool_owner` fallback fires.
       const { org, tier1 } = await createFullOrg('wp4-original-bug');
       const coCreator = await seedCreatorWithConnect(org.id);
       await seedAgreement(org.id, coCreator, 3000);
@@ -3803,7 +3835,110 @@ describe('SubscriptionService', () => {
         (c) => c.idempotencyKey === `${chargeId}_creator_${coCreator}`
       );
       expect(coCreatorCall).toBeDefined();
-      expect(coCreatorCall?.amount).toBeGreaterThan(0);
+      // Exact-amount assertion locks in the C1 fix:
+      expect(coCreatorCall?.amount).toBe(270);
+
+      // The org receives its 70% residual via the existing org_fee key,
+      // NOT via the no-agreements `creator_pool_owner` fallback.
+      const allCalls = (stripe.transfers.create as ReturnType<typeof vi.fn>)
+        .mock.calls;
+      const ownerFallbackCalls = allCalls.filter((call) => {
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        return opts?.idempotencyKey === `${chargeId}_creator_pool_owner`;
+      });
+      expect(ownerFallbackCalls).toHaveLength(0);
+
+      // Org residual via the `${chargeId}_org_fee` key:
+      //   effectiveOrgFeePercent = 10000 - 3000 = 7000
+      //   orgFee = floor(900 * 7000 / 10000) = 630
+      const orgFeeCalls = allCalls.filter((call) => {
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        return opts?.idempotencyKey === `${chargeId}_org_fee`;
+      });
+      expect(orgFeeCalls).toHaveLength(1);
+      const orgFeeParams = orgFeeCalls[0][0] as { amount: number };
+      expect(orgFeeParams.amount).toBe(630);
+    });
+
+    it('WP-4 / Codex-ez3tl I1: multi-creator exact split (30/20/10%) sums to gross', async () => {
+      // Three creators at 30/20/10% share. Sums via the new math:
+      //   gross = 1000, platform = 10% = 100, post = 900
+      //   totalShareBps = 6000, effectiveOrgFeePercent = 4000
+      //   org_fee = floor(900 * 4000 / 10000) = 360
+      //   c1 (30%) = floor(900 * 3000 / 10000) = 270
+      //   c2 (20%) = floor(900 * 2000 / 10000) = 180
+      //   c3 (10%) = floor(900 * 1000 / 10000) =  90
+      //   sum: 100 + 360 + 270 + 180 + 90 = 1000 ✓ exact
+      const { org, tier1 } = await createFullOrg('wp4-multi-exact');
+      const c1 = await seedCreatorWithConnect(org.id);
+      const c2 = await seedCreatorWithConnect(org.id);
+      const c3 = await seedCreatorWithConnect(org.id);
+
+      await seedAgreement(org.id, c1, 3000);
+      await seedAgreement(org.id, c2, 2000);
+      await seedAgreement(org.id, c3, 1000);
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_wp4_multi_exact';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            {
+              payment: {
+                charge: chargeId,
+                payment_intent: 'pi_wp4_multi_exact',
+              },
+            },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(invoice);
+
+      const allCalls = (stripe.transfers.create as ReturnType<typeof vi.fn>)
+        .mock.calls;
+      const byKey = new Map<string, number>();
+      for (const call of allCalls) {
+        const params = call[0] as { amount: number };
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        if (opts?.idempotencyKey) {
+          byKey.set(opts.idempotencyKey, params.amount);
+        }
+      }
+
+      expect(byKey.get(`${chargeId}_creator_${c1}`)).toBe(270);
+      expect(byKey.get(`${chargeId}_creator_${c2}`)).toBe(180);
+      expect(byKey.get(`${chargeId}_creator_${c3}`)).toBe(90);
+      expect(byKey.get(`${chargeId}_org_fee`)).toBe(360);
+
+      // No creator_pool_owner fallback (agreements exist).
+      const ownerFallbackCalls = allCalls.filter((call) => {
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        return opts?.idempotencyKey === `${chargeId}_creator_pool_owner`;
+      });
+      expect(ownerFallbackCalls).toHaveLength(0);
+
+      // Sum invariant: platform (100, retained, not transferred) +
+      // org_fee (360) + creator payouts (270+180+90=540) = gross (1000).
+      const sum =
+        100 +
+        (byKey.get(`${chargeId}_org_fee`) ?? 0) +
+        (byKey.get(`${chargeId}_creator_${c1}`) ?? 0) +
+        (byKey.get(`${chargeId}_creator_${c2}`) ?? 0) +
+        (byKey.get(`${chargeId}_creator_${c3}`) ?? 0);
+      expect(sum).toBe(1000);
     });
 
     it('WP-4: agreement terminated BEFORE invoice fires → no payout (Q3 strict cutoff)', async () => {
@@ -4093,6 +4228,85 @@ describe('SubscriptionService', () => {
       expect(creatorCalls).toHaveLength(0);
 
       // Owner-fallback transfer must have fired.
+      const allCalls = (stripe.transfers.create as ReturnType<typeof vi.fn>)
+        .mock.calls;
+      const ownerFallbackCalls = allCalls.filter((call) => {
+        const opts = call[1] as { idempotencyKey?: string } | undefined;
+        return opts?.idempotencyKey === `${chargeId}_creator_pool_owner`;
+      });
+      expect(ownerFallbackCalls).toHaveLength(1);
+    });
+
+    // Codex-ez3tl (I3): ghost-agreement guard
+    //
+    // `current_proposal_id` is a FK with `onDelete: 'set null'`, so an
+    // admin tool that deletes a proposal will null the link on its
+    // agreement row. The pre-fix `innerJoin` silently dropped such rows;
+    // the post-fix `leftJoin` surfaces them — the pipeline skips with a
+    // warn log and the org gets the full pool via the no-agreements path
+    // (a single orphan agreement → 0 effective creators).
+    it('WP-4 / Codex-ez3tl I3: agreement with NULL current_proposal_id is skipped (no silent drop)', async () => {
+      const { org, tier1 } = await createFullOrg('ez3tl-null-proposal');
+      const orphanCreator = await seedCreatorWithConnect(org.id);
+
+      // Insert an agreement WITHOUT a current_proposal_id — mirrors what
+      // happens when a future admin tool deletes the linked proposal
+      // (FK onDelete: 'set null'). The pre-fix pipeline's innerJoin
+      // silently dropped this row; the post-fix leftJoin must surface
+      // it for the skip-with-warn handler.
+      const [orphanAgreement] = await db
+        .insert(creatorOrganizationAgreements)
+        .values({
+          creatorId: orphanCreator,
+          organizationId: org.id,
+          organizationFeePercentage: 5000,
+          revenueType: 'subscription',
+          status: 'active',
+          currentProposalId: null,
+          effectiveFrom: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        })
+        .returning();
+      expect(orphanAgreement).toBeDefined();
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      const chargeId = 'ch_ez3tl_orphan';
+      const invoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_ez3tl_op' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await expect(
+        service.handleInvoicePaymentSucceeded(invoice)
+      ).resolves.toBeDefined();
+
+      // The orphan creator MUST NOT receive a per-creator transfer.
+      const creatorCalls = perCreatorTransferCalls(
+        stripe.transfers.create as ReturnType<typeof vi.fn>
+      );
+      expect(
+        creatorCalls.find(
+          (c) => c.idempotencyKey === `${chargeId}_creator_${orphanCreator}`
+        )
+      ).toBeUndefined();
+
+      // With zero effective agreements (the orphan was skipped), the
+      // empty-agreements branch fires the creator_pool_owner transfer to
+      // route the entire pool to the org.
       const allCalls = (stripe.transfers.create as ReturnType<typeof vi.fn>)
         .mock.calls;
       const ownerFallbackCalls = allCalls.filter((call) => {

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -3974,114 +3974,14 @@ export class SubscriptionService extends BaseService {
     // transfers route to the same account checkout validated against.
     const orgConnect = await resolvePrimaryConnect(this.db, orgId);
 
-    // Transfer org fee
-    if (orgConnect?.chargesEnabled && orgFeeCents > 0) {
-      try {
-        const transfer = await this.stripe.transfers.create(
-          {
-            amount: orgFeeCents,
-            currency: CURRENCY.GBP,
-            destination: orgConnect.stripeAccountId,
-            source_transaction: chargeId,
-            transfer_group: transferGroup,
-            metadata: {
-              subscription_id: subscriptionId,
-              type: 'organization_fee',
-            },
-          },
-          { idempotencyKey: `${chargeId}_org_fee` }
-        );
-        // Record success in the ledger. The unique partial index on
-        // stripe_transfer_id collapses webhook double-fires to a single row;
-        // any other DB error gets logged loud — money moved but the ledger
-        // missed the entry, which is a data-integrity event worth paging on.
-        try {
-          await this.db.insert(payouts).values({
-            userId: orgConnect.userId,
-            organizationId: orgId,
-            subscriptionId,
-            amountCents: orgFeeCents,
-            payoutType: 'organization_fee',
-            status: 'paid',
-            stripeTransferId: transfer.id,
-            stripeChargeId: chargeId,
-            transferGroup,
-            resolvedAt: new Date(),
-          });
-        } catch (insertError) {
-          if (!isUniqueViolation(insertError)) {
-            this.obs.error(
-              'Org transfer succeeded but payouts ledger insert failed',
-              {
-                subscriptionId,
-                organizationId: orgId,
-                stripeTransferId: transfer.id,
-                amountCents: orgFeeCents,
-                error: (insertError as Error).message,
-              }
-            );
-          }
-        }
-      } catch (transferError) {
-        this.obs.error('Org transfer failed, accumulating as pending payout', {
-          subscriptionId,
-          organizationId: orgId,
-          amountCents: orgFeeCents,
-          error: (transferError as Error).message,
-        });
-        try {
-          await this.db.insert(payouts).values({
-            userId: orgConnect.userId,
-            organizationId: orgId,
-            subscriptionId,
-            amountCents: orgFeeCents,
-            payoutType: 'organization_fee',
-            status: 'failed',
-            reason: 'transfer_failed',
-          });
-        } catch (insertError) {
-          this.obs.error('Failed to record pending payout for org transfer', {
-            subscriptionId,
-            organizationId: orgId,
-            amountCents: orgFeeCents,
-            error: (insertError as Error).message,
-          });
-        }
-      }
-    } else if (orgFeeCents > 0) {
-      // Accumulate if Connect not ready — resolve the org owner's userId
-      const ownerId =
-        orgConnect?.userId ?? (await this.resolveOrgOwnerId(orgId));
-      if (!ownerId) {
-        this.obs.error(
-          'Cannot record pending payout: no Connect account and no org owner found',
-          { subscriptionId, organizationId: orgId, amountCents: orgFeeCents }
-        );
-      } else {
-        try {
-          await this.db.insert(payouts).values({
-            userId: ownerId,
-            organizationId: orgId,
-            subscriptionId,
-            amountCents: orgFeeCents,
-            payoutType: 'organization_fee',
-            status: 'pending',
-            reason: 'connect_not_ready',
-          });
-        } catch (insertError) {
-          this.obs.error(
-            'Failed to record pending payout (Connect not ready)',
-            {
-              subscriptionId,
-              organizationId: orgId,
-              amountCents: orgFeeCents,
-              error: (insertError as Error).message,
-            }
-          );
-        }
-      }
-    }
-
+    // Codex-ez3tl (C1): query agreements BEFORE the org transfer so the
+    // org's transfer amount reflects the post-platform residual when
+    // creator agreements exist. Per the agreement-math.ts ADR header,
+    // `proposed_creator_share_percent` is the creator's absolute fraction
+    // of the POST-PLATFORM pool — NOT a relative weight. When agreements
+    // exist the fee-config's static `orgFeePercent` is overridden by
+    // `effectiveOrgFeePercent = max(0, 10000 - totalShareBps)`.
+    //
     // Codex-rzfjw (WP-4): query the agreements model with all four
     // WP-1 filters pinned at invoice fire time, and JOIN to the
     // accepted proposal to read `proposed_creator_share_percent` as
@@ -4101,13 +4001,20 @@ export class SubscriptionService extends BaseService {
     // pointing at a synthesised round-1 'accepted' proposal whose
     // `proposed_creator_share_percent = 10000 - organization_fee_percentage`,
     // so this JOIN handles both pre-WP-1 and post-WP-1 rows uniformly.
-    const creatorAgreements = await this.db
+    //
+    // Codex-ez3tl (I3): leftJoin + NULL skip. `current_proposal_id` is
+    // FK `onDelete: 'set null'`, so a proposal delete nulls the link.
+    // The pre-fix `innerJoin` silently dropped such rows. The leftJoin
+    // surfaces them; rows with NULL share are skipped with a warn log
+    // so misconfigurations don't go undetected.
+    const creatorAgreementsRaw = await this.db
       .select({
+        agreementId: creatorOrganizationAgreements.id,
         creatorId: creatorOrganizationAgreements.creatorId,
         sharePercent: agreementProposals.proposedCreatorSharePercent,
       })
       .from(creatorOrganizationAgreements)
-      .innerJoin(
+      .leftJoin(
         agreementProposals,
         eq(
           agreementProposals.id,
@@ -4138,6 +4045,170 @@ export class SubscriptionService extends BaseService {
           )
         )
       );
+
+    const creatorAgreements: Array<{
+      creatorId: string;
+      sharePercent: number;
+    }> = [];
+    for (const row of creatorAgreementsRaw) {
+      if (row.sharePercent === null) {
+        this.obs.warn(
+          'payout: agreement has no current_proposal_id; skipping',
+          {
+            agreementId: row.agreementId,
+            organizationId: orgId,
+            creatorId: row.creatorId,
+            subscriptionId,
+          }
+        );
+        continue;
+      }
+      creatorAgreements.push({
+        creatorId: row.creatorId,
+        sharePercent: row.sharePercent,
+      });
+    }
+
+    // Codex-ez3tl (C1): compute the effective splits. When agreements
+    // exist with a positive totalShareBps, the org's fee is the
+    // post-platform residual (not the fee-config's static slice). When
+    // no agreements exist (or all are zero-share), the inputs from
+    // `computeSubscriptionSplit` are honoured unchanged — the org gets
+    // its fee-config slice and the org owner receives the creator pool
+    // via the fallback transfer below.
+    //
+    // `postPlatformCents` is the gross minus platform fee; reconstructed
+    // from the inputs since `calculateRevenueSplit` produced
+    // (platform + org + creator_pool == gross) and we have all three.
+    const postPlatformCents = orgFeeCents + creatorPayoutCents;
+    const totalShareBps = creatorAgreements.reduce(
+      (sum, a) => sum + a.sharePercent,
+      0
+    );
+
+    // When totalShareBps > 0, override the fee-config org slice with the
+    // post-platform residual. When totalShareBps == 0 (no agreements or
+    // all zero-share), keep the original orgFeeCents — the empty-agreements
+    // branch below will route the creator pool to the org owner.
+    const effectiveOrgFeeCents =
+      totalShareBps > 0
+        ? Math.floor(
+            (postPlatformCents * Math.max(0, 10_000 - totalShareBps)) / 10_000
+          )
+        : orgFeeCents;
+    const effectiveCreatorPoolCents = postPlatformCents - effectiveOrgFeeCents;
+
+    // Transfer org fee (now using the effective amount).
+    if (orgConnect?.chargesEnabled && effectiveOrgFeeCents > 0) {
+      try {
+        const transfer = await this.stripe.transfers.create(
+          {
+            amount: effectiveOrgFeeCents,
+            currency: CURRENCY.GBP,
+            destination: orgConnect.stripeAccountId,
+            source_transaction: chargeId,
+            transfer_group: transferGroup,
+            metadata: {
+              subscription_id: subscriptionId,
+              type: 'organization_fee',
+            },
+          },
+          { idempotencyKey: `${chargeId}_org_fee` }
+        );
+        // Record success in the ledger. The unique partial index on
+        // stripe_transfer_id collapses webhook double-fires to a single row;
+        // any other DB error gets logged loud — money moved but the ledger
+        // missed the entry, which is a data-integrity event worth paging on.
+        try {
+          await this.db.insert(payouts).values({
+            userId: orgConnect.userId,
+            organizationId: orgId,
+            subscriptionId,
+            amountCents: effectiveOrgFeeCents,
+            payoutType: 'organization_fee',
+            status: 'paid',
+            stripeTransferId: transfer.id,
+            stripeChargeId: chargeId,
+            transferGroup,
+            resolvedAt: new Date(),
+          });
+        } catch (insertError) {
+          if (!isUniqueViolation(insertError)) {
+            this.obs.error(
+              'Org transfer succeeded but payouts ledger insert failed',
+              {
+                subscriptionId,
+                organizationId: orgId,
+                stripeTransferId: transfer.id,
+                amountCents: effectiveOrgFeeCents,
+                error: (insertError as Error).message,
+              }
+            );
+          }
+        }
+      } catch (transferError) {
+        this.obs.error('Org transfer failed, accumulating as pending payout', {
+          subscriptionId,
+          organizationId: orgId,
+          amountCents: effectiveOrgFeeCents,
+          error: (transferError as Error).message,
+        });
+        try {
+          await this.db.insert(payouts).values({
+            userId: orgConnect.userId,
+            organizationId: orgId,
+            subscriptionId,
+            amountCents: effectiveOrgFeeCents,
+            payoutType: 'organization_fee',
+            status: 'failed',
+            reason: 'transfer_failed',
+          });
+        } catch (insertError) {
+          this.obs.error('Failed to record pending payout for org transfer', {
+            subscriptionId,
+            organizationId: orgId,
+            amountCents: effectiveOrgFeeCents,
+            error: (insertError as Error).message,
+          });
+        }
+      }
+    } else if (effectiveOrgFeeCents > 0) {
+      // Accumulate if Connect not ready — resolve the org owner's userId
+      const ownerId =
+        orgConnect?.userId ?? (await this.resolveOrgOwnerId(orgId));
+      if (!ownerId) {
+        this.obs.error(
+          'Cannot record pending payout: no Connect account and no org owner found',
+          {
+            subscriptionId,
+            organizationId: orgId,
+            amountCents: effectiveOrgFeeCents,
+          }
+        );
+      } else {
+        try {
+          await this.db.insert(payouts).values({
+            userId: ownerId,
+            organizationId: orgId,
+            subscriptionId,
+            amountCents: effectiveOrgFeeCents,
+            payoutType: 'organization_fee',
+            status: 'pending',
+            reason: 'connect_not_ready',
+          });
+        } catch (insertError) {
+          this.obs.error(
+            'Failed to record pending payout (Connect not ready)',
+            {
+              subscriptionId,
+              organizationId: orgId,
+              amountCents: effectiveOrgFeeCents,
+              error: (insertError as Error).message,
+            }
+          );
+        }
+      }
+    }
 
     if (creatorAgreements.length === 0) {
       // No creator agreements — org owner gets the full creator pool
@@ -4226,23 +4297,14 @@ export class SubscriptionService extends BaseService {
 
     // Distribute creator pool by per-creator share basis points
     // (Codex-rzfjw, WP-4 of Codex-nk4km): `creatorAgreements[i].sharePercent`
-    // is the creator's slice of the post-platform pool, derived from the
-    // legacy `organization_fee_percentage` column via
-    // `creatorShareFromLegacyOrgFee()` above. The sum may be < 10000
-    // (org owner retains the residual via the existing org_fee branch),
-    // = 10000 (org residual is zero — legal outcome), or > 10000 by
-    // design (multiple creators each accept their slice and the org
-    // ate the gap on negotiation). We normalise by the actual sum so
-    // total transferred never exceeds the creator pool.
-    const totalShareBps = creatorAgreements.reduce(
-      (sum, a) => sum + a.sharePercent,
-      0
-    );
-
+    // is the creator's slice of the POST-PLATFORM pool, per the
+    // agreement-math.ts ADR header. `totalShareBps` was computed above
+    // (before the org transfer) so the org's effective fee equals the
+    // post-platform residual `max(0, 10000 - totalShareBps)`.
+    //
     // Edge: every agreement carries `sharePercent=0` (e.g. legacy rows
-    // backfilled with org_fee=10000). totalShareBps would be 0 → divide
-    // by zero. Bail to the no-agreements branch — full creator pool
-    // routes to the org owner. Preserves the "org keeps all" fallback.
+    // backfilled with org_fee=10000). totalShareBps == 0 means there is
+    // no creator pool to distribute — route to the org owner instead.
     if (totalShareBps <= 0) {
       this.obs.info(
         'All active subscription agreements have zero creator share; routing pool to org owner',
@@ -4351,9 +4413,21 @@ export class SubscriptionService extends BaseService {
       );
     const connectByCreator = new Map(creatorConnects.map((c) => [c.userId, c]));
 
+    // Codex-ez3tl (C1): per-creator amount uses the POST-PLATFORM pool
+    // as the base and the creator's absolute share fraction — matching
+    // the ADR (agreement-math.ts header) and the content-purchase
+    // pipeline (purchase-service.ts via calculateRevenueSplit). The
+    // divisor is `max(totalShareBps, 10000)`:
+    //   - For well-formed configs where `validateProposedShare` bounds
+    //     sum ≤ 10000, the divisor is 10000 and each creator gets their
+    //     absolute share of post-platform.
+    //   - For oversum (totalShareBps > 10000) defensive clamp: divide
+    //     by the actual sum so total transferred never exceeds the pool
+    //     (creators jointly take 100% of post-platform, org gets 0).
+    const shareDivisor = Math.max(totalShareBps, 10_000);
     for (const agreement of creatorAgreements) {
       const creatorAmount = Math.floor(
-        (creatorPayoutCents * agreement.sharePercent) / totalShareBps
+        (postPlatformCents * agreement.sharePercent) / shareDivisor
       );
 
       // Codex-rzfjw: per-creator split observability. Emit one
@@ -4366,6 +4440,9 @@ export class SubscriptionService extends BaseService {
         amountCents: creatorAmount,
         sharePercent: agreement.sharePercent,
         totalShareBps,
+        postPlatformCents,
+        effectiveOrgFeeCents,
+        effectiveCreatorPoolCents,
       });
 
       if (creatorAmount <= 0) continue;


### PR DESCRIPTION
## Summary

Closes Codex-ez3tl. Fixes the pre-existing semantic mismatch in the subscription payout pipeline (flagged in PR #212's review) where creator shares were normalized as relative weights instead of treated as absolute fractions of the post-platform pool.

### C1 - Math alignment

When agreements exist, subscription pipeline now computes:
- `effectiveOrgFeePercent = max(0, 10000 - totalCreatorShareBps)`
- `creatorAmount = floor(postPlatform * sharePercent / max(totalShareBps, 10000))`

A 30% share creator now receives 30% of post-platform - matching the agreement-math ADR, the content-purchase pipeline (purchase-service.ts), `RevenueSplitPie`, and `validateProposedShare`.

The `max(totalShareBps, 10000)` divisor preserves the spec-prescribed `/10000` for well-formed configs while clamping defensively for oversum (no money creation).

### I1 - Exact-amount tests

Original-bug-reproduction test now asserts `expect(coCreatorCall.amount).toBe(270)` (the exact amount for 30% of 900-cent post-platform pool) plus an `org_fee` transfer of 630 (70% residual). Added a multi-creator exact-sum test (30/20/10%: 270+180+90 creator + 360 org = 900 post-platform, sums perfectly to 1000-cent invoice). Pre-existing under/over-sum tests reworked with exact-amount assertions to lock in post-fix economics.

### I3 - Ghost-agreement guard

Switched `innerJoin` to `leftJoin` in the agreement query inside `executeTransfers` and added a `warn` + skip handler for rows with NULL `current_proposal_id`. Closes the silent-drop window where a future admin tool could delete a proposal (FK `onDelete: 'set null'`) and the old `innerJoin` would drop the agreement without alerting.

**Chose Option B (leftJoin) over Option A (NOT NULL constraint)** because the FK delete behavior is `onDelete: 'set null'` - a NOT NULL schema constraint would conflict and block any future proposal delete. The leftJoin + skip handler is correct integrity behavior here. Added regression test seeding an orphan agreement that exercises the warn + skip path.

## Base branch

Stacks on `feat/codex-rzfjw-payout-pipeline` (WP-4 PR #212). Chain: WP-1 -> WP-2 -> WP-3 -> WP-4 -> this.

## Test plan

- [x] Subscription single-creator at 30%: exact 270 cents to creator (was 765 pre-fix), 630 to org
- [x] Subscription multi-creator at 30/20/10%: exact 270/180/90 + 360 org_fee, sums to invoice gross
- [x] No-agreements fallback: 100% to org via creator_pool_owner (unchanged behaviour)
- [x] Zero-share branch: all to org (unchanged)
- [x] Undersum 4000+4000=8000: 360 each creator + 180 org_fee residual
- [x] Oversum 6000+5000=11000: clamped via max-divisor; no over-pay
- [x] Orphan agreement (NULL current_proposal_id): warn-log + skip; no silent drop
- [x] Content-purchase pipeline math unchanged (already correct)
- [x] Subscription typecheck + tests (211 subscription-service tests pass)
- [x] Purchase typecheck + tests (220 tests pass)
- [x] Agreements typecheck + tests (70 tests pass)
- [x] Database typecheck

Bead: Codex-ez3tl
Epic: Codex-nk4km