### PR TITLE
feat(creators): WP-8 creator-side revenue-share negotiations

### DIFF
--- a/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte
+++ b/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte
@@ -27,7 +27,6 @@
   interface Props {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    proposalId: string;
     /** The owner's current proposed share % in basis points (0-10000). */
     currentSharePercent: number;
     /** The owner's current proposed term in months. */
@@ -49,7 +48,6 @@
   const {
     open,
     onOpenChange,
-    proposalId: _proposalId,
     currentSharePercent,
     currentTermMonths,
     ownerName,

--- a/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte
+++ b/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte
@@ -1,0 +1,362 @@
+<!--
+  @component CounterProposalDialog
+
+  Dialog the creator uses to counter an open owner proposal (WP-8 —
+  Codex-bw2wf). Pre-fills the slider + term picker with the OWNER's
+  current offer, and shows a "their offer was X%; your counter:" hint
+  comparing the new value against the pre-filled baseline.
+
+  Mirrors `ProposeAgreementDialog` (WP-7) in layout and tone — same
+  BrandSliderField + radio-group term picker + optional note — but with
+  copy that frames the action as a counter rather than a fresh proposal.
+
+  Idempotent open-state handler per [[melt-controlled-components]] —
+  `onOpenChange` early-returns when next === current to avoid spurious
+  side-effect echoes from Melt UI's controlled-component lifecycle.
+
+  Copy explicitly says "X% of post-platform [revenue_type] revenue" so
+  the creator understands the post-platform-pool semantic (per the C1
+  math decision; see project_revenue_share_decisions Q2). Currency GBP.
+-->
+<script lang="ts">
+  import BrandSliderField from '$lib/components/brand-editor/BrandSliderField.svelte';
+  import { DialogForm } from '$lib/components/ui/DialogForm';
+
+  type RevenueType = 'subscription' | 'content_purchase';
+
+  interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    proposalId: string;
+    /** The owner's current proposed share % in basis points (0-10000). */
+    currentSharePercent: number;
+    /** The owner's current proposed term in months. */
+    currentTermMonths: number | null;
+    /** Human name of the party currently waiting on a response. */
+    ownerName: string;
+    revenueType: RevenueType;
+    /**
+     * Submit handler. Returns when the counter succeeds; the dialog closes
+     * on success. Throw to surface an error message inline.
+     */
+    onSubmit: (input: {
+      sharePercent: number;
+      termMonths: number;
+      note?: string;
+    }) => Promise<void>;
+  }
+
+  const {
+    open,
+    onOpenChange,
+    proposalId: _proposalId,
+    currentSharePercent,
+    currentTermMonths,
+    ownerName,
+    revenueType,
+    onSubmit,
+  }: Props = $props();
+
+  // ─── Form state ──────────────────────────────────────────────────────────
+  // Seed from the owner's current offer; the user owns the values from
+  // there. Reset on (re-)open so switching proposals does not bleed prior
+  // edits into a different counter (per the Svelte 5 "seed from a prop,
+  // then own it" pattern documented in ProposeAgreementDialog).
+
+  let shareBp = $state(currentSharePercent);
+  let termMonths = $state(currentTermMonths ?? 12);
+  let note = $state('');
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  $effect(() => {
+    if (open) {
+      shareBp = currentSharePercent;
+      termMonths = currentTermMonths ?? 12;
+      note = '';
+      error = null;
+    }
+  });
+
+  const revenueLabel = $derived(
+    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
+  );
+  const sharePercent = $derived(shareBp / 100);
+  const ownerSharePercent = $derived(currentSharePercent / 100);
+  const formattedShare = $derived(
+    Number.isInteger(sharePercent)
+      ? `${sharePercent}%`
+      : `${sharePercent.toFixed(1)}%`
+  );
+  const formattedOwnerShare = $derived(
+    Number.isInteger(ownerSharePercent)
+      ? `${ownerSharePercent}%`
+      : `${ownerSharePercent.toFixed(1)}%`
+  );
+  const ariaValueText = $derived(
+    `${formattedShare} of post-platform ${revenueLabel} revenue`
+  );
+  const isChanged = $derived(shareBp !== currentSharePercent || termMonths !== (currentTermMonths ?? 12));
+
+  const termOptions = [
+    { value: 3, label: '3 months' },
+    { value: 6, label: '6 months' },
+    { value: 12, label: '12 months' },
+    { value: 24, label: '24 months' },
+    { value: 36, label: '36 months' },
+  ];
+
+  function onShareInput(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const raw = Number(target.value);
+    if (!Number.isFinite(raw)) return;
+    shareBp = Math.min(10000, Math.max(0, Math.round(raw * 100)));
+  }
+
+  async function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    error = null;
+
+    if (note.length > 500) {
+      error = 'Note must be 500 characters or less';
+      return;
+    }
+    if (!isChanged) {
+      error =
+        'Counters must change either the share or term. Use Accept to take the existing offer.';
+      return;
+    }
+
+    submitting = true;
+    try {
+      await onSubmit({
+        sharePercent: shareBp,
+        termMonths,
+        note: note.trim() || undefined,
+      });
+      // Parent closes on success; the form resets via the $effect above
+      // when `open` flips next.
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to send counter';
+    } finally {
+      submitting = false;
+    }
+  }
+
+  /**
+   * Idempotent open-change handler — Melt UI fires onOpenChange during
+   * its controlled-component sync (mount/unmount); short-circuit if the
+   * next value matches the current to avoid re-running side effects.
+   */
+  function handleOpenChange(next: boolean) {
+    if (next === open) return;
+    onOpenChange(next);
+  }
+
+  const dialogTitle = $derived(
+    `Counter ${revenueLabel} proposal from ${ownerName}`
+  );
+  const dialogDescription =
+    'Share is calculated against post-platform revenue. The platform fee is taken first; this percentage applies to what remains.';
+</script>
+
+<DialogForm
+  title={dialogTitle}
+  description={dialogDescription}
+  {open}
+  {submitting}
+  {error}
+  onsubmit={handleSubmit}
+  onOpenChange={handleOpenChange}
+  submitLabel="Send counter"
+>
+  <div class="counter-form">
+    <BrandSliderField
+      id="counter-share"
+      label="Your share"
+      value={formattedShare}
+      min={0}
+      max={100}
+      step={1}
+      current={sharePercent}
+      minLabel="0%"
+      maxLabel="100%"
+      ariaValueText={ariaValueText}
+      oninput={onShareInput}
+    />
+    <p class="counter-form__comparison" aria-live="polite">
+      <span class="counter-form__comparison-baseline">
+        {ownerName}'s offer was <strong>{formattedOwnerShare}</strong>.
+      </span>
+      <span class="counter-form__comparison-counter">
+        Your counter: <strong>{formattedShare}</strong>
+        of post-platform {revenueLabel} revenue.
+      </span>
+    </p>
+
+    <fieldset class="counter-form__field">
+      <legend class="counter-form__field-label">Soft-lock term</legend>
+      <p class="counter-form__field-hint">
+        How long this rate is locked before either side can amend.
+      </p>
+      <div
+        class="counter-form__term-options"
+        role="radiogroup"
+        aria-label="Soft-lock term"
+      >
+        {#each termOptions as option (option.value)}
+          <label class="counter-form__term-option">
+            <input
+              type="radio"
+              name="counter-term"
+              value={option.value}
+              checked={termMonths === option.value}
+              onchange={() => (termMonths = option.value)}
+              disabled={submitting}
+            />
+            <span>{option.label}</span>
+          </label>
+        {/each}
+      </div>
+    </fieldset>
+
+    <div class="counter-form__field">
+      <label class="counter-form__field-label" for="counter-note">
+        Note (optional)
+      </label>
+      <p class="counter-form__field-hint">
+        Visible to {ownerName}. Use this to explain your counter.
+      </p>
+      <textarea
+        id="counter-note"
+        class="counter-form__textarea"
+        bind:value={note}
+        rows="3"
+        maxlength="500"
+        disabled={submitting}
+        placeholder="e.g. I'd like a longer term to reflect ongoing work."
+      ></textarea>
+      <span class="counter-form__char-count" aria-live="polite">
+        {note.length} / 500
+      </span>
+    </div>
+  </div>
+</DialogForm>
+
+<style>
+  .counter-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
+  .counter-form__comparison {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    margin: 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-info-50);
+    color: var(--color-text);
+    border-inline-start: var(--border-width-thick) solid var(--color-info-200);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+  }
+
+  .counter-form__comparison-baseline {
+    color: var(--color-text-secondary);
+  }
+
+  .counter-form__comparison-counter {
+    color: var(--color-text);
+  }
+
+  .counter-form__comparison strong {
+    font-family: var(--font-mono);
+    color: var(--color-text);
+  }
+
+  .counter-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .counter-form__field-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text);
+  }
+
+  .counter-form__field-hint {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .counter-form__term-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+
+  .counter-form__term-option {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .counter-form__term-option:hover {
+    background: var(--color-surface-secondary);
+  }
+
+  .counter-form__term-option:has(input:checked) {
+    background: var(--color-interactive-subtle);
+    border-color: var(--color-interactive);
+    color: var(--color-text);
+  }
+
+  .counter-form__term-option:has(input:focus-visible) {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .counter-form__textarea {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    resize: vertical;
+    min-height: var(--space-16);
+  }
+
+  .counter-form__textarea:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+    border-color: var(--color-border-focus);
+  }
+
+  .counter-form__char-count {
+    align-self: flex-end;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+</style>

--- a/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte.test.ts
@@ -1,0 +1,140 @@
+/**
+ * CounterProposalDialog unit tests (WP-8 — Codex-bw2wf)
+ *
+ * Verifies:
+ *   - Initial values populate from `currentSharePercent` + `currentTermMonths`
+ *   - Slider comparison hint shows the owner's offer and the creator's
+ *     in-progress counter side by side
+ *   - Submit dispatches with the new values when changed
+ *   - Submit rejects an unchanged counter (must change something or use Accept)
+ *   - Idempotent `onOpenChange` — duplicate values short-circuit
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import CounterProposalDialog from './CounterProposalDialog.svelte';
+
+describe('CounterProposalDialog', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test("pre-fills slider with owner's offer", () => {
+    component = mount(CounterProposalDialog, {
+      target: document.body,
+      props: {
+        open: true,
+        onOpenChange: vi.fn(),
+        proposalId: '11111111-1111-1111-1111-111111111111',
+        currentSharePercent: 4000,
+        currentTermMonths: 12,
+        ownerName: 'Acme Studio',
+        revenueType: 'subscription',
+        onSubmit: vi.fn(),
+      },
+    });
+    flushSync();
+
+    // The slider input is the range input within BrandSliderField; its
+    // initial value should match the current share (40%).
+    const sliderInput = document.querySelector<HTMLInputElement>(
+      'input[type="range"]'
+    );
+    expect(sliderInput).toBeTruthy();
+    expect(sliderInput?.value).toBe('40');
+  });
+
+  test('renders post-platform comparison copy with owner name + share', () => {
+    component = mount(CounterProposalDialog, {
+      target: document.body,
+      props: {
+        open: true,
+        onOpenChange: vi.fn(),
+        proposalId: '11111111-1111-1111-1111-111111111111',
+        currentSharePercent: 3500,
+        currentTermMonths: 6,
+        ownerName: 'Acme Studio',
+        revenueType: 'subscription',
+        onSubmit: vi.fn(),
+      },
+    });
+    flushSync();
+    const text = document.body.textContent ?? '';
+    expect(text).toContain("Acme Studio's offer was");
+    expect(text).toContain('35%');
+    expect(text).toContain('Your counter');
+    expect(text).toContain('post-platform subscription revenue');
+  });
+
+  test('uses content-purchase label for content_purchase revenue type', () => {
+    component = mount(CounterProposalDialog, {
+      target: document.body,
+      props: {
+        open: true,
+        onOpenChange: vi.fn(),
+        proposalId: '11111111-1111-1111-1111-111111111111',
+        currentSharePercent: 2500,
+        currentTermMonths: 12,
+        ownerName: 'Acme Studio',
+        revenueType: 'content_purchase',
+        onSubmit: vi.fn(),
+      },
+    });
+    flushSync();
+    expect(document.body.textContent).toContain(
+      'post-platform content-purchase revenue'
+    );
+  });
+
+  test('selects the supplied term option by default', () => {
+    component = mount(CounterProposalDialog, {
+      target: document.body,
+      props: {
+        open: true,
+        onOpenChange: vi.fn(),
+        proposalId: '11111111-1111-1111-1111-111111111111',
+        currentSharePercent: 3000,
+        currentTermMonths: 24,
+        ownerName: 'Acme Studio',
+        revenueType: 'subscription',
+        onSubmit: vi.fn(),
+      },
+    });
+    flushSync();
+    const checkedRadio = document.querySelector<HTMLInputElement>(
+      'input[name="counter-term"]:checked'
+    );
+    expect(checkedRadio?.value).toBe('24');
+  });
+
+  test('idempotent onOpenChange short-circuits when next === current', () => {
+    const onOpenChange = vi.fn();
+    component = mount(CounterProposalDialog, {
+      target: document.body,
+      props: {
+        open: false,
+        onOpenChange,
+        proposalId: '11111111-1111-1111-1111-111111111111',
+        currentSharePercent: 3000,
+        currentTermMonths: 12,
+        ownerName: 'Acme Studio',
+        revenueType: 'subscription',
+        onSubmit: vi.fn(),
+      },
+    });
+    flushSync();
+    // No portal content when closed; nothing to assert other than that
+    // construction didn't throw and onOpenChange wasn't invoked.
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte.test.ts
@@ -35,7 +35,6 @@ describe('CounterProposalDialog', () => {
       props: {
         open: true,
         onOpenChange: vi.fn(),
-        proposalId: '11111111-1111-1111-1111-111111111111',
         currentSharePercent: 4000,
         currentTermMonths: 12,
         ownerName: 'Acme Studio',
@@ -60,7 +59,6 @@ describe('CounterProposalDialog', () => {
       props: {
         open: true,
         onOpenChange: vi.fn(),
-        proposalId: '11111111-1111-1111-1111-111111111111',
         currentSharePercent: 3500,
         currentTermMonths: 6,
         ownerName: 'Acme Studio',
@@ -82,7 +80,6 @@ describe('CounterProposalDialog', () => {
       props: {
         open: true,
         onOpenChange: vi.fn(),
-        proposalId: '11111111-1111-1111-1111-111111111111',
         currentSharePercent: 2500,
         currentTermMonths: 12,
         ownerName: 'Acme Studio',
@@ -102,7 +99,6 @@ describe('CounterProposalDialog', () => {
       props: {
         open: true,
         onOpenChange: vi.fn(),
-        proposalId: '11111111-1111-1111-1111-111111111111',
         currentSharePercent: 3000,
         currentTermMonths: 24,
         ownerName: 'Acme Studio',
@@ -124,7 +120,6 @@ describe('CounterProposalDialog', () => {
       props: {
         open: false,
         onOpenChange,
-        proposalId: '11111111-1111-1111-1111-111111111111',
         currentSharePercent: 3000,
         currentTermMonths: 12,
         ownerName: 'Acme Studio',

--- a/apps/web/src/lib/components/agreements/creator-anonymisation.test.ts
+++ b/apps/web/src/lib/components/agreements/creator-anonymisation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Anonymisation invariant tests (WP-8 — Codex-bw2wf)
+ *
+ * Pin tests for the creator-side anonymisation contract. The portfolio
+ * + detail surfaces MUST never render peer identifiers — only the
+ * `peers: { count, aggregateSharePercent }` aggregate that the worker
+ * route emits.
+ *
+ * These tests render the WP-7 components (RevenueSplitPie in
+ * `mode='creator'`) with the exact shapes the WP-8 pages pass through.
+ * If a future change leaks peer fields to the UI surface, these tests
+ * fail loudly.
+ */
+
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  flushSync,
+  mount,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+import RevenueSplitPie from './RevenueSplitPie.svelte';
+import type { RevenueSplitSlice } from './types';
+
+describe('creator-side anonymisation', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('anonymised peer slice never displays a peer identifier', () => {
+    const peerCreatorId = 'peer-creator-id-must-not-leak';
+    const peerName = 'Peer Creator Name Must Not Leak';
+
+    // Construct slices the way the detail page does — peer slice marked
+    // `anonymous: true`. The label parameter is intentionally a generic
+    // count; even if a caller accidentally passed a peer name, the
+    // component swaps it for "Other creator N" when `anonymous: true`.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: '__me__',
+        label: 'Your share',
+        percent: 3000,
+        color: 'var(--color-interactive)',
+        locked: true,
+        anonymous: false,
+      },
+      {
+        id: '__peers__',
+        // Even if a caller messes up the label here, the component
+        // replaces it with "Other creator N" via displayLabel().
+        label: 'Other creators (2)',
+        percent: 4000,
+        color: 'var(--color-info-600)',
+        locked: true,
+        anonymous: true,
+      },
+    ];
+
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'creator',
+        platformFeePercent: 1000,
+        slices,
+        readOnly: true,
+      },
+    });
+    flushSync();
+
+    const text = document.body.textContent ?? '';
+    expect(text).not.toContain(peerCreatorId);
+    expect(text).not.toContain(peerName);
+  });
+
+  test('creator mode swaps anonymous label even when caller passes a real name', () => {
+    // Defence-in-depth: even if a future refactor wires a peer's real
+    // name into `label`, `mode='creator'` + `anonymous: true` swaps it
+    // for "Other creator 1".
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: '__me__',
+        label: 'Your share',
+        percent: 3000,
+        color: 'var(--color-interactive)',
+        locked: true,
+        anonymous: false,
+      },
+      {
+        id: '__peer__',
+        label: 'Sandra Aniston',
+        percent: 2500,
+        color: 'var(--color-info-600)',
+        locked: true,
+        anonymous: true,
+      },
+    ];
+
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'creator',
+        platformFeePercent: 1000,
+        slices,
+        readOnly: true,
+      },
+    });
+    flushSync();
+
+    const text = document.body.textContent ?? '';
+    expect(text).not.toContain('Sandra Aniston');
+    expect(text).toContain('Other creator');
+  });
+
+  test('owner-mode preserves identifying labels (negative control)', () => {
+    // Confirms the anonymisation gate hinges on `mode='creator'` —
+    // owner-side surfaces still show real names. Without this pin, a
+    // future refactor that swaps the mode parameter would silently
+    // succeed in test.
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: 'creator-1',
+        label: 'Sandra Aniston',
+        percent: 4000,
+        color: 'var(--color-info-600)',
+        locked: true,
+        anonymous: false,
+      },
+    ];
+
+    component = mount(RevenueSplitPie, {
+      target: document.body,
+      props: {
+        mode: 'owner',
+        platformFeePercent: 1000,
+        slices,
+        readOnly: true,
+      },
+    });
+    flushSync();
+    expect(document.body.textContent).toContain('Sandra Aniston');
+  });
+});

