### PR TITLE
fix(ci): bootstrap-dev-env.sh bash 3.2 compatibility

### DIFF
--- a/.github/scripts/bootstrap-dev-env.sh
+++ b/.github/scripts/bootstrap-dev-env.sh
@@ -56,19 +56,20 @@ fi
 echo ""
 
 # Step 3: Set environment variables (per-environment overrides)
+# Bash 3.2 (macOS default) doesn't support associative arrays, so we use
+# inline calls instead of a loop. Each line is one gh variable set.
 echo "🔧 Step 3: Setting environment variables..."
-declare -A VARS=(
-  [DB_METHOD]="PRODUCTION"
-  [R2_BUCKET_MEDIA]="codex-media-dev"
-  [R2_BUCKET_ASSETS]="codex-assets-dev"
-  [R2_BUCKET_PLATFORM]="codex-platform-dev"
-  [R2_BUCKET_RESOURCES]="codex-resources-dev"
-)
-for KEY in "${!VARS[@]}"; do
-  VALUE="${VARS[$KEY]}"
+set_var() {
+  local KEY="$1"
+  local VALUE="$2"
   gh variable set "$KEY" --env "$ENV" --body "$VALUE" > /dev/null
   echo "   ✅ ${KEY} = ${VALUE}"
-done
+}
+set_var DB_METHOD "PRODUCTION"
+set_var R2_BUCKET_MEDIA "codex-media-dev"
+set_var R2_BUCKET_ASSETS "codex-assets-dev"
+set_var R2_BUCKET_PLATFORM "codex-platform-dev"
+set_var R2_BUCKET_RESOURCES "codex-resources-dev"
 echo ""
 
 # Step 4: Generate + set the three random secrets


### PR DESCRIPTION
## Bug

When running \`./.github/scripts/bootstrap-dev-env.sh\` on macOS, Step 3 fails:

\`\`\`
./.github/scripts/bootstrap-dev-env.sh: line 60: DB_METHOD: unbound variable
\`\`\`

## Root cause

macOS ships bash 3.2 as the default \`/bin/bash\`. The script's \`#!/usr/bin/env bash\` resolves to that 3.2 unless the user installed a newer bash via homebrew.

Bash 3.2 doesn't support associative arrays — \`declare -A\` was added in bash 4.0. The directive is silently ignored in 3.2, but the array literal \`([KEY]="value")\` still parses — just with completely different semantics:

- bash 4+: associative-array assignment, key=\`"DB_METHOD"\`
- bash 3.2: indexed-array assignment, index=\`$DB_METHOD\` (variable expansion)

With \`set -u\` (nounset, enabled at script top), expanding the unset \`$DB_METHOD\` errors out. The bug surfaces on line 60, after \`declare -A\` line 60-65 has silently no-op'd.

## Fix

Replaced Step 3's associative array + loop with a \`set_var()\` helper function and 5 inline calls:

\`\`\`bash
set_var() {
  local KEY=\"\$1\"
  local VALUE=\"\$2\"
  gh variable set \"\$KEY\" --env \"\$ENV\" --body \"\$VALUE\" > /dev/null
  echo \"   ✅ \${KEY} = \${VALUE}\"
}
set_var DB_METHOD \"PRODUCTION\"
set_var R2_BUCKET_MEDIA \"codex-media-dev\"
...
\`\`\`

No associative arrays, no version-dependent syntax. Portable to bash 3.2+.

Step 4 is already bash 3.2-compatible (regular \`for KEY in word1 word2 word3\` loop). Steps 1, 2, 5, 6, 7 don't use arrays at all.

## Test

- [x] \`bash -n .github/scripts/bootstrap-dev-env.sh\` — syntax OK
- [x] \`grep -n \"declare -A\\|\\[.*\\]=\"\` — no remaining associative array patterns
- [ ] After merge, re-run script on macOS — Step 3 completes through all 5 vars

## Idempotency note

When you re-run the script, Steps 1 and 2 are already complete from your previous attempt (env exists, dev branch policy already set) — they'll fast-succeed via their existing idempotency checks. Steps 3 onwards will execute fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)