### PR TITLE
fix(studio): WP-7 polish — counter dialog mode + pagination warning + token-driven fee

### DIFF
--- a/apps/web/src/lib/components/agreements/AgreementCard.svelte
+++ b/apps/web/src/lib/components/agreements/AgreementCard.svelte
@@ -23,7 +23,11 @@
   Props mirror the WP-7 spec in Codex-s80r6.
 -->
 <script lang="ts">
-  import type { AgreementProposal, CreatorOrganizationAgreement } from '@codex/agreements';
+  import {
+    type AgreementProposal,
+    type CreatorOrganizationAgreement,
+    formatRevenueTypeLabel,
+  } from '@codex/agreements';
 
   interface Creator {
     id: string;
@@ -185,8 +189,22 @@
 
   <div class="agreement-card__rows">
     {#each [
-      { revType: 'subscription' as const, label: 'Subscription', state: subscriptionState },
-      { revType: 'content_purchase' as const, label: 'Content purchase', state: contentPurchaseState },
+      {
+        revType: 'subscription' as const,
+        label: 'Subscription',
+        // copyLabel is what gets interpolated into prose ("of post-platform
+        // {copyLabel} revenue"). Sourced from `formatRevenueTypeLabel` so it
+        // matches the hyphenated `revenue_type` enum value used in
+        // NegotiationThread, ProposeAgreementDialog, +page.svelte etc.
+        copyLabel: formatRevenueTypeLabel('subscription'),
+        state: subscriptionState,
+      },
+      {
+        revType: 'content_purchase' as const,
+        label: 'Content purchase',
+        copyLabel: formatRevenueTypeLabel('content_purchase'),
+        state: contentPurchaseState,
+      },
     ] as row (row.revType)}
       <section
         class="agreement-card__row"
@@ -223,7 +241,7 @@
                 <dd>
                   <strong>{formatPercent(row.state.sharePercent)}</strong>
                   <span class="agreement-card__row-detail-hint">
-                    of post-platform {row.label.toLowerCase()} revenue
+                    of post-platform {row.copyLabel} revenue
                   </span>
                 </dd>
               </div>
@@ -245,7 +263,7 @@
                   <dd>
                     <strong>{formatPercent(row.state.pendingShare)}</strong>
                     <span class="agreement-card__row-detail-hint">
-                      of post-platform {row.label.toLowerCase()} revenue
+                      of post-platform {row.copyLabel} revenue
                     </span>
                   </dd>
                 </div>
@@ -258,14 +276,14 @@
                 <dd>
                   <strong>{formatPercent(row.state.sharePercent)}</strong>
                   <span class="agreement-card__row-detail-hint">
-                    of post-platform {row.label.toLowerCase()} revenue
+                    of post-platform {row.copyLabel} revenue
                   </span>
                 </dd>
               </div>
             </dl>
           {:else}
             <p class="agreement-card__row-empty">
-              No revenue share configured. Default: org keeps 100% of post-platform {row.label.toLowerCase()} revenue.
+              No revenue share configured. Default: org keeps 100% of post-platform {row.copyLabel} revenue.
             </p>
           {/if}
         </div>

--- a/apps/web/src/lib/components/agreements/AgreementCard.svelte.test.ts
+++ b/apps/web/src/lib/components/agreements/AgreementCard.svelte.test.ts
@@ -186,8 +186,11 @@ describe('AgreementCard', () => {
     expect(document.body.textContent).toContain('Waiting on creator');
     expect(document.body.textContent).toContain('Round 1');
     expect(document.body.textContent).toContain('35%');
+    // Body copy uses the canonical hyphenated label from
+    // `formatRevenueTypeLabel('content_purchase')` so it matches the
+    // revenue_type enum value and reads identically across surfaces.
     expect(document.body.textContent).toContain(
-      'post-platform content purchase revenue'
+      'post-platform content-purchase revenue'
     );
   });
 });

--- a/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte
+++ b/apps/web/src/lib/components/agreements/CounterProposalDialog.svelte
@@ -19,6 +19,7 @@
   math decision; see project_revenue_share_decisions Q2). Currency GBP.
 -->
 <script lang="ts">
