### PR TITLE
debug(ci): trace what wrangler is doing in CI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -171,18 +171,21 @@ jobs:
 
       # --- WORKER DEPLOYMENTS ---
 
-      - name: Deploy media-api
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: workers/media-api
-          command: >
-            deploy --env dev
-            --var R2_BUCKET_MEDIA:${{ vars.R2_BUCKET_MEDIA }}
-            --var R2_BUCKET_ASSETS:${{ vars.R2_BUCKET_ASSETS }}
-            --var R2_BUCKET_PLATFORM:${{ vars.R2_BUCKET_PLATFORM }}
-            --var R2_BUCKET_RESOURCES:${{ vars.R2_BUCKET_RESOURCES }}
+      - name: Deploy media-api (direct wrangler, with debug)
+        working-directory: workers/media-api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG: debug
+        run: |
+          echo "Account ID first 6 chars: $(printf '%s' "$CLOUDFLARE_ACCOUNT_ID" | head -c 6)..."
+          echo "Token first 10 chars: $(printf '%s' "$CLOUDFLARE_API_TOKEN" | head -c 10)..."
+          npx wrangler whoami || true
+          npx wrangler deploy --env dev \
+            --var "R2_BUCKET_MEDIA:${{ vars.R2_BUCKET_MEDIA }}" \
+            --var "R2_BUCKET_ASSETS:${{ vars.R2_BUCKET_ASSETS }}" \
+            --var "R2_BUCKET_PLATFORM:${{ vars.R2_BUCKET_PLATFORM }}" \
+            --var "R2_BUCKET_RESOURCES:${{ vars.R2_BUCKET_RESOURCES }}"
 
       - name: Upload media-api secrets
         run: .github/scripts/upload-worker-secrets.sh dev media-api


### PR DESCRIPTION
Locally same token + flags succeed, CI fails 9106. Adding WRANGLER_LOG=debug + acct/token prefixes + whoami to media-api step. Revert after diagnosis.