### PR TITLE
fix(ci): CNAME→AAAA for dev DNS + paste-safety in bootstrap script

### DIFF
--- a/.github/scripts/bootstrap-dev-env.sh
+++ b/.github/scripts/bootstrap-dev-env.sh
@@ -82,6 +82,10 @@ done
 echo ""
 
 # Step 5: Prompt for Stripe test-mode key
+# Defensive: bracketed-paste mode in some terminals can eat the first
+# character of pasted input under `read`. We show a masked preview of
+# what was actually captured and require explicit confirmation before
+# uploading, so paste artefacts don't ship silently.
 echo "💳 Step 5: Stripe test-mode secret key"
 echo "   Get it from: https://dashboard.stripe.com/test/apikeys"
 echo "   Should start with sk_test_..."
@@ -90,6 +94,14 @@ echo ""
 if [[ ! "$STRIPE_KEY" =~ ^sk_test_ ]]; then
   echo "   ❌ That doesn't look like a test-mode key (should start with sk_test_)."
   echo "   Aborting to prevent accidentally uploading a live key."
+  exit 1
+fi
+# Show first 11 chars + last 4 so the user can verify what was captured
+PREVIEW="${STRIPE_KEY:0:11}…${STRIPE_KEY: -4}"
+echo "   Captured: ${PREVIEW}  (length ${#STRIPE_KEY})"
+read -r -p "   Does that look right? (y/n) " CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "   ❌ Aborted. Re-run the script when ready."
   exit 1
 fi
 echo "$STRIPE_KEY" | gh secret set STRIPE_SECRET_KEY --env "$ENV" --body -
@@ -103,6 +115,16 @@ echo "   or use a dev-specific bucket name (e.g. codex-media-dev)."
 read -r -p "   B2_BUCKET name: " B2_BUCKET
 if [ -z "$B2_BUCKET" ]; then
   echo "   ❌ Empty value rejected."
+  exit 1
+fi
+# Show what was captured so paste artefacts (e.g. bracketed-paste eating
+# the first character) don't ship silently. Real-world bite that
+# prompted this safeguard: typed `codex-media-dev`, captured
+# `odex-media-dev`, uploaded as B2_BUCKET before anyone noticed.
+echo "   Captured: [${B2_BUCKET}]"
+read -r -p "   Does that look right? (y/n) " CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "   ❌ Aborted. Re-run the script when ready."
   exit 1
 fi
 echo "$B2_BUCKET" | gh secret set B2_BUCKET --env "$ENV" --body -

--- a/.github/workflows/bootstrap-dev-infra.yml
+++ b/.github/workflows/bootstrap-dev-infra.yml
@@ -60,11 +60,15 @@ jobs:
               echo "✅ $B already exists"
             elif [ "$CREATE" = "true" ]; then
               echo "🌱 Creating $B..."
-              if curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
-                "$API" -d "{\"name\":\"$B\"}" > /dev/null; then
+              # Drop -f so we capture the body even on 4xx
+              RESPONSE=$(curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+                "$API" -d "{\"name\":\"$B\"}")
+              if echo "$RESPONSE" | jq -e '.success' > /dev/null 2>&1; then
                 echo "| $B | 🌱 created |" >> "$GITHUB_STEP_SUMMARY"
               else
-                echo "| $B | ❌ failed to create |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| $B | ❌ failed |" >> "$GITHUB_STEP_SUMMARY"
+                echo "❌ Failed to create R2 bucket $B. Full API response:"
+                echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
                 exit 1
               fi
             else
@@ -82,15 +86,19 @@ jobs:
           API="https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records"
           AUTH="Authorization: Bearer ${CF_DNS_TOKEN}"
 
-          # Records we need. Wildcards + apex CNAMEs proxied through Cloudflare
-          # so the orange-cloud terminator routes requests to the worker.
-          # Cloudflare workers don't accept A records — CNAMEs to the
-          # placeholder `100::` are the documented pattern for routes that
-          # are entirely served by Workers (the worker route bindings
-          # determine which worker handles the request).
+          # Records we need. For Cloudflare Workers zone_name routes (used
+          # by apps/web for the dev apex + wildcard), the documented
+          # placeholder pattern is an AAAA record pointing at `100::` —
+          # an IPv6 sink that ensures DNS resolution succeeds while the
+          # actual request routing happens via the Worker route binding.
+          #
+          # CNAME does NOT work here because CNAME content must be a
+          # hostname, not an IPv6 literal (Cloudflare API returns 400).
+          # A records also work with `192.0.2.1` (TEST-NET-1) but AAAA
+          # is the more common convention in Cloudflare docs.
           declare -A RECORDS=(
-            [dev.revelations.studio]=CNAME
-            [*.dev.revelations.studio]=CNAME
+            [dev.revelations.studio]=AAAA
+            [*.dev.revelations.studio]=AAAA
           )
           CONTENT="100::"
 
