### PR TITLE
feat(studio): WP-9 FocusRail integration for revenue-share signals

### DIFF
--- a/apps/web/src/lib/components/studio/dashboard/FocusRail.svelte
+++ b/apps/web/src/lib/components/studio/dashboard/FocusRail.svelte
@@ -10,27 +10,36 @@
   intentionally quiet when empty ("All caught up") to avoid giving
   every creator the same five-bullet todo list.
 
-  @prop items  Ordered list of focus items (highest-signal first)
--->
-<script lang="ts">
-  import type { Component } from 'svelte';
-  import { ChevronRightIcon } from '$lib/components/ui/Icon';
+  Dismissal (WP-9 — Codex-k9no0):
+   - `dismissable: true` items render an inline "× Dismiss" button.
+   - The parent owns dismissal persistence (today: localStorage via
+     `$lib/collections/dismissals`) and re-filters the items list on the
+     next render. The rail itself stays presentational.
 
-  export interface FocusItem {
-    id: string;
-    eyebrow: string; // e.g. "2 drafts" — monospace meter
-    title: string; // e.g. "Ready to publish"
-    description?: string; // optional one-line supporting text
-    href: string;
-    tone?: 'action' | 'warning' | 'muted'; // colour accent
-    icon?: Component<{ size?: number | string; class?: string }>;
-  }
+  @prop items     Ordered list of focus items (highest-signal first)
+  @prop onDismiss Optional callback fired when a dismissable item is
+                  dismissed. Omit to disable dismissal entirely.
+-->
+<script lang="ts" module>
+  // The FocusItem shape lives in a sibling .ts module so non-Svelte
+  // consumers (the WP-9 aggregator, its unit tests) can import the type
+  // — `.svelte` files only expose default exports to non-Svelte
+  // importers. We re-export here so the original
+  // `import type { FocusItem } from './FocusRail.svelte'` path keeps
+  // working unchanged.
+  export type { FocusItem } from './focus-rail-types';
+</script>
+
+<script lang="ts">
+  import { ChevronRightIcon } from '$lib/components/ui/Icon';
+  import type { FocusItem } from './focus-rail-types';
 
   interface Props {
     items: FocusItem[];
+    onDismiss?: (itemId: string) => void;
   }
 
-  const { items }: Props = $props();
+  const { items, onDismiss }: Props = $props();
 </script>
 
 <aside class="focus-rail" aria-labelledby="focus-rail-heading">
@@ -67,6 +76,16 @@
               {/if}
             </span>
           </a>
+          {#if item.dismissable && onDismiss}
+            <button
+              type="button"
+              class="rail-dismiss"
+              aria-label={`Dismiss: ${item.title}`}
+              onclick={() => onDismiss(item.id)}
+            >
+              <span aria-hidden="true">×</span>
+            </button>
+          {/if}
         </li>
       {/each}
     </ol>
@@ -198,6 +217,45 @@
 
   .rail-link[data-tone='warning'] .rail-ordinal {
     color: var(--color-warning-700);
+  }
+
+  /* ── Item row (needed once dismiss button overlays the link) ─────── */
+  .rail-item {
+    position: relative;
+  }
+
+  /* ── Dismiss button (WP-9) ────────────────────────────────────────── */
+  .rail-dismiss {
+    position: absolute;
+    top: var(--space-1);
+    right: var(--space-1);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    padding: 0;
+    border: var(--border-width) var(--border-style) transparent;
+    border-radius: var(--radius-full, 9999px);
+    background: transparent;
+    color: var(--color-text-muted);
+    font-family: var(--font-sans);
+    font-size: var(--text-lg);
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      color var(--duration-fast) var(--ease-out);
+  }
+
+  .rail-dismiss:hover {
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text);
+  }
+
+  .rail-dismiss:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--space-0-5);
   }
 
   /* ── Body ────────────────────────────────────────────────── */

