### PR TITLE
fix(payouts): WP-4 polish — extract owner fallback, pin Date, enrich payout logs

### DIFF
--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,6 +1,6 @@
 # Codex Packages
 
-22 packages across 3 layers: Foundation, Service, Utility.
+23 packages across 3 layers: Foundation, Service, Utility.
 
 ## Package Registry
 
@@ -21,6 +21,7 @@
 | **@codex/organization** | Org CRUD, membership | `OrganizationService` | [organization/CLAUDE.md](organization/CLAUDE.md) |
 | **@codex/identity** | User profiles, identity | `IdentityService` | [identity/CLAUDE.md](identity/CLAUDE.md) |
 | **@codex/access** | Access control, signed URLs, playback | `ContentAccessService` | [access/CLAUDE.md](access/CLAUDE.md) |
+| **@codex/agreements** | Revenue-share agreement state machine (Codex-nk4km) | `AgreementService`, `validateProposedShare` | [agreements/CLAUDE.md](agreements/CLAUDE.md) |
 | **@codex/purchase** | Stripe one-time checkout, purchase history | `PurchaseService`, `createStripeClient` | [purchase/CLAUDE.md](purchase/CLAUDE.md) |
 | **@codex/subscription** | Subscription tiers, Stripe Connect, revenue splits | `TierService`, `SubscriptionService`, `ConnectAccountService`, `calculateRevenueSplit` | [subscription/CLAUDE.md](subscription/CLAUDE.md) |
 | **@codex/notifications** | Email templates, sending | `NotificationsService`, `TemplateService`, `NotificationPreferencesService` | [notifications/CLAUDE.md](notifications/CLAUDE.md) |
@@ -51,8 +52,9 @@ Services (depend on Foundation):
   organization → database, service-errors, validation
   identity     → database, service-errors, validation, cloudflare-clients, cache
   access       → database, service-errors, cloudflare-clients, purchase
-  purchase     → database, service-errors, validation (+ Stripe SDK)
-  subscription → database, service-errors, validation, constants (+ Stripe SDK)
+  agreements   → database, service-errors, validation, shared-types, observability, constants
+  purchase     → database, service-errors, validation, agreements (+ Stripe SDK)
+  subscription → database, service-errors, validation, constants, agreements (+ Stripe SDK)
   notifications→ database, service-errors, validation, platform-settings
   admin        → database, service-errors
   transcoding  → database, service-errors, cloudflare-clients
@@ -79,6 +81,7 @@ Utilities (used by Workers and Services):
 | Org settings (branding, features, contact) | `@codex/platform-settings` |
 | One-time purchases, purchase history | `@codex/purchase` |
 | Subscription tiers, billing, Stripe Connect | `@codex/subscription` |
+| Revenue-share agreements, proposal state machine | `@codex/agreements` |
 | Send emails, manage templates | `@codex/notifications` |
 | Transcode media, R2 key builders | `@codex/transcoding` |
 | Admin analytics, content moderation | `@codex/admin` |

--- a/packages/agreements/src/services/__tests__/agreement-service.test.ts
+++ b/packages/agreements/src/services/__tests__/agreement-service.test.ts
@@ -1459,113 +1459,13 @@ describe('AgreementService', () => {
       expect(results).toHaveLength(0);
     });
 