@@ -112,13 +120,16 @@ jobs:
               echo "✅ $NAME ($TYPE) already exists"
             elif [ "$CREATE" = "true" ]; then
               echo "🌱 Creating $NAME ($TYPE)..."
-              RESPONSE=$(curl -fsS -X POST -H "$AUTH" -H "Content-Type: application/json" \
+              # Drop -f so we capture the body even on 4xx; check .success
+              # afterwards. Without this, curl exits silently on error.
+              RESPONSE=$(curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
                 "$API" -d "{\"type\":\"$TYPE\",\"name\":\"$NAME\",\"content\":\"$CONTENT\",\"proxied\":true,\"ttl\":1}")
-              if echo "$RESPONSE" | jq -e '.success' > /dev/null; then
+              if echo "$RESPONSE" | jq -e '.success' > /dev/null 2>&1; then
                 echo "| $NAME | $TYPE | 🌱 created |" >> "$GITHUB_STEP_SUMMARY"
               else
                 echo "| $NAME | $TYPE | ❌ failed |" >> "$GITHUB_STEP_SUMMARY"
-                echo "Response: $RESPONSE"
+                echo "❌ Failed to create $NAME ($TYPE). Full API response:"
+                echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
                 exit 1
               fi
             else


### PR DESCRIPTION
## Two fixes from the first real run

### 1. \`bootstrap-dev-infra.yml\`: CNAME → AAAA

The DNS step failed with \`curl 400\` trying to create \`dev.revelations.studio\` and \`*.dev.revelations.studio\`. Root cause: CNAME records require a **hostname** as content, but I was passing the IPv6 literal \`100::\`.

The documented Cloudflare Workers placeholder pattern is **AAAA → \`100::\`**, not CNAME. AAAA accepts IPv6 literals natively. The actual request routing is still determined by the Worker route binding — the DNS record just needs to resolve so the request reaches Cloudflare's edge.

Also improved error capture: switched both R2 and DNS create paths from \`curl -fsS\` (silent exit on 4xx) to \`curl -sS\` with manual \`.success\` check + \`jq\` pretty-printing of the response body. Future API failures will show the real Cloudflare error message instead of \`Process completed with exit code 22\`.

### 2. \`bootstrap-dev-env.sh\`: paste-safety confirmations

Real bug from the run: I typed \`codex-media-dev\` at the B2_BUCKET prompt, but the variable received \`odex-media-dev\` (leading \`c\` eaten). Almost certainly bracketed-paste escape sequences interacting with bash's \`read\` builtin. The same issue could affect the Stripe key in Step 5, except \`read -s\` (silent) hides the captured value entirely.

Added \"show + confirm\" gates to both prompts:
- **Stripe key:** preview shows \`sk_test_5K1J…u09R\` (first 11 + last 4 chars). Enough to verify without exposing the full secret. Requires explicit \`y\` to proceed.
- **B2 bucket:** echoes the captured value verbatim. Requires \`y\`.

Either prompt aborts cleanly if the user types anything other than \`y\`.

## Why this PR targets \`main\` directly

The \`main-protection\` ruleset I created in step 7 of yesterday's bootstrap requires PRs to \`main\` come from \`dev\`. But \`dev\` branch doesn't exist yet — it can't, until DNS + R2 are ready and tested. Bootstrap chicken-and-egg.

One-time options to merge:
1. **\`gh pr merge --admin\`** — repo owner override (you have the permission). Justified here because the fix is to my own broken workflow infrastructure, blocking nothing else can land.
2. Temporarily disable \`main-protection\` ruleset.

After this merges and I successfully create \`dev\`, the protection model takes over and all future feature PRs target \`dev\` properly.

## Test plan

- [ ] \`gh workflow run \"Bootstrap Dev Infrastructure\"\` after merge — should now show both R2 buckets exist + both DNS records created
- [ ] Re-run \`./.github/scripts/bootstrap-dev-env.sh\` — prompts now show captured values + ask for confirmation before uploading
- [ ] No other workflows touched; existing prod deploy path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)