### PR TITLE
fix(ci): deploy-dev triggers on push, not workflow_run

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,10 +13,17 @@ name: Deploy to Dev
 #   - Created R2 buckets codex-{media,assets,platform,resources}-dev
 
 on:
-  workflow_run:
-    workflows: ["PR and Push CI (Neon ephemeral DB)"]
-    types:
-      - completed
+  # Trigger directly on push to dev. We don't use workflow_run because:
+  #   1. workflow_run executes from the default branch (main), so the
+  #      `environment: dev` branch policy correctly rejected main as a
+  #      non-`dev` source — making workflow_run incompatible with strict
+  #      env branch policies.
+  #   2. workflow_run's actions/checkout defaults to main's HEAD, so we'd
+  #      be deploying main's code, not dev's.
+  # Direct push trigger means the workflow runs on dev with dev's code
+  # checked out, and github.ref matches refs/heads/dev so the env policy
+  # is satisfied.
+  push:
     branches:
       - dev
   workflow_dispatch:
@@ -34,11 +41,6 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'dev')
     environment:
       name: dev
       url: https://dev.revelations.studio


### PR DESCRIPTION
## Bug

First deploy-dev run failed with:

\`\`\`
Branch \"main\" is not allowed to deploy to dev due to environment protection rules.
The deployment was rejected or didn't satisfy other protection rules.
\`\`\`

## Root cause

GitHub workflow_run triggers always execute from the **default** branch (main), not the branch that triggered the parent workflow. Two consequences:

1. **Environment branch policy conflict.** The \`dev\` GitHub environment has a branch policy restricting deploys to the \`dev\` branch only. But workflow_run runs from main, so the policy correctly rejected the deploy.

2. **Wrong code deployed.** \`actions/checkout@v4\` with no explicit ref clones the default branch (main). So even if the policy was permissive, the workflow would deploy main's code, not dev's.

## Fix

Switch trigger from \`workflow_run\` → \`push: branches: [dev]\`. Now:
- Workflow runs ON the dev branch
- \`github.ref\` = \`refs/heads/dev\`
- \`actions/checkout\` gets dev's HEAD
- Environment policy is satisfied

Also removed the now-redundant \`if:\` condition that checked \`workflow_run.event == 'push' && head_branch == 'dev'\` — the trigger itself enforces both.

## Trade-off

Deploys no longer gate on \`testing.yml\` success. For dev, this is acceptable:
- testing.yml still runs in parallel on every push to dev (it'll surface failures)
- Re-deploy cost is low (~10 min, retriggerable)
- Dev is the integration sandbox, not steady-state prod

Production unchanged — it uses workflow_run but \`main\` IS its default branch, so no context mismatch.

## Test plan

- [ ] Merge this PR to dev
- [ ] Push to dev triggers a fresh Deploy to Dev run on the dev branch
- [ ] Environment policy passes (\`github.ref\` matches \`refs/heads/dev\`)
- [ ] Workers + web actually deploy to \*.dev.revelations.studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)