+  import { formatRevenueTypeLabel } from '@codex/agreements';
   import BrandSliderField from '$lib/components/brand-editor/BrandSliderField.svelte';
   import { DialogForm } from '$lib/components/ui/DialogForm';
 
@@ -76,9 +77,7 @@
     }
   });
 
-  const revenueLabel = $derived(
-    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
-  );
+  const revenueLabel = $derived(formatRevenueTypeLabel(revenueType));
   const sharePercent = $derived(shareBp / 100);
   const ownerSharePercent = $derived(currentSharePercent / 100);
   const formattedShare = $derived(

--- a/apps/web/src/lib/components/agreements/NegotiationThread.svelte
+++ b/apps/web/src/lib/components/agreements/NegotiationThread.svelte
@@ -15,7 +15,7 @@
   renders buttons for whatever callbacks it received.
 -->
 <script lang="ts">
-  import type { AgreementProposal } from '@codex/agreements';
+  import { type AgreementProposal, formatRevenueTypeLabel } from '@codex/agreements';
 
   type RevenueType = 'subscription' | 'content_purchase';
 
@@ -92,9 +92,7 @@
     }
   }
 
-  const revenueLabel = $derived(
-    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
-  );
+  const revenueLabel = $derived(formatRevenueTypeLabel(revenueType));
 
   // The latest proposal — open ones are the only actionable rows.
   const latestProposal = $derived(proposals.at(-1) ?? null);
@@ -240,7 +238,7 @@
 
   .negotiation-thread__item[data-status='superseded'],
   .negotiation-thread__item[data-status='withdrawn'] {
-    opacity: var(--opacity-60, 0.6);
+    opacity: var(--opacity-60);
   }
 
   .negotiation-thread__item-head {

--- a/apps/web/src/lib/components/agreements/ProposeAgreementDialog.svelte
+++ b/apps/web/src/lib/components/agreements/ProposeAgreementDialog.svelte
@@ -18,6 +18,7 @@
   pre-fills the slider with the current share).
 -->
 <script lang="ts">
+  import { formatRevenueTypeLabel } from '@codex/agreements';
   import BrandSliderField from '$lib/components/brand-editor/BrandSliderField.svelte';
   import { DialogForm } from '$lib/components/ui/DialogForm';
 
@@ -41,8 +42,13 @@
       termMonths: number;
       note?: string;
     }) => Promise<void>;
-    /** Used in the dialog title — "Propose…" vs "Amend…". */
-    mode?: 'propose' | 'amend';
+    /**
+     * Title + submit-label variant. Distinguishes a round-1 propose flow
+     * from an amendment to an existing active agreement, and from a counter
+     * to a creator-initiated proposal — the form fields are identical but
+     * the copy must match the user's actual action.
+     */
+    mode?: 'propose' | 'amend' | 'counter';
   }
 
   const {
@@ -83,9 +89,7 @@
     }
   });
 
-  const revenueLabel = $derived(
-    revenueType === 'subscription' ? 'subscription' : 'content-purchase'
-  );
+  const revenueLabel = $derived(formatRevenueTypeLabel(revenueType));
   const sharePercent = $derived(shareBp / 100);
   const formattedShare = $derived(
     Number.isInteger(sharePercent)
@@ -146,9 +150,26 @@
     onOpenChange(next);
   }
 
-  const dialogTitle = $derived(
-    `${mode === 'amend' ? 'Amend' : 'Propose'} ${revenueLabel} agreement with ${creatorName}`
-  );
+  const dialogTitle = $derived.by(() => {
+    switch (mode) {
+      case 'amend':
+        return `Amend ${revenueLabel} agreement with ${creatorName}`;
+      case 'counter':
+        return `Counter ${revenueLabel} proposal from ${creatorName}`;
+      default:
+        return `Propose ${revenueLabel} agreement with ${creatorName}`;
+    }
+  });
+  const submitLabel = $derived.by(() => {
+    switch (mode) {
+      case 'amend':
+        return 'Send amendment';
+      case 'counter':
+        return 'Send counter';
+      default:
+        return 'Send proposal';
+    }
+  });
   const dialogDescription =
     'Share is calculated against post-platform revenue. The platform fee is taken first; this percentage applies to what remains.';
 </script>
@@ -161,7 +182,7 @@
   {error}
   onsubmit={handleSubmit}
   onOpenChange={handleOpenChange}