--- a/apps/web/src/lib/components/studio/dashboard/agreement-focus-items.test.ts
+++ b/apps/web/src/lib/components/studio/dashboard/agreement-focus-items.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Unit tests for the agreement focus-item aggregators (WP-9 — Codex-k9no0).
+ *
+ * Pure-function tests — no Svelte render, no DB, no remote calls. The
+ * aggregators receive plain inputs and produce `FocusItem[]`; these
+ * tests pin the priority order, copy templates, and edge cases.
+ *
+ * Coverage matrix:
+ *   - Owner: propose-nudge, counter-received, expiring (in-window /
+ *     out-window / indefinite)
+ *   - Creator: pending-from-org, expiring
+ *   - Dismissal contract is enforced at the caller level (page
+ *     component), so it isn't covered here directly — but the
+ *     `dismissable: true` flag IS asserted on each card type.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildCreatorAgreementFocusItems,
+  buildOwnerAgreementFocusItems,
+} from './agreement-focus-items';
+
+const NOW = new Date('2026-06-01T00:00:00.000Z');
+const daysFromNow = (n: number) => new Date(NOW.getTime() + n * 86400000);
+
+describe('buildOwnerAgreementFocusItems', () => {
+  it('emits a propose nudge for every team creator without a subscription agreement', () => {
+    // 3 team creators, only 1 has an active subscription agreement.
+    // Expect 2 propose nudges.
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+        {
+          userId: 'creator-2',
+          name: 'Bob',
+          email: 'bob@x.test',
+          role: 'creator',
+        },
+        {
+          userId: 'creator-3',
+          name: 'Carol',
+          email: 'carol@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: null,
+        },
+      ],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+
+    const proposeNudges = items.filter((i) =>
+      i.id.startsWith('agreement-propose-')
+    );
+    expect(proposeNudges).toHaveLength(2);
+    expect(proposeNudges.map((i) => i.id).sort()).toEqual([
+      'agreement-propose-creator-2',
+      'agreement-propose-creator-3',
+    ]);
+    // Tone + copy contract
+    expect(proposeNudges[0]?.tone).toBe('action');
+    expect(proposeNudges[0]?.dismissable).toBe(true);
+    expect(proposeNudges[0]?.title).toMatch(/Set up revenue share with/);
+    // Member display name uses `name`, not `email`
+    const forBob = proposeNudges.find(
+      (i) => i.id === 'agreement-propose-creator-2'
+    );
+    expect(forBob?.title).toContain('Bob');
+  });
+
+  it('skips propose nudge when only a content_purchase agreement exists (subscription is the gate)', () => {
+    // Decision Q1: subscription + content_purchase are separate pools.
+    // The team-add nudge specifically targets the subscription pool —
+    // a creator with only content_purchase still gets the nudge.
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'content_purchase',
+          organizationFeePercentage: 7000,
+          effectiveUntil: null,
+        },
+      ],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+
+    const proposeNudges = items.filter((i) =>
+      i.id.startsWith('agreement-propose-')
+    );
+    expect(proposeNudges).toHaveLength(1);
+    expect(proposeNudges[0]?.id).toBe('agreement-propose-creator-1');
+  });
+
+  it('emits a non-dismissable counter card for every creator-proposed open proposal', () => {
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: null,
+        },
+      ],
+      pendingCreatorCounters: [
+        {
+          id: 'proposal-1',
+          creatorId: 'creator-1',
+          proposedByRole: 'creator',
+          revenueType: 'subscription',
+          proposedCreatorSharePercent: 4000, // 40%
+        },
+      ],
+      now: NOW,
+    });
+
+    const counter = items.find((i) => i.id === 'agreement-counter-proposal-1');
+    expect(counter).toBeDefined();
+    expect(counter?.tone).toBe('action');
+    expect(counter?.dismissable).toBe(false);
+    expect(counter?.title).toContain('Alice sent a counter-proposal');
+    expect(counter?.description).toContain('40%');
+    expect(counter?.description).toContain(
+      'post-platform subscription revenue'
+    );
+  });
+
+  it('does NOT emit a counter card for owner-proposed open proposals (those are owner-side waiting)', () => {
+    // The aggregator filters proposedByRole — defence-in-depth in case
+    // the worker route is ever called without the role filter.
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: null,
+        },
+      ],
+      pendingCreatorCounters: [
+        {
+          id: 'proposal-1',
+          creatorId: 'creator-1',
+          proposedByRole: 'owner',
+          revenueType: 'subscription',
+          proposedCreatorSharePercent: 3000,
+        },
+      ],
+      now: NOW,
+    });
+
+    expect(
+      items.find((i) => i.id.startsWith('agreement-counter-'))
+    ).toBeUndefined();
+  });
+
+  it('emits an expiring warning when effectiveUntil is within the 30-day window', () => {
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: daysFromNow(25),
+        },
+      ],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+
+    const expiring = items.find((i) => i.id === 'agreement-expiring-agr-1');
+    expect(expiring).toBeDefined();
+    expect(expiring?.tone).toBe('warning');
+    expect(expiring?.dismissable).toBe(true);
+    expect(expiring?.title).toMatch(/expires in 25 days/);
+  });
+
+  it('does NOT emit an expiring warning when effectiveUntil is beyond the 30-day window', () => {
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: daysFromNow(35),
+        },
+      ],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+
+    expect(
+      items.find((i) => i.id.startsWith('agreement-expiring-'))
+    ).toBeUndefined();
+  });
+
+  it('does NOT emit an expiring warning for indefinite agreements (effectiveUntil = null)', () => {
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: null,
+        },
+      ],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+
+    expect(
+      items.find((i) => i.id.startsWith('agreement-expiring-'))
+    ).toBeUndefined();
+  });
+
+  it('skips subscribers when assembling team-add nudges', () => {
+    // The settings page filters out subscribers; the aggregator's
+    // role-check enforces the same invariant if the caller forgets.
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'subscriber-1',
+          name: 'Sub',
+          email: 'sub@x.test',
+          role: 'subscriber',
+        },
+      ],
+      activeAgreements: [],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+
+    expect(
+      items.filter((i) => i.id.startsWith('agreement-propose-'))
+    ).toHaveLength(0);
+  });
+
+  it('returns an empty array when there is no agreement signal at all', () => {
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [],
+      activeAgreements: [],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+    expect(items).toEqual([]);
+  });
+
+  it('accepts effectiveUntil as ISO string and as Date interchangeably', () => {
+    const items = buildOwnerAgreementFocusItems({
+      teamMembers: [
+        {
+          userId: 'creator-1',
+          name: 'Alice',
+          email: 'alice@x.test',
+          role: 'creator',
+        },
+      ],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          creatorId: 'creator-1',
+          revenueType: 'subscription',
+          organizationFeePercentage: 7000,
+          effectiveUntil: daysFromNow(10).toISOString(),
+        },
+      ],
+      pendingCreatorCounters: [],
+      now: NOW,
+    });
+    expect(
+      items.find((i) => i.id === 'agreement-expiring-agr-1')
+    ).toBeDefined();
+  });
+});
+
+describe('buildCreatorAgreementFocusItems', () => {
+  it('emits a non-dismissable action card for every pending owner proposal', () => {
+    const items = buildCreatorAgreementFocusItems({
+      pendingProposalsFromOrg: [
+        {
+          proposalId: 'proposal-1',
+          organizationId: 'org-1',
+          organizationName: 'Studio Alpha',
+          revenueType: 'subscription',
+          proposedSharePercent: 3500, // 35%
+        },
+      ],
+      activeAgreements: [],
+      now: NOW,
+    });
+
+    const pending = items.find((i) => i.id === 'agreement-pending-proposal-1');
+    expect(pending).toBeDefined();
+    expect(pending?.tone).toBe('action');
+    expect(pending?.dismissable).toBe(false);
+    expect(pending?.title).toContain('Studio Alpha proposed a revenue share');
+    expect(pending?.description).toContain('35%');
+    expect(pending?.description).toContain(
+      'post-platform subscription revenue'
+    );
+    expect(pending?.href).toBe('/studio/negotiations/proposal-1');
+  });
+
+  it('falls back to a generic org name when organizationName is null', () => {
+    const items = buildCreatorAgreementFocusItems({
+      pendingProposalsFromOrg: [
+        {
+          proposalId: 'proposal-1',
+          organizationId: 'org-1',
+          organizationName: null,
+          revenueType: 'subscription',
+          proposedSharePercent: 3500,
+        },
+      ],
+      activeAgreements: [],
+      now: NOW,
+    });
+    expect(items[0]?.title).toContain('An organisation');
+  });
+
+  it('emits a dismissable warning when an active agreement is expiring in 30d', () => {
+    const items = buildCreatorAgreementFocusItems({
+      pendingProposalsFromOrg: [],
+      activeAgreements: [
+        {
+          id: 'agr-1',
+          organizationId: 'org-1',
+          organizationName: 'Studio Alpha',
+          effectiveUntil: daysFromNow(20),
+        },
+      ],
+      now: NOW,
+    });
+
+    const expiring = items.find((i) => i.id === 'agreement-expiring-agr-1');
+    expect(expiring).toBeDefined();
+    expect(expiring?.tone).toBe('warning');
+    expect(expiring?.dismissable).toBe(true);
+    expect(expiring?.title).toMatch(
+      /Your agreement with Studio Alpha expires in 20 days/
+    );
+  });
+
+  it('returns an empty array when the portfolio is empty', () => {
+    const items = buildCreatorAgreementFocusItems({
+      pendingProposalsFromOrg: [],
+      activeAgreements: [],
+      now: NOW,
+    });
+    expect(items).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/components/studio/dashboard/agreement-focus-items.ts
+++ b/apps/web/src/lib/components/studio/dashboard/agreement-focus-items.ts
@@ -1,0 +1,381 @@
+/**
+ * Revenue-share focus-item aggregators (WP-9 — Codex-k9no0).
+ *
+ * Pure functions that translate the three (owner) / two (creator)
+ * agreement signal types into `FocusItem[]` consumed by FocusRail.
+ *
+ * Why pure functions live outside the page component:
+ *  - The studio dashboard is `ssr=false`, so all data fan-in happens via
+ *    remote queries — these aggregators receive the resolved data as
+ *    plain inputs and stay free of `$derived` / browser-only globals.
+ *  - Unit testing the aggregator without spinning up a Svelte render is
+ *    cheap; the page component then just wires inputs and outputs.
+ *
+ * Unit semantics:
+ *  - `sharePercent` (a.k.a. `proposed_creator_share_percent` on the
+ *    proposals table; `10000 - organizationFeePercentage` on the
+ *    legacy active-agreement row) is BASIS POINTS of post-platform
+ *    revenue (0–10000). All copy says "of post-platform
+ *    [revenueType] revenue" per the C1 math semantic
+ *    (`project_revenue_share_decisions.md`).
+ *  - Currency is GBP — no `$` symbols. Display copy is currency-free
+ *    in this surface; percentages only.
+ *  - Dates are real `Date` objects (or ISO strings that the page-level
+ *    code is expected to coerce before calling here). The helper
+ *    accepts both shapes and normalises internally so the test surface
+ *    can pass whichever is convenient.
+ *
+ * Dismissal:
+ *  - `dismissable: true` items can be filtered by the caller using the
+ *    existing `$lib/collections/dismissals` helper. The aggregator does
+ *    NOT consult dismissal state itself — that lives in the browser-only
+ *    localStorage collection. The caller filters returned items via
+ *    `isDismissed(item.id)` before passing to FocusRail.
+ */
+
+import { EditIcon } from '$lib/components/ui/Icon';
+import type { FocusItem } from './focus-rail-types';
+
+// ─── Input shapes ─────────────────────────────────────────────────────────
+
+/**
+ * Subset of OrgMemberItem this aggregator needs. The full type lives in
+ * `$lib/types` but we narrow here so the test fixtures don't need to
+ * mock unrelated fields (email, joinedAt, status).
+ */
+export interface TeamMemberInput {
+  userId: string;
+  name: string | null;
+  email: string;
+  role: string;
+}
+
+/**
+ * Subset of `CreatorOrganizationAgreement` this aggregator consumes.
+ * The legacy `organizationFeePercentage` column is the dual-write source
+ * of truth for active rows today (per WP-1 discoveries); we accept it as
+ * a number and translate to display % at render time.
+ */
+export interface ActiveAgreementInput {
+  id: string;
+  creatorId: string;
+  revenueType: string;
+  /** Basis points (0–10000) of the org's slice; share = 10000 - this. */
+  organizationFeePercentage: number;
+  /** ISO string or Date. `null` = indefinite. */
+  effectiveUntil: string | Date | null;
+}
+
+/**
+ * Subset of `AgreementProposal` this aggregator consumes. Mirrors the
+ * shape returned by `listPendingProposals` (owner) and the
+ * `pendingActionRequired` slice of the creator portfolio.
+ */
+export interface OpenProposalInput {
+  id: string;
+  creatorId: string;
+  proposedByRole: string;
+  revenueType: string;
+  proposedCreatorSharePercent: number;
+}
+
+/**
+ * Creator-side: a pending proposal from an org (round-1 owner-initiated).
+ * Mirrors the `pendingActionRequired` row from the creator portfolio
+ * endpoint.
+ */
+export interface PendingProposalForCreatorInput {
+  proposalId: string;
+  organizationId: string;
+  organizationName: string | null;
+  revenueType: string;
+  proposedSharePercent: number;
+}
+
+/**
+ * Creator-side: an active agreement on some org, used by the
+ * "expiring in 30 days" warning. Mirrors the `active` row from the
+ * creator portfolio endpoint.
+ */
+export interface ActiveAgreementForCreatorInput {
+  id: string;
+  organizationId: string;
+  organizationName: string | null;
+  /** ISO string or Date. `null` = indefinite. */
+  effectiveUntil: string | Date | null;
+}
+
+// ─── Display helpers (private — kept inline; not exported) ────────────────
+
+/** Format a basis-points share (0–10000) as a display string ("30%"). */
+function formatSharePercent(basisPoints: number): string {
+  const asPercent = basisPoints / 100;
+  return Number.isInteger(asPercent)
+    ? `${asPercent}%`
+    : `${asPercent.toFixed(1)}%`;
+}
+
+/** Translate the schema enum to the body copy form. */
+function revenueTypeLabel(revenueType: string): string {
+  return revenueType === 'subscription' ? 'subscription' : 'content-purchase';
+}
+
+/** Resolve a team member's display name, falling back to email. */
+function memberDisplayName(member: TeamMemberInput): string {
+  return member.name?.trim() || member.email;
+}
+
+/**
+ * Window in days for "agreement expiring soon" warnings. Mirrors the
+ * `agreement.expiring_soon` notification trigger documented in the plan
+ * (148: "30d before expiry"). Hardcoded here as a derived UI constant —
+ * if the notification window ever changes, the email service and this
+ * helper must move in lockstep.
+ */
+const EXPIRING_SOON_WINDOW_DAYS = 30;
+
+/**
+ * Compute whole days until `effectiveUntil`. Returns `null` for
+ * indefinite agreements (no `effectiveUntil`) and for already-expired
+ * windows (negative — the FocusRail does not surface past-expiry).
+ *
+ * @param now Injected for deterministic tests. Defaults to `new Date()`.
+ */
+function daysUntil(
+  effectiveUntil: string | Date | null,
+  now: Date = new Date()
+): number | null {
+  if (effectiveUntil == null) return null;
+  const target =
+    effectiveUntil instanceof Date ? effectiveUntil : new Date(effectiveUntil);
+  if (Number.isNaN(target.getTime())) return null;
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const diff = Math.ceil((target.getTime() - now.getTime()) / msPerDay);
+  return diff;
+}
+
+// ─── Public aggregators ───────────────────────────────────────────────────
+
+export interface OwnerFocusItemInput {
+  /** Active org team members (excluding subscribers) — see the settings
+   *  page for the same filtering rule. */
+  teamMembers: TeamMemberInput[];
+  /** Active agreements on the org across both revenue types. */
+  activeAgreements: ActiveAgreementInput[];
+  /** Open proposals on the org with `proposedByRole='creator'`. */
+  pendingCreatorCounters: OpenProposalInput[];
+  /** Injected clock — tests pass a fixed `Date`. */
+  now?: Date;
+}
+
+/**
+ * Three owner-dashboard signal types:
+ *
+ *   1. Propose-revenue-share nudge — surfaced for every active team
+ *      creator who has NO active subscription agreement. Persists until
+ *      the owner proposes (the creator gains a subscription agreement)
+ *      or dismisses the card (`dismissable: true`).
+ *
+ *   2. Counter-proposal received — surfaced for every open proposal on
+ *      this org with `proposedByRole='creator'`. Not dismissable; the
+ *      card clears when the owner accepts / declines / counters.
+ *
+ *   3. Agreement expiring soon — surfaced for every active agreement
+ *      whose `effectiveUntil` is within {@link EXPIRING_SOON_WINDOW_DAYS}.
+ *      Dismissable warning; the email notifier covers the persistent
+ *      reminder channel.
+ *
+ * Returned items are NOT filtered by dismissal — caller does that.
+ *
+ * Per the plan's signal ordering (line 131–136): action > warning >
+ * muted. We emit (counter-received, propose-nudge, expiring) in that
+ * priority order, with the FocusRail rendering them in array order.
+ */
+export function buildOwnerAgreementFocusItems(
+  input: OwnerFocusItemInput
+): FocusItem[] {
+  const items: FocusItem[] = [];
+  const now = input.now ?? new Date();
+
+  // Member name index for description copy.
+  const memberById = new Map<string, TeamMemberInput>();
+  for (const m of input.teamMembers) {
+    memberById.set(m.userId, m);
+  }
+
+  // 1. Counter-proposal received (action, non-dismissable). Ordered by
+  //    creator name for deterministic surfacing.
+  const sortedCounters = [...input.pendingCreatorCounters].sort((a, b) => {
+    const nameA = memberById.get(a.creatorId);
+    const nameB = memberById.get(b.creatorId);
+    const labelA = nameA ? memberDisplayName(nameA) : 'Creator';
+    const labelB = nameB ? memberDisplayName(nameB) : 'Creator';
+    return labelA.localeCompare(labelB);
+  });
+  for (const proposal of sortedCounters) {
+    if (proposal.proposedByRole !== 'creator') continue;
+    const creator = memberById.get(proposal.creatorId);
+    const name = creator ? memberDisplayName(creator) : 'A creator';
+    const revLabel = revenueTypeLabel(proposal.revenueType);
+    items.push({
+      id: `agreement-counter-${proposal.id}`,
+      eyebrow: 'Revenue share',
+      title: `${name} sent a counter-proposal`,
+      description: `${formatSharePercent(proposal.proposedCreatorSharePercent)} of post-platform ${revLabel} revenue`,
+      href: '/studio/settings/revenue-share',
+      tone: 'action',
+      icon: EditIcon,
+      dismissable: false,
+    });
+  }
+
+  // 2. Propose-nudge (action, dismissable). For every active team
+  //    creator without a subscription agreement. We scope to role=creator
+  //    + role=admin (rank-and-file creators on the team); subscribers
+  //    are not team and must be excluded by the caller. The settings
+  //    page uses the same filter.
+  const creatorIdsWithSubAgreement = new Set(
+    input.activeAgreements
+      .filter((a) => a.revenueType === 'subscription')
+      .map((a) => a.creatorId)
+  );
+  const sortedMembers = [...input.teamMembers].sort((a, b) =>
+    memberDisplayName(a).localeCompare(memberDisplayName(b))
+  );
+  for (const member of sortedMembers) {
+    // Only team creators qualify — owners/admins are the org operators,
+    // not the audience-facing creators we'd negotiate revenue with.
+    // The settings page renders cards for every non-subscriber, so we
+    // include role='creator' AND role='admin' here for parity.
+    if (member.role !== 'creator' && member.role !== 'admin') continue;
+    if (creatorIdsWithSubAgreement.has(member.userId)) continue;
+    const name = memberDisplayName(member);
+    items.push({
+      id: `agreement-propose-${member.userId}`,
+      eyebrow: 'Revenue share',
+      title: `Set up revenue share with ${name}`,
+      description: "They'll get nothing until you propose a split.",
+      href: `/studio/settings/revenue-share?focus=${encodeURIComponent(member.userId)}`,
+      tone: 'action',
+      icon: EditIcon,
+      dismissable: true,
+    });
+  }
+
+  // 3. Expiring soon (warning, dismissable). Ordered by soonest first.
+  const expiring = input.activeAgreements
+    .map((agreement) => ({
+      agreement,
+      days: daysUntil(agreement.effectiveUntil, now),
+    }))
+    .filter(
+      (entry): entry is { agreement: ActiveAgreementInput; days: number } =>
+        entry.days !== null &&
+        entry.days >= 0 &&
+        entry.days <= EXPIRING_SOON_WINDOW_DAYS
+    )
+    .sort((a, b) => a.days - b.days);
+  for (const { agreement, days } of expiring) {
+    const creator = memberById.get(agreement.creatorId);
+    const name = creator ? memberDisplayName(creator) : 'a creator';
+    items.push({
+      id: `agreement-expiring-${agreement.id}`,
+      eyebrow: 'Revenue share',
+      title: `Agreement with ${name} expires in ${days} day${days === 1 ? '' : 's'}`,
+      description: 'Renew or terminate before it auto-expires.',
+      href: `/studio/settings/revenue-share?focus=${encodeURIComponent(agreement.creatorId)}`,
+      tone: 'warning',
+      dismissable: true,
+    });
+  }
+
+  return items;
+}
+
+export interface CreatorFocusItemInput {
+  /** `pendingActionRequired` slice of the creator portfolio. */
+  pendingProposalsFromOrg: PendingProposalForCreatorInput[];
+  /** `active` slice of the creator portfolio. */
+  activeAgreements: ActiveAgreementForCreatorInput[];
+  /** Injected clock — tests pass a fixed `Date`. */
+  now?: Date;
+}
+
+/**
+ * Two creator-dashboard signal types:
+ *
+ *   1. Pending proposal from org — surfaced for every row in
+ *      `pendingActionRequired`. Per
+ *      [[pending-proposals-no-agreement-row]], these proposals exist
+ *      ONLY as `agreement_proposals` rows; the creator's portfolio
+ *      endpoint queries the proposals table directly to surface them.
+ *      Not dismissable; cleared when the creator accepts / declines /
+ *      counters.
+ *
+ *   2. Active agreement expiring — surfaced for every active agreement
+ *      whose `effectiveUntil` is within
+ *      {@link EXPIRING_SOON_WINDOW_DAYS}. Dismissable warning.
+ *
+ * Returned items are NOT filtered by dismissal — caller does that.
+ */
+export function buildCreatorAgreementFocusItems(
+  input: CreatorFocusItemInput
+): FocusItem[] {
+  const items: FocusItem[] = [];
+  const now = input.now ?? new Date();
+
+  // 1. Pending proposal from org (action, non-dismissable). Ordered by
+  //    org name for determinism.
+  const sortedPending = [...input.pendingProposalsFromOrg].sort((a, b) => {
+    const nameA = a.organizationName ?? 'An organisation';
+    const nameB = b.organizationName ?? 'An organisation';
+    return nameA.localeCompare(nameB);
+  });
+  for (const proposal of sortedPending) {
+    const orgName = proposal.organizationName ?? 'An organisation';
+    const revLabel = revenueTypeLabel(proposal.revenueType);
+    items.push({
+      id: `agreement-pending-${proposal.proposalId}`,
+      eyebrow: 'Revenue share',
+      title: `${orgName} proposed a revenue share`,
+      description: `${formatSharePercent(proposal.proposedSharePercent)} of post-platform ${revLabel} revenue`,
+      href: `/studio/negotiations/${encodeURIComponent(proposal.proposalId)}`,
+      tone: 'action',
+      icon: EditIcon,
+      dismissable: false,
+    });
+  }
+
+  // 2. Expiring soon (warning, dismissable). Ordered by soonest first.
+  const expiring = input.activeAgreements
+    .map((agreement) => ({
+      agreement,
+      days: daysUntil(agreement.effectiveUntil, now),
+    }))
+    .filter(
+      (
+        entry
+      ): entry is {
+        agreement: ActiveAgreementForCreatorInput;
+        days: number;
+      } =>
+        entry.days !== null &&
+        entry.days >= 0 &&
+        entry.days <= EXPIRING_SOON_WINDOW_DAYS
+    )
+    .sort((a, b) => a.days - b.days);
+  for (const { agreement, days } of expiring) {
+    const orgName = agreement.organizationName ?? 'an organisation';
+    items.push({
+      id: `agreement-expiring-${agreement.id}`,
+      eyebrow: 'Revenue share',
+      title: `Your agreement with ${orgName} expires in ${days} day${days === 1 ? '' : 's'}`,
+      description: 'Renew with the org or it auto-expires.',
+      href: `/studio/negotiations/${encodeURIComponent(agreement.id)}`,
+      tone: 'warning',
+      dismissable: true,
+    });
+  }
+
+  return items;
+}

--- a/apps/web/src/lib/components/studio/dashboard/focus-rail-types.ts
+++ b/apps/web/src/lib/components/studio/dashboard/focus-rail-types.ts
@@ -1,0 +1,37 @@
+/**
+ * Type-only module for the FocusRail component (WP-9 — Codex-k9no0).
+ *
+ * Lives here (rather than inside `FocusRail.svelte`) so non-Svelte
+ * consumers (the agreement focus-item aggregator, the unit test for
+ * the aggregator) can import the shape without hitting TypeScript's
+ * limitation that named exports from `.svelte` files are not resolvable
+ * from `.ts` files.
+ *
+ * FocusRail.svelte re-exports `FocusItem` for Svelte consumers so the
+ * original import paths keep working without churn.
+ */
+
+import type { Component } from 'svelte';
+
+export interface FocusItem {
+  id: string;
+  /** Eyebrow microcopy — e.g. "2 drafts" — rendered in monospace. */
+  eyebrow: string;
+  /** Title — primary headline of the card. */
+  title: string;
+  /** Optional one-line supporting copy. */
+  description?: string;
+  /** Destination href (root-relative; org subdomain inferred from host). */
+  href: string;
+  /** Colour accent. Defaults to `'action'` if omitted. */
+  tone?: 'action' | 'warning' | 'muted';
+  /** Optional leading icon. */
+  icon?: Component<{ size?: number | string; class?: string }>;
+  /**
+   * When true, the rail renders an inline dismiss button. The parent
+   * receives the dismissal via `onDismiss` and is expected to filter the
+   * item out on the next render (typically via the localStorage
+   * dismissal collection — see `$lib/collections/dismissals`).
+   */
+  dismissable?: boolean;
+}

--- a/apps/web/src/lib/remote/agreements.remote.ts
+++ b/apps/web/src/lib/remote/agreements.remote.ts
@@ -28,6 +28,11 @@ const listAgreementsArgsSchema = z.object({
   revenueType: revenueTypeSchema.optional(),
 });
 
+const listPendingProposalsArgsSchema = z.object({
+  organizationId: z.string().uuid(),
+  proposedByRole: z.enum(['owner', 'creator']).optional(),
+});
+
 const getThreadArgsSchema = z.object({
   organizationId: z.string().uuid(),
   creatorId: z.string().uuid(),
@@ -79,6 +84,24 @@ export const listActiveAgreements = query(
     return api.agreements.list(
       organizationId,
       revenueType ? { revenueType } : undefined
+    );
+  }
+);
+
+/**
+ * Owner-view open proposals on the org (WP-9 — Codex-k9no0). Powers the
+ * FocusRail "counter-proposal received" signal on the owner studio
+ * dashboard. `proposedByRole='creator'` narrows to the subset waiting on
+ * owner action.
+ */
+export const listPendingProposals = query(
+  listPendingProposalsArgsSchema,
+  async ({ organizationId, proposedByRole }) => {
+    const { platform, cookies } = getRequestEvent();
+    const api = createServerApi(platform, cookies);
+    return api.agreements.listPending(
+      organizationId,
+      proposedByRole ? { proposedByRole } : undefined
     );
   }
 );

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1824,6 +1824,26 @@ export function createServerApi(
       },
 
       /**
+       * Owner-view open proposals on this org (WP-9 — Codex-k9no0).
+       * Optional `proposedByRole` filter narrows to "counter-proposals
+       * from creators waiting on owner action" in a single round-trip.
+       * Same `requireOrgManagement` gate as `list`.
+       */
+      listPending: (
+        organizationId: string,
+        params?: { proposedByRole?: 'owner' | 'creator' }
+      ) => {
+        const search = new URLSearchParams();
+        if (params?.proposedByRole) {
+          search.set('proposedByRole', params.proposedByRole);
+        }
+        return request<PaginatedListResponse<AgreementProposal>>(
+          'ecom',
+          withOrg('/agreements/pending', organizationId, search)
+        );
+      },
+
+      /**
        * Owner-view negotiation thread for one (creator, revenueType) on
        * this org. Empty array if no thread exists.
        */

--- a/apps/web/src/routes/_creators/studio/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/+page.svelte
@@ -10,15 +10,20 @@
 <script lang="ts">
   import StatCard from '$lib/components/studio/StatCard.svelte';
   import ActivityFeed from '$lib/components/studio/ActivityFeed.svelte';
+  import FocusRail from '$lib/components/studio/dashboard/FocusRail.svelte';
+  import type { FocusItem } from '$lib/components/studio/dashboard/FocusRail.svelte';
+  import { buildCreatorAgreementFocusItems } from '$lib/components/studio/dashboard/agreement-focus-items';
   import {
     PlusIcon,
     UploadIcon,
     TrendingUpIcon,
     GlobeIcon,
   } from '$lib/components/ui/Icon';
+  import { dismiss, isDismissed } from '$lib/collections/dismissals';
   import { listContent } from '$lib/remote/content.remote';
   import { listMedia } from '$lib/remote/media.remote';
   import { getActivityFeed } from '$lib/remote/admin.remote';
+  import { getMyAgreementPortfolio } from '$lib/remote/agreements.remote';
   import type { Component } from 'svelte';
   import * as m from '$paraglide/messages';
 
@@ -33,6 +38,42 @@
 
   // Derive loading state: both stat queries must resolve
   const statsLoading = $derived(contentQuery?.loading || mediaQuery?.loading);
+
+  // ── Revenue-share focus signals (WP-9 — Codex-k9no0) ────────────────────
+  // Creator-side portfolio includes pending-action-required proposals
+  // (per [[pending-proposals-no-agreement-row]] these only exist as
+  // agreement_proposals rows until accept) and active agreements with
+  // their effectiveUntil for expiry warnings.
+  const portfolioQuery = $derived(getMyAgreementPortfolio());
+
+  // Bump on dismissal so derivations re-run (localStorage mutates
+  // synchronously but Svelte 5 needs an explicit trigger).
+  let dismissTick = $state(0);
+  function handleFocusDismiss(itemId: string) {
+    dismiss(itemId);
+    dismissTick += 1;
+  }
+
+  const focusItems = $derived.by<FocusItem[]>(() => {
+    void dismissTick;
+    const portfolio = portfolioQuery?.current;
+    if (!portfolio) return [];
+    return buildCreatorAgreementFocusItems({
+      pendingProposalsFromOrg: portfolio.pendingActionRequired.map((p) => ({
+        proposalId: p.proposalId,
+        organizationId: p.organizationId,
+        organizationName: p.organizationName,
+        revenueType: p.revenueType,
+        proposedSharePercent: p.proposedSharePercent,
+      })),
+      activeAgreements: portfolio.active.map((a) => ({
+        id: a.id,
+        organizationId: a.organizationId,
+        organizationName: a.organizationName,
+        effectiveUntil: a.effectiveUntil,
+      })),
+    }).filter((item) => !item.dismissable || !isDismissed(item.id));
+  });
 
   // ── Quick Actions ──────────────────────────────────────────────────────────
 
@@ -82,6 +123,13 @@
         value={mediaQuery?.current?.pagination?.total ?? '--'}
         loading={!mediaQuery?.current}
       />
+    </section>
+  {/if}
+
+  {#if focusItems.length > 0}
+    <section class="focus-section" aria-labelledby="creator-focus-heading">
+      <h2 id="creator-focus-heading" class="visually-hidden">Today's priorities</h2>
+      <FocusRail items={focusItems} onDismiss={handleFocusDismiss} />
     </section>
   {/if}
 
@@ -143,6 +191,25 @@
     color: var(--color-text-secondary);
     margin: 0;
     line-height: var(--leading-normal);
+  }
+
+  /* WP-9 — agreement focus rail section */
+  .focus-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
   }
 
   .stats-grid {

--- a/apps/web/src/routes/_org/[slug]/studio/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/+page.svelte
@@ -26,14 +26,21 @@
   import FocusRail from '$lib/components/studio/dashboard/FocusRail.svelte';
   import ActivityStream from '$lib/components/studio/dashboard/ActivityStream.svelte';
   import type { FocusItem } from '$lib/components/studio/dashboard/FocusRail.svelte';
+  import { buildOwnerAgreementFocusItems } from '$lib/components/studio/dashboard/agreement-focus-items';
   import {
     PlusIcon,
     EditIcon,
     UsersIcon,
     FileTextIcon,
   } from '$lib/components/ui/Icon';
+  import { dismiss, isDismissed } from '$lib/collections/dismissals';
   import { formatPrice } from '$lib/utils/format';
   import { getDashboardStats, getActivityFeed } from '$lib/remote/admin.remote';
+  import {
+    listActiveAgreements,
+    listPendingProposals,
+  } from '$lib/remote/agreements.remote';
+  import { getOrgMembers } from '$lib/remote/org.remote';
   import * as m from '$paraglide/messages';
 
   let { data } = $props();
@@ -51,6 +58,43 @@
       ? getActivityFeed({ organizationId: data.org.id, limit: 12 })
       : null
   );
+
+  // ── Revenue-share signal data (WP-9 — Codex-k9no0) ──────────────────────
+  // Only admin/owner see agreement focus items — the worker route gates
+  // both endpoints with requireOrgManagement. Skipping the query for
+  // creator/non-admin roles avoids a guaranteed 403.
+  const agreementsQuery = $derived(
+    isAdmin && data.org?.id
+      ? listActiveAgreements({ organizationId: data.org.id })
+      : null
+  );
+  const pendingCountersQuery = $derived(
+    isAdmin && data.org?.id
+      ? listPendingProposals({
+          organizationId: data.org.id,
+          proposedByRole: 'creator',
+        })
+      : null
+  );
+  // Team members feed the propose-nudge — every non-subscriber creator
+  // without a subscription agreement gets a card.
+  const teamMembersQuery = $derived(
+    isAdmin && data.org?.id
+      ? getOrgMembers({ orgId: data.org.id, limit: 100 })
+      : null
+  );
+
+  // ── Dismissal reactivity ────────────────────────────────────────────────
+  // dismiss() / isDismissed() read from the localStorage collection; the
+  // collection mutates synchronously, but Svelte 5 derived values need an
+  // explicit trigger to re-evaluate. We bump `dismissTick` on every
+  // dismissal, then read it inside the focusItems $derived so the rebuild
+  // fires.
+  let dismissTick = $state(0);
+  function handleFocusDismiss(itemId: string) {
+    dismiss(itemId);
+    dismissTick += 1;
+  }
 
   const stats = $derived(statsQuery?.current ?? null);
   const statsLoading = $derived(statsQuery?.loading ?? false);
@@ -98,7 +142,14 @@
   });
 
   // ── Focus items (contextual — real work, not generic links) ──────────────
+  // Order: drafts > revenue-share signals > customers > branding nudges.
+  // Dismissable items are filtered against the localStorage dismissal
+  // collection (WP-9). The `dismissTick` read forces re-derivation when
+  // the user dismisses a card.
   const focusItems = $derived.by<FocusItem[]>(() => {
+    // Touch the tick so dismissals re-fire derivation.
+    void dismissTick;
+
     const items: FocusItem[] = [];
     const drafts = data.badgeCounts?.draftContent ?? 0;
 
@@ -130,6 +181,45 @@
     }
 
     if (isAdmin) {
+      // WP-9 revenue-share signals — only when all three data sources
+      // have resolved. We deliberately don't render partial sets while
+      // queries are still loading; the rest of the rail covers the
+      // skeleton state.
+      const activeAgreements = agreementsQuery?.current?.items ?? [];
+      const pendingCounters = pendingCountersQuery?.current?.items ?? [];
+      const teamMembers = teamMembersQuery?.current?.items ?? [];
+      const dataReady =
+        agreementsQuery?.current != null &&
+        pendingCountersQuery?.current != null &&
+        teamMembersQuery?.current != null;
+      if (dataReady) {
+        const agreementItems = buildOwnerAgreementFocusItems({
+          teamMembers: teamMembers
+            .filter((m) => m.role !== 'subscriber')
+            .map((m) => ({
+              userId: m.userId,
+              name: m.name,
+              email: m.email,
+              role: m.role,
+            })),
+          activeAgreements: activeAgreements.map((a) => ({
+            id: a.id,
+            creatorId: a.creatorId,
+            revenueType: a.revenueType,
+            organizationFeePercentage: a.organizationFeePercentage,
+            effectiveUntil: a.effectiveUntil,
+          })),
+          pendingCreatorCounters: pendingCounters.map((p) => ({
+            id: p.id,
+            creatorId: p.creatorId,
+            proposedByRole: p.proposedByRole,
+            revenueType: p.revenueType,
+            proposedCreatorSharePercent: p.proposedCreatorSharePercent,
+          })),
+        }).filter((item) => !item.dismissable || !isDismissed(item.id));
+        items.push(...agreementItems);
+      }
+
       // Customers tile — visible only to admin/owner, prompts CRM review
       const customerCount = stats?.customers?.value ?? 0;
       if (customerCount > 0) {
@@ -275,7 +365,7 @@
 
   <!-- ── 03  Split: Focus rail + Activity stream ── -->
   <section class="below-fold">
-    <FocusRail items={focusItems} />
+    <FocusRail items={focusItems} onDismiss={handleFocusDismiss} />
     <ActivityStream
       activities={activities}
       loading={activitiesLoading}

--- a/packages/agreements/src/services/__tests__/agreement-service.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-service.test.ts
@@ -1304,6 +1304,95 @@ describe('AgreementService', () => {
     });
   });
 
+  // ── getProposalsForOrg (WP-9 — Codex-k9no0) ────────────────────────────
+  //
+  // Org-scoped mirror of getProposalsForCreator. Powers the FocusRail
+  // "counter-proposal received" signal on the owner studio dashboard.
+  // Status + proposedByRole filters narrow the result set to the
+  // "creator countered, waiting on owner" subset in a single round-trip.
+  describe('getProposalsForOrg', () => {
+    it('returns proposals where organizationId matches', async () => {
+      const fxA = await seedOrgFixture(db);
+      const fxB = await seedOrgFixture(db);
+      await service.proposeAgreement({
+        organizationId: fxA.orgId,
+        creatorId: fxA.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fxA.ownerId,
+      });
+      await service.proposeAgreement({
+        organizationId: fxB.orgId,
+        creatorId: fxB.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 4000,
+        termMonths: 6,
+        proposedByUserId: fxB.ownerId,
+      });
+      const forA = await service.getProposalsForOrg({
+        organizationId: fxA.orgId,
+      });
+      expect(forA).toHaveLength(1);
+      expect(forA[0]?.organizationId).toBe(fxA.orgId);
+    });
+
+    it('proposedByRole=creator narrows to creator-counter signals', async () => {
+      // Seed: owner proposes (round 1) → creator counters (round 2).
+      // proposedByRole filter for 'creator' must return ONLY the counter.
+      const fx = await seedOrgFixture(db);
+      const p1 = await service.proposeAgreement({
+        organizationId: fx.orgId,
+        creatorId: fx.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fx.ownerId,
+      });
+      const p2 = await service.counterPropose({
+        proposalId: p1.id,
+        sharePercent: 4000,
+        termMonths: 6,
+        counteredByUserId: fx.creatorAId,
+      });
+      const counters = await service.getProposalsForOrg({
+        organizationId: fx.orgId,
+        status: ['open'],
+        proposedByRole: 'creator',
+      });
+      expect(counters).toHaveLength(1);
+      expect(counters[0]?.id).toBe(p2.id);
+      expect(counters[0]?.proposedByRole).toBe('creator');
+    });
+
+    it('cross-tenant pin: returns nothing for a different org', async () => {
+      // Proposal seeded on org A only; querying org B's id must return
+      // zero rows.
+      const fxA = await seedOrgFixture(db);
+      const fxB = await seedOrgFixture(db);
+      await service.proposeAgreement({
+        organizationId: fxA.orgId,
+        creatorId: fxA.creatorAId,
+        revenueType: 'subscription',
+        sharePercent: 3000,
+        termMonths: 6,
+        proposedByUserId: fxA.ownerId,
+      });
+      const forB = await service.getProposalsForOrg({
+        organizationId: fxB.orgId,
+      });
+      expect(forB).toEqual([]);
+    });
+
+    it('returns empty array when org has no proposals', async () => {
+      const fx = await seedOrgFixture(db);
+      const result = await service.getProposalsForOrg({
+        organizationId: fx.orgId,
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('getOrgName', () => {
     it('returns the human-readable name for an existing org', async () => {
       // seedOrgFixture inserts orgs with name "Test Org" — assert.

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -1194,6 +1194,56 @@ export class AgreementService extends BaseService {
   }
 
   /**
+   * All proposals on an organization, regardless of which creator they
+   * target. Mirrors {@link getProposalsForCreator} but org-scoped — used
+   * by WP-9 (Codex-k9no0) to surface "counter-proposal received" signals
+   * on the owner studio dashboard. The org-status composite index
+   * (`idx_agreement_proposals_org_status`) already exists on the schema,
+   * so the typical "open proposals on this org" query is index-served.
+   *
+   * Optional `proposedByRole` filter lets the FocusRail aggregator pull
+   * "open proposals from creators waiting on owner action" in a single
+   * round-trip instead of pulling all open proposals and filtering
+   * client-side.
+   *
+   * Returns chronological proposals (oldest first) — same ordering as
+   * {@link getProposalsForCreator} so consumers can reuse the same
+   * iteration code on both sides.
+   *
+   * Authorisation note: the SERVICE applies no auth gate; callers are
+   * expected to scope the request by an org the actor is already
+   * authorised to read (see the `requireOrgManagement` route gate in
+   * `workers/ecom-api/src/routes/agreements.ts`).
+   */
+  async getProposalsForOrg(input: {
+    organizationId: string;
+    status?: AgreementProposal['status'] | AgreementProposal['status'][];
+    proposedByRole?: 'owner' | 'creator';
+  }): Promise<AgreementProposal[]> {
+    try {
+      const statusFilter = (() => {
+        if (!input.status) return undefined;
+        const arr = Array.isArray(input.status) ? input.status : [input.status];
+        if (arr.length === 0) return undefined;
+        return inArray(agreementProposals.status, arr);
+      })();
+      const roleFilter = input.proposedByRole
+        ? eq(agreementProposals.proposedByRole, input.proposedByRole)
+        : undefined;
+      return await this.db.query.agreementProposals.findMany({
+        where: and(
+          eq(agreementProposals.organizationId, input.organizationId),
+          statusFilter,
+          roleFilter
+        ),
+        orderBy: [asc(agreementProposals.createdAt)],
+      });
+    } catch (error) {
+      this.handleError(error, 'getProposalsForOrg');
+    }
+  }
+
+  /**
    * Resolve a human-readable org name for one organization id. Returns
    * `null` for unknown / hard-deleted orgs (rare). Used by the
    * creator-side portfolio route to surface friendly org names — the

--- a/packages/validation/src/schemas/agreements.ts
+++ b/packages/validation/src/schemas/agreements.ts
@@ -236,3 +236,23 @@ export const ownerThreadParamSchema = z.object({
   creatorId: uuidSchema,
 });
 export type OwnerThreadParamInput = z.infer<typeof ownerThreadParamSchema>;
+
+/**
+ * GET /agreements/pending — owner-view open-proposal feed (WP-9 — Codex-k9no0).
+ *
+ * Powers the FocusRail "counter-proposal received" signal on the owner
+ * studio dashboard. `proposedByRole='creator'` returns ONLY the open
+ * proposals where the creator countered (or initiated, in a future
+ * reverse-proposal world) — i.e. proposals waiting on owner action.
+ *
+ * `organizationId` is in the query string per the org-resolution
+ * contract (see `feedback_secure_route_org_resolution`); the service
+ * receives `ctx.organizationId` and ignores the body value.
+ */
+export const listPendingProposalsQuerySchema = z.object({
+  organizationId: uuidSchema.optional(),
+  proposedByRole: z.enum(['owner', 'creator']).optional(),
+});
+export type ListPendingProposalsQueryInput = z.infer<
+  typeof listPendingProposalsQuerySchema
+>;

--- a/workers/ecom-api/src/routes/agreements.ts
+++ b/workers/ecom-api/src/routes/agreements.ts
@@ -59,6 +59,7 @@ import {
   declineProposalInputSchema,
   getNegotiationThreadQuerySchema,
   listAgreementsQuerySchema,
+  listPendingProposalsQuerySchema,
   ownerThreadParamSchema,
   proposalIdParamSchema,
   proposeAgreementInputSchema,
@@ -328,6 +329,46 @@ agreements.get(
         organizationId: ctx.organizationId,
         creatorId: ctx.input.params.creatorId,
         revenueType: ctx.input.query.revenueType,
+      });
+    },
+  })
+);
+
+/**
+ * GET /agreements/pending?organizationId=...&proposedByRole=creator
+ *
+ * Owner/admin-view open proposals on this org (WP-9 — Codex-k9no0).
+ * Powers the FocusRail "counter-proposal received" signal on the owner
+ * studio dashboard. Returns chronological proposals (oldest first).
+ *
+ * `proposedByRole=creator` narrows to the high-signal subset: creators
+ * who have countered (or, in a future reverse-proposal world, initiated)
+ * a proposal that the owner has not yet acted on. Without the role
+ * filter, the response also includes the owner's own outstanding
+ * proposals — which the dashboard already knows about and would
+ * double-count.
+ *
+ * Gated with `requireOrgManagement: true` for the same reason as
+ * `GET /agreements`: rank-and-file members must not see peer negotiation
+ * details.
+ */
+agreements.get(
+  '/pending',
+  procedure({
+    policy: { auth: 'required', requireOrgManagement: true },
+    input: { query: listPendingProposalsQuerySchema },
+    handler: async (ctx) => {
+      const proposals = await ctx.services.agreements.getProposalsForOrg({
+        organizationId: ctx.organizationId,
+        status: ['open'],
+        proposedByRole: ctx.input.query.proposedByRole,
+      });
+      // Synthetic envelope to match the rest of the worker's list contract.
+      return new PaginatedResult(proposals, {
+        page: 1,
+        limit: proposals.length,
+        total: proposals.length,
+        totalPages: 1,
       });
     },
   })


### PR DESCRIPTION
## Summary

WP-9 of the Revenue-Share Agreements epic (Codex-nk4km). Wires three owner-dashboard + two creator-dashboard signal types into the existing FocusRail widget.

### Owner dashboard
- **Propose-revenue-share** after team-add (persistent until proposed or dismissed)
- **Counter-proposal received** from creator (clears on owner action)
- **Agreement expiring in 30d** (dismissable warning)

### Creator dashboard
- **Pending proposal from org** (clears on creator action)
- **Active agreement expiring in 30d** (dismissable warning)

### Service + Worker
Adds `AgreementService.getProposalsForOrg({ organizationId, status?, proposedByRole? })` mirroring `getProposalsForCreator`, served by a new `GET /agreements/pending` route on ecom-api with `requireOrgManagement`. Owner-side reads route through `ctx.services.agreements`; creator-side reads via the existing `/agreements/me/portfolio` aggregator (per [[pending-proposals-no-agreement-row]] — proposals have no agreement row until accept).

### Aggregator architecture
`buildOwnerAgreementFocusItems` / `buildCreatorAgreementFocusItems` are pure functions in `apps/web/src/lib/components/studio/dashboard/agreement-focus-items.ts`. Page components call them with resolved query data; the helpers return `FocusItem[]` with priority order applied. 14 unit tests cover copy templates, priority, edge cases (indefinite, out-of-window, subscriber filter).

### Dismissal
Reuses existing `$lib/collections/dismissals` localStorage helper (`isDismissed` / `dismiss`). Counter-received + pending-creator items are non-dismissable; they clear on the next action. Propose-nudge + expiring warnings are dismissable.

### Type extraction
Extracted `FocusItem` from `FocusRail.svelte` into a sibling `focus-rail-types.ts` so the aggregator (a `.ts` module) can import the shape; `FocusRail.svelte` re-exports for original import-path stability.

## Base branch
Stacks on `feat/codex-bw2wf-creator-ui` (WP-8).

## Test plan
- [x] Service: 4 new tests for `getProposalsForOrg` (org-scope, role filter, cross-tenant pin, empty)
- [x] Aggregator: 14 unit tests for owner + creator focus items
- [x] Typecheck clean on apps/web (no new errors), packages/agreements, workers/ecom-api
- [x] apps/web build clean
- [x] biome format clean
- [ ] Manual: owner adds team member, focus rail nudge appears (Playwright deferred — WP-10 owns apps/web/tests/*)

Bead: Codex-k9no0
Epic: Codex-nk4km