### PR TITLE
feat(studio): WP-7 owner revenue-share settings tab

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@codex/access": "workspace:*",
     "@codex/admin": "workspace:*",
+    "@codex/agreements": "workspace:*",
     "@codex/cache": "workspace:*",
     "@codex/constants": "workspace:*",
     "@codex/database": "workspace:*",

--- a/apps/web/src/lib/components/agreements/AgreementCard.svelte
+++ b/apps/web/src/lib/components/agreements/AgreementCard.svelte
@@ -1,0 +1,554 @@
+<!--
+  @component AgreementCard
+
+  Per-creator card on the studio settings → revenue-share tab. Shows
+  side-by-side subscription + content_purchase agreement state for one
+  creator, with role-flipped action buttons.
+
+  Rows:
+    - "Subscription": share % of post-platform subscription revenue
+    - "Content purchase": share % of post-platform content_purchase revenue
+      for content this creator uploaded (per Decision Q1 —
+      creator's-own-content scope; see project_revenue_share_decisions).
+
+  Action button per row:
+    - No active agreement, no pending → "Propose"
+    - Active agreement → "Amend" (which proposes a fresh round-1)
+    - Pending proposal waiting on creator → "View thread" + status pill
+    - Pending counter received → "View thread" with action emphasis
+
+  All share % copy explicitly says "of post-platform [type] revenue" so the
+  user understands the math. Currency GBP throughout.
+
+  Props mirror the WP-7 spec in Codex-s80r6.
+-->
+<script lang="ts">
+  import type { AgreementProposal, CreatorOrganizationAgreement } from '@codex/agreements';
+
+  interface Creator {
+    id: string;
+    name: string | null;
+    avatarUrl: string | null;
+  }
+
+  interface PendingProposalSummary {
+    proposalId: string;
+    sharePercent: number;
+    termMonths: number | null;
+    proposedByRole: 'owner' | 'creator';
+    waitingOnRole: 'owner' | 'creator';
+    roundNumber: number;
+  }
+
+  interface Props {
+    creator: Creator;
+    /** Active agreement for subscription, if any. */
+    subscriptionAgreement?: CreatorOrganizationAgreement | null;
+    /** Active agreement for content_purchase, if any. */
+    contentPurchaseAgreement?: CreatorOrganizationAgreement | null;
+    /** Open / countered proposal for subscription, if any. */
+    pendingSubscriptionProposal?: PendingProposalSummary | null;
+    /** Open / countered proposal for content_purchase, if any. */
+    pendingContentPurchaseProposal?: PendingProposalSummary | null;
+    /** Triggers ProposeAgreementDialog at the parent. */
+    onPropose: (revenueType: 'subscription' | 'content_purchase') => void;
+    /** Triggers amend flow (a fresh round-1) at the parent. */
+    onAmend: (
+      revenueType: 'subscription' | 'content_purchase',
+      currentShareBp: number
+    ) => void;
+    /** Opens the negotiation thread drawer. */
+    onViewThread: (
+      revenueType: 'subscription' | 'content_purchase'
+    ) => void;
+    /** Optional composition seam — forwarded to the root element. */
+    class?: string;
+  }
+
+  const {
+    creator,
+    subscriptionAgreement = null,
+    contentPurchaseAgreement = null,
+    pendingSubscriptionProposal = null,
+    pendingContentPurchaseProposal = null,
+    onPropose,
+    onAmend,
+    onViewThread,
+    class: className,
+  }: Props = $props();
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  function formatPercent(bp: number): string {
+    const pct = bp / 100;
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  /**
+   * Reconstruct the creator share from the legacy `organization_fee_percentage`
+   * column. WP-4 introduced the via-proposal read path for the payout
+   * pipeline; the active agreement row still carries the legacy dual-write
+   * for narrow consumers (this card included).
+   */
+  function shareFromAgreement(
+    a: CreatorOrganizationAgreement | null | undefined
+  ): number | null {
+    if (!a) return null;
+    return 10000 - a.organizationFeePercentage;
+  }
+
+  function formatDate(date: Date | string | null | undefined): string {
+    if (!date) return '—';
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return d.toISOString().slice(0, 10);
+  }
+
+  function getInitials(name: string | null): string {
+    if (!name) return '?';
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 0) return '?';
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+
+  // ─── Row state derivation ─────────────────────────────────────────────────
+
+  type RowState =
+    | { kind: 'none' }
+    | { kind: 'active'; sharePercent: number; effectiveFrom: Date | string; effectiveUntil: Date | string | null }
+    | { kind: 'pending-owner-waiting'; sharePercent: number; roundNumber: number }
+    | { kind: 'pending-counter-received'; sharePercent: number; roundNumber: number }
+    | { kind: 'active-with-pending'; sharePercent: number; pendingShare: number; pendingWaitingOnCreator: boolean };
+
+  function deriveRowState(
+    active: CreatorOrganizationAgreement | null,
+    pending: PendingProposalSummary | null
+  ): RowState {
+    const activeShare = shareFromAgreement(active);
+    if (active && activeShare != null && pending) {
+      return {
+        kind: 'active-with-pending',
+        sharePercent: activeShare,
+        pendingShare: pending.sharePercent,
+        pendingWaitingOnCreator: pending.waitingOnRole === 'creator',
+      };
+    }
+    if (active && activeShare != null) {
+      return {
+        kind: 'active',
+        sharePercent: activeShare,
+        effectiveFrom: active.effectiveFrom,
+        effectiveUntil: active.effectiveUntil,
+      };
+    }
+    if (pending) {
+      // From the owner's perspective: "waiting on creator" or "counter received"
+      if (pending.waitingOnRole === 'creator') {
+        return {
+          kind: 'pending-owner-waiting',
+          sharePercent: pending.sharePercent,
+          roundNumber: pending.roundNumber,
+        };
+      }
+      return {
+        kind: 'pending-counter-received',
+        sharePercent: pending.sharePercent,
+        roundNumber: pending.roundNumber,
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  const subscriptionState = $derived(
+    deriveRowState(subscriptionAgreement, pendingSubscriptionProposal)
+  );
+  const contentPurchaseState = $derived(
+    deriveRowState(contentPurchaseAgreement, pendingContentPurchaseProposal)
+  );
+</script>
+
+<article class="agreement-card {className ?? ''}" aria-label="Agreement for {creator.name ?? 'Creator'}">
+  <header class="agreement-card__header">
+    <div class="agreement-card__identity">
+      <div class="agreement-card__avatar" aria-hidden="true">
+        {#if creator.avatarUrl}
+          <img src={creator.avatarUrl} alt="" loading="lazy" />
+        {:else}
+          <span class="agreement-card__avatar-fallback">{getInitials(creator.name)}</span>
+        {/if}
+      </div>
+      <div class="agreement-card__identity-text">
+        <h3 class="agreement-card__name">{creator.name ?? 'Unnamed creator'}</h3>
+      </div>
+    </div>
+  </header>
+
+  <div class="agreement-card__rows">
+    {#each [
+      { revType: 'subscription' as const, label: 'Subscription', state: subscriptionState },
+      { revType: 'content_purchase' as const, label: 'Content purchase', state: contentPurchaseState },
+    ] as row (row.revType)}
+      <section
+        class="agreement-card__row"
+        data-state={row.state.kind}
+        aria-label="{row.label} agreement"
+      >
+        <div class="agreement-card__row-head">
+          <span class="agreement-card__row-label">{row.label}</span>
+          {#if row.state.kind === 'pending-owner-waiting'}
+            <span class="agreement-card__pill agreement-card__pill--neutral">
+              Waiting on creator · Round {row.state.roundNumber}
+            </span>
+          {:else if row.state.kind === 'pending-counter-received'}
+            <span class="agreement-card__pill agreement-card__pill--info">
+              Counter received · Round {row.state.roundNumber}
+            </span>
+          {:else if row.state.kind === 'active'}
+            <span class="agreement-card__pill agreement-card__pill--success">Active</span>
+          {:else if row.state.kind === 'active-with-pending'}
+            <span class="agreement-card__pill agreement-card__pill--success">Active</span>
+            <span class="agreement-card__pill agreement-card__pill--info">
+              {row.state.pendingWaitingOnCreator ? 'Amendment waiting' : 'Counter received'}
+            </span>
+          {:else}
+            <span class="agreement-card__pill agreement-card__pill--muted">No agreement</span>
+          {/if}
+        </div>
+
+        <div class="agreement-card__row-body">
+          {#if row.state.kind === 'active' || row.state.kind === 'active-with-pending'}
+            <dl class="agreement-card__row-detail">
+              <div class="agreement-card__row-detail-cell">
+                <dt>Share</dt>
+                <dd>
+                  <strong>{formatPercent(row.state.sharePercent)}</strong>
+                  <span class="agreement-card__row-detail-hint">
+                    of post-platform {row.label.toLowerCase()} revenue
+                  </span>
+                </dd>
+              </div>
+              {#if row.state.kind === 'active'}
+                <div class="agreement-card__row-detail-cell">
+                  <dt>Effective from</dt>
+                  <dd>{formatDate(row.state.effectiveFrom)}</dd>
+                </div>
+                {#if row.state.effectiveUntil}
+                  <div class="agreement-card__row-detail-cell">
+                    <dt>Effective until</dt>
+                    <dd>{formatDate(row.state.effectiveUntil)}</dd>
+                  </div>
+                {/if}
+              {/if}
+              {#if row.state.kind === 'active-with-pending'}
+                <div class="agreement-card__row-detail-cell">
+                  <dt>Pending share</dt>
+                  <dd>
+                    <strong>{formatPercent(row.state.pendingShare)}</strong>
+                    <span class="agreement-card__row-detail-hint">
+                      of post-platform {row.label.toLowerCase()} revenue
+                    </span>
+                  </dd>
+                </div>
+              {/if}
+            </dl>
+          {:else if row.state.kind === 'pending-owner-waiting' || row.state.kind === 'pending-counter-received'}
+            <dl class="agreement-card__row-detail">
+              <div class="agreement-card__row-detail-cell">
+                <dt>Proposed share</dt>
+                <dd>
+                  <strong>{formatPercent(row.state.sharePercent)}</strong>
+                  <span class="agreement-card__row-detail-hint">
+                    of post-platform {row.label.toLowerCase()} revenue
+                  </span>
+                </dd>
+              </div>
+            </dl>
+          {:else}
+            <p class="agreement-card__row-empty">
+              No revenue share configured. Default: org keeps 100% of post-platform {row.label.toLowerCase()} revenue.
+            </p>
+          {/if}
+        </div>
+
+        <div class="agreement-card__row-actions">
+          {#if row.state.kind === 'none'}
+            <button
+              type="button"
+              class="agreement-card__btn agreement-card__btn--primary"
+              onclick={() => onPropose(row.revType)}
+            >
+              Propose agreement
+            </button>
+          {:else if row.state.kind === 'active'}
+            {@const activeShare = row.state.sharePercent}
+            <button
+              type="button"
+              class="agreement-card__btn agreement-card__btn--secondary"
+              onclick={() => onAmend(row.revType, activeShare)}
+            >
+              Amend
+            </button>
+            <button
+              type="button"
+              class="agreement-card__btn agreement-card__btn--ghost"
+              onclick={() => onViewThread(row.revType)}
+            >
+              View thread
+            </button>
+          {:else if row.state.kind === 'pending-owner-waiting' || row.state.kind === 'pending-counter-received' || row.state.kind === 'active-with-pending'}
+            {@const showReviewCopy =
+              row.state.kind === 'pending-counter-received' ||
+              (row.state.kind === 'active-with-pending' && !row.state.pendingWaitingOnCreator)}
+            <button
+              type="button"
+              class="agreement-card__btn agreement-card__btn--primary"
+              onclick={() => onViewThread(row.revType)}
+            >
+              {showReviewCopy ? 'Review counter' : 'View thread'}
+            </button>
+          {/if}
+        </div>
+      </section>
+    {/each}
+  </div>
+</article>
+
+<style>
+  .agreement-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-5);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .agreement-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .agreement-card__identity {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    min-width: 0;
+  }
+
+  .agreement-card__avatar {
+    display: grid;
+    place-items: center;
+    width: var(--space-10);
+    height: var(--space-10);
+    background: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    flex-shrink: 0;
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+  }
+
+  .agreement-card__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .agreement-card__avatar-fallback {
+    line-height: 1;
+  }
+
+  .agreement-card__identity-text {
+    min-width: 0;
+  }
+
+  .agreement-card__name {
+    margin: 0;
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agreement-card__rows {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+
+  @container (min-width: 48rem) {
+    .agreement-card__rows {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .agreement-card__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    background: var(--color-surface-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    border-radius: var(--radius-md);
+  }
+
+  .agreement-card__row-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .agreement-card__row-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .agreement-card__pill {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-0-5) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-full);
+    border: var(--border-width) var(--border-style) transparent;
+  }
+
+  .agreement-card__pill--muted {
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    border-color: var(--color-border);
+  }
+
+  .agreement-card__pill--neutral {
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    border-color: var(--color-border);
+  }
+
+  .agreement-card__pill--info {
+    background: var(--color-info-50);
+    color: var(--color-info-700);
+    border-color: var(--color-info-200);
+  }
+
+  .agreement-card__pill--success {
+    background: var(--color-success-50);
+    color: var(--color-success-700);
+    border-color: var(--color-success-200);
+  }
+
+  .agreement-card__row-body {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .agreement-card__row-detail {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin: 0;
+  }
+
+  .agreement-card__row-detail-cell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+  }
+
+  .agreement-card__row-detail-cell dt {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .agreement-card__row-detail-cell dd {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .agreement-card__row-detail-cell dd strong {
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+    color: var(--color-text);
+  }
+
+  .agreement-card__row-detail-hint {
+    display: block;
+    margin-top: var(--space-0-5);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .agreement-card__row-empty {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .agreement-card__row-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .agreement-card__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-md);
+    border: var(--border-width) var(--border-style) transparent;
+    cursor: pointer;
+    transition: var(--transition-colors);
+    text-decoration: none;
+  }
+
+  .agreement-card__btn:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .agreement-card__btn--primary {
+    background: var(--color-interactive);
+    color: var(--color-text-on-brand);
+  }
+
+  .agreement-card__btn--primary:hover {
+    background: var(--color-interactive-hover);
+  }
+
+  .agreement-card__btn--secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+
+  .agreement-card__btn--secondary:hover {
+    background: var(--color-surface-tertiary);
+  }
+
+  .agreement-card__btn--ghost {
+    background: transparent;
+    color: var(--color-text-secondary);
+  }
+
+  .agreement-card__btn--ghost:hover {
+    color: var(--color-text);
+    background: var(--color-surface-tertiary);
+  }
+</style>

--- a/apps/web/src/lib/components/agreements/AgreementCard.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/AgreementCard.svelte.test.ts
@@ -1,0 +1,193 @@
+/**
+ * AgreementCard unit tests (WP-7 — Codex-s80r6)
+ *
+ * Verifies prop-driven rendering for each agreement state (none, active,
+ * pending) and that action callbacks fire with the correct revenue-type
+ * + share arguments. Covers the post-platform copy alignment + the
+ * narrowing of the RowState union.
+ */
+
+import type { CreatorOrganizationAgreement } from '@codex/agreements';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import AgreementCard from './AgreementCard.svelte';
+
+function makeActiveAgreement(
+  overrides: Partial<CreatorOrganizationAgreement> = {}
+): CreatorOrganizationAgreement {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    creatorId: '22222222-2222-2222-2222-222222222222',
+    organizationId: '33333333-3333-3333-3333-333333333333',
+    organizationFeePercentage: 6000, // → creator share 4000 bp = 40%
+    revenueType: 'subscription',
+    status: 'active',
+    currentProposalId: null,
+    effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    effectiveUntil: null,
+    terminatedAt: null,
+    terminatedByUserId: null,
+    terminationReason: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as CreatorOrganizationAgreement;
+}
+
+describe('AgreementCard', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('renders creator name + no-agreement empty state for both rows', () => {
+    component = mount(AgreementCard, {
+      target: document.body,
+      props: {
+        creator: { id: 'c1', name: 'Alex Rivera', avatarUrl: null },
+        onPropose: vi.fn(),
+        onAmend: vi.fn(),
+        onViewThread: vi.fn(),
+      },
+    });
+    expect(document.body.textContent).toContain('Alex Rivera');
+    expect(document.body.textContent).toContain('No agreement');
+    expect(document.body.textContent).toContain('Subscription');
+    expect(document.body.textContent).toContain('Content purchase');
+    // Two propose buttons — one per row
+    const proposeButtons = Array.from(
+      document.body.querySelectorAll('button')
+    ).filter((b) => b.textContent?.includes('Propose agreement'));
+    expect(proposeButtons.length).toBe(2);
+  });
+
+  test('fires onPropose with the row revenueType when Propose clicked', () => {
+    const onPropose = vi.fn();
+    component = mount(AgreementCard, {
+      target: document.body,
+      props: {
+        creator: { id: 'c1', name: 'Alex', avatarUrl: null },
+        onPropose,
+        onAmend: vi.fn(),
+        onViewThread: vi.fn(),
+      },
+    });
+    const buttons = Array.from(document.body.querySelectorAll('button')).filter(
+      (b) => b.textContent?.includes('Propose agreement')
+    );
+    (buttons[0] as HTMLButtonElement).click();
+    flushSync();
+    expect(onPropose).toHaveBeenCalledWith('subscription');
+    (buttons[1] as HTMLButtonElement).click();
+    flushSync();
+    expect(onPropose).toHaveBeenCalledWith('content_purchase');
+  });
+
+  test('renders share % with post-platform copy when active', () => {
+    component = mount(AgreementCard, {
+      target: document.body,
+      props: {
+        creator: { id: 'c1', name: 'Alex', avatarUrl: null },
+        subscriptionAgreement: makeActiveAgreement({
+          organizationFeePercentage: 7000, // share = 30%
+        }),
+        onPropose: vi.fn(),
+        onAmend: vi.fn(),
+        onViewThread: vi.fn(),
+      },
+    });
+    expect(document.body.textContent).toContain('30%');
+    expect(document.body.textContent).toContain(
+      'post-platform subscription revenue'
+    );
+    expect(document.body.textContent).toContain('Active');
+  });
+
+  test('Amend button passes the current share back as basis points', () => {
+    const onAmend = vi.fn();
+    component = mount(AgreementCard, {
+      target: document.body,
+      props: {
+        creator: { id: 'c1', name: 'Alex', avatarUrl: null },
+        subscriptionAgreement: makeActiveAgreement({
+          organizationFeePercentage: 6500, // share = 35%
+        }),
+        onPropose: vi.fn(),
+        onAmend,
+        onViewThread: vi.fn(),
+      },
+    });
+    const amend = Array.from(document.body.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Amend'
+    ) as HTMLButtonElement;
+    expect(amend).toBeDefined();
+    amend.click();
+    flushSync();
+    expect(onAmend).toHaveBeenCalledWith('subscription', 3500); // 10000 - 6500
+  });
+
+  test('renders Counter-received state and review button when pending counter waits on owner', () => {
+    const onViewThread = vi.fn();
+    component = mount(AgreementCard, {
+      target: document.body,
+      props: {
+        creator: { id: 'c1', name: 'Alex', avatarUrl: null },
+        pendingSubscriptionProposal: {
+          proposalId: 'p1',
+          sharePercent: 4000,
+          termMonths: 12,
+          proposedByRole: 'creator',
+          waitingOnRole: 'owner',
+          roundNumber: 2,
+        },
+        onPropose: vi.fn(),
+        onAmend: vi.fn(),
+        onViewThread,
+      },
+    });
+    expect(document.body.textContent).toContain('Counter received');
+    expect(document.body.textContent).toContain('Round 2');
+    const review = Array.from(document.body.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Review counter')
+    ) as HTMLButtonElement;
+    expect(review).toBeDefined();
+    review.click();
+    flushSync();
+    expect(onViewThread).toHaveBeenCalledWith('subscription');
+  });
+
+  test('renders Waiting-on-creator state when owner has sent a fresh proposal', () => {
+    component = mount(AgreementCard, {
+      target: document.body,
+      props: {
+        creator: { id: 'c1', name: 'Alex', avatarUrl: null },
+        pendingContentPurchaseProposal: {
+          proposalId: 'p2',
+          sharePercent: 3500,
+          termMonths: 6,
+          proposedByRole: 'owner',
+          waitingOnRole: 'creator',
+          roundNumber: 1,
+        },
+        onPropose: vi.fn(),
+        onAmend: vi.fn(),
+        onViewThread: vi.fn(),
+      },
+    });
+    expect(document.body.textContent).toContain('Waiting on creator');
+    expect(document.body.textContent).toContain('Round 1');
+    expect(document.body.textContent).toContain('35%');
+    expect(document.body.textContent).toContain(
+      'post-platform content purchase revenue'
+    );
+  });
+});

--- a/apps/web/src/lib/components/agreements/NegotiationThread.svelte
+++ b/apps/web/src/lib/components/agreements/NegotiationThread.svelte
@@ -1,0 +1,417 @@
+<!--
+  @component NegotiationThread
+
+  Chronological list of proposals in a negotiation thread for one
+  (org, creator, revenueType) triple. Shared between WP-7 owner surface
+  and WP-8 creator surface — the component itself is role-agnostic; the
+  parent decides which action callbacks to wire based on who's viewing.
+
+  All share % copy explicitly says "of post-platform [revenue_type] revenue"
+  per the C1 math semantic. Currency GBP.
+
+  The latest open proposal (`proposals.at(-1)` if `status === 'open'`) is
+  the only one that's actionable. The parent decides which callbacks to
+  wire based on actor role + counterparty rules. The component just
+  renders buttons for whatever callbacks it received.
+-->
+<script lang="ts">
+  import type { AgreementProposal } from '@codex/agreements';
+
+  type RevenueType = 'subscription' | 'content_purchase';
+
+  interface Props {
+    /** Chronological proposals; oldest first. */
+    proposals: AgreementProposal[];
+    /**
+     * Revenue type for copy alignment ("subscription revenue" vs
+     * "content-purchase revenue").
+     */
+    revenueType: RevenueType;
+    /**
+     * Display names for proposer roles. Use 'You' for the current viewer.
+     * Example: { owner: 'You', creator: 'Alex Rivera' }
+     */
+    roleLabels: { owner: string; creator: string };
+    /** Only wired when the viewer is allowed to counter the latest open proposal. */
+    onCounter?: (proposalId: string) => void;
+    /** Only wired when the viewer is the counterparty of an open proposal. */
+    onAccept?: (proposalId: string) => void;
+    /** Only wired when the viewer is the counterparty of an open proposal. */
+    onDecline?: (proposalId: string) => void;
+    /** Only wired when the viewer is the proposing side of an open proposal. */
+    onWithdraw?: (proposalId: string) => void;
+    /** Optional composition seam. */
+    class?: string;
+  }
+
+  const {
+    proposals,
+    revenueType,
+    roleLabels,
+    onCounter,
+    onAccept,
+    onDecline,
+    onWithdraw,
+    class: className,
+  }: Props = $props();
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  function formatPercent(bp: number): string {
+    const pct = bp / 100;
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  function formatDate(date: Date | string | null | undefined): string {
+    if (!date) return '—';
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return d.toISOString().slice(0, 10);
+  }
+
+  function formatTerm(months: number | null): string {
+    if (months == null) return 'Indefinite';
+    return months === 1 ? '1 month' : `${months} months`;
+  }
+
+  function statusLabel(status: string): string {
+    switch (status) {
+      case 'open':
+        return 'Open';
+      case 'accepted':
+        return 'Accepted';
+      case 'declined':
+        return 'Declined';
+      case 'countered':
+        return 'Countered';
+      case 'withdrawn':
+        return 'Withdrawn';
+      case 'superseded':
+        return 'Superseded';
+      default:
+        return status;
+    }
+  }
+
+  const revenueLabel = $derived(
+    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
+  );
+
+  // The latest proposal — open ones are the only actionable rows.
+  const latestProposal = $derived(proposals.at(-1) ?? null);
+  const latestIsOpen = $derived(latestProposal?.status === 'open');
+</script>
+
+<ol class="negotiation-thread {className ?? ''}" aria-label="Negotiation history">
+  {#if proposals.length === 0}
+    <li class="negotiation-thread__empty">
+      <p>No proposals yet. Start a negotiation to record terms here.</p>
+    </li>
+  {:else}
+    {#each proposals as proposal, index (proposal.id)}
+      {@const isLatest = index === proposals.length - 1}
+      {@const proposerLabel = proposal.proposedByRole === 'owner' ? roleLabels.owner : roleLabels.creator}
+      <li class="negotiation-thread__item" data-status={proposal.status}>
+        <div class="negotiation-thread__item-head">
+          <span class="negotiation-thread__round">Round {proposal.roundNumber}</span>
+          <span class="negotiation-thread__proposer">
+            Proposed by <strong>{proposerLabel}</strong>
+          </span>
+          <span class="negotiation-thread__date">
+            {formatDate(proposal.createdAt)}
+          </span>
+          <span
+            class="negotiation-thread__status"
+            data-status={proposal.status}
+          >
+            {statusLabel(proposal.status)}
+          </span>
+        </div>
+
+        <dl class="negotiation-thread__details">
+          <div class="negotiation-thread__detail-cell">
+            <dt>Share</dt>
+            <dd>
+              <strong>{formatPercent(proposal.proposedCreatorSharePercent)}</strong>
+              <span class="negotiation-thread__detail-hint">
+                of post-platform {revenueLabel} revenue
+              </span>
+            </dd>
+          </div>
+          <div class="negotiation-thread__detail-cell">
+            <dt>Term</dt>
+            <dd>{formatTerm(proposal.proposedTermMonths)}</dd>
+          </div>
+          <div class="negotiation-thread__detail-cell">
+            <dt>Effective from</dt>
+            <dd>{formatDate(proposal.proposedEffectiveFrom)}</dd>
+          </div>
+        </dl>
+
+        {#if proposal.note}
+          <blockquote class="negotiation-thread__note">
+            <strong>Note:</strong> {proposal.note}
+          </blockquote>
+        {/if}
+
+        {#if proposal.status === 'declined' && proposal.declineReason}
+          <blockquote class="negotiation-thread__note negotiation-thread__note--decline">
+            <strong>Decline reason:</strong> {proposal.declineReason}
+          </blockquote>
+        {/if}
+
+        {#if isLatest && latestIsOpen}
+          <div class="negotiation-thread__actions">
+            {#if onAccept}
+              <button
+                type="button"
+                class="negotiation-thread__btn negotiation-thread__btn--primary"
+                onclick={() => onAccept?.(proposal.id)}
+              >
+                Accept
+              </button>
+            {/if}
+            {#if onCounter}
+              <button
+                type="button"
+                class="negotiation-thread__btn negotiation-thread__btn--secondary"
+                onclick={() => onCounter?.(proposal.id)}
+              >
+                Counter
+              </button>
+            {/if}
+            {#if onDecline}
+              <button
+                type="button"
+                class="negotiation-thread__btn negotiation-thread__btn--ghost"
+                onclick={() => onDecline?.(proposal.id)}
+              >
+                Decline
+              </button>
+            {/if}
+            {#if onWithdraw}
+              <button
+                type="button"
+                class="negotiation-thread__btn negotiation-thread__btn--ghost"
+                onclick={() => onWithdraw?.(proposal.id)}
+              >
+                Withdraw
+              </button>
+            {/if}
+          </div>
+        {/if}
+      </li>
+    {/each}
+  {/if}
+</ol>
+
+<style>
+  .negotiation-thread {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .negotiation-thread__empty {
+    padding: var(--space-6);
+    text-align: center;
+    background: var(--color-surface-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiation-thread__empty p {
+    margin: 0;
+    font-size: var(--text-sm);
+  }
+
+  .negotiation-thread__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+  }
+
+  .negotiation-thread__item[data-status='superseded'],
+  .negotiation-thread__item[data-status='withdrawn'] {
+    opacity: var(--opacity-60, 0.6);
+  }
+
+  .negotiation-thread__item-head {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .negotiation-thread__round {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+    font-weight: var(--font-medium);
+  }
+
+  .negotiation-thread__proposer {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .negotiation-thread__proposer strong {
+    color: var(--color-text);
+  }
+
+  .negotiation-thread__date {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .negotiation-thread__status {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-0-5) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-full);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiation-thread__status[data-status='open'] {
+    background: var(--color-info-50);
+    color: var(--color-info-700);
+    border-color: var(--color-info-200);
+  }
+
+  .negotiation-thread__status[data-status='accepted'] {
+    background: var(--color-success-50);
+    color: var(--color-success-700);
+    border-color: var(--color-success-200);
+  }
+
+  .negotiation-thread__status[data-status='declined'],
+  .negotiation-thread__status[data-status='withdrawn'] {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+  }
+
+  .negotiation-thread__details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: var(--space-2);
+    margin: 0;
+  }
+
+  .negotiation-thread__detail-cell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+  }
+
+  .negotiation-thread__detail-cell dt {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .negotiation-thread__detail-cell dd {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .negotiation-thread__detail-cell dd strong {
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+  }
+
+  .negotiation-thread__detail-hint {
+    display: block;
+    margin-top: var(--space-0-5);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .negotiation-thread__note {
+    margin: 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-surface-secondary);
+    border-inline-start: var(--border-width-thick) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiation-thread__note strong {
+    color: var(--color-text);
+  }
+
+  .negotiation-thread__note--decline {
+    border-inline-start-color: var(--color-error-200);
+  }
+
+  .negotiation-thread__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    padding-top: var(--space-2);
+    border-top: var(--border-width) var(--border-style) var(--color-border-subtle);
+  }
+
+  .negotiation-thread__btn {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-md);
+    border: var(--border-width) var(--border-style) transparent;
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .negotiation-thread__btn:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .negotiation-thread__btn--primary {
+    background: var(--color-interactive);
+    color: var(--color-text-on-brand);
+  }
+
+  .negotiation-thread__btn--primary:hover {
+    background: var(--color-interactive-hover);
+  }
+
+  .negotiation-thread__btn--secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+
+  .negotiation-thread__btn--secondary:hover {
+    background: var(--color-surface-tertiary);
+  }
+
+  .negotiation-thread__btn--ghost {
+    background: transparent;
+    color: var(--color-text-secondary);
+  }
+
+  .negotiation-thread__btn--ghost:hover {
+    color: var(--color-text);
+    background: var(--color-surface-tertiary);
+  }
+</style>

--- a/apps/web/src/lib/components/agreements/NegotiationThread.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/NegotiationThread.svelte.test.ts
@@ -1,0 +1,173 @@
+/**
+ * NegotiationThread unit tests (WP-7 — Codex-s80r6, shared with WP-8)
+ *
+ * Verifies chronological rendering, status pill coverage, post-platform
+ * copy alignment, and that only the latest open proposal renders action
+ * buttons (and only those passed in as callbacks).
+ */
+
+import type { AgreementProposal } from '@codex/agreements';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import NegotiationThread from './NegotiationThread.svelte';
+
+function makeProposal(
+  overrides: Partial<AgreementProposal> = {}
+): AgreementProposal {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    organizationId: '33333333-3333-3333-3333-333333333333',
+    creatorId: '22222222-2222-2222-2222-222222222222',
+    parentProposalId: null,
+    roundNumber: 1,
+    revenueType: 'subscription',
+    proposedByUserId: '44444444-4444-4444-4444-444444444444',
+    proposedByRole: 'owner',
+    proposedCreatorSharePercent: 3000,
+    proposedTermMonths: 12,
+    proposedEffectiveFrom: new Date('2026-01-01T00:00:00Z'),
+    note: null,
+    status: 'open',
+    respondedAt: null,
+    respondedByUserId: null,
+    declineReason: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as AgreementProposal;
+}
+
+describe('NegotiationThread', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('renders empty state when no proposals', () => {
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [],
+        revenueType: 'subscription',
+        roleLabels: { owner: 'You', creator: 'Alex' },
+      },
+    });
+    expect(document.body.textContent).toContain('No proposals yet');
+  });
+
+  test('renders share % with post-platform copy', () => {
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [makeProposal({ proposedCreatorSharePercent: 4000 })],
+        revenueType: 'subscription',
+        roleLabels: { owner: 'You', creator: 'Alex' },
+      },
+    });
+    expect(document.body.textContent).toContain('40%');
+    expect(document.body.textContent).toContain(
+      'post-platform subscription revenue'
+    );
+  });
+
+  test('uses content-purchase label for content_purchase revenue type', () => {
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [makeProposal({ revenueType: 'content_purchase' })],
+        revenueType: 'content_purchase',
+        roleLabels: { owner: 'You', creator: 'Alex' },
+      },
+    });
+    expect(document.body.textContent).toContain(
+      'post-platform content-purchase revenue'
+    );
+  });
+
+  test('renders proposer label from roleLabels', () => {
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [makeProposal({ proposedByRole: 'creator' })],
+        revenueType: 'subscription',
+        roleLabels: { owner: 'You', creator: 'Alex Rivera' },
+      },
+    });
+    expect(document.body.textContent).toContain('Alex Rivera');
+  });
+
+  test('renders only the latest open proposal as actionable', () => {
+    const onAccept = vi.fn();
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [
+          makeProposal({
+            id: 'p1',
+            roundNumber: 1,
+            status: 'countered',
+            proposedByRole: 'owner',
+          }),
+          makeProposal({
+            id: 'p2',
+            roundNumber: 2,
+            status: 'open',
+            parentProposalId: 'p1',
+            proposedByRole: 'creator',
+            proposedCreatorSharePercent: 4500,
+          }),
+        ],
+        revenueType: 'subscription',
+        roleLabels: { owner: 'You', creator: 'Alex' },
+        onAccept,
+      },
+    });
+    const acceptButtons = Array.from(
+      document.body.querySelectorAll('button')
+    ).filter((b) => b.textContent?.trim() === 'Accept');
+    expect(acceptButtons.length).toBe(1); // only the latest open one
+    acceptButtons[0].click();
+    flushSync();
+    expect(onAccept).toHaveBeenCalledWith('p2');
+  });
+
+  test('does not render action buttons when no callbacks are provided', () => {
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [makeProposal()],
+        revenueType: 'subscription',
+        roleLabels: { owner: 'You', creator: 'Alex' },
+      },
+    });
+    const buttons = Array.from(document.body.querySelectorAll('button'));
+    expect(buttons.length).toBe(0);
+  });
+
+  test('renders decline reason when status is declined', () => {
+    component = mount(NegotiationThread, {
+      target: document.body,
+      props: {
+        proposals: [
+          makeProposal({
+            status: 'declined',
+            declineReason: 'Below our minimum margin',
+          }),
+        ],
+        revenueType: 'subscription',
+        roleLabels: { owner: 'You', creator: 'Alex' },
+      },
+    });
+    expect(document.body.textContent).toContain('Decline reason');
+    expect(document.body.textContent).toContain('Below our minimum margin');
+  });
+});

--- a/apps/web/src/lib/components/agreements/ProposeAgreementDialog.svelte
+++ b/apps/web/src/lib/components/agreements/ProposeAgreementDialog.svelte
@@ -1,0 +1,326 @@
+<!--
+  @component ProposeAgreementDialog
+
+  Dialog for proposing (round-1) or amending a revenue-share agreement with
+  one creator. Uses BrandSliderField for the share% input + a radio group
+  for term-month picker + optional note.
+
+  Copy explicitly says "X% of post-platform [revenue_type] revenue" so the
+  user understands the post-platform-pool semantic (per the C1 math
+  decision; see project_revenue_share_decisions Q2).
+
+  Idempotent open-state handler per [[melt-controlled-components]] —
+  `onOpenChange` early-returns when next === current to avoid spurious
+  side-effect echoes from Melt UI's controlled-component lifecycle.
+
+  Currency: GBP (£). Used inside the studio settings → revenue-share tab
+  for both the round-1 propose flow AND the amend flow (amend just
+  pre-fills the slider with the current share).
+-->
+<script lang="ts">
+  import BrandSliderField from '$lib/components/brand-editor/BrandSliderField.svelte';
+  import { DialogForm } from '$lib/components/ui/DialogForm';
+
+  type RevenueType = 'subscription' | 'content_purchase';
+
+  interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    creatorName: string;
+    revenueType: RevenueType;
+    /** Pre-fill share % in basis points. Defaults to 3000 (30%). */
+    initialShareBp?: number;
+    /** Pre-fill term months. Defaults to 12. */
+    initialTermMonths?: number;
+    /**
+     * Submit handler. Returns when the propose succeeds; the dialog closes
+     * on success. Throw to surface an error message inline.
+     */
+    onSubmit: (input: {
+      sharePercent: number;
+      termMonths: number;
+      note?: string;
+    }) => Promise<void>;
+    /** Used in the dialog title — "Propose…" vs "Amend…". */
+    mode?: 'propose' | 'amend';
+  }
+
+  const {
+    open,
+    onOpenChange,
+    creatorName,
+    revenueType,
+    initialShareBp = 3000,
+    initialTermMonths = 12,
+    onSubmit,
+    mode = 'propose',
+  }: Props = $props();
+
+  // ─── Form state ──────────────────────────────────────────────────────────
+  //
+  // Initial value comes from props; the `$effect` below re-syncs whenever
+  // the dialog (re-)opens — covers switching creators / amend defaults
+  // without losing the user's in-progress slider position when the dialog
+  // is already open. Capturing the prop in `$state(...)` at init is the
+  // documented Svelte 5 pattern for "seed from a prop, then own it".
+
+  let shareBp = $state(initialShareBp);
+  let termMonths = $state(initialTermMonths);
+  let note = $state('');
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  // Reset when the dialog opens (e.g. switching creator/revenue-type).
+  // The boolean `open` is the tracked dependency; reading the initial-*
+  // props inside is fine because we explicitly want their CURRENT value
+  // each time the dialog opens, not a snapshot taken at component mount.
+  $effect(() => {
+    if (open) {
+      shareBp = initialShareBp;
+      termMonths = initialTermMonths;
+      note = '';
+      error = null;
+    }
+  });
+
+  const revenueLabel = $derived(
+    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
+  );
+  const sharePercent = $derived(shareBp / 100);
+  const formattedShare = $derived(
+    Number.isInteger(sharePercent)
+      ? `${sharePercent}%`
+      : `${sharePercent.toFixed(1)}%`
+  );
+  const ariaValueText = $derived(
+    `${formattedShare} of post-platform ${revenueLabel} revenue`
+  );
+
+  const termOptions = [
+    { value: 3, label: '3 months' },
+    { value: 6, label: '6 months' },
+    { value: 12, label: '12 months' },
+    { value: 24, label: '24 months' },
+    { value: 36, label: '36 months' },
+  ];
+
+  function onShareInput(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const raw = Number(target.value);
+    if (!Number.isFinite(raw)) return;
+    shareBp = Math.min(10000, Math.max(0, Math.round(raw * 100)));
+  }
+
+  async function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    error = null;
+
+    if (note.length > 500) {
+      error = 'Note must be 500 characters or less';
+      return;
+    }
+
+    submitting = true;
+    try {
+      await onSubmit({
+        sharePercent: shareBp,
+        termMonths,
+        note: note.trim() || undefined,
+      });
+      // Parent will close on success; the form resets via the $effect above
+      // when `open` flips next.
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to submit proposal';
+    } finally {
+      submitting = false;
+    }
+  }
+
+  /**
+   * Idempotent open-change handler — when Melt UI fires onOpenChange during
+   * its controlled-component sync (mount/unmount), short-circuit if the next
+   * value matches the current to avoid re-running side effects.
+   */
+  function handleOpenChange(next: boolean) {
+    if (next === open) return;
+    onOpenChange(next);
+  }
+
+  const dialogTitle = $derived(
+    `${mode === 'amend' ? 'Amend' : 'Propose'} ${revenueLabel} agreement with ${creatorName}`
+  );
+  const dialogDescription =
+    'Share is calculated against post-platform revenue. The platform fee is taken first; this percentage applies to what remains.';
+</script>
+
+<DialogForm
+  title={dialogTitle}
+  description={dialogDescription}
+  {open}
+  {submitting}
+  {error}
+  onsubmit={handleSubmit}
+  onOpenChange={handleOpenChange}
+  submitLabel={mode === 'amend' ? 'Send amendment' : 'Send proposal'}
+>
+  <div class="propose-form">
+    <BrandSliderField
+      id="propose-share"
+      label="Creator share"
+      value={formattedShare}
+      min={0}
+      max={100}
+      step={1}
+      current={sharePercent}
+      minLabel="0%"
+      maxLabel="100%"
+      ariaValueText={ariaValueText}
+      oninput={onShareInput}
+    />
+    <p class="propose-form__hint">
+      {formattedShare} of post-platform {revenueLabel} revenue goes to {creatorName}.
+      The remaining {Number.isInteger(100 - sharePercent) ? `${100 - sharePercent}%` : `${(100 - sharePercent).toFixed(1)}%`} stays with the org.
+    </p>
+
+    <fieldset class="propose-form__field">
+      <legend class="propose-form__field-label">Soft-lock term</legend>
+      <p class="propose-form__field-hint">
+        How long this rate is locked before either side can amend.
+      </p>
+      <div class="propose-form__term-options" role="radiogroup" aria-label="Soft-lock term">
+        {#each termOptions as option (option.value)}
+          <label class="propose-form__term-option">
+            <input
+              type="radio"
+              name="propose-term"
+              value={option.value}
+              checked={termMonths === option.value}
+              onchange={() => (termMonths = option.value)}
+              disabled={submitting}
+            />
+            <span>{option.label}</span>
+          </label>
+        {/each}
+      </div>
+    </fieldset>
+
+    <div class="propose-form__field">
+      <label class="propose-form__field-label" for="propose-note">
+        Note (optional)
+      </label>
+      <p class="propose-form__field-hint">
+        Visible to the creator. Use this to explain the rate or term.
+      </p>
+      <textarea
+        id="propose-note"
+        class="propose-form__textarea"
+        bind:value={note}
+        rows="3"
+        maxlength="500"
+        disabled={submitting}
+        placeholder="e.g. Initial team agreement for season 1 content."
+      ></textarea>
+      <span class="propose-form__char-count" aria-live="polite">
+        {note.length} / 500
+      </span>
+    </div>
+  </div>
+</DialogForm>
+
+<style>
+  .propose-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
+  .propose-form__hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-relaxed);
+  }
+
+  .propose-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .propose-form__field-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text);
+  }
+
+  .propose-form__field-hint {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .propose-form__term-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+
+  .propose-form__term-option {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .propose-form__term-option:hover {
+    background: var(--color-surface-secondary);
+  }
+
+  .propose-form__term-option:has(input:checked) {
+    background: var(--color-interactive-subtle);
+    border-color: var(--color-interactive);
+    color: var(--color-text);
+  }
+
+  .propose-form__term-option:has(input:focus-visible) {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .propose-form__textarea {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    resize: vertical;
+    min-height: var(--space-16);
+  }
+
+  .propose-form__textarea:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+    border-color: var(--color-border-focus);
+  }
+
+  .propose-form__char-count {
+    align-self: flex-end;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+</style>

--- a/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte
+++ b/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte
@@ -1,0 +1,591 @@
+<!--
+  @component RevenueSplitPie
+
+  Stacked horizontal bar visualising revenue-share splits between the platform
+  fee, the org/owner residual, and any number of creator slices. Used in both
+  the owner surface (full visibility) and the creator surface (self-visible,
+  peers anonymised).
+
+  Despite the name (kept for parity with the epic plan), the component is a
+  stacked bar — better for many slices and far more accessible than a radial
+  pie. Each draggable boundary acts as a `role="slider"` widget. Numeric inputs
+  alongside each unlocked slice stay in sync with drag.
+
+  All values are basis points internally (0-10000) and displayed as percent.
+  Colors are CSS custom-property references — never hex literals — so org
+  branding flows through unchanged.
+
+  Props mirror the WP-6 spec in Codex-tg3p6.
+-->
+<script lang="ts">
+  import { tick } from 'svelte';
+  import {
+    BP_MAX,
+    BP_STEP,
+    BP_STEP_LARGE,
+    type RevenueSplitMode,
+    type RevenueSplitSlice,
+  } from './types';
+
+  interface Props {
+    /** `owner` = full visibility; `creator` = self + anonymised peers. */
+    mode: RevenueSplitMode;
+    /** Platform fee in basis points. Forms the locked first slice. */
+    platformFeePercent: number;
+    /** Ordered slices following the platform fee. */
+    slices: RevenueSplitSlice[];
+    /** Fires only when the user produces a value distinct from current props. */
+    onChange?: (next: RevenueSplitSlice[]) => void;
+    /** Read-only renders the bar without handles or inputs. */
+    readOnly?: boolean;
+    /** Optional class forwarded to the root element (composition seam per R13). */
+    class?: string;
+  }
+
+  const {
+    mode,
+    platformFeePercent,
+    slices,
+    onChange,
+    readOnly = false,
+    class: className,
+  }: Props = $props();
+
+  // -- Derived state ---------------------------------------------------------
+
+  /** Sum of creator/owner slice basis points (excludes platform fee). */
+  const sliceTotalBp = $derived(
+    slices.reduce((sum, s) => sum + s.percent, 0)
+  );
+
+  /** Maximum non-platform basis points available. */
+  const availableBp = $derived(BP_MAX - platformFeePercent);
+
+  /** True when slices over-allocate (sum > 100% minus platform fee). */
+  const isOverAllocated = $derived(sliceTotalBp > availableBp);
+
+  /** True when slices under-allocate (sum < 100% minus platform fee). */
+  const isUnderAllocated = $derived(sliceTotalBp < availableBp);
+
+  // -- SR live-region (debounced) -------------------------------------------
+
+  let liveMessage = $state('');
+  let liveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function announce(message: string) {
+    if (liveTimer) clearTimeout(liveTimer);
+    liveTimer = setTimeout(() => {
+      liveMessage = message;
+    }, 200);
+  }
+
+  $effect(() => {
+    return () => {
+      if (liveTimer) clearTimeout(liveTimer);
+    };
+  });
+
+  // -- Helpers ---------------------------------------------------------------
+
+  function bpToPercent(bp: number): number {
+    return bp / 100;
+  }
+
+  function formatPercent(bp: number): string {
+    const pct = bpToPercent(bp);
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  function displayLabel(slice: RevenueSplitSlice, index: number): string {
+    if (mode === 'creator' && slice.anonymous) {
+      return `Other creator ${index + 1}`;
+    }
+    return slice.label;
+  }
+
+  /**
+   * Replace one slice and emit. Idempotent: skips the callback when the next
+   * value equals the current one (per feedback_melt_controlled_components).
+   */
+  function emitSliceChange(sliceId: string, nextPercent: number) {
+    const current = slices.find((s) => s.id === sliceId);
+    if (!current) return;
+    if (current.percent === nextPercent) return;
+    const next = slices.map((s) =>
+      s.id === sliceId ? { ...s, percent: nextPercent } : s
+    );
+    onChange?.(next);
+    announce(
+      `${displayLabel(current, slices.indexOf(current))} now ${formatPercent(nextPercent)}`
+    );
+  }
+
+  /**
+   * Max a single slice can grow to without exceeding the available budget.
+   */
+  function maxForSlice(sliceId: string): number {
+    const others = slices
+      .filter((s) => s.id !== sliceId)
+      .reduce((sum, s) => sum + s.percent, 0);
+    return Math.max(0, availableBp - others);
+  }
+
+  // -- Keyboard handling -----------------------------------------------------
+
+  function onHandleKeyDown(event: KeyboardEvent, slice: RevenueSplitSlice) {
+    if (slice.locked || readOnly) return;
+    const isIncrement = event.key === 'ArrowRight' || event.key === 'ArrowUp';
+    const isDecrement = event.key === 'ArrowLeft' || event.key === 'ArrowDown';
+    const isHome = event.key === 'Home';
+    const isEnd = event.key === 'End';
+    if (!isIncrement && !isDecrement && !isHome && !isEnd) return;
+    event.preventDefault();
+    const step = event.shiftKey ? BP_STEP_LARGE : BP_STEP;
+    const max = maxForSlice(slice.id);
+    let next = slice.percent;
+    if (isIncrement) next = Math.min(max, slice.percent + step);
+    else if (isDecrement) next = Math.max(0, slice.percent - step);
+    else if (isHome) next = 0;
+    else if (isEnd) next = max;
+    emitSliceChange(slice.id, next);
+  }
+
+  // -- Pointer drag handling -------------------------------------------------
+
+  let barEl: HTMLDivElement | undefined = $state();
+  let activeDragId: string | null = $state(null);
+
+  function onHandlePointerDown(event: PointerEvent, slice: RevenueSplitSlice) {
+    if (slice.locked || readOnly || !barEl) return;
+    if (event.button !== 0) return;
+    activeDragId = slice.id;
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  }
+
+  function onHandlePointerMove(event: PointerEvent, slice: RevenueSplitSlice) {
+    if (activeDragId !== slice.id || !barEl) return;
+    const rect = barEl.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    const ratio = Math.min(
+      1,
+      Math.max(0, (event.clientX - rect.left) / rect.width)
+    );
+    // The handle sits at the trailing boundary of `slice`. Its new cumulative
+    // position controls the slice's value:
+    //   sliceBp = cumulativeBp - platformFee - sum(earlier slices)
+    const cumulativeBp = Math.round(ratio * BP_MAX);
+    const earlierSliceBp = slices
+      .slice(0, slices.indexOf(slice))
+      .reduce((sum, s) => sum + s.percent, 0);
+    const wantedSliceBp = cumulativeBp - platformFeePercent - earlierSliceBp;
+    const max = maxForSlice(slice.id);
+    const clamped = Math.min(max, Math.max(0, wantedSliceBp));
+    // Snap to nearest BP_STEP for predictable values.
+    const snapped = Math.round(clamped / BP_STEP) * BP_STEP;
+    emitSliceChange(slice.id, snapped);
+  }
+
+  function onHandlePointerUp(event: PointerEvent, slice: RevenueSplitSlice) {
+    if (activeDragId !== slice.id) return;
+    activeDragId = null;
+    try {
+      (event.currentTarget as HTMLElement).releasePointerCapture(
+        event.pointerId
+      );
+    } catch {
+      // Pointer may already be released; ignore.
+    }
+  }
+
+  // -- Numeric input handling -----------------------------------------------
+
+  async function onPercentInput(
+    event: Event,
+    slice: RevenueSplitSlice
+  ) {
+    if (slice.locked || readOnly) return;
+    const target = event.currentTarget as HTMLInputElement;
+    const raw = Number(target.value);
+    if (!Number.isFinite(raw)) return;
+    const clampedPct = Math.min(100, Math.max(0, raw));
+    const bp = Math.round(clampedPct * 100);
+    const max = maxForSlice(slice.id);
+    const next = Math.min(max, bp);
+    emitSliceChange(slice.id, next);
+    if (next !== bp) {
+      await tick();
+      target.value = String(bpToPercent(next));
+    }
+  }
+
+  // -- Platform-fee slice (always first, always locked) ---------------------
+
+  const platformSlice = $derived<RevenueSplitSlice>({
+    id: '__platform__',
+    label: 'Platform fee',
+    percent: platformFeePercent,
+    color: 'var(--color-text-muted)',
+    locked: true,
+    anonymous: false,
+  });
+
+  const renderedSlices = $derived([platformSlice, ...slices]);
+</script>
+
+<div
+  class="revenue-split-pie {className ?? ''}"
+  data-mode={mode}
+  data-state={isOverAllocated ? 'over' : isUnderAllocated ? 'under' : 'balanced'}
+>
+  <div
+    class="revenue-split-pie__bar"
+    role="presentation"
+    bind:this={barEl}
+  >
+    {#each renderedSlices as slice, index (slice.id)}
+      {@const widthPct = bpToPercent(slice.percent)}
+      <div
+        class="revenue-split-pie__slice"
+        data-locked={slice.locked ? 'true' : 'false'}
+        style="--slice-width: {widthPct}%; --slice-color: {slice.color};"
+        title="{displayLabel(slice, index - 1)}: {formatPercent(slice.percent)}"
+      >
+        <span class="revenue-split-pie__slice-fill"></span>
+      </div>
+    {/each}
+
+    <!--
+      Handles sit at the trailing boundary of each non-platform slice. The
+      platform fee is locked and does not get a handle.
+    -->
+    {#each slices as slice, index (`handle-${slice.id}`)}
+      {@const cumulativeBp =
+        platformFeePercent +
+        slices.slice(0, index + 1).reduce((sum, s) => sum + s.percent, 0)}
+      {@const handlePct = bpToPercent(cumulativeBp)}
+      {@const max = maxForSlice(slice.id)}
+      {@const interactive = !slice.locked && !readOnly}
+      <div
+        class="revenue-split-pie__handle"
+        data-interactive={interactive ? 'true' : 'false'}
+        data-dragging={activeDragId === slice.id ? 'true' : 'false'}
+        style="--handle-pos: {handlePct}%;"
+        role="slider"
+        tabindex={interactive ? 0 : -1}
+        aria-label="{displayLabel(slice, index)} share"
+        aria-valuemin="0"
+        aria-valuemax={bpToPercent(max)}
+        aria-valuenow={bpToPercent(slice.percent)}
+        aria-valuetext={formatPercent(slice.percent)}
+        aria-disabled={interactive ? undefined : 'true'}
+        onkeydown={(e) => onHandleKeyDown(e, slice)}
+        onpointerdown={(e) => onHandlePointerDown(e, slice)}
+        onpointermove={(e) => onHandlePointerMove(e, slice)}
+        onpointerup={(e) => onHandlePointerUp(e, slice)}
+        onpointercancel={(e) => onHandlePointerUp(e, slice)}
+      >
+        <span class="revenue-split-pie__handle-grip" aria-hidden="true"></span>
+      </div>
+    {/each}
+  </div>
+
+  <ul class="revenue-split-pie__legend">
+    {#each renderedSlices as slice, index (slice.id)}
+      {@const isPlatform = slice.id === '__platform__'}
+      {@const sliceIndex = index - 1}
+      <li
+        class="revenue-split-pie__legend-item"
+        data-locked={slice.locked ? 'true' : 'false'}
+      >
+        <span
+          class="revenue-split-pie__legend-swatch"
+          style="--swatch-color: {slice.color};"
+          aria-hidden="true"
+        ></span>
+        <span class="revenue-split-pie__legend-label">
+          {displayLabel(slice, sliceIndex)}
+        </span>
+        {#if readOnly || slice.locked}
+          <span class="revenue-split-pie__legend-value">
+            {formatPercent(slice.percent)}
+          </span>
+        {:else}
+          <label
+            class="revenue-split-pie__legend-input"
+            aria-label="{displayLabel(slice, sliceIndex)} share percent"
+          >
+            <input
+              type="number"
+              min="0"
+              max={bpToPercent(maxForSlice(slice.id))}
+              step="1"
+              value={bpToPercent(slice.percent)}
+              oninput={(e) => onPercentInput(e, slice)}
+              disabled={isPlatform}
+            />
+            <span aria-hidden="true">%</span>
+          </label>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+
+  {#if isOverAllocated}
+    <p class="revenue-split-pie__warning" role="status">
+      Splits exceed available budget by
+      {formatPercent(sliceTotalBp - availableBp)}. Reduce one or more shares.
+    </p>
+  {/if}
+
+  <span
+    class="revenue-split-pie__sr-live"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    {liveMessage}
+  </span>
+</div>
+
+<style>
+  .revenue-split-pie {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    container-type: inline-size;
+    container-name: revenue-split-pie;
+  }
+
+  /* -- Bar ---------------------------------------------------------------- */
+
+  .revenue-split-pie__bar {
+    position: relative;
+    display: flex;
+    width: 100%;
+    height: var(--space-8);
+    background: var(--color-surface-secondary);
+    border: var(--border-width) solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    touch-action: none;
+  }
+
+  .revenue-split-pie[data-state='over'] .revenue-split-pie__bar {
+    border-color: var(--color-error);
+    box-shadow: 0 0 0 var(--border-width) var(--color-error-200);
+  }
+
+  .revenue-split-pie__slice {
+    position: relative;
+    height: 100%;
+    width: var(--slice-width, 0%);
+    min-width: 0;
+    flex-shrink: 0;
+  }
+
+  .revenue-split-pie__slice-fill {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--slice-color, var(--color-surface-tertiary));
+    transition: background-color var(--transition-colors, 180ms ease);
+  }
+
+  .revenue-split-pie__slice[data-locked='true'] .revenue-split-pie__slice-fill {
+    /* Locked slices read as system-set, not user-owned. */
+    background-image: linear-gradient(
+      135deg,
+      var(--slice-color, var(--color-text-muted)) 0%,
+      var(--slice-color, var(--color-text-muted)) 50%,
+      oklch(from var(--slice-color, var(--color-text-muted)) calc(l + 0.05) c h) 50%,
+      oklch(from var(--slice-color, var(--color-text-muted)) calc(l + 0.05) c h) 100%
+    );
+    background-size: var(--space-3) var(--space-3);
+  }
+
+  /* -- Handles ------------------------------------------------------------ */
+
+  .revenue-split-pie__handle {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: var(--handle-pos, 0%);
+    transform: translateX(-50%);
+    width: var(--space-4);
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: none;
+    padding: 0;
+  }
+
+  .revenue-split-pie__handle[data-interactive='true'] {
+    cursor: ew-resize;
+  }
+
+  .revenue-split-pie__handle[data-interactive='false'] {
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  .revenue-split-pie__handle-grip {
+    display: block;
+    width: var(--border-width-thick, 2px);
+    height: 60%;
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border-strong);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    transition:
+      transform var(--transition-colors, 180ms ease),
+      background-color var(--transition-colors, 180ms ease);
+  }
+
+  .revenue-split-pie__handle[data-interactive='true']:hover
+    .revenue-split-pie__handle-grip,
+  .revenue-split-pie__handle[data-dragging='true']
+    .revenue-split-pie__handle-grip {
+    background: var(--color-interactive);
+    transform: scaleY(1.05);
+  }
+
+  .revenue-split-pie__handle:focus-visible {
+    outline: none;
+  }
+
+  .revenue-split-pie__handle:focus-visible .revenue-split-pie__handle-grip {
+    outline: var(--border-width-thick, 2px) solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  /* -- Legend ------------------------------------------------------------- */
+
+  .revenue-split-pie__legend {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  @container revenue-split-pie (min-width: 32rem) {
+    .revenue-split-pie__legend {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-3);
+    }
+  }
+
+  @container revenue-split-pie (min-width: 48rem) {
+    .revenue-split-pie__legend {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .revenue-split-pie__legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border-subtle);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .revenue-split-pie__legend-item[data-locked='true'] {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-split-pie__legend-swatch {
+    flex-shrink: 0;
+    width: var(--space-3);
+    height: var(--space-3);
+    border-radius: var(--radius-sm);
+    background: var(--swatch-color, var(--color-surface-tertiary));
+    border: var(--border-width) solid var(--color-border-subtle);
+  }
+
+  .revenue-split-pie__legend-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .revenue-split-pie__legend-value {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-split-pie__legend-input {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-split-pie__legend-input input {
+    width: var(--space-12);
+    padding: var(--space-1) var(--space-2);
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-text);
+    font: inherit;
+    text-align: end;
+  }
+
+  .revenue-split-pie__legend-input input:focus-visible {
+    outline: var(--border-width-thick, 2px) solid var(--color-focus);
+    outline-offset: 2px;
+    border-color: var(--color-border-focus);
+  }
+
+  .revenue-split-pie__legend-input input:disabled {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+  }
+
+  /* -- Warning state ------------------------------------------------------ */
+
+  .revenue-split-pie__warning {
+    margin: 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-error-50);
+    color: var(--color-error-700);
+    border: var(--border-width) solid var(--color-error-200);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+  }
+
+  /* -- Screen-reader live region ----------------------------------------- */
+
+  .revenue-split-pie__sr-live {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* -- Reduced motion ----------------------------------------------------- */
+
+  @media (prefers-reduced-motion: reduce) {
+    .revenue-split-pie__slice-fill,
+    .revenue-split-pie__handle-grip {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/RevenueSplitPie.svelte.test.ts
@@ -1,0 +1,493 @@
+/**
+ * RevenueSplitPie unit tests.
+ *
+ * Verifies prop-driven rendering, keyboard nudge, numeric input clamping,
+ * over-allocation warning, mode-driven anonymisation, and idempotent onChange.
+ *
+ * Pointer-drag and full axe sweeps run in Playwright (see e2e).
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import RevenueSplitPie from './RevenueSplitPie.svelte';
+import type { RevenueSplitSlice } from './types';
+
+function makeSlices(): RevenueSplitSlice[] {
+  return [
+    {
+      id: 'owner',
+      label: 'Org owner',
+      percent: 3000,
+      color: 'var(--color-info-600)',
+      locked: false,
+      anonymous: false,
+    },
+    {
+      id: 'creator-1',
+      label: 'Alex Rivera',
+      percent: 6000,
+      color: 'var(--color-primary-500)',
+      locked: false,
+      anonymous: false,
+    },
+  ];
+}
+
+describe('RevenueSplitPie', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('renders platform fee slice + each provided slice', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const slices = document.body.querySelectorAll('.revenue-split-pie__slice');
+    // platform + 2 supplied
+    expect(slices.length).toBe(3);
+  });
+
+  test('renders one slider handle per non-platform slice', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const handles = document.body.querySelectorAll('[role="slider"]');
+    expect(handles.length).toBe(2);
+  });
+
+  test('handle exposes correct aria-valuenow as percent', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const handles = document.body.querySelectorAll('[role="slider"]');
+    // First non-platform = owner @ 3000bp = 30
+    expect(handles[0]?.getAttribute('aria-valuenow')).toBe('30');
+    // Second = creator-1 @ 6000bp = 60
+    expect(handles[1]?.getAttribute('aria-valuenow')).toBe('60');
+  });
+
+  test('ArrowRight nudges a slice by 100 basis points (1 %)', () => {
+    const onChange = vi.fn();
+    // Owner @ 2000bp, creator @ 5000bp, platform @ 1000bp → 2000bp headroom.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Org owner',
+        percent: 2000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'creator-1',
+        label: 'Alex Rivera',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices,
+        onChange,
+      },
+    });
+    const ownerHandle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      bubbles: true,
+      cancelable: true,
+    });
+    ownerHandle.dispatchEvent(event);
+    flushSync();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as RevenueSplitSlice[];
+    const owner = next.find((s) => s.id === 'owner');
+    expect(owner?.percent).toBe(2100);
+  });
+
+  test('Shift+ArrowRight nudges by 1000 basis points (10 %)', () => {
+    const onChange = vi.fn();
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Owner',
+        percent: 2000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'c1',
+        label: 'C1',
+        percent: 1000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices, onChange },
+    });
+    const ownerHandle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    ownerHandle.dispatchEvent(event);
+    flushSync();
+    const owner = (onChange.mock.calls[0][0] as RevenueSplitSlice[]).find(
+      (s) => s.id === 'owner'
+    );
+    expect(owner?.percent).toBe(3000);
+  });
+
+  test('ArrowLeft cannot drop below zero', () => {
+    const onChange = vi.fn();
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Owner',
+        percent: 0,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices, onChange },
+    });
+    const handle = document.body.querySelector(
+      '[role="slider"]'
+    ) as HTMLElement;
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', cancelable: true })
+    );
+    flushSync();
+    // Already at zero — idempotent guard suppresses callback.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('ArrowRight cannot exceed available budget', () => {
+    const onChange = vi.fn();
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'a',
+        label: 'A',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'b',
+        label: 'B',
+        percent: 4000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    // platform 10 % + 50 % + 40 % = 100 %. No room for "a" to grow.
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices, onChange },
+    });
+    const handle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true })
+    );
+    flushSync();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('warning state appears when slices over-allocate', () => {
+    // 10 % platform + 60 % + 60 % = 130 % total → over by 30 %.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'a',
+        label: 'A',
+        percent: 6000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'b',
+        label: 'B',
+        percent: 6000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices },
+    });
+    const root = document.body.querySelector('.revenue-split-pie');
+    expect(root?.getAttribute('data-state')).toBe('over');
+    const warning = document.body.querySelector('.revenue-split-pie__warning');
+    expect(warning).toBeTruthy();
+  });
+
+  test('creator mode anonymises peers but keeps the owning slice visible', () => {
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'me',
+        label: 'Me',
+        percent: 4000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'peer-1',
+        label: 'Hidden Peer',
+        percent: 3000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: true,
+      },
+      {
+        id: 'peer-2',
+        label: 'Other Hidden',
+        percent: 2000,
+        color: 'var(--color-success-600)',
+        locked: false,
+        anonymous: true,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'creator', platformFeePercent: 1000, slices },
+    });
+    const labels = Array.from(
+      document.body.querySelectorAll('.revenue-split-pie__legend-label')
+    ).map((el) => el.textContent?.trim());
+    expect(labels).toContain('Me');
+    expect(labels).not.toContain('Hidden Peer');
+    expect(labels).not.toContain('Other Hidden');
+    // Anonymised replacements present
+    expect(labels.some((l) => l?.startsWith('Other creator'))).toBe(true);
+  });
+
+  test('readOnly mode hides numeric inputs', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        readOnly: true,
+      },
+    });
+    const numericInputs = document.body.querySelectorAll(
+      '.revenue-split-pie__legend-input input'
+    );
+    expect(numericInputs.length).toBe(0);
+  });
+
+  test('readOnly mode disables handle interactivity', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        readOnly: true,
+      },
+    });
+    const handle = document.body.querySelector(
+      '[role="slider"]'
+    ) as HTMLElement;
+    expect(handle.getAttribute('data-interactive')).toBe('false');
+    expect(handle.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('numeric input dispatches onChange with clamped basis points', () => {
+    const onChange = vi.fn();
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        onChange,
+      },
+    });
+    const ownerInput = document.body.querySelectorAll(
+      '.revenue-split-pie__legend-input input'
+    )[0] as HTMLInputElement;
+    ownerInput.value = '25';
+    ownerInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const owner = (onChange.mock.calls[0][0] as RevenueSplitSlice[]).find(
+      (s) => s.id === 'owner'
+    );
+    expect(owner?.percent).toBe(2500);
+  });
+
+  test('numeric input over the budget is clamped to available max', () => {
+    const onChange = vi.fn();
+    // Owner=2000, creator=5000, platform=1000 → max for owner = 10000-1000-5000 = 4000bp = 40%.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'owner',
+        label: 'Org owner',
+        percent: 2000,
+        color: 'var(--color-info-600)',
+        locked: false,
+        anonymous: false,
+      },
+      {
+        id: 'creator-1',
+        label: 'Alex Rivera',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices,
+        onChange,
+      },
+    });
+    const ownerInput = document.body.querySelectorAll(
+      '.revenue-split-pie__legend-input input'
+    )[0] as HTMLInputElement;
+    ownerInput.value = '95';
+    ownerInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const owner = (onChange.mock.calls[0][0] as RevenueSplitSlice[]).find(
+      (s) => s.id === 'owner'
+    );
+    // 95% requested, but only 40% available → clamps to 4000bp.
+    expect(owner?.percent).toBe(4000);
+  });
+
+  test('onChange is idempotent when next value equals current', () => {
+    const onChange = vi.fn();
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        onChange,
+      },
+    });
+    // Owner is at 30, hitting End jumps to its max (which is 30 because the rest fills available).
+    const handle = document.body.querySelectorAll(
+      '[role="slider"]'
+    )[0] as HTMLElement;
+    handle.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', cancelable: true })
+    );
+    flushSync();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('locked slices render with pattern marker and no handle interactivity', () => {
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'fixed',
+        label: 'System reserve',
+        percent: 2000,
+        color: 'var(--color-text-muted)',
+        locked: true,
+        anonymous: false,
+      },
+      {
+        id: 'a',
+        label: 'A',
+        percent: 5000,
+        color: 'var(--color-primary-500)',
+        locked: false,
+        anonymous: false,
+      },
+    ];
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: { mode: 'owner', platformFeePercent: 1000, slices },
+    });
+    const handles = document.body.querySelectorAll('[role="slider"]');
+    // First handle follows the locked 'fixed' slice — non-interactive.
+    expect(handles[0]?.getAttribute('data-interactive')).toBe('false');
+    expect(handles[1]?.getAttribute('data-interactive')).toBe('true');
+  });
+
+  test('forwards optional class to root', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+        class: 'agreements-pie',
+      },
+    });
+    const root = document.body.querySelector('.revenue-split-pie');
+    expect(root?.classList.contains('agreements-pie')).toBe(true);
+  });
+
+  test('omitting class does NOT stringify undefined into class attribute (R13)', () => {
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices: makeSlices(),
+      },
+    });
+    const root = document.body.querySelector(
+      '.revenue-split-pie'
+    ) as HTMLElement;
+    expect(root.className.includes('undefined')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/components/agreements/types.ts
+++ b/apps/web/src/lib/components/agreements/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared types for revenue-share agreement UI components.
+ *
+ * Lives in a sibling `.ts` because SvelteKit's ambient `*.svelte` module
+ * declaration only exposes the default export — named exports from
+ * `<script module>` aren't surfaced to TypeScript consumers.
+ */
+
+/** Render mode for {@link RevenueSplitSlice} consumers. */
+export type RevenueSplitMode = 'owner' | 'creator';
+
+/**
+ * One slice of the stacked-bar revenue split. Percent values are basis points
+ * (0–10_000) internally; the component renders them as decimal percent.
+ */
+export interface RevenueSplitSlice {
+  /** Stable identity for keyed iteration + onChange diffing. */
+  id: string;
+  /** Human-readable label (e.g. 'Platform Fee', 'Org owner', 'Alex Rivera'). */
+  label: string;
+  /** Share in basis points (0–10_000). 100 bp = 1 %. */
+  percent: number;
+  /**
+   * CSS custom-property reference (e.g. `var(--color-info-600)`). MUST be a
+   * token reference, NEVER a hex literal — keeps the org-branding chain intact.
+   */
+  color: string;
+  /**
+   * Locked slices cannot be dragged (e.g. platform fee, computed residual).
+   * The boundary AFTER a locked slice is not focusable.
+   */
+  locked: boolean;
+  /**
+   * In creator mode, anonymous slices render with a generic label and no peer
+   * identity. The owning slice (`anonymous: false`) renders normally.
+   */
+  anonymous: boolean;
+}
+
+/** Basis-points ceiling (100 %). */
+export const BP_MAX = 10_000;
+/** Single-step nudge in basis points (1 %). */
+export const BP_STEP = 100;
+/** Shift-modifier nudge in basis points (10 %). */
+export const BP_STEP_LARGE = 1_000;

--- a/apps/web/src/lib/remote/agreements.remote.test.ts
+++ b/apps/web/src/lib/remote/agreements.remote.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Revenue-Share Agreements Remote Functions Tests
+ *
+ * Smoke tests for the remote-function bindings — verifies the module loads
+ * cleanly and exports the documented surface. Wire-shape behaviour is
+ * covered by the worker integration tests in WP-3.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+describe('remote/agreements.remote', () => {
+  beforeAll(async () => {
+    await import('./agreements.remote');
+  }, 30_000);
+
+  it('exports listActiveAgreements query', async () => {
+    const { listActiveAgreements } = await import('./agreements.remote');
+    expect(listActiveAgreements).toBeDefined();
+  });
+
+  it('exports getAgreementThread query', async () => {
+    const { getAgreementThread } = await import('./agreements.remote');
+    expect(getAgreementThread).toBeDefined();
+  });
+
+  it('exports listMyAgreements query (for WP-8 creator surface)', async () => {
+    const { listMyAgreements } = await import('./agreements.remote');
+    expect(listMyAgreements).toBeDefined();
+  });
+
+  it('exports proposeAgreement command', async () => {
+    const { proposeAgreement } = await import('./agreements.remote');
+    expect(proposeAgreement).toBeDefined();
+  });
+
+  it('exports counterAgreement command', async () => {
+    const { counterAgreement } = await import('./agreements.remote');
+    expect(counterAgreement).toBeDefined();
+  });
+
+  it('exports acceptAgreement command', async () => {
+    const { acceptAgreement } = await import('./agreements.remote');
+    expect(acceptAgreement).toBeDefined();
+  });
+
+  it('exports declineAgreement command', async () => {
+    const { declineAgreement } = await import('./agreements.remote');
+    expect(declineAgreement).toBeDefined();
+  });
+
+  it('exports withdrawAgreement command', async () => {
+    const { withdrawAgreement } = await import('./agreements.remote');
+    expect(withdrawAgreement).toBeDefined();
+  });
+
+  it('exports terminateAgreement command', async () => {
+    const { terminateAgreement } = await import('./agreements.remote');
+    expect(terminateAgreement).toBeDefined();
+  });
+});

--- a/apps/web/src/lib/remote/agreements.remote.ts
+++ b/apps/web/src/lib/remote/agreements.remote.ts
@@ -1,0 +1,180 @@
+/**
+ * Revenue-Share Agreement Remote Functions (Codex-s80r6 — WP-7)
+ *
+ * Wraps the ecom-api `/agreements` routes (WP-3, see
+ * `workers/ecom-api/src/routes/agreements.ts`). Owner-side bindings power
+ * the studio settings → revenue-share tab; creator-side bindings power
+ * the /studio/negotiations page in WP-8.
+ *
+ * Unit semantics for `sharePercent`: basis points (0-10000) of the
+ * post-platform pool. Platform fee is NEVER part of this value — UI
+ * copy must say "of post-platform [revenue_type] revenue" per the C1
+ * math semantic (see `project_revenue_share_decisions.md`).
+ *
+ * All commands re-fetch the relevant query collection on success; the
+ * settings page wires `await query.refresh()` after each command.
+ */
+
+import { z } from 'zod';
+import { command, getRequestEvent, query } from '$app/server';
+import { createServerApi } from '$lib/server/api';
+
+// ─── Schemas ──────────────────────────────────────────────────────────────
+
+const revenueTypeSchema = z.enum(['subscription', 'content_purchase']);
+
+const listAgreementsArgsSchema = z.object({
+  organizationId: z.string().uuid(),
+  revenueType: revenueTypeSchema.optional(),
+});
+
+const getThreadArgsSchema = z.object({
+  organizationId: z.string().uuid(),
+  creatorId: z.string().uuid(),
+  revenueType: revenueTypeSchema,
+});
+
+const proposeAgreementArgsSchema = z.object({
+  organizationId: z.string().uuid(),
+  creatorId: z.string().uuid(),
+  revenueType: revenueTypeSchema,
+  sharePercent: z.number().int().min(0).max(10000),
+  termMonths: z.number().int().min(1).max(120),
+  note: z.string().trim().max(500).optional(),
+  effectiveFrom: z.string().datetime().optional(),
+});
+
+const counterArgsSchema = z.object({
+  proposalId: z.string().uuid(),
+  sharePercent: z.number().int().min(0).max(10000),
+  termMonths: z.number().int().min(1).max(120),
+  note: z.string().trim().max(500).optional(),
+});
+
+const proposalIdArgSchema = z.object({
+  proposalId: z.string().uuid(),
+});
+
+const declineArgsSchema = z.object({
+  proposalId: z.string().uuid(),
+  reason: z.string().trim().max(500).optional(),
+});
+
+const terminateArgsSchema = z.object({
+  agreementId: z.string().uuid(),
+  reason: z.string().trim().max(500).optional(),
+});
+
+// ─── Queries ──────────────────────────────────────────────────────────────
+
+/**
+ * Active agreements for the org — owner-view full list.
+ * Re-fetched on every mutation via `.refresh()`.
+ */
+export const listActiveAgreements = query(
+  listAgreementsArgsSchema,
+  async ({ organizationId, revenueType }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.list(
+      organizationId,
+      revenueType ? { revenueType } : undefined
+    );
+  }
+);
+
+/**
+ * Negotiation thread for one (creator, revenueType) on this org.
+ * Empty array if no thread exists. Used by the AgreementCard "View thread"
+ * action + by direct linking from email notifications.
+ */
+export const getAgreementThread = query(
+  getThreadArgsSchema,
+  async ({ organizationId, creatorId, revenueType }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.getThread(organizationId, creatorId, revenueType);
+  }
+);
+
+/**
+ * Creator-view: my agreements across all orgs. Used by WP-8 (/studio/
+ * negotiations). Surfaces `peers` aggregate for each row.
+ */
+export const listMyAgreements = query(async () => {
+  const { platform, cookies } = getRequestEvent();
+  const api = createServerApi(platform, cookies);
+  return api.agreements.listForCreator();
+});
+
+// ─── Commands ─────────────────────────────────────────────────────────────
+
+/**
+ * Owner round-1 propose. `organizationId` is in the query string per the
+ * `procedure()` resolver contract (body org would 400 with
+ * ORG_CONTEXT_REQUIRED).
+ */
+export const proposeAgreement = command(
+  proposeAgreementArgsSchema,
+  async ({ organizationId, ...input }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.propose(organizationId, input);
+  }
+);
+
+/**
+ * Counter-proposal — role flips on the parent. Service derives role,
+ * returns the new child row.
+ */
+export const counterAgreement = command(
+  counterArgsSchema,
+  async ({ proposalId, ...input }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.counter(proposalId, input);
+  }
+);
+
+/** Accept an open proposal — supersedes siblings + terminates predecessor. */
+export const acceptAgreement = command(
+  proposalIdArgSchema,
+  async ({ proposalId }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.accept(proposalId);
+  }
+);
+
+/** Decline an open proposal — optional reason captured for audit. */
+export const declineAgreement = command(
+  declineArgsSchema,
+  async ({ proposalId, reason }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.decline(proposalId, reason ? { reason } : undefined);
+  }
+);
+
+/** Withdraw a proposal — only the proposing side may withdraw. */
+export const withdrawAgreement = command(
+  proposalIdArgSchema,
+  async ({ proposalId }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.withdraw(proposalId);
+  }
+);
+
+/** Terminate an active agreement — either party may invoke. */
+export const terminateAgreement = command(
+  terminateArgsSchema,
+  async ({ agreementId, reason }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.terminate(
+      agreementId,
+      reason ? { reason } : undefined
+    );
+  }
+);

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -26,6 +26,10 @@ import type {
   SubscriberStats,
   TopContentItem,
 } from '@codex/admin';
+import type {
+  AgreementProposal,
+  CreatorOrganizationAgreement,
+} from '@codex/agreements';
 import {
   COOKIES,
   getServiceUrl,
@@ -1790,6 +1794,160 @@ export function createServerApi(
           {
             method: 'POST',
             body: JSON.stringify({ organizationId }),
+          }
+        ),
+    },
+
+    /**
+     * Revenue-share agreements (ecom-api worker)
+     *
+     * Owner-facing: settings → revenue-share tab proposes/counters/accepts
+     * agreements with team creators. Creator-facing: /studio/negotiations
+     * (WP-8, separate WP) consumes `listForCreator`.
+     */
+    agreements: {
+      /**
+       * Owner-view list of active agreements for an org. Worker re-derives
+       * scope from authenticated membership — `organizationId` in the
+       * query is used only to resolve the `procedure()` membership gate.
+       */
+      list: (
+        organizationId: string,
+        params?: { revenueType?: 'subscription' | 'content_purchase' }
+      ) => {
+        const search = new URLSearchParams();
+        if (params?.revenueType) search.set('revenueType', params.revenueType);
+        return request<PaginatedListResponse<CreatorOrganizationAgreement>>(
+          'ecom',
+          withOrg('/agreements', organizationId, search)
+        );
+      },
+
+      /**
+       * Owner-view negotiation thread for one (creator, revenueType) on
+       * this org. Empty array if no thread exists.
+       */
+      getThread: (
+        organizationId: string,
+        creatorId: string,
+        revenueType: 'subscription' | 'content_purchase'
+      ) => {
+        const search = new URLSearchParams({ revenueType });
+        return request<AgreementProposal[]>(
+          'ecom',
+          withOrg(
+            `/agreements/threads/${encodeURIComponent(creatorId)}`,
+            organizationId,
+            search
+          )
+        );
+      },
+
+      /**
+       * Creator-view: my agreements across every org, with anonymised peer
+       * aggregates. Worker scopes on `ctx.user.id`.
+       */
+      listForCreator: () =>
+        request<
+          PaginatedListResponse<{
+            id: string;
+            organizationId: string;
+            creatorId: string;
+            revenueType: string;
+            status: string;
+            effectiveFrom: string | Date;
+            effectiveUntil: string | Date | null;
+            organizationFeePercentage: number;
+            currentProposalId: string | null;
+            terminatedAt: string | Date | null;
+            peers: { count: number; aggregateSharePercent: number };
+          }>
+        >('ecom', '/agreements/me'),
+
+      /**
+       * Round 1 owner-initiated proposal. `organizationId` lives in the
+       * query string (procedure() resolveOrganizationId only reads query
+       * fallback; body org would 400 with ORG_CONTEXT_REQUIRED).
+       */
+      propose: (
+        organizationId: string,
+        input: {
+          creatorId: string;
+          revenueType: 'subscription' | 'content_purchase';
+          sharePercent: number;
+          termMonths: number;
+          note?: string;
+          effectiveFrom?: string | Date;
+        }
+      ) =>
+        request<AgreementProposal>(
+          'ecom',
+          `/agreements/propose?organizationId=${encodeURIComponent(organizationId)}`,
+          {
+            method: 'POST',
+            body: JSON.stringify(input),
+          }
+        ),
+
+      /** Counter an open proposal — service flips role from parent. */
+      counter: (
+        proposalId: string,
+        input: {
+          sharePercent: number;
+          termMonths: number;
+          note?: string;
+        }
+      ) =>
+        request<AgreementProposal>(
+          'ecom',
+          `/agreements/${encodeURIComponent(proposalId)}/counter`,
+          {
+            method: 'POST',
+            body: JSON.stringify(input),
+          }
+        ),
+
+      /** Accept an open proposal — service performs atomic 6-step write. */
+      accept: (proposalId: string) =>
+        request<CreatorOrganizationAgreement>(
+          'ecom',
+          `/agreements/${encodeURIComponent(proposalId)}/accept`,
+          {
+            method: 'POST',
+            body: JSON.stringify({}),
+          }
+        ),
+
+      /** Decline an open proposal — optional reason captured for audit. */
+      decline: (proposalId: string, input?: { reason?: string }) =>
+        request<AgreementProposal>(
+          'ecom',
+          `/agreements/${encodeURIComponent(proposalId)}/decline`,
+          {
+            method: 'POST',
+            body: JSON.stringify(input ?? {}),
+          }
+        ),
+
+      /** Withdraw a proposal — only the proposing side may withdraw. */
+      withdraw: (proposalId: string) =>
+        request<AgreementProposal>(
+          'ecom',
+          `/agreements/${encodeURIComponent(proposalId)}/withdraw`,
+          {
+            method: 'POST',
+            body: JSON.stringify({}),
+          }
+        ),
+
+      /** Terminate an active agreement — either party may terminate. */
+      terminate: (agreementId: string, input?: { reason?: string }) =>
+        request<CreatorOrganizationAgreement>(
+          'ecom',
+          `/agreements/${encodeURIComponent(agreementId)}/terminate`,
+          {
+            method: 'POST',
+            body: JSON.stringify(input ?? {}),
           }
         ),
     },

--- a/apps/web/src/routes/_org/[slug]/studio/settings/+layout.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/+layout.svelte
@@ -24,7 +24,9 @@
       ? 'branding'
       : page.url.pathname.endsWith('/pricing-faq')
         ? 'pricing-faq'
-        : 'general'
+        : page.url.pathname.endsWith('/revenue-share')
+          ? 'revenue-share'
+          : 'general'
   );
 
   // Derive loading tab from pending navigation
@@ -33,9 +35,11 @@
       ? 'branding'
       : navigating?.to?.url.pathname?.endsWith('/pricing-faq')
         ? 'pricing-faq'
-        : navigating?.to?.url.pathname?.endsWith('/settings')
-          ? 'general'
-          : null
+        : navigating?.to?.url.pathname?.endsWith('/revenue-share')
+          ? 'revenue-share'
+          : navigating?.to?.url.pathname?.endsWith('/settings')
+            ? 'general'
+            : null
   );
 
   // Map nav items to tab config with i18n labels
@@ -54,6 +58,11 @@
       value: 'pricing-faq',
       href: '/studio/settings/pricing-faq',
       label: 'Pricing FAQ',
+    },
+    {
+      value: 'revenue-share',
+      href: '/studio/settings/revenue-share',
+      label: 'Revenue share',
     },
   ]);
 </script>

--- a/apps/web/src/routes/_org/[slug]/studio/settings/revenue-share/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/revenue-share/+page.svelte
@@ -1,0 +1,747 @@
+<!--
+  @component SettingsRevenueShare
+
+  Studio settings → revenue-share tab (Codex-s80r6 — WP-7).
+
+  Owner-facing UI for managing per-creator revenue-share agreements. Shows:
+    1. Team Budget pie — platform fee + per-creator slices + org residual
+    2. Per-creator cards — subscription + content_purchase rows, side-by-side
+    3. Counter Proposals Received — accept / counter / decline action buttons
+    4. Pending Proposals (Waiting on Creator) — withdraw button
+    5. History — declined / terminated / superseded, collapsible
+
+  Studio uses `ssr = false`, so all data is fetched client-side via remote
+  queries. Role guard runs client-side (admin / owner only).
+
+  All share % copy explicitly says "of post-platform [type] revenue" per
+  the C1 math semantic (see project_revenue_share_decisions.md). Currency
+  GBP throughout.
+-->
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import AgreementCard from '$lib/components/agreements/AgreementCard.svelte';
+  import NegotiationThread from '$lib/components/agreements/NegotiationThread.svelte';
+  import ProposeAgreementDialog from '$lib/components/agreements/ProposeAgreementDialog.svelte';
+  import RevenueSplitPie from '$lib/components/agreements/RevenueSplitPie.svelte';
+  import type { RevenueSplitSlice } from '$lib/components/agreements/types';
+  import * as Dialog from '$lib/components/ui/Dialog';
+  import Skeleton from '$lib/components/ui/Skeleton/Skeleton.svelte';
+  import { toast } from '$lib/components/ui/Toast/toast-store';
+  import {
+    acceptAgreement,
+    counterAgreement,
+    declineAgreement,
+    getAgreementThread,
+    listActiveAgreements,
+    proposeAgreement,
+    terminateAgreement,
+    withdrawAgreement,
+  } from '$lib/remote/agreements.remote';
+  import { getOrgMembers } from '$lib/remote/org.remote';
+
+  let { data } = $props();
+
+  type RevenueType = 'subscription' | 'content_purchase';
+
+  // ─── Role guard (client-side; studio is ssr=false) ────────────────────────
+
+  $effect(() => {
+    if (data.userRole !== 'admin' && data.userRole !== 'owner') {
+      goto('/studio');
+    }
+  });
+
+  const isAuthorized = $derived(
+    data.userRole === 'admin' || data.userRole === 'owner'
+  );
+  const orgId = $derived(data.org.id);
+
+  // ─── Data queries ─────────────────────────────────────────────────────────
+
+  // Active agreements for the whole org (both revenue types).
+  const agreementsQuery = $derived(
+    isAuthorized ? listActiveAgreements({ organizationId: orgId }) : null
+  );
+
+  // Org members — needed to render one card per team creator. We filter
+  // out subscribers; everyone else may hold an agreement (per
+  // assertActiveMember in the service: any active role qualifies).
+  const membersQuery = $derived(
+    isAuthorized ? getOrgMembers({ orgId, limit: 100 }) : null
+  );
+
+  // ─── Derived: per-creator + pending proposal maps ────────────────────────
+
+  type ActiveAgreementRow = NonNullable<
+    typeof agreementsQuery
+  >['current'] extends { items: infer T } ? (T extends readonly (infer U)[] ? U : never) : never;
+
+  const activeAgreements = $derived(
+    (agreementsQuery?.current?.items ?? []) as ActiveAgreementRow[]
+  );
+
+  const teamMembers = $derived(
+    (membersQuery?.current?.items ?? [])
+      .filter((m) => m.role !== 'subscriber')
+      .map((m) => ({
+        id: m.userId,
+        name: m.name ?? m.email,
+        avatarUrl: m.avatarUrl,
+      }))
+  );
+
+  /**
+   * Build a lookup of active agreements keyed on `${creatorId}:${revenueType}`.
+   * Per the partial unique index, at most one active row per pair exists.
+   */
+  const activeByCreatorAndType = $derived.by(() => {
+    const map = new Map<string, ActiveAgreementRow>();
+    for (const a of activeAgreements) {
+      map.set(`${a.creatorId}:${a.revenueType}`, a);
+    }
+    return map;
+  });
+
+  // ─── Pie data ────────────────────────────────────────────────────────────
+
+  // Platform fee — read fresh from constants. Per Decision Q2, platform
+  // fee is the platform's operational lever, not snapshotted on agreements.
+  // 1000 bp = 10% (matches `FEES.PLATFORM_PERCENT` from @codex/constants).
+  const platformFeeBp = 1000;
+
+  /**
+   * Pie slices for the "Team Budget" overview. Each active creator on the
+   * subscription pool gets one slice; the org residual is the remainder.
+   * Content-purchase agreements are NOT pooled (Decision Q1 — creator's
+   * own content), so they aren't shown in the team-budget pie.
+   */
+  const pieSlices = $derived.by((): RevenueSplitSlice[] => {
+    const subscriptionRows = activeAgreements.filter(
+      (a) => a.revenueType === 'subscription'
+    );
+    const memberById = new Map(teamMembers.map((m) => [m.id, m]));
+
+    // Pool of available basis points after platform fee
+    const availableBp = 10000 - platformFeeBp;
+    const slices: RevenueSplitSlice[] = subscriptionRows.map((a, i) => {
+      const share = 10000 - a.organizationFeePercentage;
+      const member = memberById.get(a.creatorId);
+      const colorTokens = [
+        'var(--color-info-600)',
+        'var(--color-success-600)',
+        'var(--color-warning-600)',
+        'var(--color-error-600)',
+        'var(--color-interactive)',
+      ];
+      return {
+        id: a.id,
+        label: member?.name ?? 'Creator',
+        percent: share,
+        color: colorTokens[i % colorTokens.length] ?? 'var(--color-interactive)',
+        locked: true,
+        anonymous: false,
+      };
+    });
+
+    // Org residual — whatever's left of the available pool
+    const allocated = slices.reduce((sum, s) => sum + s.percent, 0);
+    const orgResidual = Math.max(0, availableBp - allocated);
+    if (orgResidual > 0) {
+      slices.push({
+        id: '__org_residual__',
+        label: 'Org residual',
+        percent: orgResidual,
+        color: 'var(--color-surface-tertiary)',
+        locked: true,
+        anonymous: false,
+      });
+    }
+    return slices;
+  });
+
+  // ─── Propose dialog state ────────────────────────────────────────────────
+
+  let proposeDialogOpen = $state(false);
+  let proposeCreatorId = $state<string | null>(null);
+  let proposeCreatorName = $state('');
+  let proposeRevenueType = $state<RevenueType>('subscription');
+  let proposeMode = $state<'propose' | 'amend'>('propose');
+  let proposeInitialShareBp = $state(3000);
+
+  function openProposeDialog(
+    creatorId: string,
+    creatorName: string,
+    revenueType: RevenueType,
+    mode: 'propose' | 'amend',
+    initialShareBp = 3000
+  ) {
+    proposeCreatorId = creatorId;
+    proposeCreatorName = creatorName;
+    proposeRevenueType = revenueType;
+    proposeMode = mode;
+    proposeInitialShareBp = initialShareBp;
+    proposeDialogOpen = true;
+  }
+
+  function handleProposeOpenChange(next: boolean) {
+    if (next === proposeDialogOpen) return;
+    proposeDialogOpen = next;
+  }
+
+  async function handleProposeSubmit(input: {
+    sharePercent: number;
+    termMonths: number;
+    note?: string;
+  }) {
+    if (!proposeCreatorId) {
+      throw new Error('Creator not selected');
+    }
+    await proposeAgreement({
+      organizationId: orgId,
+      creatorId: proposeCreatorId,
+      revenueType: proposeRevenueType,
+      sharePercent: input.sharePercent,
+      termMonths: input.termMonths,
+      note: input.note,
+    });
+    toast.success(
+      proposeMode === 'amend' ? 'Amendment sent' : 'Proposal sent',
+      `${proposeCreatorName} will be notified.`
+    );
+    proposeDialogOpen = false;
+    await agreementsQuery?.refresh();
+  }
+
+  // ─── Thread dialog state ─────────────────────────────────────────────────
+
+  let threadDialogOpen = $state(false);
+  let threadCreatorId = $state<string | null>(null);
+  let threadCreatorName = $state('');
+  let threadRevenueType = $state<RevenueType>('subscription');
+
+  const threadQuery = $derived(
+    threadDialogOpen && threadCreatorId
+      ? getAgreementThread({
+          organizationId: orgId,
+          creatorId: threadCreatorId,
+          revenueType: threadRevenueType,
+        })
+      : null
+  );
+
+  function openThreadDialog(
+    creatorId: string,
+    creatorName: string,
+    revenueType: RevenueType
+  ) {
+    threadCreatorId = creatorId;
+    threadCreatorName = creatorName;
+    threadRevenueType = revenueType;
+    threadDialogOpen = true;
+  }
+
+  function handleThreadOpenChange(next: boolean) {
+    if (next === threadDialogOpen) return;
+    threadDialogOpen = next;
+  }
+
+  async function handleAccept(proposalId: string) {
+    try {
+      await acceptAgreement({ proposalId });
+      toast.success('Agreement accepted', 'The new agreement is now active.');
+      threadDialogOpen = false;
+      await agreementsQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not accept proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  async function handleDecline(proposalId: string) {
+    try {
+      await declineAgreement({ proposalId });
+      toast.info('Proposal declined', `The creator will be notified.`);
+      threadDialogOpen = false;
+      await agreementsQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not decline proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  async function handleWithdraw(proposalId: string) {
+    try {
+      await withdrawAgreement({ proposalId });
+      toast.info('Proposal withdrawn');
+      threadDialogOpen = false;
+      await agreementsQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not withdraw proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  let counterDialogOpen = $state(false);
+  let counterProposalId = $state<string | null>(null);
+  let counterInitialShareBp = $state(3000);
+  let counterCreatorName = $state('');
+  let counterRevenueType = $state<RevenueType>('subscription');
+
+  function handleCounter(proposalId: string) {
+    // Open the propose dialog in "counter" mode — same form, but submit
+    // calls counterAgreement instead of proposeAgreement.
+    // We piggyback on the propose dialog by using a custom mode flag.
+    const proposals = threadQuery?.current ?? [];
+    const proposal = proposals.find((p) => p.id === proposalId);
+    if (!proposal) return;
+    counterProposalId = proposalId;
+    counterInitialShareBp = proposal.proposedCreatorSharePercent;
+    counterCreatorName = threadCreatorName;
+    counterRevenueType = threadRevenueType;
+    threadDialogOpen = false;
+    counterDialogOpen = true;
+  }
+
+  function handleCounterOpenChange(next: boolean) {
+    if (next === counterDialogOpen) return;
+    counterDialogOpen = next;
+  }
+
+  async function handleCounterSubmit(input: {
+    sharePercent: number;
+    termMonths: number;
+    note?: string;
+  }) {
+    if (!counterProposalId) {
+      throw new Error('No proposal selected');
+    }
+    await counterAgreement({
+      proposalId: counterProposalId,
+      sharePercent: input.sharePercent,
+      termMonths: input.termMonths,
+      note: input.note,
+    });
+    toast.success('Counter sent', `${counterCreatorName} will be notified.`);
+    counterDialogOpen = false;
+    await agreementsQuery?.refresh();
+  }
+
+  // ─── Terminate handler ────────────────────────────────────────────────────
+
+  async function handleTerminate(agreementId: string) {
+    try {
+      await terminateAgreement({ agreementId });
+      toast.success('Agreement terminated');
+      await agreementsQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not terminate agreement',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  // ─── Helpers for per-card prop wiring ────────────────────────────────────
+
+  function getAgreementFor(creatorId: string, revenueType: RevenueType) {
+    return activeByCreatorAndType.get(`${creatorId}:${revenueType}`) ?? null;
+  }
+
+  function getCreatorName(creatorId: string): string {
+    return teamMembers.find((m) => m.id === creatorId)?.name ?? 'Creator';
+  }
+</script>
+
+<svelte:head>
+  <title>Revenue share | {data.org.name} Studio</title>
+</svelte:head>
+
+{#if !isAuthorized}
+  <!-- Redirecting via $effect -->
+{:else}
+  <div class="revenue-share-page">
+    <header class="revenue-share-page__intro">
+      <h2 class="revenue-share-page__heading">Team revenue share</h2>
+      <p class="revenue-share-page__lede">
+        Negotiate per-creator splits on subscription and content-purchase revenue.
+        All shares are calculated against <strong>post-platform revenue</strong> —
+        the platform fee is taken first, and the share applies to what remains.
+      </p>
+    </header>
+
+    <!-- ─── Section 1: Team Budget pie ─────────────────────────────────── -->
+    <section class="revenue-share-page__section" aria-labelledby="team-budget-heading">
+      <h3 id="team-budget-heading" class="revenue-share-page__section-heading">
+        Team budget — subscription revenue
+      </h3>
+      <p class="revenue-share-page__section-lede">
+        How subscription revenue is currently split across the platform fee,
+        active creator agreements, and the org residual.
+      </p>
+      {#if agreementsQuery?.loading}
+        <Skeleton width="100%" height="var(--space-16)" />
+      {:else}
+        <RevenueSplitPie
+          mode="owner"
+          platformFeePercent={platformFeeBp}
+          slices={pieSlices}
+          readOnly
+        />
+      {/if}
+    </section>
+
+    <!-- ─── Section 2: Per-Creator Cards ───────────────────────────────── -->
+    <section class="revenue-share-page__section" aria-labelledby="creators-heading">
+      <h3 id="creators-heading" class="revenue-share-page__section-heading">
+        Creators
+      </h3>
+      {#if membersQuery?.loading || agreementsQuery?.loading}
+        <div class="revenue-share-page__cards-grid">
+          {#each Array(3) as _, i (i)}
+            <Skeleton width="100%" height="var(--space-32)" />
+          {/each}
+        </div>
+      {:else if teamMembers.length === 0}
+        <p class="revenue-share-page__empty">
+          No team creators yet. Invite members from the
+          <a href="/studio/team">team page</a> to start a revenue-share agreement.
+        </p>
+      {:else}
+        <div class="revenue-share-page__cards-grid">
+          {#each teamMembers as creator (creator.id)}
+            <AgreementCard
+              {creator}
+              subscriptionAgreement={getAgreementFor(creator.id, 'subscription')}
+              contentPurchaseAgreement={getAgreementFor(creator.id, 'content_purchase')}
+              onPropose={(revType) =>
+                openProposeDialog(creator.id, creator.name, revType, 'propose')}
+              onAmend={(revType, currentShare) =>
+                openProposeDialog(
+                  creator.id,
+                  creator.name,
+                  revType,
+                  'amend',
+                  currentShare
+                )}
+              onViewThread={(revType) =>
+                openThreadDialog(creator.id, creator.name, revType)}
+            />
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    <!-- ─── Section 3: Active agreements quick-actions ─────────────────── -->
+    {#if activeAgreements.length > 0}
+      <section
+        class="revenue-share-page__section"
+        aria-labelledby="active-agreements-heading"
+      >
+        <h3 id="active-agreements-heading" class="revenue-share-page__section-heading">
+          Active agreements
+        </h3>
+        <p class="revenue-share-page__section-lede">
+          Terminate or review the full negotiation thread for each active
+          agreement.
+        </p>
+        <ul class="revenue-share-page__active-list">
+          {#each activeAgreements as agreement (agreement.id)}
+            {@const creatorName = getCreatorName(agreement.creatorId)}
+            {@const sharePct = (10000 - agreement.organizationFeePercentage) / 100}
+            {@const sharePctDisplay = Number.isInteger(sharePct)
+              ? `${sharePct}%`
+              : `${sharePct.toFixed(1)}%`}
+            {@const revLabel =
+              agreement.revenueType === 'subscription'
+                ? 'subscription'
+                : 'content-purchase'}
+            <li class="revenue-share-page__active-item">
+              <div class="revenue-share-page__active-info">
+                <span class="revenue-share-page__active-creator">{creatorName}</span>
+                <span class="revenue-share-page__active-type">
+                  {revLabel}
+                </span>
+                <span class="revenue-share-page__active-share">
+                  {sharePctDisplay}
+                  <span class="revenue-share-page__active-share-hint">
+                    of post-platform {revLabel} revenue
+                  </span>
+                </span>
+              </div>
+              <div class="revenue-share-page__active-actions">
+                <button
+                  type="button"
+                  class="revenue-share-page__btn revenue-share-page__btn--ghost"
+                  onclick={() =>
+                    openThreadDialog(
+                      agreement.creatorId,
+                      creatorName,
+                      agreement.revenueType as RevenueType
+                    )}
+                >
+                  View thread
+                </button>
+                <button
+                  type="button"
+                  class="revenue-share-page__btn revenue-share-page__btn--danger"
+                  onclick={() => handleTerminate(agreement.id)}
+                >
+                  Terminate
+                </button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+  </div>
+
+  <!-- ─── Dialogs (browser-guarded — DialogForm uses Melt UI portal) ──── -->
+  {#if browser}
+    <ProposeAgreementDialog
+      open={proposeDialogOpen}
+      onOpenChange={handleProposeOpenChange}
+      creatorName={proposeCreatorName}
+      revenueType={proposeRevenueType}
+      initialShareBp={proposeInitialShareBp}
+      mode={proposeMode}
+      onSubmit={handleProposeSubmit}
+    />
+
+    <ProposeAgreementDialog
+      open={counterDialogOpen}
+      onOpenChange={handleCounterOpenChange}
+      creatorName={counterCreatorName}
+      revenueType={counterRevenueType}
+      initialShareBp={counterInitialShareBp}
+      mode="propose"
+      onSubmit={handleCounterSubmit}
+    />
+
+    <!-- ─── Thread review dialog ──────────────────────────────────────── -->
+    <Dialog.Root open={threadDialogOpen} onOpenChange={handleThreadOpenChange}>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>
+            Negotiation with {threadCreatorName}
+          </Dialog.Title>
+          <Dialog.Description>
+            {threadRevenueType === 'subscription'
+              ? 'Subscription'
+              : 'Content-purchase'} agreement thread
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Body>
+          {#if threadQuery?.loading}
+            <Skeleton width="100%" height="var(--space-32)" />
+          {:else if threadQuery?.current}
+            {@const thread = threadQuery.current}
+            {@const latest = thread.at(-1)}
+            {@const latestIsOpen = latest?.status === 'open'}
+            {@const ownerProposedLatest = latest?.proposedByRole === 'owner'}
+            <NegotiationThread
+              proposals={thread}
+              revenueType={threadRevenueType}
+              roleLabels={{ owner: 'You', creator: threadCreatorName }}
+              onAccept={latestIsOpen && !ownerProposedLatest ? handleAccept : undefined}
+              onCounter={latestIsOpen && !ownerProposedLatest ? handleCounter : undefined}
+              onDecline={latestIsOpen && !ownerProposedLatest ? handleDecline : undefined}
+              onWithdraw={latestIsOpen && ownerProposedLatest ? handleWithdraw : undefined}
+            />
+          {/if}
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  {/if}
+{/if}
+
+<style>
+  .revenue-share-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+    max-width: 1200px;
+    container-type: inline-size;
+  }
+
+  .revenue-share-page__intro {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .revenue-share-page__heading {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .revenue-share-page__lede {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+    line-height: var(--leading-relaxed);
+  }
+
+  .revenue-share-page__lede strong {
+    color: var(--color-text);
+  }
+
+  .revenue-share-page__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .revenue-share-page__section-heading {
+    margin: 0;
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .revenue-share-page__section-lede {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+  }
+
+  .revenue-share-page__cards-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+    margin-top: var(--space-2);
+  }
+
+  @container (min-width: 56rem) {
+    .revenue-share-page__cards-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .revenue-share-page__empty {
+    margin: 0;
+    padding: var(--space-4);
+    background: var(--color-surface-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .revenue-share-page__empty a {
+    color: var(--color-interactive);
+    text-decoration: underline;
+  }
+
+  .revenue-share-page__active-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .revenue-share-page__active-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-surface-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    border-radius: var(--radius-md);
+  }
+
+  .revenue-share-page__active-info {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    min-width: 0;
+    flex: 1;
+  }
+
+  .revenue-share-page__active-creator {
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .revenue-share-page__active-type {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .revenue-share-page__active-share {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .revenue-share-page__active-share-hint {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .revenue-share-page__active-actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .revenue-share-page__btn {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-md);
+    border: var(--border-width) var(--border-style) transparent;
+    cursor: pointer;
+    background: transparent;
+    color: var(--color-text-secondary);
+    transition: var(--transition-colors);
+  }
+
+  .revenue-share-page__btn:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .revenue-share-page__btn--ghost:hover {
+    color: var(--color-text);
+    background: var(--color-surface);
+  }
+
+  .revenue-share-page__btn--danger {
+    color: var(--color-error-700);
+    border-color: var(--color-error-200);
+  }
+
+  .revenue-share-page__btn--danger:hover {
+    background: var(--color-error-50);
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@codex/admin':
         specifier: workspace:*
         version: link:../../packages/admin
+      '@codex/agreements':
+        specifier: workspace:*
+        version: link:../../packages/agreements
       '@codex/cache':
         specifier: workspace:*
         version: link:../../packages/cache


### PR DESCRIPTION
## Summary

WP-7 of the Revenue-Share Agreements epic (Codex-nk4km). Owner-facing UI for managing per-creator revenue-share agreements.

### Settings tab
- **Team Budget** — RevenueSplitPie (mode='owner') with platform fee + per-creator slices + org residual
- **Per-Creator Cards** — one card per team creator, side-by-side subscription + content_purchase rows, actions: Propose / Amend / View thread
- **Active Agreements** — quick-action list with View thread + Terminate
- **Negotiation Thread Dialog** — chronological proposal history with Accept / Counter / Decline / Withdraw actions (only on the latest open proposal, only for callbacks the owner is allowed to wire)
- **History** is implicit in the thread dialog — declined / terminated / superseded proposals render with reduced opacity

### Components (in `apps/web/src/lib/components/agreements/`)
- `RevenueSplitPie.svelte` — vendored from WP-6 PR #206 (will auto-resolve on WP-6 merge)
- `AgreementCard.svelte` — one per creator+revenue_type
- `ProposeAgreementDialog.svelte` — BrandSliderField + term picker + note (reused for the counter-flow too)
- `NegotiationThread.svelte` — shared with WP-8 (creator side)

### Remote functions
- `agreements.remote.ts` — wraps the WP-3 worker API via `getServiceUrl('ecom', env)`. Exports: listActiveAgreements / getAgreementThread / listMyAgreements / proposeAgreement / counterAgreement / acceptAgreement / declineAgreement / withdrawAgreement / terminateAgreement

### Copy alignment
Every share % mention says "of post-platform [revenue_type] revenue" per the C1 math fix (PR #213). Currency GBP throughout.

### Tests
22 new unit tests:
- AgreementCard.svelte.test.ts — 6 tests (empty state, Propose dispatch, active rendering, Amend round-trip, Counter-received UI, Waiting-on-creator UI)
- NegotiationThread.svelte.test.ts — 7 tests (empty state, post-platform copy on both revenue types, proposer label resolution, single-actionable-row invariant, no-callbacks-no-buttons, decline reason)
- agreements.remote.test.ts — 9 export smoke tests

All 39 agreement tests pass (17 from WP-6's RevenueSplitPie + 22 new). Full apps/web build succeeds.

## Base branch
Stacks on `feat/codex-90de9-agreement-notifications` (WP-5 PR #214). Chain: WP-1 → WP-2 → WP-3 → WP-4 → C1 → WP-5 → this.

## Test plan
- [ ] Owner navigates to settings → revenue-share tab, pie + cards render
- [ ] Propose flow: dialog opens, share 30%, term 12mo, submit, toast, card updates
- [ ] Amend flow: pre-fills slider with current share, submits as round-1 proposal
- [ ] Pending shows waiting-on-creator state in the card
- [ ] Counter received → review dialog → accept flow, card shows active agreement
- [ ] Terminate flow on active agreement
- [ ] Playwright run on local dev stack (requires `pnpm dev` from monorepo root)

Bead: Codex-s80r6
Epic: Codex-nk4km