-  submitLabel={mode === 'amend' ? 'Send amendment' : 'Send proposal'}
+  {submitLabel}
 >
   <div class="propose-form">
     <BrandSliderField

--- a/apps/web/src/routes/_org/[slug]/studio/settings/revenue-share/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/settings/revenue-share/+page.svelte
@@ -20,6 +20,11 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
+  import {
+    type CreatorOrganizationAgreement,
+    formatRevenueTypeLabel,
+  } from '@codex/agreements';
+  import { FEES } from '@codex/constants';
   import AgreementCard from '$lib/components/agreements/AgreementCard.svelte';
   import NegotiationThread from '$lib/components/agreements/NegotiationThread.svelte';
   import ProposeAgreementDialog from '$lib/components/agreements/ProposeAgreementDialog.svelte';
@@ -73,9 +78,11 @@
 
   // ─── Derived: per-creator + pending proposal maps ────────────────────────
 
-  type ActiveAgreementRow = NonNullable<
-    typeof agreementsQuery
-  >['current'] extends { items: infer T } ? (T extends readonly (infer U)[] ? U : never) : never;
+  // Use the canonical row type from @codex/agreements directly. The earlier
+  // conditional `infer` chain collapsed to `never` under Vite SSR module-load
+  // cascades (see [[vite_ssr_module_load_cascade]]) when one of the
+  // intermediate imports failed; the explicit import is robust to that.
+  type ActiveAgreementRow = CreatorOrganizationAgreement;
 
   const activeAgreements = $derived(
     (agreementsQuery?.current?.items ?? []) as ActiveAgreementRow[]
@@ -89,6 +96,15 @@
         name: m.name ?? m.email,
         avatarUrl: m.avatarUrl,
       }))