-    it('getActiveAgreement (singular): returns matching active row', async () => {
-      const fx = await seedOrgFixture(db);
-      await db.insert(schema.creatorOrganizationAgreements).values({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        organizationFeePercentage: 7000,
-        revenueType: 'content_purchase',
-        status: 'active',
-      });
-      const result = await service.getActiveAgreement({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        revenueType: 'content_purchase',
-      });
-      expect(result).not.toBeNull();
-      expect(result?.creatorId).toBe(fx.creatorAId);
-      expect(result?.revenueType).toBe('content_purchase');
-    });
-
-    it('getActiveAgreement: returns null when no matching agreement', async () => {
-      const fx = await seedOrgFixture(db);
-      const result = await service.getActiveAgreement({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        revenueType: 'subscription',
-      });
-      expect(result).toBeNull();
-    });
-
-    it('getActiveAgreement: wrong revenueType returns null', async () => {
-      const fx = await seedOrgFixture(db);
-      await db.insert(schema.creatorOrganizationAgreements).values({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        organizationFeePercentage: 7000,
-        revenueType: 'subscription',
-        status: 'active',
-      });
-      const result = await service.getActiveAgreement({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        revenueType: 'content_purchase',
-      });
-      expect(result).toBeNull();
-    });
-
-    it('getActiveAgreement: terminated before activeAt returns null', async () => {
-      const fx = await seedOrgFixture(db);
-      const invoiceAt = new Date('2026-01-15T00:00:00Z');
-      await db.insert(schema.creatorOrganizationAgreements).values({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        organizationFeePercentage: 7000,
-        revenueType: 'subscription',
-        status: 'terminated',
-        terminatedAt: new Date('2026-01-10T00:00:00Z'),
-        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
-      });
-      const result = await service.getActiveAgreement({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        revenueType: 'subscription',
-        activeAt: invoiceAt,
-      });
-      expect(result).toBeNull();
-    });
-
-    it('getActiveAgreement: terminated AFTER activeAt still returns the agreement (Q3)', async () => {
-      const fx = await seedOrgFixture(db);
-      const invoiceAt = new Date('2026-01-15T00:00:00Z');
-      await db.insert(schema.creatorOrganizationAgreements).values({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        organizationFeePercentage: 7000,
-        revenueType: 'subscription',
-        status: 'terminated',
-        terminatedAt: new Date('2026-01-20T00:00:00Z'), // terminated AFTER invoice
-        effectiveFrom: new Date('2025-12-01T00:00:00Z'),
-      });
-      const result = await service.getActiveAgreement({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        revenueType: 'subscription',
-        activeAt: invoiceAt,
-      });
-      expect(result).not.toBeNull();
-    });
-
-    it('getActiveAgreement: effective_from > activeAt returns null (not yet active)', async () => {
-      const fx = await seedOrgFixture(db);
-      const invoiceAt = new Date('2026-01-15T00:00:00Z');
-      await db.insert(schema.creatorOrganizationAgreements).values({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        organizationFeePercentage: 7000,
-        revenueType: 'subscription',
-        status: 'active',
-        effectiveFrom: new Date('2026-02-01T00:00:00Z'),
-      });
-      const result = await service.getActiveAgreement({
-        organizationId: fx.orgId,
-        creatorId: fx.creatorAId,
-        revenueType: 'subscription',
-        activeAt: invoiceAt,
-      });
-      expect(result).toBeNull();
-    });
+    // Codex-xz61z (I6): `getActiveAgreement` (singular) was dropped —
+    // no production consumer wired it up (the purchase pipeline still
+    // hand-rolls its own transaction-scoped JOIN with `tx`), and the
+    // plural `getActiveAgreements` + `getActiveAgreementsForCreator`
+    // cover the read patterns the service exposes today. The singular
+    // form can be reintroduced with `{ agreement, sharePercent }`
+    // when a non-transaction consumer needs it.
 
     it('getActiveAgreementsForCreator: revenueType filter scopes the portfolio', async () => {
       const fx = await seedOrgFixture(db);

--- a/packages/agreements/src/services/agreement-service.ts
+++ b/packages/agreements/src/services/agreement-service.ts
@@ -1038,57 +1038,6 @@ export class AgreementService extends BaseService {
   }
 
   /**
-   * Single active agreement for one (org, creator, revenueType) triple,
-   * if any. Mirrors the partial unique
-   * `uq_creator_org_agreement_active_per_type` invariant — at most one
-   * row can be returned. Returns `null` when no active agreement
-   * matches.
-   *
-   * Used by the WP-4 content-purchase payout path (Codex-rzfjw): the
-   * uploader (`content.creatorId`) is looked up against their
-   * `revenueType='content_purchase'` agreement at purchase time
-   * (Decision Q1 — creator's-own-content scope).
-   *
-   * `activeAt` semantics match {@link getActiveAgreements}.
-   */
-  async getActiveAgreement(input: {
-    organizationId: string;
-    creatorId: string;
-    revenueType: RevenueType;
-    activeAt?: Date;
-  }): Promise<CreatorOrganizationAgreement | null> {
-    try {
-      const at = input.activeAt ?? new Date();
-      const row = await this.db.query.creatorOrganizationAgreements.findFirst({
-        where: and(
-          eq(
-            creatorOrganizationAgreements.organizationId,
-            input.organizationId
-          ),
-          eq(creatorOrganizationAgreements.creatorId, input.creatorId),
-          eq(creatorOrganizationAgreements.revenueType, input.revenueType),
-          // Q3 semantics (see getActiveAgreements above):
-          or(
-            eq(creatorOrganizationAgreements.status, 'active'),
-            and(
-              eq(creatorOrganizationAgreements.status, 'terminated'),
-              gt(creatorOrganizationAgreements.terminatedAt, at)
-            )
-          ),
-          lte(creatorOrganizationAgreements.effectiveFrom, at),
-          or(
-            isNull(creatorOrganizationAgreements.effectiveUntil),
-            gt(creatorOrganizationAgreements.effectiveUntil, at)
-          )
-        ),
-      });
-      return row ?? null;
-    } catch (error) {
-      this.handleError(error, 'getActiveAgreement');
-    }
-  }
-
-  /**
    * Creator's portfolio across all orgs — used by the creator-studio
    * /negotiations page. Filters to `status='active'` only with the same
    * temporal predicates as {@link getActiveAgreements}.

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -558,6 +558,15 @@ export class PurchaseService extends BaseService {
         // .proposedCreatorSharePercent` via `current_proposal_id` so
         // this read works for both pre-WP-1 backfilled rows (migration
         // 0072 synthesised a proposal) and new agreements.
+        //
+        // Codex-xz61z (I5): pin `purchasedAt` once and reuse in all
+        // three Q3 predicates. Previously three `new Date()` calls
+        // could produce slightly different millisecond values when
+        // executed back-to-back, which is harmless in practice but
+        // makes the predicate non-deterministic — webhook replays
+        // can land on the wrong side of an agreement boundary that
+        // occurred mid-millisecond.
+        const purchasedAt = new Date();
         const [agreementRow] = await tx
           .select({
             sharePercent: agreementProposals.proposedCreatorSharePercent,
@@ -585,13 +594,13 @@ export class PurchaseService extends BaseService {
                 eq(creatorOrganizationAgreements.status, 'active'),
                 and(
                   eq(creatorOrganizationAgreements.status, 'terminated'),
-                  gt(creatorOrganizationAgreements.terminatedAt, new Date())
+                  gt(creatorOrganizationAgreements.terminatedAt, purchasedAt)
                 )
               ),
-              lte(creatorOrganizationAgreements.effectiveFrom, new Date()),
+              lte(creatorOrganizationAgreements.effectiveFrom, purchasedAt),
               or(
                 isNull(creatorOrganizationAgreements.effectiveUntil),
-                gt(creatorOrganizationAgreements.effectiveUntil, new Date())
+                gt(creatorOrganizationAgreements.effectiveUntil, purchasedAt)
               )
             )
           )

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -15,6 +15,7 @@
  * - Stripe v19 shapes for period dates and invoice payments
  */
 
+import { CURRENCY } from '@codex/constants';
 import * as schema from '@codex/database/schema';
 import {
   creatorOrganizationAgreements,
@@ -4235,6 +4236,13 @@ describe('SubscriptionService', () => {
         return opts?.idempotencyKey === `${chargeId}_creator_pool_owner`;
       });
       expect(ownerFallbackCalls).toHaveLength(1);
+      // Codex-xz61z (N3): pin GBP on the zero-share fallback transfer.
+      // The pipeline is GBP-only (Codex-yv18n) — assert at the call
+      // boundary so any drift to USD/EUR fails the test fast.
+      const transferParams = ownerFallbackCalls[0]?.[0] as
+        | { currency?: string }
+        | undefined;
+      expect(transferParams?.currency).toBe(CURRENCY.GBP);
     });
 
     // Codex-ez3tl (I3): ghost-agreement guard

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -3904,6 +3904,121 @@ export class SubscriptionService extends BaseService {
   }
 
   /**
+   * Codex-xz61z (I2): shared owner-fallback for the two zero-creator-payout
+   * branches in `executeTransfers`:
+   *
+   *   1. The "empty agreements" branch (no rows matched the Q3 filter).
+   *   2. The "all zero-share" branch (rows matched but `totalShareBps == 0`).
+   *
+   * Both routes the entire creator pool to the org owner via a single
+   * `creator_payout_to_owner` transfer + ledger row. They share an
+   * idempotency key (`${chargeId}_creator_pool_owner`) so a webhook
+   * replay collapses to one Stripe transfer regardless of which branch
+   * fires on the replay.
+   *
+   * `logContext` is appended to ledger-error log messages so the
+   * branch is identifiable in observability without duplicating the
+   * code path.
+   *
+   * If `orgConnect` is missing or `chargesEnabled === false`, the
+   * helper exits silently — the upstream org-fee transfer block above
+   * already accumulated a pending payout for the same Connect account,
+   * which is the correct end state.
+   */
+  private async transferCreatorPoolToOwner(
+    subscriptionId: string,
+    orgId: string,
+    chargeId: string,
+    transferGroup: string,
+    creatorPayoutCents: number,
+    orgConnect:
+      | { userId: string; stripeAccountId: string; chargesEnabled: boolean }
+      | null
+      | undefined,
+    logContext: string
+  ): Promise<void> {
+    if (!orgConnect?.chargesEnabled || creatorPayoutCents <= 0) {
+      return;
+    }
+    try {
+      const transfer = await this.stripe.transfers.create(
+        {
+          amount: creatorPayoutCents,
+          currency: CURRENCY.GBP,
+          destination: orgConnect.stripeAccountId,
+          source_transaction: chargeId,
+          transfer_group: transferGroup,
+          metadata: {
+            subscription_id: subscriptionId,
+            type: 'creator_payout_to_owner',
+          },
+        },
+        { idempotencyKey: `${chargeId}_creator_pool_owner` }
+      );
+      try {
+        await this.db.insert(payouts).values({
+          userId: orgConnect.userId,
+          organizationId: orgId,
+          subscriptionId,
+          amountCents: creatorPayoutCents,
+          payoutType: 'creator_payout_to_owner',
+          status: 'paid',
+          stripeTransferId: transfer.id,
+          stripeChargeId: chargeId,
+          transferGroup,
+          resolvedAt: new Date(),
+        });
+      } catch (insertError) {
+        if (!isUniqueViolation(insertError)) {
+          this.obs.error(
+            `Creator-pool transfer to owner succeeded but payouts ledger insert failed (${logContext})`,
+            {
+              subscriptionId,
+              organizationId: orgId,
+              stripeTransferId: transfer.id,
+              amountCents: creatorPayoutCents,
+              error: (insertError as Error).message,
+            }
+          );
+        }
+      }
+    } catch (transferError) {
+      this.obs.error(
+        `Creator pool transfer to owner failed (${logContext}), accumulating`,
+        {
+          subscriptionId,
+          organizationId: orgId,
+          amountCents: creatorPayoutCents,
+          error: (transferError as Error).message,
+        }
+      );
+      // BUG-036: Wrap pending payout insert in try/catch so a DB failure
+      // doesn't crash the entire transfer flow.
+      try {
+        await this.db.insert(payouts).values({
+          userId: orgConnect.userId,
+          organizationId: orgId,
+          subscriptionId,
+          amountCents: creatorPayoutCents,
+          payoutType: 'creator_payout_to_owner',
+          status: 'failed',
+          reason: 'transfer_failed',
+        });
+      } catch (insertError) {
+        this.obs.error(
+          `Failed to record pending payout for creator pool to owner (${logContext})`,
+          {
+            subscriptionId,
+            organizationId: orgId,
+            amountCents: creatorPayoutCents,
+            error: (insertError as Error).message,
+          }
+        );
+      }
+    }
+  }
+
+  /**
    * Execute revenue transfers to org and creator(s) after invoice payment.
    * Uses source_transaction to link transfers to the charge.
    * Creators without active Connect accounts have their share accumulated.
@@ -4212,86 +4327,17 @@ export class SubscriptionService extends BaseService {
 
     if (creatorAgreements.length === 0) {
       // No creator agreements — org owner gets the full creator pool
-      // (Already handled by org transfer above or accumulated)
-      // Transfer remaining to the org Connect account as creator payout
-      if (orgConnect?.chargesEnabled && creatorPayoutCents > 0) {
-        try {
-          const transfer = await this.stripe.transfers.create(
-            {
-              amount: creatorPayoutCents,
-              currency: CURRENCY.GBP,
-              destination: orgConnect.stripeAccountId,
-              source_transaction: chargeId,
-              transfer_group: transferGroup,
-              metadata: {
-                subscription_id: subscriptionId,
-                type: 'creator_payout_to_owner',
-              },
-            },
-            { idempotencyKey: `${chargeId}_creator_pool_owner` }
-          );
-          try {
-            await this.db.insert(payouts).values({
-              userId: orgConnect.userId,
-              organizationId: orgId,
-              subscriptionId,
-              amountCents: creatorPayoutCents,
-              payoutType: 'creator_payout_to_owner',
-              status: 'paid',
-              stripeTransferId: transfer.id,
-              stripeChargeId: chargeId,
-              transferGroup,
-              resolvedAt: new Date(),
-            });
-          } catch (insertError) {
-            if (!isUniqueViolation(insertError)) {
-              this.obs.error(
-                'Creator-pool transfer to owner succeeded but payouts ledger insert failed',
-                {
-                  subscriptionId,
-                  organizationId: orgId,
-                  stripeTransferId: transfer.id,
-                  amountCents: creatorPayoutCents,
-                  error: (insertError as Error).message,
-                }
-              );
-            }
-          }
-        } catch (transferError) {
-          this.obs.error(
-            'Creator pool transfer to owner failed, accumulating',
-            {
-              subscriptionId,
-              organizationId: orgId,
-              amountCents: creatorPayoutCents,
-              error: (transferError as Error).message,
-            }
-          );
-          // BUG-036: Wrap pending payout insert in try/catch so a DB failure
-          // doesn't crash the entire transfer flow.
-          try {
-            await this.db.insert(payouts).values({
-              userId: orgConnect.userId,
-              organizationId: orgId,
-              subscriptionId,
-              amountCents: creatorPayoutCents,
-              payoutType: 'creator_payout_to_owner',
-              status: 'failed',
-              reason: 'transfer_failed',
-            });
-          } catch (insertError) {
-            this.obs.error(
-              'Failed to record pending payout for creator pool to owner',
-              {
-                subscriptionId,
-                organizationId: orgId,
-                amountCents: creatorPayoutCents,
-                error: (insertError as Error).message,
-              }
-            );
-          }
-        }
-      }
+      // (Already handled by org transfer above or accumulated).
+      // Codex-xz61z (I2): delegate to the shared helper.
+      await this.transferCreatorPoolToOwner(
+        subscriptionId,
+        orgId,
+        chargeId,
+        transferGroup,
+        creatorPayoutCents,
+        orgConnect,
+        'empty_agreements'
+      );
       return;
     }
 
@@ -4314,89 +4360,21 @@ export class SubscriptionService extends BaseService {
           agreementCount: creatorAgreements.length,
         }
       );
-      // Effectively the same as the empty-agreements branch above.
-      // Recurse-via-fallthrough is messy here; re-enter the empty
-      // branch path by zeroing creatorAgreements and breaking out.
-      creatorAgreements.length = 0;
-      // Re-route to the org owner using the same idempotency key as
-      // the empty branch. Inline (not a function call) to keep the
-      // method's shape recognisable.
-      if (orgConnect?.chargesEnabled && creatorPayoutCents > 0) {
-        try {
-          const transfer = await this.stripe.transfers.create(
-            {
-              amount: creatorPayoutCents,
-              currency: CURRENCY.GBP,
-              destination: orgConnect.stripeAccountId,
-              source_transaction: chargeId,
-              transfer_group: transferGroup,
-              metadata: {
-                subscription_id: subscriptionId,
-                type: 'creator_payout_to_owner',
-              },
-            },
-            { idempotencyKey: `${chargeId}_creator_pool_owner` }
-          );
-          try {
-            await this.db.insert(payouts).values({
-              userId: orgConnect.userId,
-              organizationId: orgId,
-              subscriptionId,
-              amountCents: creatorPayoutCents,
-              payoutType: 'creator_payout_to_owner',
-              status: 'paid',
-              stripeTransferId: transfer.id,
-              stripeChargeId: chargeId,
-              transferGroup,
-              resolvedAt: new Date(),
-            });
-          } catch (insertError) {
-            if (!isUniqueViolation(insertError)) {
-              this.obs.error(
-                'Creator-pool transfer to owner succeeded but payouts ledger insert failed (zero-share branch)',
-                {
-                  subscriptionId,
-                  organizationId: orgId,
-                  stripeTransferId: transfer.id,
-                  amountCents: creatorPayoutCents,
-                  error: (insertError as Error).message,
-                }
-              );
-            }
-          }
-        } catch (transferError) {
-          this.obs.error(
-            'Creator pool transfer to owner failed (zero-share branch), accumulating',
-            {
-              subscriptionId,
-              organizationId: orgId,
-              amountCents: creatorPayoutCents,
-              error: (transferError as Error).message,
-            }
-          );
-          try {
-            await this.db.insert(payouts).values({
-              userId: orgConnect.userId,
-              organizationId: orgId,
-              subscriptionId,
-              amountCents: creatorPayoutCents,
-              payoutType: 'creator_payout_to_owner',
-              status: 'failed',
-              reason: 'transfer_failed',
-            });
-          } catch (insertError) {
-            this.obs.error(
-              'Failed to record pending payout for zero-share fallback',
-              {
-                subscriptionId,
-                organizationId: orgId,
-                amountCents: creatorPayoutCents,
-                error: (insertError as Error).message,
-              }
-            );
-          }
-        }
-      }
+      // Codex-xz61z (I2): delegate to the shared helper. Same
+      // idempotency key as the empty-agreements branch so a webhook
+      // replay still collapses to one Stripe transfer regardless of
+      // which branch fires on the replay.
+      // Codex-xz61z (N1): dropped dead `creatorAgreements.length = 0;`
+      // mutation — the function returns immediately below, no reader.
+      await this.transferCreatorPoolToOwner(
+        subscriptionId,
+        orgId,
+        chargeId,
+        transferGroup,
+        creatorPayoutCents,
+        orgConnect,
+        'zero_share'
+      );
       return;
     }
 
@@ -4430,22 +4408,25 @@ export class SubscriptionService extends BaseService {
         (postPlatformCents * agreement.sharePercent) / shareDivisor
       );
 
-      // Codex-rzfjw: per-creator split observability. Emit one
-      // structured event per agreement so the payout pipeline is
-      // auditable end-to-end (creator → amount → agreement share).
-      this.obs.info('payout_split_computed', {
-        subscriptionId,
-        organizationId: orgId,
-        creatorId: agreement.creatorId,
-        amountCents: creatorAmount,
-        sharePercent: agreement.sharePercent,
-        totalShareBps,
-        postPlatformCents,
-        effectiveOrgFeeCents,
-        effectiveCreatorPoolCents,
-      });
-
-      if (creatorAmount <= 0) continue;
+      // Codex-xz61z (I4): emit `payout_split_skipped` for iterations
+      // that never reach the transfer call. The previous code emitted
+      // `payout_split_computed` BEFORE the zero-amount + min-transfer
+      // gates, which made the log misleading — it claimed an amount
+      // was paid out when it was actually skipped or accumulated as
+      // pending. Each iteration now emits exactly one log line whose
+      // shape matches the iteration's terminal state.
+      if (creatorAmount <= 0) {
+        this.obs.info('payout_split_skipped', {
+          subscriptionId,
+          organizationId: orgId,
+          creatorId: agreement.creatorId,
+          amountCents: creatorAmount,
+          sharePercent: agreement.sharePercent,
+          totalShareBps,
+          pendingReason: 'zero_amount',
+        });
+        continue;
+      }
 
       // Codex-m644n: per-creator min-transfer floor. Walk the override chain
       // for this specific (org, creator) pair — Creator A and Creator B can
@@ -4464,6 +4445,18 @@ export class SubscriptionService extends BaseService {
           creatorId: agreement.creatorId,
           amountCents: creatorAmount,
           minTransferCents: creatorFees.minTransferCents,
+        });
+        // Codex-xz61z (I4): tagged-skip log so split-vs-transfer
+        // accounting can be reconstructed from observability alone.
+        this.obs.info('payout_split_skipped', {
+          subscriptionId,
+          organizationId: orgId,
+          creatorId: agreement.creatorId,
+          amountCents: creatorAmount,
+          sharePercent: agreement.sharePercent,
+          totalShareBps,
+          minTransferCents: creatorFees.minTransferCents,
+          pendingReason: 'min_transfer_floor',
         });
         try {
           await this.db.insert(payouts).values({
@@ -4492,6 +4485,8 @@ export class SubscriptionService extends BaseService {
       const creatorConnect = connectByCreator.get(agreement.creatorId);
 
       if (creatorConnect?.chargesEnabled) {
+        let transferred = false;
+        let pendingReason: string | undefined;
         try {
           const transfer = await this.stripe.transfers.create(
             {
@@ -4508,6 +4503,7 @@ export class SubscriptionService extends BaseService {
             },
             { idempotencyKey: `${chargeId}_creator_${agreement.creatorId}` }
           );
+          transferred = true;
           try {
             await this.db.insert(payouts).values({
               userId: agreement.creatorId,
@@ -4536,6 +4532,7 @@ export class SubscriptionService extends BaseService {
             }
           }
         } catch (transferError) {
+          pendingReason = 'transfer_failed';
           this.obs.error('Creator transfer failed, accumulating as pending', {
             subscriptionId,
             creatorId: agreement.creatorId,
@@ -4566,10 +4563,30 @@ export class SubscriptionService extends BaseService {
             );
           }
         }
+        // Codex-xz61z (I4): emit `payout_split_computed` AFTER the
+        // transfer attempt so `actuallyTransferred` reflects the
+        // terminal state of the iteration. `pendingReason` is set
+        // when the transfer failed and the row was accumulated.
+        this.obs.info('payout_split_computed', {
+          subscriptionId,
+          organizationId: orgId,
+          creatorId: agreement.creatorId,
+          amountCents: creatorAmount,
+          sharePercent: agreement.sharePercent,
+          totalShareBps,
+          postPlatformCents,
+          effectiveOrgFeeCents,
+          effectiveCreatorPoolCents,
+          actuallyTransferred: transferred,
+          pendingReason,
+        });
       } else {
         // Accumulate pending payout
         // BUG-036: Wrap pending payout insert in try/catch so a DB failure
         // doesn't crash the entire transfer flow.
+        const pendingReason = creatorConnect
+          ? 'connect_restricted'
+          : 'connect_not_ready';
         try {
           await this.db.insert(payouts).values({
             userId: agreement.creatorId,
@@ -4578,7 +4595,7 @@ export class SubscriptionService extends BaseService {
             amountCents: creatorAmount,
             payoutType: 'creator_payout',
             status: 'pending',
-            reason: creatorConnect ? 'connect_restricted' : 'connect_not_ready',
+            reason: pendingReason,
           });
         } catch (insertError) {
           this.obs.error(
@@ -4596,6 +4613,22 @@ export class SubscriptionService extends BaseService {
           creatorId: agreement.creatorId,
           amountCents: creatorAmount,
           subscriptionId,
+        });
+        // Codex-xz61z (I4): emit `payout_split_computed` for the
+        // Connect-not-ready path so the per-creator audit log
+        // captures every iteration, with `actuallyTransferred=false`.
+        this.obs.info('payout_split_computed', {
+          subscriptionId,
+          organizationId: orgId,
+          creatorId: agreement.creatorId,
+          amountCents: creatorAmount,
+          sharePercent: agreement.sharePercent,
+          totalShareBps,
+          postPlatformCents,
+          effectiveOrgFeeCents,
+          effectiveCreatorPoolCents,
+          actuallyTransferred: false,
+          pendingReason,
         });
       }
     }


### PR DESCRIPTION
## Summary

Closes Codex-xz61z. Polish-only follow-up to WP-4 PR #212. No money-correctness changes; all transfers still GBP-only with the same idempotency keys.

### Changes (per WP-4 review)
- **I2**: Extracted duplicated owner-fallback into a private `transferCreatorPoolToOwner` helper (~100 LOC near-byte-identical between empty-agreements + zero-share branches collapsed to one helper + two branch-tagged callers).
- **I4**: Moved `payout_split_computed` log AFTER the zero-amount + min-transfer-floor checks; added `actuallyTransferred` + `pendingReason` fields. Introduced `payout_split_skipped` log for the skipped paths (`zero_amount`, `min_transfer_floor`).
- **I5**: Pinned `purchasedAt = new Date()` once in the content-purchase Q3 filter; reused in all three temporal predicates (`terminatedAt`, `effectiveFrom`, `effectiveUntil`). Removes a sub-millisecond non-determinism that could let webhook replays land on the wrong side of an agreement boundary.
- **I6**: Dropped `AgreementService.getActiveAgreement` (singular) — no production consumer (purchase pipeline still hand-rolls a `tx`-scoped JOIN). 5 tests removed + replaced with a rationale comment so a future consumer knows to reintroduce with `{ agreement, sharePercent }` return shape.
- **N1**: Dropped dead `creatorAgreements.length = 0;` mutation in the zero-share branch — function returns immediately below it.
- **N2**: Updated `packages/CLAUDE.md`: registered `@codex/agreements` in the Services row + Dependency Graph + "Where Do I Find X?" table; recorded `purchase` + `subscription` depending on agreements; bumped 22→23 package count.
- **N3**: Pinned `expect(transferParams?.currency).toBe(CURRENCY.GBP)` on the zero-share fallback transfer in `WP-4: all-zero-share agreements fall through to "org keeps all" branch`.

### I6 resolution
**Dropped**, not extended. Rationale: the only candidate consumer (purchase pipeline at `purchase-service.ts:561`) runs inside a `tx` (transaction) and the service abstraction uses `this.db` (not the tx handle), so swapping the inline JOIN for a service call would change behaviour (transaction isolation). Extending to `{ agreement, sharePercent }` without a consumer is YAGNI. The rationale comment in the test file explicitly says reintroduce-with-share-shape when a non-transaction consumer materialises.

## Base branch
Stacks on `feat/codex-bw2wf-creator-ui` (WP-8). Sibling to WP-9 / WP-10 / WP-11 / WP-7-polish.

## Test plan
- [x] `pnpm --filter @codex/subscription typecheck` — no new errors in `subscription-service.ts` or its test (pre-existing `tier-service.ts` errors unrelated)
- [x] `pnpm --filter @codex/subscription test` — 379 pass / 1 pre-existing denoise-proof failure unrelated to changes (`F5-dup-bump-with-logger.test.ts` syntax error)
- [x] `pnpm --filter @codex/purchase typecheck` — clean
- [x] `pnpm --filter @codex/purchase test` — 220 / 220 pass
- [x] `pnpm --filter @codex/agreements typecheck` — clean
- [x] `pnpm --filter @codex/agreements test` — 84 / 84 pass (5 dropped tests removed)
- [x] `biome format --write` — no fixes applied

Bead: Codex-xz61z
Epic: Codex-nk4km