--- a/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
+++ b/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
@@ -25,6 +25,7 @@
   import {
     LayoutDashboardIcon,
     FileIcon,
+    FileTextIcon,
     VideoIcon,
     TrendingUpIcon,
     UsersIcon,
@@ -67,6 +68,7 @@
     monetisation: CoinsIcon,
     payouts: BanknoteIcon,
     billing: CreditCardIcon,
+    agreements: FileTextIcon,
   };
 
   interface StudioUser {

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -22,7 +22,8 @@ export type SidebarIcon =
   | 'settings'
   | 'billing'
   | 'monetisation'
-  | 'payouts';
+  | 'payouts'
+  | 'agreements';
 
 export interface SidebarLink extends NavLink {
   icon: SidebarIcon;
@@ -78,6 +79,7 @@ export const SIDEBAR_OWNER_LINKS: SidebarLink[] = [
 
 /** Studio sidebar — personal studio links (settings without admin gate) */
 export const SIDEBAR_PERSONAL_LINKS: SidebarLink[] = [
+  { href: '/studio/negotiations', label: 'Negotiations', icon: 'agreements' },
   { href: '/studio/settings', label: 'Settings', icon: 'settings' },
 ];
 

--- a/apps/web/src/lib/remote/agreements.remote.test.ts
+++ b/apps/web/src/lib/remote/agreements.remote.test.ts
@@ -57,4 +57,14 @@ describe('remote/agreements.remote', () => {
     const { terminateAgreement } = await import('./agreements.remote');
     expect(terminateAgreement).toBeDefined();
   });
+
+  it('exports getMyAgreementPortfolio query (for WP-8 creator surface)', async () => {
+    const { getMyAgreementPortfolio } = await import('./agreements.remote');
+    expect(getMyAgreementPortfolio).toBeDefined();
+  });
+
+  it('exports getMyAgreementThread query (for WP-8 creator detail page)', async () => {
+    const { getMyAgreementThread } = await import('./agreements.remote');
+    expect(getMyAgreementThread).toBeDefined();
+  });
 });

--- a/apps/web/src/lib/remote/agreements.remote.ts
+++ b/apps/web/src/lib/remote/agreements.remote.ts
@@ -107,6 +107,36 @@ export const listMyAgreements = query(async () => {
   return api.agreements.listForCreator();
 });
 
+/**
+ * Creator-view portfolio aggregator (WP-8 — Codex-bw2wf). Drives the
+ * /studio/negotiations page: active + pending-action-required +
+ * waiting-on-org + past in a single round-trip.
+ *
+ * Anonymisation contract: peer aggregates only, never identifiers. The
+ * UI consumes the masked data as-is.
+ */
+export const getMyAgreementPortfolio = query(async () => {
+  const { platform, cookies } = getRequestEvent();
+  const api = createServerApi(platform, cookies);
+  return api.agreements.getCreatorPortfolio();
+});
+
+/**
+ * Creator-view: full negotiation thread by ANY proposal id within the
+ * thread. Used by the agreement-detail page on /studio/negotiations/[id].
+ * Worker enumerates threads where the caller is the named creator,
+ * including pending-only threads (round-1 owner proposals not yet
+ * accepted).
+ */
+export const getMyAgreementThread = query(
+  proposalIdArgSchema,
+  async ({ proposalId }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.getMyThread(proposalId);
+  }
+);
+
 // ─── Commands ─────────────────────────────────────────────────────────────
 
 /**

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1865,6 +1865,79 @@ export function createServerApi(
         >('ecom', '/agreements/me'),
 
       /**
+       * Creator-view portfolio aggregator (WP-8). Returns active +
+       * pending-action-required + waiting-on-org + past in one round-trip.
+       * Anonymisation contract preserved: peer aggregates only, never peer
+       * identifiers.
+       */
+      getCreatorPortfolio: () =>
+        request<{
+          active: Array<{
+            id: string;
+            organizationId: string;
+            organizationName: string | null;
+            creatorId: string;
+            revenueType: string;
+            status: string;
+            effectiveFrom: string | Date;
+            effectiveUntil: string | Date | null;
+            organizationFeePercentage: number;
+            currentProposalId: string | null;
+            terminatedAt: string | Date | null;
+            peers: { count: number; aggregateSharePercent: number };
+          }>;
+          pendingActionRequired: Array<{
+            proposalId: string;
+            organizationId: string;
+            organizationName: string | null;
+            revenueType: string;
+            proposedSharePercent: number;
+            proposedTermMonths: number | null;
+            proposedByRole: string;
+            roundNumber: number;
+            createdAt: string | Date;
+            note: string | null;
+            threadProposalId: string;
+          }>;
+          pendingWaitingOnOrg: Array<{
+            proposalId: string;
+            organizationId: string;
+            organizationName: string | null;
+            revenueType: string;
+            proposedSharePercent: number;
+            proposedTermMonths: number | null;
+            proposedByRole: string;
+            roundNumber: number;
+            createdAt: string | Date;
+            note: string | null;
+            threadProposalId: string;
+          }>;
+          past: Array<{
+            proposalId: string;
+            organizationId: string;
+            organizationName: string | null;
+            revenueType: string;
+            status: string;
+            proposedSharePercent: number;
+            proposedByRole: string;
+            roundNumber: number;
+            endedAt: string | Date | null;
+            declineReason: string | null;
+          }>;
+        }>('ecom', '/agreements/me/portfolio'),
+
+      /**
+       * Creator-view negotiation thread by ANY proposal id within the
+       * thread. Worker enumerates threads where the caller is the named
+       * creator (including pending-only threads without an active row).
+       */
+      getMyThread: (proposalId: string) =>
+        request<AgreementProposal[]>(
+          'ecom',
+          `/agreements/me/threads/${encodeURIComponent(proposalId)}`
+        ),
+
+      /**
        * Round 1 owner-initiated proposal. `organizationId` lives in the
        * query string (procedure() resolveOrganizationId only reads query
        * fallback; body org would 400 with ORG_CONTEXT_REQUIRED).

--- a/apps/web/src/routes/_creators/studio/negotiations/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/negotiations/+page.svelte
@@ -1,0 +1,746 @@
+<!--
+  @component CreatorStudioNegotiations
+
+  Creator-side revenue-share negotiations portfolio (WP-8 — Codex-bw2wf).
+
+  First major surface on the personal creator studio subdomain. Four
+  sections:
+    1. Pending — Action Required: owner proposed; creator must respond.
+    2. Pending — Waiting on Org: creator countered; org owner must respond.
+    3. Active Agreements: signed and in force.
+    4. Past: declined / withdrawn / superseded / terminated (read-only).
+
+  Studio is `ssr = false`, so data is fetched client-side via the
+  `getMyAgreementPortfolio` remote query. The worker enforces the
+  anonymisation contract — only `peers: { count, aggregateSharePercent }`
+  ever crosses the wire; never peer userId / creatorId / name.
+
+  All share % copy explicitly says "of post-platform [type] revenue" per
+  the C1 math semantic (see project_revenue_share_decisions.md).
+  Currency GBP throughout.
+-->
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import Skeleton from '$lib/components/ui/Skeleton/Skeleton.svelte';
+  import {
+    acceptAgreement,
+    declineAgreement,
+    getMyAgreementPortfolio,
+    withdrawAgreement,
+  } from '$lib/remote/agreements.remote';
+  import { toast } from '$lib/components/ui/Toast/toast-store';
+
+  type RevenueType = 'subscription' | 'content_purchase';
+
+  // ─── Data ─────────────────────────────────────────────────────────────────
+  const portfolioQuery = $derived(browser ? getMyAgreementPortfolio() : null);
+
+  const portfolio = $derived(portfolioQuery?.current ?? null);
+  const isLoading = $derived(portfolioQuery?.loading ?? true);
+
+  const pendingActionRequired = $derived(portfolio?.pendingActionRequired ?? []);
+  const pendingWaitingOnOrg = $derived(portfolio?.pendingWaitingOnOrg ?? []);
+  const active = $derived(portfolio?.active ?? []);
+  const past = $derived(portfolio?.past ?? []);
+
+  const isEmpty = $derived(
+    !isLoading &&
+      pendingActionRequired.length === 0 &&
+      pendingWaitingOnOrg.length === 0 &&
+      active.length === 0 &&
+      past.length === 0
+  );
+
+  let pastExpanded = $state(false);
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  function formatPercent(bp: number): string {
+    const pct = bp / 100;
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  function formatDate(date: Date | string | null | undefined): string {
+    if (!date) return '—';
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return d.toISOString().slice(0, 10);
+  }
+
+  function formatTerm(months: number | null): string {
+    if (months == null) return 'Indefinite';
+    return months === 1 ? '1 month' : `${months} months`;
+  }
+
+  function revenueLabel(revenueType: string): string {
+    return revenueType === 'subscription' ? 'subscription' : 'content-purchase';
+  }
+
+  function statusLabel(status: string): string {
+    switch (status) {
+      case 'declined':
+        return 'Declined';
+      case 'withdrawn':
+        return 'Withdrawn';
+      case 'superseded':
+        return 'Superseded';
+      case 'terminated':
+        return 'Terminated';
+      case 'active':
+        return 'Active';
+      default:
+        return status;
+    }
+  }
+
+  function detailHref(proposalId: string): string {
+    return `/studio/negotiations/${proposalId}`;
+  }
+
+  function activeDetailHref(activeRow: { currentProposalId: string | null; id: string }): string {
+    // currentProposalId is always set on active rows (set by acceptProposal);
+    // fall back to agreement id if somehow null.
+    return `/studio/negotiations/${activeRow.currentProposalId ?? activeRow.id}`;
+  }
+
+  // ─── Row actions ──────────────────────────────────────────────────────────
+
+  async function handleAccept(proposalId: string) {
+    try {
+      await acceptAgreement({ proposalId });
+      toast.success('Agreement accepted', 'The agreement is now active.');
+      await portfolioQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not accept proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  async function handleDecline(proposalId: string) {
+    try {
+      await declineAgreement({ proposalId });
+      toast.info('Proposal declined', 'The org owner will be notified.');
+      await portfolioQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not decline proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  async function handleWithdraw(proposalId: string) {
+    try {
+      await withdrawAgreement({ proposalId });
+      toast.info('Counter withdrawn');
+      await portfolioQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not withdraw counter',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Negotiations | Creator Studio</title>
+</svelte:head>
+
+<div class="negotiations-page">
+  <header class="negotiations-page__intro">
+    <h2 class="negotiations-page__heading">Negotiations</h2>
+    <p class="negotiations-page__lede">
+      Revenue-share agreements with the orgs you create for. All shares are
+      calculated against <strong>post-platform revenue</strong> — the platform
+      fee is taken first, and your share applies to what remains.
+    </p>
+  </header>
+
+  {#if isLoading}
+    <div class="negotiations-page__loading">
+      <Skeleton width="100%" height="var(--space-24)" />
+      <Skeleton width="100%" height="var(--space-24)" />
+    </div>
+  {:else if isEmpty}
+    <section
+      class="negotiations-page__section negotiations-page__section--empty"
+      aria-labelledby="empty-heading"
+    >
+      <h3 id="empty-heading" class="negotiations-page__section-heading">
+        No revenue-share agreements yet
+      </h3>
+      <p class="negotiations-page__section-lede">
+        When an org owner proposes a revenue-share agreement with you, it will
+        appear here. You can accept, counter, or decline each proposal — and
+        track your active agreements once accepted.
+      </p>
+    </section>
+  {:else}
+    <!-- ─── 1. Pending — Action Required ────────────────────────────────── -->
+    {#if pendingActionRequired.length > 0}
+      <section
+        class="negotiations-page__section negotiations-page__section--alert"
+        aria-labelledby="action-required-heading"
+      >
+        <header class="negotiations-page__section-head">
+          <h3
+            id="action-required-heading"
+            class="negotiations-page__section-heading"
+          >
+            Action required
+          </h3>
+          <span class="negotiations-page__count-pill" aria-hidden="true">
+            {pendingActionRequired.length}
+          </span>
+        </header>
+        <p class="negotiations-page__section-lede">
+          Proposals waiting on your response.
+        </p>
+        <ul class="negotiations-page__list">
+          {#each pendingActionRequired as row (row.proposalId)}
+            {@const revLabel = revenueLabel(row.revenueType)}
+            <li class="negotiations-page__item" data-tone="alert">
+              <div class="negotiations-page__item-info">
+                <a
+                  href={detailHref(row.threadProposalId)}
+                  class="negotiations-page__item-org"
+                >
+                  {row.organizationName ?? 'Organisation'}
+                </a>
+                <span class="negotiations-page__item-type">
+                  {revLabel}
+                </span>
+                <span class="negotiations-page__item-share">
+                  {formatPercent(row.proposedSharePercent)}
+                  <span class="negotiations-page__item-hint">
+                    of post-platform {revLabel} revenue · {formatTerm(row.proposedTermMonths)} · Round {row.roundNumber}
+                  </span>
+                </span>
+                {#if row.note}
+                  <p class="negotiations-page__item-note">
+                    <strong>Note:</strong> {row.note}
+                  </p>
+                {/if}
+              </div>
+              <div class="negotiations-page__item-actions">
+                <button
+                  type="button"
+                  class="negotiations-page__btn negotiations-page__btn--primary"
+                  onclick={() => handleAccept(row.proposalId)}
+                >
+                  Accept
+                </button>
+                <a
+                  href={detailHref(row.threadProposalId)}
+                  class="negotiations-page__btn negotiations-page__btn--secondary"
+                >
+                  Counter
+                </a>
+                <button
+                  type="button"
+                  class="negotiations-page__btn negotiations-page__btn--ghost"
+                  onclick={() => handleDecline(row.proposalId)}
+                >
+                  Decline
+                </button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- ─── 2. Pending — Waiting on Org ─────────────────────────────────── -->
+    {#if pendingWaitingOnOrg.length > 0}
+      <section
+        class="negotiations-page__section"
+        aria-labelledby="waiting-on-org-heading"
+      >
+        <header class="negotiations-page__section-head">
+          <h3
+            id="waiting-on-org-heading"
+            class="negotiations-page__section-heading"
+          >
+            Waiting on org
+          </h3>
+          <span class="negotiations-page__count-pill" aria-hidden="true">
+            {pendingWaitingOnOrg.length}
+          </span>
+        </header>
+        <p class="negotiations-page__section-lede">
+          Counters you've sent. The org owner will be notified.
+        </p>
+        <ul class="negotiations-page__list">
+          {#each pendingWaitingOnOrg as row (row.proposalId)}
+            {@const revLabel = revenueLabel(row.revenueType)}
+            <li class="negotiations-page__item">
+              <div class="negotiations-page__item-info">
+                <a
+                  href={detailHref(row.threadProposalId)}
+                  class="negotiations-page__item-org"
+                >
+                  {row.organizationName ?? 'Organisation'}
+                </a>
+                <span class="negotiations-page__item-type">
+                  {revLabel}
+                </span>
+                <span class="negotiations-page__item-share">
+                  {formatPercent(row.proposedSharePercent)}
+                  <span class="negotiations-page__item-hint">
+                    of post-platform {revLabel} revenue · {formatTerm(row.proposedTermMonths)} · Round {row.roundNumber}
+                  </span>
+                </span>
+              </div>
+              <div class="negotiations-page__item-actions">
+                <a
+                  href={detailHref(row.threadProposalId)}
+                  class="negotiations-page__btn negotiations-page__btn--secondary"
+                >
+                  View thread
+                </a>
+                <button
+                  type="button"
+                  class="negotiations-page__btn negotiations-page__btn--ghost"
+                  onclick={() => handleWithdraw(row.proposalId)}
+                >
+                  Withdraw
+                </button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- ─── 3. Active Agreements ─────────────────────────────────────────── -->
+    {#if active.length > 0}
+      <section
+        class="negotiations-page__section"
+        aria-labelledby="active-heading"
+      >
+        <header class="negotiations-page__section-head">
+          <h3 id="active-heading" class="negotiations-page__section-heading">
+            Active agreements
+          </h3>
+          <span class="negotiations-page__count-pill" aria-hidden="true">
+            {active.length}
+          </span>
+        </header>
+        <ul class="negotiations-page__list">
+          {#each active as row (row.id)}
+            {@const revLabel = revenueLabel(row.revenueType)}
+            {@const myShareBp = 10000 - row.organizationFeePercentage}
+            <li class="negotiations-page__item" data-tone="success">
+              <div class="negotiations-page__item-info">
+                <a
+                  href={activeDetailHref(row)}
+                  class="negotiations-page__item-org"
+                >
+                  {row.organizationName ?? 'Organisation'}
+                </a>
+                <span class="negotiations-page__item-type">
+                  {revLabel}
+                </span>
+                <span class="negotiations-page__item-share">
+                  {formatPercent(myShareBp)}
+                  <span class="negotiations-page__item-hint">
+                    of post-platform {revLabel} revenue · effective from
+                    {formatDate(row.effectiveFrom)}{row.effectiveUntil
+                      ? ` until ${formatDate(row.effectiveUntil)}`
+                      : ''}
+                  </span>
+                </span>
+                {#if row.peers.count > 0}
+                  <span class="negotiations-page__item-peers">
+                    {row.peers.count}
+                    {row.peers.count === 1 ? 'other creator' : 'other creators'}
+                    on this pool ({formatPercent(row.peers.aggregateSharePercent)} aggregate share)
+                  </span>
+                {/if}
+              </div>
+              <div class="negotiations-page__item-actions">
+                <a
+                  href={activeDetailHref(row)}
+                  class="negotiations-page__btn negotiations-page__btn--secondary"
+                >
+                  Manage
+                </a>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- ─── 4. Past (collapsible, read-only) ─────────────────────────────── -->
+    {#if past.length > 0}
+      <section
+        class="negotiations-page__section"
+        aria-labelledby="past-heading"
+      >
+        <header class="negotiations-page__section-head">
+          <h3 id="past-heading" class="negotiations-page__section-heading">
+            Past
+          </h3>
+          <span class="negotiations-page__count-pill" aria-hidden="true">
+            {past.length}
+          </span>
+          <button
+            type="button"
+            class="negotiations-page__toggle"
+            aria-expanded={pastExpanded}
+            aria-controls="past-list"
+            onclick={() => (pastExpanded = !pastExpanded)}
+          >
+            {pastExpanded ? 'Hide' : 'Show'}
+          </button>
+        </header>
+        {#if pastExpanded}
+          <ul id="past-list" class="negotiations-page__list">
+            {#each past as row (row.proposalId)}
+              {@const revLabel = revenueLabel(row.revenueType)}
+              <li class="negotiations-page__item" data-tone="muted">
+                <div class="negotiations-page__item-info">
+                  <span class="negotiations-page__item-org-static">
+                    {row.organizationName ?? 'Organisation'}
+                  </span>
+                  <span class="negotiations-page__item-type">
+                    {revLabel}
+                  </span>
+                  <span class="negotiations-page__item-share">
+                    {formatPercent(row.proposedSharePercent)}
+                    <span class="negotiations-page__item-hint">
+                      of post-platform {revLabel} revenue · Round {row.roundNumber} · {formatDate(row.endedAt)}
+                    </span>
+                  </span>
+                  {#if row.declineReason}
+                    <p class="negotiations-page__item-note">
+                      <strong>Decline reason:</strong> {row.declineReason}
+                    </p>
+                  {/if}
+                </div>
+                <div class="negotiations-page__item-actions">
+                  <span
+                    class="negotiations-page__pill"
+                    data-status={row.status}
+                  >
+                    {statusLabel(row.status)}
+                  </span>
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .negotiations-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+    max-width: 1100px;
+    container-type: inline-size;
+  }
+
+  .negotiations-page__intro {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .negotiations-page__heading {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .negotiations-page__lede {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+    line-height: var(--leading-relaxed);
+  }
+
+  .negotiations-page__lede strong {
+    color: var(--color-text);
+  }
+
+  .negotiations-page__loading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .negotiations-page__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .negotiations-page__section--alert {
+    border-color: var(--color-warning-200);
+    background: var(--color-warning-50);
+  }
+
+  .negotiations-page__section--empty {
+    text-align: center;
+    padding: var(--space-8) var(--space-5);
+  }
+
+  .negotiations-page__section-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .negotiations-page__section-heading {
+    margin: 0;
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .negotiations-page__section-lede {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+  }
+
+  .negotiations-page__count-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--space-5);
+    height: var(--space-5);
+    padding: 0 var(--space-2);
+    background: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    border-radius: var(--radius-full);
+    border: var(--border-width) var(--border-style) var(--color-border);
+  }
+
+  .negotiations-page__section--alert .negotiations-page__count-pill {
+    background: var(--color-warning-100);
+    color: var(--color-warning-700);
+    border-color: var(--color-warning-200);
+  }
+
+  .negotiations-page__toggle {
+    margin-inline-start: auto;
+    padding: var(--space-1) var(--space-2);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .negotiations-page__toggle:hover {
+    background: var(--color-surface-secondary);
+    color: var(--color-text);
+  }
+
+  .negotiations-page__toggle:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .negotiations-page__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .negotiations-page__item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    border-radius: var(--radius-md);
+  }
+
+  .negotiations-page__item[data-tone='alert'] {
+    border-color: var(--color-warning-200);
+    background: var(--color-surface);
+  }
+
+  .negotiations-page__item[data-tone='success'] {
+    border-color: var(--color-success-200);
+  }
+
+  .negotiations-page__item[data-tone='muted'] {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiations-page__item-info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+    flex: 1;
+  }
+
+  .negotiations-page__item-org {
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .negotiations-page__item-org:hover {
+    color: var(--color-interactive);
+    text-decoration: underline;
+  }
+
+  .negotiations-page__item-org:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+    border-radius: var(--radius-sm);
+  }
+
+  .negotiations-page__item-org-static {
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .negotiations-page__item-type {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+
+  .negotiations-page__item-share {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .negotiations-page__item-hint {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .negotiations-page__item-peers {
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiations-page__item-note {
+    margin: var(--space-1) 0 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-surface-secondary);
+    border-inline-start: var(--border-width-thick) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiations-page__item-note strong {
+    color: var(--color-text);
+  }
+
+  .negotiations-page__item-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .negotiations-page__btn {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-md);
+    border: var(--border-width) var(--border-style) transparent;
+    cursor: pointer;
+    text-decoration: none;
+    transition: var(--transition-colors);
+  }
+
+  .negotiations-page__btn:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .negotiations-page__btn--primary {
+    background: var(--color-interactive);
+    color: var(--color-text-on-brand);
+  }
+
+  .negotiations-page__btn--primary:hover {
+    background: var(--color-interactive-hover);
+  }
+
+  .negotiations-page__btn--secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+
+  .negotiations-page__btn--secondary:hover {
+    background: var(--color-surface-tertiary);
+  }
+
+  .negotiations-page__btn--ghost {
+    background: transparent;
+    color: var(--color-text-secondary);
+  }
+
+  .negotiations-page__btn--ghost:hover {
+    color: var(--color-text);
+    background: var(--color-surface-tertiary);
+  }
+
+  .negotiations-page__pill {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-0-5) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-full);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+  }
+
+  .negotiations-page__pill[data-status='declined'],
+  .negotiations-page__pill[data-status='withdrawn'],
+  .negotiations-page__pill[data-status='superseded'] {
+    background: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+  }
+</style>

--- a/apps/web/src/routes/_creators/studio/negotiations/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/negotiations/+page.svelte
@@ -443,7 +443,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
-    max-width: 1100px;
+    max-width: var(--container-lg);
     container-type: inline-size;
   }
 
@@ -633,7 +633,7 @@
   .negotiations-page__item-type {
     font-size: var(--text-xs);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--tracking-wider);
     color: var(--color-text-muted);
   }
 

--- a/apps/web/src/routes/_creators/studio/negotiations/[proposalId]/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/negotiations/[proposalId]/+page.svelte
@@ -186,6 +186,14 @@
     return slices;
   });
 
+  // ─── Display helpers (referenced by handlers below — hoisted) ────────────
+  const ownerName = $derived(organizationName ?? 'The org owner');
+
+  function formatPercent(bp: number): string {
+    const pct = bp / 100;
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
   // ─── Counter dialog state ────────────────────────────────────────────────
   let counterDialogOpen = $state(false);
 
@@ -290,14 +298,7 @@
     }
   }
 
-  // ─── Display helpers ──────────────────────────────────────────────────────
-  const ownerName = $derived(organizationName ?? 'The org owner');
-
-  function formatPercent(bp: number): string {
-    const pct = bp / 100;
-    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
-  }
-
+  // ─── Display helpers (cont.) ─────────────────────────────────────────────
   function statusLabel(): string {
     if (activeAgreement) return 'Active';
     if (!latestProposal) return 'Unknown';
@@ -486,7 +487,6 @@
   <CounterProposalDialog
     open={counterDialogOpen}
     onOpenChange={handleCounterOpenChange}
-    proposalId={latestProposal.id}
     currentSharePercent={latestProposal.proposedCreatorSharePercent}
     currentTermMonths={latestProposal.proposedTermMonths}
     ownerName={ownerName}
@@ -500,7 +500,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-5);
-    max-width: 1100px;
+    max-width: var(--container-lg);
     container-type: inline-size;
   }
 
@@ -558,7 +558,7 @@
     font-weight: var(--font-medium);
     color: var(--color-text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--tracking-wider);
   }
 
   .agreement-detail__lede {

--- a/apps/web/src/routes/_creators/studio/negotiations/[proposalId]/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/negotiations/[proposalId]/+page.svelte
@@ -1,0 +1,715 @@
+<!--
+  @component CreatorStudioNegotiationDetail
+
+  Single-thread detail view for a creator-side revenue-share agreement
+  (WP-8 — Codex-bw2wf). The URL takes ANY proposal id within the thread;
+  the worker resolves the full chronological thread + portfolio context
+  so we can show:
+    - Org name + revenue type + thread status
+    - Anonymised revenue split (creator's slice + peer aggregate +
+      platform fee) via RevenueSplitPie in `mode='creator'`
+    - Full chronological NegotiationThread, role-agnostic
+    - Action bar appropriate to current state (accept / counter /
+      decline / withdraw / terminate)
+
+  Cross-tenant access — if `proposalId` doesn't belong to the caller,
+  the worker returns 404 and we render an access-denied state.
+
+  Studio is `ssr = false`, so all data is fetched client-side. The
+  anonymisation contract is enforced server-side by the worker (peer
+  aggregate only, no peer identifiers); UI defensively renders only
+  what's provided.
+
+  All share % copy explicitly says "of post-platform [type] revenue".
+  Currency GBP.
+-->
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import CounterProposalDialog from '$lib/components/agreements/CounterProposalDialog.svelte';
+  import NegotiationThread from '$lib/components/agreements/NegotiationThread.svelte';
+  import RevenueSplitPie from '$lib/components/agreements/RevenueSplitPie.svelte';
+  import type { RevenueSplitSlice } from '$lib/components/agreements/types';
+  import Skeleton from '$lib/components/ui/Skeleton/Skeleton.svelte';
+  import { toast } from '$lib/components/ui/Toast/toast-store';
+  import {
+    acceptAgreement,
+    counterAgreement,
+    declineAgreement,
+    getMyAgreementPortfolio,
+    getMyAgreementThread,
+    terminateAgreement,
+    withdrawAgreement,
+  } from '$lib/remote/agreements.remote';
+
+  type RevenueType = 'subscription' | 'content_purchase';
+
+  // Platform fee — read fresh from constants. Matches FEES.PLATFORM_PERCENT.
+  // Per Decision Q2, platform fee is the platform's operational lever; agreements
+  // don't snapshot it. WP-7 mirror.
+  const PLATFORM_FEE_BP = 1000;
+
+  // ─── URL state ────────────────────────────────────────────────────────────
+  const proposalId = $derived(page.params.proposalId ?? '');
+
+  // ─── Queries ──────────────────────────────────────────────────────────────
+  const threadQuery = $derived(
+    browser && proposalId ? getMyAgreementThread({ proposalId }) : null
+  );
+  const portfolioQuery = $derived(browser ? getMyAgreementPortfolio() : null);
+
+  const thread = $derived(threadQuery?.current ?? null);
+  const portfolio = $derived(portfolioQuery?.current ?? null);
+  const isLoading = $derived(
+    (threadQuery?.loading ?? true) || (portfolioQuery?.loading ?? true)
+  );
+  const threadError = $derived(threadQuery?.error ?? null);
+
+  // The thread is chronological — first proposal carries the org+type
+  // identity; the latest proposal is the actionable one (if open).
+  const firstProposal = $derived(thread?.[0] ?? null);
+  const latestProposal = $derived(thread && thread.length > 0 ? thread[thread.length - 1] : null);
+  const latestIsOpen = $derived(latestProposal?.status === 'open');
+  const latestProposedByOwner = $derived(latestProposal?.proposedByRole === 'owner');
+
+  // Locate the active agreement (if any) corresponding to this thread.
+  // Match on (organizationId, revenueType) so direct links to historical
+  // proposals still surface the active row.
+  const activeAgreement = $derived.by(() => {
+    if (!firstProposal || !portfolio) return null;
+    return (
+      portfolio.active.find(
+        (a) =>
+          a.organizationId === firstProposal.organizationId &&
+          a.revenueType === firstProposal.revenueType
+      ) ?? null
+    );
+  });
+
+  const organizationId = $derived(firstProposal?.organizationId ?? null);
+  const revenueType = $derived<RevenueType | null>(
+    firstProposal?.revenueType === 'subscription' ||
+      firstProposal?.revenueType === 'content_purchase'
+      ? (firstProposal.revenueType as RevenueType)
+      : null
+  );
+  const revenueLabel = $derived(
+    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
+  );
+
+  // Resolve the org name from the portfolio (any matching row, active or pending).
+  const organizationName = $derived.by(() => {
+    if (!organizationId || !portfolio) return null;
+    const fromActive = portfolio.active.find(
+      (a) => a.organizationId === organizationId
+    );
+    if (fromActive?.organizationName) return fromActive.organizationName;
+    const fromPending = [
+      ...portfolio.pendingActionRequired,
+      ...portfolio.pendingWaitingOnOrg,
+    ].find((p) => p.organizationId === organizationId);
+    if (fromPending?.organizationName) return fromPending.organizationName;
+    const fromPast = portfolio.past.find(
+      (p) => p.organizationId === organizationId
+    );
+    return fromPast?.organizationName ?? null;
+  });
+
+  // Peer aggregate — only meaningful when there's an active agreement OR
+  // a portfolio row referencing the same (org, revenueType) pool. The
+  // anonymisation contract is enforced server-side; we don't fabricate
+  // peer rows here.
+  const peersForPool = $derived.by(() => {
+    if (!activeAgreement) return null;
+    return activeAgreement.peers;
+  });
+
+  // The creator's own current share (BP) in this pool. Source of truth
+  // priority:
+  //   1. Active agreement row (`10000 - organizationFeePercentage`)
+  //   2. Latest open proposal's proposed share (proposal-only thread)
+  //   3. Latest proposal in thread (for past states)
+  const mySharePercent = $derived.by(() => {
+    if (activeAgreement) {
+      return 10000 - activeAgreement.organizationFeePercentage;
+    }
+    if (latestProposal) {
+      return latestProposal.proposedCreatorSharePercent;
+    }
+    return 0;
+  });
+
+  // Build the anonymised pie slices for `mode='creator'`. Slice order:
+  // platform fee (locked, handled by component) → my slice → anonymised
+  // peer aggregate (single slice) → org residual. No peer identifiers
+  // present anywhere in this array — defensive against any future
+  // server-side leak.
+  const pieSlices = $derived.by((): RevenueSplitSlice[] => {
+    const availableBp = 10000 - PLATFORM_FEE_BP;
+    const peerAggregate = peersForPool?.aggregateSharePercent ?? 0;
+    const orgResidual = Math.max(
+      0,
+      availableBp - mySharePercent - peerAggregate
+    );
+
+    const slices: RevenueSplitSlice[] = [
+      {
+        id: '__me__',
+        label: 'Your share',
+        percent: mySharePercent,
+        color: 'var(--color-interactive)',
+        locked: true,
+        anonymous: false,
+      },
+    ];
+    if (peersForPool && peersForPool.count > 0) {
+      slices.push({
+        id: '__peers__',
+        label: `Other creators (${peersForPool.count})`,
+        percent: peerAggregate,
+        color: 'var(--color-info-600)',
+        locked: true,
+        anonymous: true,
+      });
+    }
+    if (orgResidual > 0) {
+      slices.push({
+        id: '__org_residual__',
+        label: 'Org residual',
+        percent: orgResidual,
+        color: 'var(--color-surface-tertiary)',
+        locked: true,
+        anonymous: false,
+      });
+    }
+    return slices;
+  });
+
+  // ─── Counter dialog state ────────────────────────────────────────────────
+  let counterDialogOpen = $state(false);
+
+  function openCounter() {
+    if (!latestProposal) return;
+    counterDialogOpen = true;
+  }
+
+  function handleCounterOpenChange(next: boolean) {
+    if (next === counterDialogOpen) return;
+    counterDialogOpen = next;
+  }
+
+  async function handleCounterSubmit(input: {
+    sharePercent: number;
+    termMonths: number;
+    note?: string;
+  }) {
+    if (!latestProposal) {
+      throw new Error('No proposal to counter');
+    }
+    await counterAgreement({
+      proposalId: latestProposal.id,
+      sharePercent: input.sharePercent,
+      termMonths: input.termMonths,
+      note: input.note,
+    });
+    toast.success('Counter sent', `${ownerName} will be notified.`);
+    counterDialogOpen = false;
+    await threadQuery?.refresh();
+    await portfolioQuery?.refresh();
+  }
+
+  // ─── Action handlers ──────────────────────────────────────────────────────
+  async function handleAccept() {
+    if (!latestProposal) return;
+    try {
+      await acceptAgreement({ proposalId: latestProposal.id });
+      toast.success('Agreement accepted', 'The agreement is now active.');
+      await threadQuery?.refresh();
+      await portfolioQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not accept proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  async function handleDecline() {
+    if (!latestProposal) return;
+    try {
+      await declineAgreement({ proposalId: latestProposal.id });
+      toast.info('Proposal declined', 'The org owner will be notified.');
+      await threadQuery?.refresh();
+      await portfolioQuery?.refresh();
+      goto('/studio/negotiations');
+    } catch (err) {
+      toast.error(
+        'Could not decline proposal',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  async function handleWithdraw() {
+    if (!latestProposal) return;
+    try {
+      await withdrawAgreement({ proposalId: latestProposal.id });
+      toast.info('Counter withdrawn');
+      await threadQuery?.refresh();
+      await portfolioQuery?.refresh();
+    } catch (err) {
+      toast.error(
+        'Could not withdraw counter',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  let terminateConfirming = $state(false);
+  let terminateReason = $state('');
+
+  async function handleTerminate() {
+    if (!activeAgreement) return;
+    try {
+      await terminateAgreement({
+        agreementId: activeAgreement.id,
+        reason: terminateReason.trim() || undefined,
+      });
+      toast.success('Agreement terminated');
+      terminateConfirming = false;
+      terminateReason = '';
+      await threadQuery?.refresh();
+      await portfolioQuery?.refresh();
+      goto('/studio/negotiations');
+    } catch (err) {
+      toast.error(
+        'Could not terminate agreement',
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    }
+  }
+
+  // ─── Display helpers ──────────────────────────────────────────────────────
+  const ownerName = $derived(organizationName ?? 'The org owner');
+
+  function formatPercent(bp: number): string {
+    const pct = bp / 100;
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  function statusLabel(): string {
+    if (activeAgreement) return 'Active';
+    if (!latestProposal) return 'Unknown';
+    switch (latestProposal.status) {
+      case 'open':
+        return latestProposedByOwner ? 'Awaiting your response' : 'Waiting on org';
+      case 'declined':
+        return 'Declined';
+      case 'withdrawn':
+        return 'Withdrawn';
+      case 'superseded':
+        return 'Superseded';
+      case 'accepted':
+        return 'Accepted';
+      default:
+        return latestProposal.status;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Negotiation | Creator Studio</title>
+</svelte:head>
+
+<div class="agreement-detail">
+  <nav class="agreement-detail__crumbs" aria-label="Breadcrumb">
+    <a href="/studio/negotiations" class="agreement-detail__crumb-link">
+      Negotiations
+    </a>
+    <span aria-hidden="true">/</span>
+    <span>{organizationName ?? 'Detail'}</span>
+  </nav>
+
+  {#if isLoading}
+    <div class="agreement-detail__loading">
+      <Skeleton width="60%" height="var(--space-8)" />
+      <Skeleton width="100%" height="var(--space-16)" />
+      <Skeleton width="100%" height="var(--space-32)" />
+    </div>
+  {:else if threadError || !thread || thread.length === 0 || !revenueType}
+    <section
+      class="agreement-detail__section agreement-detail__section--error"
+      aria-labelledby="error-heading"
+    >
+      <h2 id="error-heading" class="agreement-detail__heading">
+        You don't have access to this agreement
+      </h2>
+      <p class="agreement-detail__lede">
+        This negotiation either doesn't exist or you're not the named
+        creator on it. If you reached this page from a link, the agreement
+        may have been removed.
+      </p>
+      <a
+        href="/studio/negotiations"
+        class="agreement-detail__btn agreement-detail__btn--secondary"
+      >
+        Back to negotiations
+      </a>
+    </section>
+  {:else}
+    <header class="agreement-detail__header">
+      <h2 class="agreement-detail__heading">
+        {organizationName ?? 'Organisation'}
+        <span class="agreement-detail__type">{revenueLabel}</span>
+      </h2>
+      <p class="agreement-detail__lede">
+        <span
+          class="agreement-detail__status-pill"
+          data-active={activeAgreement ? 'true' : 'false'}
+        >
+          {statusLabel()}
+        </span>
+      </p>
+    </header>
+
+    <section
+      class="agreement-detail__section"
+      aria-labelledby="split-heading"
+    >
+      <h3 id="split-heading" class="agreement-detail__section-heading">
+        Revenue split
+      </h3>
+      <p class="agreement-detail__section-lede">
+        How {revenueLabel} revenue is split with this org. The platform fee is
+        taken first; your share applies to what remains.
+      </p>
+      <RevenueSplitPie
+        mode="creator"
+        platformFeePercent={PLATFORM_FEE_BP}
+        slices={pieSlices}
+        readOnly
+      />
+      <p class="agreement-detail__split-summary">
+        Your share: <strong>{formatPercent(mySharePercent)}</strong>
+        of post-platform {revenueLabel} revenue.
+        {#if peersForPool && peersForPool.count > 0}
+          {peersForPool.count}
+          {peersForPool.count === 1 ? 'other creator' : 'other creators'}
+          on this pool collectively earn
+          {formatPercent(peersForPool.aggregateSharePercent)}.
+        {/if}
+      </p>
+    </section>
+
+    <section
+      class="agreement-detail__section"
+      aria-labelledby="thread-heading"
+    >
+      <h3 id="thread-heading" class="agreement-detail__section-heading">
+        Negotiation history
+      </h3>
+      <NegotiationThread
+        proposals={thread}
+        revenueType={revenueType}
+        roleLabels={{ owner: ownerName, creator: 'You' }}
+        onAccept={latestIsOpen && latestProposedByOwner ? handleAccept : undefined}
+        onCounter={latestIsOpen && latestProposedByOwner ? openCounter : undefined}
+        onDecline={latestIsOpen && latestProposedByOwner ? handleDecline : undefined}
+        onWithdraw={latestIsOpen && !latestProposedByOwner ? handleWithdraw : undefined}
+      />
+    </section>
+
+    {#if activeAgreement}
+      <section
+        class="agreement-detail__section agreement-detail__section--danger"
+        aria-labelledby="terminate-heading"
+      >
+        <h3 id="terminate-heading" class="agreement-detail__section-heading">
+          Terminate agreement
+        </h3>
+        <p class="agreement-detail__section-lede">
+          End this revenue-share agreement. You'll keep any earnings already
+          accrued under it. The org owner will be notified.
+        </p>
+        {#if terminateConfirming}
+          <div class="agreement-detail__confirm">
+            <label
+              for="terminate-reason"
+              class="agreement-detail__field-label"
+            >
+              Reason (optional)
+            </label>
+            <textarea
+              id="terminate-reason"
+              class="agreement-detail__textarea"
+              bind:value={terminateReason}
+              rows="3"
+              maxlength="500"
+              placeholder="e.g. Moving on from this team."
+            ></textarea>
+            <div class="agreement-detail__confirm-actions">
+              <button
+                type="button"
+                class="agreement-detail__btn agreement-detail__btn--ghost"
+                onclick={() => {
+                  terminateConfirming = false;
+                  terminateReason = '';
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="agreement-detail__btn agreement-detail__btn--danger"
+                onclick={handleTerminate}
+              >
+                Confirm terminate
+              </button>
+            </div>
+          </div>
+        {:else}
+          <button
+            type="button"
+            class="agreement-detail__btn agreement-detail__btn--danger"
+            onclick={() => (terminateConfirming = true)}
+          >
+            Terminate
+          </button>
+        {/if}
+      </section>
+    {/if}
+  {/if}
+</div>
+
+{#if browser && latestProposal && latestIsOpen && latestProposedByOwner}
+  <CounterProposalDialog
+    open={counterDialogOpen}
+    onOpenChange={handleCounterOpenChange}
+    proposalId={latestProposal.id}
+    currentSharePercent={latestProposal.proposedCreatorSharePercent}
+    currentTermMonths={latestProposal.proposedTermMonths}
+    ownerName={ownerName}
+    revenueType={revenueType ?? 'subscription'}
+    onSubmit={handleCounterSubmit}
+  />
+{/if}
+
+<style>
+  .agreement-detail {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    max-width: 1100px;
+    container-type: inline-size;
+  }
+
+  .agreement-detail__crumbs {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .agreement-detail__crumb-link {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+  }
+
+  .agreement-detail__crumb-link:hover {
+    color: var(--color-interactive);
+    text-decoration: underline;
+  }
+
+  .agreement-detail__crumb-link:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+    border-radius: var(--radius-sm);
+  }
+
+  .agreement-detail__loading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .agreement-detail__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .agreement-detail__heading {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .agreement-detail__type {
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .agreement-detail__lede {
+    margin: 0;
+  }
+
+  .agreement-detail__status-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-0-5) var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-full);
+    background: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border);
+  }
+
+  .agreement-detail__status-pill[data-active='true'] {
+    background: var(--color-success-50);
+    color: var(--color-success-700);
+    border-color: var(--color-success-200);
+  }
+
+  .agreement-detail__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .agreement-detail__section--error {
+    text-align: center;
+    padding: var(--space-8) var(--space-5);
+  }
+
+  .agreement-detail__section--danger {
+    border-color: var(--color-error-200);
+  }
+
+  .agreement-detail__section-heading {
+    margin: 0;
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .agreement-detail__section-lede {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    max-width: 60ch;
+    line-height: var(--leading-relaxed);
+  }
+
+  .agreement-detail__split-summary {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .agreement-detail__split-summary strong {
+    font-family: var(--font-mono);
+  }
+
+  .agreement-detail__field-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text);
+  }
+
+  .agreement-detail__textarea {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    resize: vertical;
+    min-height: var(--space-16);
+  }
+
+  .agreement-detail__textarea:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+    border-color: var(--color-border-focus);
+  }
+
+  .agreement-detail__confirm {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .agreement-detail__confirm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    justify-content: flex-end;
+  }
+
+  .agreement-detail__btn {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    border-radius: var(--radius-md);
+    border: var(--border-width) var(--border-style) transparent;
+    cursor: pointer;
+    text-decoration: none;
+    transition: var(--transition-colors);
+  }
+
+  .agreement-detail__btn:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
+  }
+
+  .agreement-detail__btn--secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+
+  .agreement-detail__btn--secondary:hover {
+    background: var(--color-surface-secondary);
+  }
+
+  .agreement-detail__btn--ghost {
+    background: transparent;
+    color: var(--color-text-secondary);
+  }
+
+  .agreement-detail__btn--ghost:hover {
+    color: var(--color-text);
+    background: var(--color-surface-tertiary);
+  }
+
+  .agreement-detail__btn--danger {
+    background: var(--color-error-50);
+    color: var(--color-error-700);
+    border-color: var(--color-error-200);
+  }
+
+  .agreement-detail__btn--danger:hover {
+    background: var(--color-error-100);
+  }
+</style>

--- a/packages/agreements/src/services/__tests__/agreement-service.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-service.test.ts
@@ -1118,6 +1118,219 @@ describe('AgreementService', () => {
     });
   });
 
+  // ── getProposalsForCreator / getOrgName (WP-8 — Codex-bw2wf) ───────────
+  //
+  // Both methods are load-bearing for the creator-side portfolio:
+  //   - getProposalsForCreator powers /agreements/me/portfolio AND
+  //     /agreements/me/threads/:proposalId enumeration. The latter cannot
+  //     fall back to getActiveAgreementsForCreator because pending round-1
+  //     proposals never have a creatorOrganizationAgreements row.
+  //   - getOrgName surfaces the friendly org name in the portfolio rows.
+  //
+  // Per [[feedback-security-deep-test]]: positive + cross-tenant-pin
+  // (negative) for any creator-scoped read. The cross-tenant pin is the
+  // load-bearing invariant — without it, a creator could enumerate someone
+  // else's proposals.
+
+  describe('getProposalsForCreator', () => {
+    it('returns proposals where creatorId matches', async () => {
+      const fxA = await seedOrgFixture(db);
+      const fxB = await seedOrgFixture(db);
+      // Owner of org A proposes to creator A. Owner of org B proposes to
+      // creator B (a different user fixture). Each has exactly one open
+      // proposal in their own org.
+      await service.proposeAgreement({
+        organizationId: fxA.orgId,
+        creatorId: fxA.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fxA.ownerId,
+      });
+      await service.proposeAgreement({
+        organizationId: fxB.orgId,
+        creatorId: fxB.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 4000,
+        termMonths: 6,
+        proposedByUserId: fxB.ownerId,
+      });
+      const forA = await service.getProposalsForCreator({
+        creatorId: fxA.creatorAId,
+      });
+      expect(forA).toHaveLength(1);
+      expect(forA[0]?.creatorId).toBe(fxA.creatorAId);
+      expect(forA[0]?.organizationId).toBe(fxA.orgId);
+    });
+
+    it('honours status filter when passed (array form, WP-8 hardening for I1)', async () => {
+      // Seed: 2 open + 1 declined + 1 withdrawn for creator A across two
+      // orgs (the propose guard refuses 2 open threads on the same triple).
+      const fxA = await seedOrgFixture(db);
+      const fxB = await seedOrgFixture(db);
+      // Two open proposals (different orgs).
+      await service.proposeAgreement({
+        organizationId: fxA.orgId,
+        creatorId: fxA.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fxA.ownerId,
+      });
+      await service.proposeAgreement({
+        organizationId: fxB.orgId,
+        creatorId: fxB.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 2500,
+        termMonths: 6,
+        proposedByUserId: fxB.ownerId,
+      });
+      // A declined proposal (same triple as fxA's open, but fxA's open
+      // must be declined first so the triple is terminal).
+      const fxC = await seedOrgFixture(db);
+      const toDecline = await service.proposeAgreement({
+        organizationId: fxC.orgId,
+        creatorId: fxC.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 2000,
+        termMonths: 6,
+        proposedByUserId: fxC.ownerId,
+      });
+      await service.declineProposal({
+        proposalId: toDecline.id,
+        declinedByUserId: fxC.creatorAId,
+      });
+      // A withdrawn proposal in yet another org.
+      const fxD = await seedOrgFixture(db);
+      const toWithdraw = await service.proposeAgreement({
+        organizationId: fxD.orgId,
+        creatorId: fxD.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 1500,
+        termMonths: 6,
+        proposedByUserId: fxD.ownerId,
+      });
+      await service.withdrawProposal({
+        proposalId: toWithdraw.id,
+        withdrawnByUserId: fxD.ownerId,
+      });
+
+      // Each fixture's creatorA is a distinct user; query each. The
+      // status-filter assertion uses fxA (the open thread).
+      const openOnly = await service.getProposalsForCreator({
+        creatorId: fxA.creatorAId,
+        status: ['open'],
+      });
+      expect(openOnly).toHaveLength(1);
+      expect(openOnly[0]?.status).toBe('open');
+
+      const allForA = await service.getProposalsForCreator({
+        creatorId: fxA.creatorAId,
+      });
+      expect(allForA).toHaveLength(1);
+
+      // Status filter as a single string also accepted.
+      const declinedOnly = await service.getProposalsForCreator({
+        creatorId: fxC.creatorAId,
+        status: 'declined',
+      });
+      expect(declinedOnly).toHaveLength(1);
+      expect(declinedOnly[0]?.status).toBe('declined');
+
+      // Multi-status filter narrows correctly.
+      const openOrDeclinedForA = await service.getProposalsForCreator({
+        creatorId: fxA.creatorAId,
+        status: ['open', 'declined', 'withdrawn'],
+      });
+      expect(openOrDeclinedForA).toHaveLength(1);
+      expect(openOrDeclinedForA[0]?.status).toBe('open');
+    });
+
+    it('returns empty array when creator has no proposals', async () => {
+      const result = await service.getProposalsForCreator({
+        creatorId: randomUUID(),
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('cross-tenant pin: returns nothing for a different creator', async () => {
+      // Two orgs, two creator users. A proposal is seeded for creator A
+      // ONLY. Querying for creator B's id must return zero rows even
+      // though they exist as users in the database.
+      const fx = await seedOrgFixture(db);
+      await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const forB = await service.getProposalsForCreator({
+        creatorId: fx.creatorBId,
+      });
+      expect(forB).toEqual([]);
+    });
+
+    it('returns proposals chronologically (oldest first)', async () => {
+      // Three proposals in three different orgs, seeded in known order.
+      // Drizzle's createdAt timestamps are server-set, so we lean on
+      // insertion order rather than predetermined timestamps; that's
+      // sufficient for asserting ASC ordering.
+      const fxA = await seedOrgFixture(db);
+      const p1 = await service.proposeAgreement({
+        organizationId: fxA.orgId,
+        creatorId: fxA.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fxA.ownerId,
+      });
+      // Counter (creates a child proposal in the same thread).
+      const p2 = await service.counterPropose({
+        proposalId: p1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fxA.creatorAId,
+      });
+      const all = await service.getProposalsForCreator({
+        creatorId: fxA.creatorAId,
+      });
+      expect(all.length).toBeGreaterThanOrEqual(2);
+      const indexOfP1 = all.findIndex((p) => p.id === p1.id);
+      const indexOfP2 = all.findIndex((p) => p.id === p2.id);
+      // p1 was created first → must appear before p2 in the ASC list.
+      expect(indexOfP1).toBeLessThan(indexOfP2);
+    });
+  });
+
+  describe('getOrgName', () => {
+    it('returns the human-readable name for an existing org', async () => {
+      // seedOrgFixture inserts orgs with name "Test Org" — assert.
+      const fx = await seedOrgFixture(db);
+      const name = await service.getOrgName(fx.orgId);
+      expect(name).toBe('Test Org');
+    });
+
+    it('returns the name for a soft-deleted org (lookup is intentionally inclusive)', async () => {
+      // Per the docstring on lookupOrgName: soft-deleted orgs still
+      // return their name — a recently-archived org with an outstanding
+      // negotiation is still useful audit context for the portfolio UI.
+      const fx = await seedOrgFixture(db);
+      await db
+        .update(schema.organizations)
+        .set({ deletedAt: new Date() })
+        .where(eq(schema.organizations.id, fx.orgId));
+      const name = await service.getOrgName(fx.orgId);
+      expect(name).toBe('Test Org');
+    });
+
+    it('returns null for an unknown org id', async () => {
+      const name = await service.getOrgName(randomUUID());
+      expect(name).toBeNull();
+    });
+  });
+
   // ── WP-4 payout-pipeline read filters (Codex-rzfjw) ────────────────────
   //
   // The payout pipeline at invoice time needs three new query shapes:

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -1157,6 +1157,55 @@ export class AgreementService extends BaseService {
     }
   }
 
+  /**
+   * All proposals where the given user is the named creator, regardless of
+   * org or revenue type. Optional `status` filter narrows the result set.
+   *
+   * Used by the creator-side portfolio (WP-8 — Codex-bw2wf) to surface
+   * pending proposals on orgs where the creator does NOT yet have an
+   * `creatorOrganizationAgreement` row — i.e. owner-initiated round-1
+   * proposals that the creator hasn't accepted yet. `getActiveAgreementsForCreator`
+   * alone misses these because no active agreement row exists until accept.
+   *
+   * Returns chronological proposals (oldest first). Empty array when the
+   * caller has no proposals.
+   */
+  async getProposalsForCreator(input: {
+    creatorId: string;
+    status?: AgreementProposal['status'] | AgreementProposal['status'][];
+  }): Promise<AgreementProposal[]> {
+    try {
+      const statusFilter = (() => {
+        if (!input.status) return undefined;
+        const arr = Array.isArray(input.status) ? input.status : [input.status];
+        if (arr.length === 0) return undefined;
+        return inArray(agreementProposals.status, arr);
+      })();
+      return await this.db.query.agreementProposals.findMany({
+        where: and(
+          eq(agreementProposals.creatorId, input.creatorId),
+          statusFilter
+        ),
+        orderBy: [asc(agreementProposals.createdAt)],
+      });
+    } catch (error) {
+      this.handleError(error, 'getProposalsForCreator');
+    }
+  }
+
+  /**
+   * Resolve a human-readable org name for one organization id. Returns
+   * `null` for unknown / hard-deleted orgs (rare). Used by the
+   * creator-side portfolio route to surface friendly org names — the
+   * agreement rows themselves only carry the id.
+   *
+   * Soft-deleted orgs are deliberately included; a recently-archived
+   * org with an outstanding negotiation is still useful audit context.
+   */
+  async getOrgName(organizationId: string): Promise<string | null> {
+    return this.lookupOrgName(organizationId);
+  }
+
   // ── Lifecycle notification dispatch (WP-5 — Codex-90de9) ────────────────
 
   /**

--- a/workers/ecom-api/src/routes/__tests__/agreements-routes.test.ts
+++ b/workers/ecom-api/src/routes/__tests__/agreements-routes.test.ts
@@ -317,6 +317,8 @@ interface AgreementServiceMock {
   getActiveAgreements: ReturnType<typeof vi.fn>;
   getActiveAgreementsForCreator: ReturnType<typeof vi.fn>;
   getNegotiationThread: ReturnType<typeof vi.fn>;
+  getProposalsForCreator: ReturnType<typeof vi.fn>;
+  getOrgName: ReturnType<typeof vi.fn>;
 }
 
 function createAgreementServiceMock(): AgreementServiceMock {
@@ -432,6 +434,33 @@ function createAgreementServiceMock(): AgreementServiceMock {
         organizationId: MANAGED_ORG_ID,
       },
     ]),
+    // WP-8 additions (Codex-bw2wf). `getProposalsForCreator` powers the
+    // `/me/threads/:proposalId` enumeration AND the `/me/portfolio`
+    // aggregator; default to a single proposal owned by CALLER_CREATOR_ID
+    // so the positive-path tests succeed without per-test setup.
+    getProposalsForCreator: vi.fn().mockResolvedValue([
+      {
+        id: PROPOSAL_ID,
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'open',
+        proposedByRole: 'owner',
+        proposedByUserId: OWNER_USER_ID,
+        proposedCreatorSharePercent: 3000,
+        proposedTermMonths: 12,
+        parentProposalId: null,
+        roundNumber: 1,
+        note: null,
+        declineReason: null,
+        respondedAt: null,
+        respondedByUserId: null,
+        proposedEffectiveFrom: new Date('2026-01-01'),
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+      },
+    ]),
+    getOrgName: vi.fn().mockResolvedValue('Test Org'),
   };
 }
 
@@ -1396,7 +1425,11 @@ describe('GET /agreements/me/threads/:proposalId — creator-view thread', () =>
 
   it('negative: caller has no agreements at all → 404', async () => {
     const services = { agreements: createAgreementServiceMock() };
+    // WP-8: thread enumeration now flows through getProposalsForCreator,
+    // not getActiveAgreementsForCreator. Clear both — the caller has no
+    // threads at all, so neither query should surface PROPOSAL_ID.
     services.agreements.getActiveAgreementsForCreator.mockResolvedValue([]);
+    services.agreements.getProposalsForCreator.mockResolvedValue([]);
     const bundle = buildApp({
       services,
       user: { id: CALLER_CREATOR_ID },
@@ -1426,5 +1459,413 @@ describe('GET /agreements/me/threads/:proposalId — creator-view thread', () =>
     expect(
       services.agreements.getActiveAgreementsForCreator
     ).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /agreements/me/portfolio (WP-8 — Codex-bw2wf) ───────────────────────
+
+describe('GET /agreements/me/portfolio (ANONYMISATION CONTRACT)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Helper: build a proposals array with shared defaults so each test only
+  // overrides the fields that matter to its scenario.
+  function makeProposal(overrides: Record<string, unknown>) {
+    return {
+      id: PROPOSAL_ID,
+      organizationId: MANAGED_ORG_ID,
+      creatorId: CALLER_CREATOR_ID,
+      revenueType: 'subscription',
+      status: 'open',
+      proposedByRole: 'owner',
+      proposedByUserId: OWNER_USER_ID,
+      proposedCreatorSharePercent: 3000,
+      proposedTermMonths: 12,
+      parentProposalId: null,
+      roundNumber: 1,
+      note: null,
+      declineReason: null,
+      respondedAt: null,
+      respondedByUserId: null,
+      proposedEffectiveFrom: new Date('2026-01-01'),
+      createdAt: new Date('2026-01-01'),
+      updatedAt: new Date('2026-01-01'),
+      ...overrides,
+    };
+  }
+
+  it('positive: returns active + pendingActionRequired + pendingWaitingOnOrg + past sections', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    // Active row: the caller has one active subscription agreement.
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([
+      {
+        id: 'agr_active',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000, // share = 3000
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+    ]);
+    // No peers on this org (caller alone holds the active row).
+    services.agreements.getActiveAgreements.mockResolvedValue([
+      {
+        id: 'agr_active',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000,
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+    ]);
+    services.agreements.getOrgName.mockResolvedValue('Test Org');
+    // Proposals: 1 owner-proposed open (pendingActionRequired), 1 creator
+    // open counter (pendingWaitingOnOrg), 1 declined (past).
+    services.agreements.getProposalsForCreator.mockResolvedValue([
+      makeProposal({
+        id: 'prop_active_anchor',
+        status: 'accepted',
+        respondedAt: new Date('2026-01-01'),
+        respondedByUserId: CALLER_CREATOR_ID,
+      }),
+      makeProposal({
+        id: 'prop_pending_from_owner',
+        organizationId: '500e4567-e89b-12d3-a456-426614174500',
+        status: 'open',
+        proposedByRole: 'owner',
+        roundNumber: 1,
+        createdAt: new Date('2026-02-01'),
+        updatedAt: new Date('2026-02-01'),
+      }),
+      makeProposal({
+        id: 'prop_creator_counter',
+        organizationId: '600e4567-e89b-12d3-a456-426614174600',
+        status: 'open',
+        proposedByRole: 'creator',
+        roundNumber: 2,
+        createdAt: new Date('2026-02-05'),
+        updatedAt: new Date('2026-02-05'),
+      }),
+      makeProposal({
+        id: 'prop_declined',
+        organizationId: '700e4567-e89b-12d3-a456-426614174700',
+        status: 'declined',
+        // Within the 90-day past cutoff — use a relative date so the
+        // test stays valid as time passes.
+        respondedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+        respondedByUserId: CALLER_CREATOR_ID,
+        declineReason: 'Not enough',
+        updatedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+      }),
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      data: {
+        active: Array<{ creatorId: string; revenueType: string }>;
+        pendingActionRequired: Array<{ proposalId: string }>;
+        pendingWaitingOnOrg: Array<{ proposalId: string }>;
+        past: Array<{ proposalId: string; status: string }>;
+      };
+    };
+    expect(payload.data.active).toHaveLength(1);
+    expect(payload.data.active[0]?.creatorId).toBe(CALLER_CREATOR_ID);
+    expect(payload.data.pendingActionRequired).toHaveLength(1);
+    expect(payload.data.pendingActionRequired[0]?.proposalId).toBe(
+      'prop_pending_from_owner'
+    );
+    expect(payload.data.pendingWaitingOnOrg).toHaveLength(1);
+    expect(payload.data.pendingWaitingOnOrg[0]?.proposalId).toBe(
+      'prop_creator_counter'
+    );
+    expect(payload.data.past).toHaveLength(1);
+    expect(payload.data.past[0]?.status).toBe('declined');
+  });
+
+  it('anonymisation: peer identifiers never appear in any section (load-bearing invariant)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    // Caller has an active subscription. Peer creator Y also has an
+    // active subscription on the same org. Peer's userId / creatorId MUST
+    // be absent from the serialised payload.
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([
+      {
+        id: 'agr_caller_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000,
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+    ]);
+    services.agreements.getActiveAgreements.mockResolvedValue([
+      {
+        id: 'agr_caller_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000,
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+      {
+        id: 'agr_peer_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_1,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 8000, // peer share = 2000
+        currentProposalId: 'prop_peer',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-02'),
+        effectiveUntil: null,
+      },
+    ]);
+    services.agreements.getOrgName.mockResolvedValue('Test Org');
+    services.agreements.getProposalsForCreator.mockResolvedValue([
+      makeProposal({
+        id: 'prop_for_caller',
+        status: 'accepted',
+      }),
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as unknown;
+    const bodyText = JSON.stringify(payload);
+    // The load-bearing invariant: NEVER let a peer's identifier into
+    // any section's wire payload. Anonymisation contract.
+    expect(bodyText).not.toContain(PEER_CREATOR_ID_1);
+    expect(bodyText).not.toContain(PEER_CREATOR_ID_2);
+  });
+
+  it('cross-pool isolation: subscription peers do not pollute content_purchase peer aggregates', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    // Caller has ONLY a subscription on the org. There's a peer with a
+    // subscription (in the same pool as the caller) and another peer with
+    // a content_purchase agreement (a different pool). The aggregate must
+    // count ONLY the subscription peer.
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([
+      {
+        id: 'agr_caller_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000, // share = 3000
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+    ]);
+    services.agreements.getActiveAgreements.mockResolvedValue([
+      // Caller's own active sub row
+      {
+        id: 'agr_caller_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: CALLER_CREATOR_ID,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 7000,
+        currentProposalId: PROPOSAL_ID,
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-01'),
+        effectiveUntil: null,
+      },
+      // Peer Y: subscription@20% — IN the caller's pool
+      {
+        id: 'agr_peer_sub',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_1,
+        revenueType: 'subscription',
+        status: 'active',
+        organizationFeePercentage: 8000, // share = 2000
+        currentProposalId: 'prop_peer_sub',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-02'),
+        effectiveUntil: null,
+      },
+      // Peer Z: content_purchase@10% — DIFFERENT pool, must not pollute
+      {
+        id: 'agr_peer_cp',
+        organizationId: MANAGED_ORG_ID,
+        creatorId: PEER_CREATOR_ID_2,
+        revenueType: 'content_purchase',
+        status: 'active',
+        organizationFeePercentage: 9000, // share = 1000
+        currentProposalId: 'prop_peer_cp',
+        terminatedAt: null,
+        effectiveFrom: new Date('2026-01-03'),
+        effectiveUntil: null,
+      },
+    ]);
+    services.agreements.getOrgName.mockResolvedValue('Test Org');
+    services.agreements.getProposalsForCreator.mockResolvedValue([
+      makeProposal({ id: 'prop_for_caller', status: 'accepted' }),
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      data: {
+        active: Array<{
+          revenueType: string;
+          peers: { count: number; aggregateSharePercent: number };
+        }>;
+      };
+    };
+    // Caller only holds the subscription row → exactly one active row.
+    expect(payload.data.active).toHaveLength(1);
+    const subRow = payload.data.active[0]!;
+    expect(subRow.revenueType).toBe('subscription');
+    // peers.count must reflect ONLY the subscription peer (Y), not the
+    // content-purchase peer (Z). Aggregate must be Y's share = 2000.
+    expect(subRow.peers.count).toBe(1);
+    expect(subRow.peers.aggregateSharePercent).toBe(2000);
+  });
+
+  it('pending split: owner-proposed → pendingActionRequired, creator-proposed → pendingWaitingOnOrg', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([]);
+    services.agreements.getActiveAgreements.mockResolvedValue([]);
+    services.agreements.getOrgName.mockResolvedValue('Test Org');
+    services.agreements.getProposalsForCreator.mockResolvedValue([
+      // Owner proposed last → action required on the creator side.
+      makeProposal({
+        id: 'prop_owner_open',
+        status: 'open',
+        proposedByRole: 'owner',
+        roundNumber: 1,
+      }),
+      // Creator countered last → waiting on org (next-actor is owner).
+      makeProposal({
+        id: 'prop_creator_counter',
+        status: 'open',
+        proposedByRole: 'creator',
+        roundNumber: 2,
+        organizationId: '500e4567-e89b-12d3-a456-426614174500',
+      }),
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      data: {
+        pendingActionRequired: Array<{ proposalId: string }>;
+        pendingWaitingOnOrg: Array<{ proposalId: string }>;
+      };
+    };
+    expect(payload.data.pendingActionRequired).toHaveLength(1);
+    expect(payload.data.pendingActionRequired[0]?.proposalId).toBe(
+      'prop_owner_open'
+    );
+    expect(payload.data.pendingWaitingOnOrg).toHaveLength(1);
+    expect(payload.data.pendingWaitingOnOrg[0]?.proposalId).toBe(
+      'prop_creator_counter'
+    );
+  });
+
+  it('past 90-day cutoff: terminal proposals older than 90 days excluded', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([]);
+    services.agreements.getActiveAgreements.mockResolvedValue([]);
+    services.agreements.getOrgName.mockResolvedValue('Test Org');
+    const now = Date.now();
+    services.agreements.getProposalsForCreator.mockResolvedValue([
+      // Recent (yesterday) — must surface
+      makeProposal({
+        id: 'prop_recent',
+        status: 'declined',
+        updatedAt: new Date(now - 1 * 24 * 60 * 60 * 1000),
+        respondedAt: new Date(now - 1 * 24 * 60 * 60 * 1000),
+        organizationId: '500e4567-e89b-12d3-a456-426614174500',
+      }),
+      // 100 days old — must be excluded by the 90-day cutoff
+      makeProposal({
+        id: 'prop_old',
+        status: 'declined',
+        updatedAt: new Date(now - 100 * 24 * 60 * 60 * 1000),
+        respondedAt: new Date(now - 100 * 24 * 60 * 60 * 1000),
+        organizationId: '600e4567-e89b-12d3-a456-426614174600',
+      }),
+    ]);
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+    });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      data: { past: Array<{ proposalId: string }> };
+    };
+    expect(payload.data.past).toHaveLength(1);
+    expect(payload.data.past[0]?.proposalId).toBe('prop_recent');
+  });
+
+  it('401 when no session', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    const bundle = buildApp({ user: null, services });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(401);
+    expect(
+      services.agreements.getActiveAgreementsForCreator
+    ).not.toHaveBeenCalled();
+    expect(services.agreements.getProposalsForCreator).not.toHaveBeenCalled();
+  });
+
+  it('callable by users with no org membership (pure auth gate, not requireOrgMembership)', async () => {
+    const services = { agreements: createAgreementServiceMock() };
+    services.agreements.getActiveAgreementsForCreator.mockResolvedValue([]);
+    services.agreements.getActiveAgreements.mockResolvedValue([]);
+    services.agreements.getOrgName.mockResolvedValue(null);
+    services.agreements.getProposalsForCreator.mockResolvedValue([]);
+    // No __testOrganizationId — orgRole=null also (no membership at all).
+    const bundle = buildApp({
+      services,
+      user: { id: CALLER_CREATOR_ID },
+      orgRole: null,
+      organizationId: undefined,
+    });
+    const res = await bundle.app.request(getReq('/agreements/me/portfolio'));
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      data: {
+        active: unknown[];
+        pendingActionRequired: unknown[];
+        pendingWaitingOnOrg: unknown[];
+        past: unknown[];
+      };
+    };
+    expect(payload.data.active).toEqual([]);
+    expect(payload.data.pendingActionRequired).toEqual([]);
+    expect(payload.data.pendingWaitingOnOrg).toEqual([]);
+    expect(payload.data.past).toEqual([]);
   });
 });

--- a/workers/ecom-api/src/routes/agreements.ts
+++ b/workers/ecom-api/src/routes/agreements.ts
@@ -491,10 +491,13 @@ agreements.get(
  * no anonymisation is needed — the proposals show owner and creator
  * actions side by side, both of which the creator is entitled to see.
  *
- * We use a service-level "list this thread by proposal id" composition
- * because the service intentionally doesn't expose a `getProposal(id)`
- * surface; we fetch the thread by triple, then narrow to the row(s)
- * matching the proposal id to assert membership.
+ * Enumeration source (WP-8 enhancement — Codex-bw2wf): we resolve which
+ * threads the caller participates in via `getProposalsForCreator` rather
+ * than `getActiveAgreementsForCreator`. The former includes orgs where
+ * the creator has any proposal (incl. pending round-1 with no active
+ * agreement yet); the latter misses those because no active row exists
+ * until accept. Without this, a creator clicking a pending-action notice
+ * would 404 on the detail page.
  */
 agreements.get(
   '/me/threads/:proposalId',
@@ -502,36 +505,47 @@ agreements.get(
     policy: { auth: 'required' },
     input: { params: proposalIdParamSchema },
     handler: async (ctx) => {
-      // Pull the creator's own agreements first to enumerate which
-      // (org, revenueType) threads they participate in, then locate the
-      // requested proposal among them. This keeps the service surface
-      // narrow and never reveals threads the caller isn't on.
-      const own = await ctx.services.agreements.getActiveAgreementsForCreator({
-        creatorId: ctx.user.id,
-      });
+      // Enumerate every (org, revenueType) thread the caller is on by
+      // pulling all proposals where they're the named creator, then
+      // dedup by (orgId, revenueType). This covers both active and
+      // pending-only threads.
+      const ownProposals = await ctx.services.agreements.getProposalsForCreator(
+        {
+          creatorId: ctx.user.id,
+        }
+      );
+      const triples = new Map<
+        string,
+        {
+          organizationId: string;
+          revenueType: 'subscription' | 'content_purchase';
+        }
+      >();
+      for (const p of ownProposals) {
+        if (
+          p.revenueType !== 'subscription' &&
+          p.revenueType !== 'content_purchase'
+        ) {
+          throw new Error(
+            `Unexpected revenueType on proposal ${p.id}: ${p.revenueType}`
+          );
+        }
+        triples.set(`${p.organizationId}:${p.revenueType}`, {
+          organizationId: p.organizationId,
+          revenueType: p.revenueType,
+        });
+      }
 
-      // Parallel fetch: each thread is one DB roundtrip; with M
-      // agreements across orgs this is M parallel queries, not M
-      // sequential. The DB CHECK constraint guarantees `revenueType` is
-      // one of the two enum values, but we runtime-guard before the
-      // narrowing cast so a future schema change surfaces loudly rather
-      // than silently lying to the type system.
+      // Parallel fetch: each thread is one DB roundtrip; for typical
+      // creators (1-3 orgs × 2 revenue types) this is a small fan-out.
       const candidates = await Promise.all(
-        own.map((a) => {
-          if (
-            a.revenueType !== 'subscription' &&
-            a.revenueType !== 'content_purchase'
-          ) {
-            throw new Error(
-              `Unexpected revenueType on agreement ${a.id}: ${a.revenueType}`
-            );
-          }
-          return ctx.services.agreements.getNegotiationThread({
-            organizationId: a.organizationId,
+        Array.from(triples.values()).map((t) =>
+          ctx.services.agreements.getNegotiationThread({
+            organizationId: t.organizationId,
             creatorId: ctx.user.id,
-            revenueType: a.revenueType,
-          });
-        })
+            revenueType: t.revenueType,
+          })
+        )
       );
 
       const match = candidates.find((thread) =>
@@ -548,6 +562,226 @@ agreements.get(
       throw new NotFoundError('Proposal thread not found', {
         proposalId: ctx.input.params.proposalId,
       });
+    },
+  })
+);
+
+/**
+ * Shape of the creator-portfolio payload (WP-8 — Codex-bw2wf).
+ *
+ * Each section is independently consumable by the UI and contains the
+ * minimum fields needed for the negotiations page sections:
+ *   - active            — agreements currently in force (peers anonymised)
+ *   - pendingActionRequired — open proposals waiting on the creator
+ *   - pendingWaitingOnOrg   — open proposals the creator has sent (waiting
+ *                              on the org)
+ *   - past              — terminal-state proposals (declined / withdrawn /
+ *                          superseded) and terminated agreements (last 90d)
+ *
+ * `organizationName` is denormalised onto every row so the UI does not
+ * need a follow-up lookup per row. NEVER include peer identifying fields
+ * — anonymisation contract is preserved across every section.
+ */
+interface CreatorPortfolioActiveRow extends CreatorAgreementWithPeers {
+  organizationName: string | null;
+}
+
+interface CreatorPortfolioPendingRow {
+  proposalId: string;
+  organizationId: string;
+  organizationName: string | null;
+  revenueType: string;
+  proposedSharePercent: number;
+  proposedTermMonths: number | null;
+  proposedByRole: string;
+  roundNumber: number;
+  createdAt: Date;
+  note: string | null;
+  /** Useful for linking to a detail page when no active agreement exists. */
+  threadProposalId: string;
+}
+
+interface CreatorPortfolioPastRow {
+  proposalId: string;
+  organizationId: string;
+  organizationName: string | null;
+  revenueType: string;
+  status: string;
+  proposedSharePercent: number;
+  proposedByRole: string;
+  roundNumber: number;
+  endedAt: Date | null;
+  declineReason: string | null;
+}
+
+interface CreatorPortfolioPayload {
+  active: CreatorPortfolioActiveRow[];
+  pendingActionRequired: CreatorPortfolioPendingRow[];
+  pendingWaitingOnOrg: CreatorPortfolioPendingRow[];
+  past: CreatorPortfolioPastRow[];
+}
+
+/**
+ * GET /agreements/me/portfolio
+ *
+ * Creator-side portfolio aggregator (WP-8 — Codex-bw2wf). Returns the
+ * four sections used by the /studio/negotiations page in a single
+ * round-trip, each one keyed by the creator's own identifier and
+ * anonymised against peer identifiers.
+ *
+ * Why a dedicated endpoint over assembling the data client-side:
+ *   - Pending round-1 proposals do NOT have a `creatorOrganizationAgreement`
+ *     row yet; `getActiveAgreementsForCreator` alone misses them, so the
+ *     creator would never see an owner's initial proposal until accept.
+ *   - Past states across orgs (declined / withdrawn) cannot be derived
+ *     from active rows alone for the same reason.
+ *
+ * Anonymisation contract: every section keeps the creator-only invariant.
+ * Active rows reuse the existing `CreatorAgreementWithPeers` shape — peer
+ * count + aggregate share only, no peer userId / creatorId / display
+ * fields. Pending + past sections never include peer rows at all; each
+ * row concerns the caller exclusively.
+ */
+agreements.get(
+  '/me/portfolio',
+  procedure({
+    policy: { auth: 'required' },
+    handler: async (ctx) => {
+      // Pull the creator's own active rows (with peer-aggregate
+      // enrichment, identical to GET /agreements/me) and every proposal
+      // they're named on. The active rows + proposal list together
+      // cover every section of the portfolio.
+      const [activeRows, ownProposals] = await Promise.all([
+        ctx.services.agreements.getActiveAgreementsForCreator({
+          creatorId: ctx.user.id,
+        }),
+        ctx.services.agreements.getProposalsForCreator({
+          creatorId: ctx.user.id,
+        }),
+      ]);
+
+      // Per-org peer aggregate (matches GET /agreements/me semantics).
+      const uniqueOrgIds = Array.from(
+        new Set([
+          ...activeRows.map((a) => a.organizationId),
+          ...ownProposals.map((p) => p.organizationId),
+        ])
+      );
+      const peerByOrgAndType = new Map<
+        string,
+        { count: number; aggregateSharePercent: number }
+      >();
+      const nameByOrg = new Map<string, string | null>();
+      await Promise.all(
+        uniqueOrgIds.map(async (orgId) => {
+          const [all, name] = await Promise.all([
+            ctx.services.agreements.getActiveAgreements({
+              organizationId: orgId,
+            }),
+            ctx.services.agreements.getOrgName(orgId),
+          ]);
+          nameByOrg.set(orgId, name);
+          for (const revType of ['subscription', 'content_purchase'] as const) {
+            const peersInType = all.filter(
+              (row) =>
+                row.revenueType === revType && row.creatorId !== ctx.user.id
+            );
+            const aggregate = peersInType.reduce(
+              (sum, p) => sum + (10000 - p.organizationFeePercentage),
+              0
+            );
+            peerByOrgAndType.set(`${orgId}:${revType}`, {
+              count: peersInType.length,
+              aggregateSharePercent: aggregate,
+            });
+          }
+        })
+      );
+
+      const active: CreatorPortfolioActiveRow[] = activeRows.map((row) => {
+        const peers = peerByOrgAndType.get(
+          `${row.organizationId}:${row.revenueType}`
+        ) ?? { count: 0, aggregateSharePercent: 0 };
+        return {
+          id: row.id,
+          organizationId: row.organizationId,
+          organizationName: nameByOrg.get(row.organizationId) ?? null,
+          creatorId: row.creatorId,
+          revenueType: row.revenueType,
+          status: row.status,
+          effectiveFrom: row.effectiveFrom,
+          effectiveUntil: row.effectiveUntil,
+          organizationFeePercentage: row.organizationFeePercentage,
+          currentProposalId: row.currentProposalId,
+          terminatedAt: row.terminatedAt,
+          peers,
+        };
+      });
+
+      // Pending: open proposals where the creator is named. Split by
+      // who is currently waited on. `proposedByRole === 'owner'` ⇒ owner
+      // proposed last, so the creator is the next-actor (action required).
+      // `proposedByRole === 'creator'` ⇒ creator countered last, so the
+      // owner is the next-actor (waiting on org).
+      const openProposals = ownProposals.filter((p) => p.status === 'open');
+      const pendingActionRequired: CreatorPortfolioPendingRow[] = [];
+      const pendingWaitingOnOrg: CreatorPortfolioPendingRow[] = [];
+      for (const p of openProposals) {
+        const row: CreatorPortfolioPendingRow = {
+          proposalId: p.id,
+          organizationId: p.organizationId,
+          organizationName: nameByOrg.get(p.organizationId) ?? null,
+          revenueType: p.revenueType,
+          proposedSharePercent: p.proposedCreatorSharePercent,
+          proposedTermMonths: p.proposedTermMonths,
+          proposedByRole: p.proposedByRole,
+          roundNumber: p.roundNumber,
+          createdAt: p.createdAt,
+          note: p.note,
+          threadProposalId: p.id,
+        };
+        if (p.proposedByRole === 'owner') {
+          pendingActionRequired.push(row);
+        } else {
+          pendingWaitingOnOrg.push(row);
+        }
+      }
+
+      // Past: terminal-state proposals. We deliberately use the proposal
+      // `updatedAt` rather than `respondedAt` so withdrawn proposals
+      // (which don't set `respondedAt`) still get a reasonable date.
+      const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+      const cutoff = new Date(Date.now() - NINETY_DAYS_MS);
+      const past: CreatorPortfolioPastRow[] = ownProposals
+        .filter(
+          (p) =>
+            (p.status === 'declined' ||
+              p.status === 'withdrawn' ||
+              p.status === 'superseded') &&
+            p.updatedAt > cutoff
+        )
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+        .slice(0, 50)
+        .map((p) => ({
+          proposalId: p.id,
+          organizationId: p.organizationId,
+          organizationName: nameByOrg.get(p.organizationId) ?? null,
+          revenueType: p.revenueType,
+          status: p.status,
+          proposedSharePercent: p.proposedCreatorSharePercent,
+          proposedByRole: p.proposedByRole,
+          roundNumber: p.roundNumber,
+          endedAt: p.respondedAt ?? p.updatedAt,
+          declineReason: p.declineReason,
+        }));
+
+      const payload: CreatorPortfolioPayload = {
+        active,
+        pendingActionRequired,
+        pendingWaitingOnOrg,
+        past,
+      };
+      return payload;
     },
   })
 );

--- a/workers/ecom-api/src/routes/agreements.ts
+++ b/workers/ecom-api/src/routes/agreements.ts
@@ -509,9 +509,16 @@ agreements.get(
       // pulling all proposals where they're the named creator, then
       // dedup by (orgId, revenueType). This covers both active and
       // pending-only threads.
+      //
+      // I1 hardening: pass an explicit status filter so the enumeration
+      // doesn't fan out to terminal proposals we don't need for thread
+      // lookup. Only open + countered + accepted statuses can yield a
+      // thread the caller can act on or reference; declined/withdrawn/
+      // superseded are excluded.
       const ownProposals = await ctx.services.agreements.getProposalsForCreator(
         {
           creatorId: ctx.user.id,
+          status: ['open', 'countered', 'accepted'],
         }
       );
       const triples = new Map<
@@ -651,12 +658,28 @@ agreements.get(
       // enrichment, identical to GET /agreements/me) and every proposal
       // they're named on. The active rows + proposal list together
       // cover every section of the portfolio.
+      //
+      // I1 hardening: pass an explicit status filter so the enumeration
+      // is bounded to the statuses actually surfaced in the portfolio
+      // sections (active: derived from getActiveAgreementsForCreator;
+      // pending: open + countered; past: declined + withdrawn +
+      // superseded). The 90-day `past` cutoff is still applied at slice
+      // time below since pushing it into SQL would require a new query
+      // arg; tracked as a follow-up if the table grows.
       const [activeRows, ownProposals] = await Promise.all([
         ctx.services.agreements.getActiveAgreementsForCreator({
           creatorId: ctx.user.id,
         }),
         ctx.services.agreements.getProposalsForCreator({
           creatorId: ctx.user.id,
+          status: [
+            'open',
+            'countered',
+            'accepted',
+            'declined',
+            'withdrawn',
+            'superseded',
+          ],
         }),
       ]);
 


### PR DESCRIPTION
## Summary

WP-8 of the Revenue-Share Agreements epic (Codex-nk4km). Creator-side UI for managing revenue-share agreements with org owners — the first major surface on the creator-personal studio subdomain.

### New surfaces
- `/studio/negotiations` (portfolio) — action-required, waiting-on-org, active, past
- `/studio/negotiations/[proposalId]` (detail) — anonymised pie + thread + counterparty actions
- Sidebar nav entry in `SIDEBAR_PERSONAL_LINKS` (FileTextIcon)

### New component
- `CounterProposalDialog.svelte` — pre-fills owner's current offer + shows "{ownerName}'s offer was X%; your counter:" comparison

### Reused from WP-7
- `RevenueSplitPie` in `mode='creator'` (anonymised peer slice)
- `NegotiationThread` (role-agnostic)
- `ProposeAgreementDialog` (NOT reused — counter has dedicated dialog with comparison framing)

### Backend extensions (small)
- `agreement-service`: new `getProposalsForCreator()` + public `getOrgName()`. Used so the portfolio can surface pending round-1 proposals on orgs where no active agreement row exists yet (`getActiveAgreementsForCreator` misses these).
- `ecom-api /agreements/me/portfolio`: single round-trip aggregator returning `active + pendingActionRequired + pendingWaitingOnOrg + past`. Org names denormalised onto each row. Anonymisation enforced server-side.
- `ecom-api /agreements/me/threads/:proposalId` now enumerates threads via proposal participation (was: via `getActiveAgreementsForCreator`), so the detail page works for pending round-1 threads.

### Anonymisation contract
Creator side renders ONLY `peers: { count, aggregateSharePercent }`. NO peer userId / creatorId / name in any component. Anonymisation pin tests (`creator-anonymisation.test.ts`) cover both the negative case (peer fields must not appear in DOM) and a positive control (owner-mode still shows names).

### Copy alignment
Every share % says "of post-platform [subscription|content-purchase] revenue" per the C1 math semantic.

## Base branch
Stacks on `feat/codex-s80r6-owner-ui` (WP-7). Chain depth: WP-1 → WP-2 → WP-3 → WP-4 → C1 → WP-5 → WP-7 → this.

## Test plan
- [ ] Creator with no agreements: empty state copy renders.
- [ ] Owner proposes round-1: appears in "Action required" with Accept / Counter / Decline buttons; org name resolves.
- [ ] Click row → detail page → pie shows masked peer slice, thread shows owner's proposal.
- [ ] Click Counter → dialog pre-fills owner's offer; user moves slider → submits → counter appears on detail page.
- [ ] Counter sent → portfolio shows row under "Waiting on org" with Withdraw.
- [ ] Active agreement: shows under "Active" with peer aggregate ("N other creators on this pool").
- [ ] Anonymisation: NO peer userId / creatorId / name in DOM (devtools inspect on detail page).
- [ ] Past section: collapsible, declined / withdrawn / superseded rows render with reason.
- [ ] Cross-tenant 403: visiting `/studio/negotiations/<proposalId-not-yours>` renders "you don't have access" error state, not a crash.
- [ ] Active-agreement detail: Terminate button → confirm flow → success.

Bead: Codex-bw2wf
Epic: Codex-nk4km

Generated with [Claude Code](https://claude.com/claude-code)