+  );
+
+  // The org-members remote caps at 100 rows per page (no pagination UI
+  // here yet — TODO once orgs grow large enough). When we receive a full
+  // 100-row page, surface an inline note so owners with bigger teams
+  // aren't silently missing creators from the cards grid.
+  const MEMBERS_PAGE_CAP = 100;
+  const membersPageCapHit = $derived(
+    (membersQuery?.current?.items?.length ?? 0) >= MEMBERS_PAGE_CAP
   );
 
   /**
@@ -105,10 +121,14 @@
 
   // ─── Pie data ────────────────────────────────────────────────────────────
 
-  // Platform fee — read fresh from constants. Per Decision Q2, platform
-  // fee is the platform's operational lever, not snapshotted on agreements.
-  // 1000 bp = 10% (matches `FEES.PLATFORM_PERCENT` from @codex/constants).
-  const platformFeeBp = 1000;
+  // Illustrative — real payouts read from feeConfigService per WP-4 (the
+  // org may run a custom rate). Sourced here from @codex/constants so the
+  // default-rate display can't drift from the SDK constant. Per Decision
+  // Q2 the platform fee is the platform's operational lever, not
+  // snapshotted on agreements.
+  // TODO(codex-hrqz6 follow-up): pipe the live FeeConfigService rate to
+  // this remote so per-org overrides also show through here.
+  const platformFeeBp = FEES.PLATFORM_PERCENT;
 
   /**
    * Pie slices for the "Team Budget" overview. Each active creator on the
@@ -166,14 +186,14 @@
   let proposeCreatorId = $state<string | null>(null);
   let proposeCreatorName = $state('');
   let proposeRevenueType = $state<RevenueType>('subscription');
-  let proposeMode = $state<'propose' | 'amend'>('propose');
+  let proposeMode = $state<'propose' | 'amend' | 'counter'>('propose');
   let proposeInitialShareBp = $state(3000);
 
   function openProposeDialog(
     creatorId: string,
     creatorName: string,
     revenueType: RevenueType,
-    mode: 'propose' | 'amend',
+    mode: 'propose' | 'amend' | 'counter',
     initialShareBp = 3000
   ) {
     proposeCreatorId = creatorId;
@@ -414,6 +434,18 @@
           <a href="/studio/team">team page</a> to start a revenue-share agreement.
         </p>
       {:else}
+        {#if membersPageCapHit}
+          <p
+            class="revenue-share-page__cap-warning"
+            role="status"
+            aria-live="polite"
+          >
+            Showing the first {MEMBERS_PAGE_CAP} team members. Pagination
+            support is on the roadmap — until then, manage agreements for
+            additional creators via direct propose links from the
+            <a href="/studio/team">team page</a>.
+          </p>
+        {/if}
         <div class="revenue-share-page__cards-grid">
           {#each teamMembers as creator (creator.id)}
             <AgreementCard
@@ -458,10 +490,9 @@
             {@const sharePctDisplay = Number.isInteger(sharePct)
               ? `${sharePct}%`
               : `${sharePct.toFixed(1)}%`}
-            {@const revLabel =
-              agreement.revenueType === 'subscription'
-                ? 'subscription'
-                : 'content-purchase'}
+            {@const revLabel = formatRevenueTypeLabel(
+              agreement.revenueType as RevenueType
+            )}
             <li class="revenue-share-page__active-item">
               <div class="revenue-share-page__active-info">
                 <span class="revenue-share-page__active-creator">{creatorName}</span>
@@ -521,7 +552,7 @@
       creatorName={counterCreatorName}
       revenueType={counterRevenueType}
       initialShareBp={counterInitialShareBp}
-      mode="propose"
+      mode="counter"
       onSubmit={handleCounterSubmit}
     />
 
@@ -646,6 +677,21 @@
 
   .revenue-share-page__empty a {
     color: var(--color-interactive);
+    text-decoration: underline;
+  }
+
+  .revenue-share-page__cap-warning {
+    margin: 0 0 var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    background: var(--color-warning-50);
+    border: var(--border-width) var(--border-style) var(--color-warning-200);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    color: var(--color-warning-700);
+  }
+
+  .revenue-share-page__cap-warning a {
+    color: inherit;
     text-decoration: underline;
   }
 

--- a/packages/agreements/src/index.ts
+++ b/packages/agreements/src/index.ts
@@ -35,6 +35,7 @@ export {
   type CounterProposeInput,
   creatorShareFromLegacyOrgFee,
   type DeclineProposalInput,
+  formatRevenueTypeLabel,
   legacyOrgFeeFromCreatorShare,
   type ProposeAgreementInput,
   sumActiveCreatorShares,

--- a/packages/agreements/src/services/__tests__/agreement-math.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-math.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from 'vitest';
 import { ShareExceedsAvailableError } from '../../errors';
 import {
   creatorShareFromLegacyOrgFee,
+  formatRevenueTypeLabel,
   legacyOrgFeeFromCreatorShare,
   sumActiveCreatorShares,
   validateProposedShare,
@@ -240,5 +241,19 @@ describe('agreement-math.creatorShareFromLegacyOrgFee', () => {
         creatorShareFromLegacyOrgFee(legacyOrgFeeFromCreatorShare(share))
       ).toBe(share);
     }
+  });
+});
+
+describe('agreement-math.formatRevenueTypeLabel', () => {
+  it('returns "subscription" for the subscription revenue type', () => {
+    expect(formatRevenueTypeLabel('subscription')).toBe('subscription');
+  });
+
+  it('returns the hyphenated "content-purchase" for content_purchase', () => {
+    // Hyphen, not space — matches the revenue_type enum value the schema
+    // stores, the email template subject lines, and the studio/creator UI
+    // copy. Catches any future drift where this collapses to the value
+    // with a space.
+    expect(formatRevenueTypeLabel('content_purchase')).toBe('content-purchase');
   });
 });

--- a/packages/agreements/src/services/agreement-math.ts
+++ b/packages/agreements/src/services/agreement-math.ts
@@ -177,3 +177,17 @@ export function legacyOrgFeeFromCreatorShare(
 export function creatorShareFromLegacyOrgFee(orgFeePercent: number): number {
   return BPS_MAX - orgFeePercent;
 }
+
+/**
+ * Canonical human-readable label for a {@link RevenueType}. Centralised so
+ * email templates (AgreementService), the studio UI (AgreementCard,
+ * NegotiationThread, ProposeAgreementDialog) and any future surface use
+ * the same string — "content-purchase" (hyphen) matches the enum value
+ * exactly and reads consistently across the product. English-only for
+ * now; i18n is a future scope (WP-5 brief).
+ */
+export function formatRevenueTypeLabel(
+  revenueType: 'subscription' | 'content_purchase'
+): string {
+  return revenueType === 'subscription' ? 'subscription' : 'content-purchase';
+}

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -64,6 +64,7 @@ import type {
 } from '../types';
 import {
   creatorShareFromLegacyOrgFee,
+  formatRevenueTypeLabel,
   legacyOrgFeeFromCreatorShare,
   validateProposedShare,
 } from './agreement-math';
