### PR TITLE
fix(infra): zone_name routes for dev API workers

### DIFF
--- a/workers/admin-api/wrangler.jsonc
+++ b/workers/admin-api/wrangler.jsonc
@@ -201,8 +201,8 @@
       ],
       "routes": [
         {
-          "pattern": "admin-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "admin-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -145,8 +145,8 @@
       ],
       "routes": [
         {
-          "pattern": "auth.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "auth.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -217,8 +217,8 @@
       ],
       "routes": [
         {
-          "pattern": "content-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "content-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -170,8 +170,8 @@
       ],
       "routes": [
         {
-          "pattern": "ecom-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "ecom-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -209,8 +209,8 @@
       ],
       "routes": [
         {
-          "pattern": "identity-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "identity-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -242,8 +242,8 @@
       ],
       "routes": [
         {
-          "pattern": "media-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "media-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -153,8 +153,8 @@
       ],
       "routes": [
         {
-          "pattern": "notifications-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "notifications-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -210,8 +210,8 @@
       ],
       "routes": [
         {
-          "pattern": "organization-api.dev.revelations.studio",
-          "custom_domain": true
+          "pattern": "organization-api.dev.revelations.studio/*",
+          "zone_name": "revelations.studio"
         }
       ]
     }


### PR DESCRIPTION
Replaces 8 custom_domain bindings with zone_name routes — matches prod pattern. The wildcard *.dev.revelations.studio/* was shadowing custom domains and serving SvelteKit HTML on every API hostname. Specific zone routes (auth.dev.revelations.studio/*) beat the wildcard via Cloudflare specificity rules.

Pre-step: deleted 8 dev custom domain bindings via API (authorized by user) so wrangler can create zone routes cleanly.