### PR TITLE
fix(infra): remove path wildcards from custom_domain routes

### DIFF
--- a/workers/admin-api/wrangler.jsonc
+++ b/workers/admin-api/wrangler.jsonc
@@ -201,7 +201,7 @@
       ],
       "routes": [
         {
-          "pattern": "admin-api.dev.revelations.studio/*",
+          "pattern": "admin-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -145,7 +145,7 @@
       ],
       "routes": [
         {
-          "pattern": "auth.dev.revelations.studio/*",
+          "pattern": "auth.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -217,7 +217,7 @@
       ],
       "routes": [
         {
-          "pattern": "content-api.dev.revelations.studio/*",
+          "pattern": "content-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -170,7 +170,7 @@
       ],
       "routes": [
         {
-          "pattern": "ecom-api.dev.revelations.studio/*",
+          "pattern": "ecom-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -209,7 +209,7 @@
       ],
       "routes": [
         {
-          "pattern": "identity-api.dev.revelations.studio/*",
+          "pattern": "identity-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -242,7 +242,7 @@
       ],
       "routes": [
         {
-          "pattern": "media-api.dev.revelations.studio/*",
+          "pattern": "media-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -153,7 +153,7 @@
       ],
       "routes": [
         {
-          "pattern": "notifications-api.dev.revelations.studio/*",
+          "pattern": "notifications-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -210,7 +210,7 @@
       ],
       "routes": [
         {
-          "pattern": "organization-api.dev.revelations.studio/*",
+          "pattern": "organization-api.dev.revelations.studio",
           "custom_domain": true
         }
       ]


### PR DESCRIPTION
## Real cause of the CI 9106 errors

Local wrangler dry-run gave a clear error:

```
ERROR  Invalid Routes:
  auth.dev.revelations.studio/*:
    Wildcard operators (*) are not allowed in Custom Domains
    Paths are not allowed in Custom Domains
```

Cloudflare's API rejected the malformed routes server-side and returned **error code 9106** ("Authentication failed" — confusingly named). I went down a token-permissions rabbit hole based on the misleading code; the actual fix is much simpler.

## The constraint

`custom_domain: true` in wrangler routes claims an entire hostname for a worker (1-to-1 mapping). The `pattern` must be a bare hostname — no `/*`, no path, no wildcards. Path/wildcard routing requires `zone_name` instead (which apps/web correctly uses).

## What changed

8 worker env.dev blocks, all the same diff:

```diff
- "pattern": "<service>.dev.revelations.studio/*",
+ "pattern": "<service>.dev.revelations.studio",
  "custom_domain": true
```

Fixed: auth, admin-api, content-api, ecom-api, identity-api, media-api, notifications-api, organization-api.

Verified with `wrangler deploy --env dev --dry-run` locally — auth-worker now parses cleanly and shows correct bindings.

## Staging has the same bug

Out of scope for this PR. Staging configs were never successfully deployed (it's been dormant per project memory), so the bug hid there. File a follow-up if staging gets used.

## Test plan

- [x] `wrangler --dry-run` succeeds locally
- [ ] Push triggers Deploy to Dev — should get past media-api this time
- [ ] All 9 services + web deploy
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)