@@ -1236,15 +1237,6 @@ export class AgreementService extends BaseService {
   }
 
   /**
-   * Map the schema's revenue_type enum to the human-readable label
-   * embedded in template subjects + bodies. English-only for now;
-   * i18n is a future scope per the WP-5 brief.
-   */
-  private formatRevenueTypeLabel(revenueType: RevenueType): string {
-    return revenueType === 'subscription' ? 'subscription' : 'content-purchase';
-  }
-
-  /**
    * Format a Date for display inside email body. ISO date (YYYY-MM-DD)
    * stays locale-neutral and machine-readable. The web UI can render
    * the absolute date in the recipient's timezone via the embedded
@@ -1397,7 +1389,7 @@ export class AgreementService extends BaseService {
       recipientName: recipient.name,
       orgName: orgName ?? 'Your organization',
       otherPartyName: counterparty?.name ?? 'The other party',
-      revenueTypeLabel: this.formatRevenueTypeLabel(params.revenueType),
+      revenueTypeLabel: formatRevenueTypeLabel(params.revenueType),
       sharePercentDisplay: this.formatSharePercent(params.sharePercent),
       termMonthsDisplay: this.formatTermMonths(params.termMonths),
       deepLinkUrl: this.buildNegotiationDeepLink(

--- a/packages/agreements/src/services/index.ts
+++ b/packages/agreements/src/services/index.ts
@@ -5,6 +5,7 @@
 export {
   type ActiveAgreementShareView,
   creatorShareFromLegacyOrgFee,
+  formatRevenueTypeLabel,
   legacyOrgFeeFromCreatorShare,
   sumActiveCreatorShares,
   type ValidateProposedShareInput,


### PR DESCRIPTION
## Summary

Closes Codex-hrqz6. Polish-only follow-up to WP-7 PR #215, addressing the 3 important findings + nits from review.

### Changes
- **Counter dialog mode**: `ProposeAgreementDialog` accepts `mode: 'propose' | 'amend' | 'counter'` with correct titles + submit labels. The counter dialog call site in `revenue-share/+page.svelte` now passes `mode='counter'` (previously misrendered as "Propose subscription agreement with…" while actually countering).
- **Pagination warning**: surface inline note when the 100-row team-member API page is hit so owners with larger teams aren't silently missing creators from the cards grid.
- **Platform fee constant**: illustrative pie now reads `FEES.PLATFORM_PERCENT` from `@codex/constants` instead of a magic `1000` literal. Comment + TODO point at WP-4's `FeeConfigService` as the future source for per-org overrides.
- **Copy consistency**: shared `formatRevenueTypeLabel` helper added to `@codex/agreements` and consumed by AgreementCard, NegotiationThread, ProposeAgreementDialog, CounterProposalDialog, and the revenue-share page. The previous duplicate private method in `AgreementService` now calls the shared export. "content-purchase" (hyphen) used everywhere — matches the `revenue_type` enum value.
- **CSS hygiene**: dropped redundant `var(--opacity-60, 0.6)` fallback in NegotiationThread (token always exists).
- **Type robustness**: `ActiveAgreementRow` uses a direct `CreatorOrganizationAgreement` import in `+page.svelte` instead of the brittle conditional `infer` chain that could collapse to `never` under Vite SSR module-load cascades.

### Tests
- Added 2 unit tests for `formatRevenueTypeLabel` (subscription + content_purchase).
- Updated AgreementCard test assertion to expect the hyphenated copy.
- All 38 agreements component tests pass; all 23 agreement-math unit tests pass; web app build clean.

## Base branch

Stacks on `feat/codex-bw2wf-creator-ui` (WP-8). Same level as WP-9 / WP-10 / WP-11.

Bead: Codex-hrqz6
Epic: Codex-nk4km