### PR TITLE
feat(dev): Cloudflare Custom Domain hook for dev orgs (Phase 7)

### DIFF
--- a/.github/scripts/upload-worker-secrets.sh
+++ b/.github/scripts/upload-worker-secrets.sh
@@ -121,9 +121,15 @@ EOF
     ;;
 
   organization-api)
+    # CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID are used by
+    # DevDomainService to provision Cloudflare Workers Custom Domains
+    # for new orgs in the dev environment. They're harmless to inject
+    # in non-dev environments (the service no-ops outside ENVIRONMENT=dev).
     SECRETS_JSON=$(cat <<EOF
 {
-  "DATABASE_URL":"${DATABASE_URL}"
+  "DATABASE_URL":"${DATABASE_URL}",
+  "CLOUDFLARE_API_TOKEN":"${CLOUDFLARE_API_TOKEN:-}",
+  "CLOUDFLARE_ACCOUNT_ID":"${CLOUDFLARE_ACCOUNT_ID:-}"
 }
 EOF
 )

--- a/.github/workflows/bootstrap-dev-infra.yml
+++ b/.github/workflows/bootstrap-dev-infra.yml
@@ -137,6 +137,75 @@ jobs:
             fi
           done
 
+      - name: Ensure seed Cloudflare Custom Domains exist
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CREATE: ${{ inputs.create_missing }}
+        run: |
+          set -euo pipefail
+          API="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/domains"
+          AUTH="Authorization: Bearer ${CF_API_TOKEN}"
+
+          # Each line: HOSTNAME|WORKER_NAME
+          # 8 API workers (each → its `-dev` worker) + 3 seed orgs (→ codex-web-dev).
+          # Other org subdomains are created dynamically at org-create time
+          # by DevDomainService (see organization-api routes).
+          DOMAINS=(
+            "auth.dev.revelations.studio|auth-worker-dev"
+            "content-api.dev.revelations.studio|content-api-dev"
+            "ecom-api.dev.revelations.studio|ecom-api-dev"
+            "identity-api.dev.revelations.studio|identity-api-dev"
+            "admin-api.dev.revelations.studio|admin-api-dev"
+            "organization-api.dev.revelations.studio|organization-api-dev"
+            "notifications-api.dev.revelations.studio|notifications-api-dev"
+            "media-api.dev.revelations.studio|media-api-dev"
+            "studio-alpha.dev.revelations.studio|codex-web-dev"
+            "studio-beta.dev.revelations.studio|codex-web-dev"
+            "of-blood-and-bones.dev.revelations.studio|codex-web-dev"
+          )
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Workers Custom Domains" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Hostname | Worker | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+
+          # Fetch the existing custom-domain list once (cheaper than checking
+          # per-host) and search it in-memory for each desired binding.
+          EXISTING=$(curl -fsS -H "$AUTH" "$API" | jq -c '.result // []')
+
+          for ENTRY in "${DOMAINS[@]}"; do
+            HOSTNAME="${ENTRY%%|*}"
+            WORKER="${ENTRY##*|}"
+
+            FOUND=$(echo "$EXISTING" | jq -r --arg h "$HOSTNAME" --arg s "$WORKER" \
+              '.[] | select(.hostname == $h and .service == $s) | .id' | head -n 1)
+
+            if [ -n "$FOUND" ]; then
+              echo "| $HOSTNAME | $WORKER | ✅ exists |" >> "$GITHUB_STEP_SUMMARY"
+              echo "✅ $HOSTNAME → $WORKER already bound"
+            elif [ "$CREATE" = "true" ]; then
+              echo "🌱 Creating $HOSTNAME → $WORKER..."
+              RESPONSE=$(curl -sS -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+                "$API" \
+                -d "{\"hostname\":\"$HOSTNAME\",\"service\":\"$WORKER\",\"environment\":\"production\",\"zone_id\":\"$CF_ZONE_ID\"}")
+              if echo "$RESPONSE" | jq -e '.success' > /dev/null 2>&1; then
+                echo "| $HOSTNAME | $WORKER | 🌱 created |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| $HOSTNAME | $WORKER | ❌ failed |" >> "$GITHUB_STEP_SUMMARY"
+                echo "❌ Failed to bind $HOSTNAME → $WORKER. Full API response:"
+                echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+                # Don't `exit 1` here: a single binding failure (e.g. worker
+                # doesn't yet exist on first run) shouldn't block the others.
+                # The workflow as a whole still surfaces failures in the summary.
+              fi
+            else
+              echo "| $HOSTNAME | $WORKER | ⚠️ missing (audit-only) |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
       - name: Next steps
         run: |
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -147,3 +216,4 @@ jobs:
           echo "3. First push triggers testing.yml → deploy-dev.yml (auto-creates Neon dev branch + deploys 9 services)" >> "$GITHUB_STEP_SUMMARY"
           echo "4. After first deploy, run \`./.github/scripts/setup-stripe-dev-webhooks.sh --upload\` to create test-mode Stripe endpoints" >> "$GITHUB_STEP_SUMMARY"
           echo "5. Re-trigger deploy to pick up the Stripe secrets" >> "$GITHUB_STEP_SUMMARY"
+          echo "6. New orgs created in dev via POST /api/organizations get their Custom Domain auto-provisioned by DevDomainService" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -153,15 +153,15 @@
         }
       ],
       "routes": [
-        // Dev platform apex
+        // Dev platform apex only. Per-org subdomains are NOT routed via
+        // a wildcard zone route — instead each org gets its own
+        // Cloudflare Custom Domain bound to this worker (see
+        // organization-api's dev-domain-service hook + bootstrap-dev-infra
+        // workflow). A wildcard zone route would shadow the API workers'
+        // custom domains (Phase 7 root-cause), so we intentionally don't
+        // ship one.
         {
           "pattern": "dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
-        },
-        // Wildcard for dev org subdomains (LAST). API workers under
-        // dev.revelations.studio register separately with custom_domain: true.
-        {
-          "pattern": "*.dev.revelations.studio/*",
           "zone_name": "revelations.studio"
         }
       ]

--- a/packages/organization/src/index.ts
+++ b/packages/organization/src/index.ts
@@ -56,7 +56,11 @@
 // Services
 // ============================================================================
 
-export { OrganizationService } from './services';
+export {
+  DevDomainService,
+  type DevDomainServiceConfig,
+  OrganizationService,
+} from './services';
 
 // ============================================================================
 // Types

--- a/packages/organization/src/services/dev-domain-service.ts
+++ b/packages/organization/src/services/dev-domain-service.ts
@@ -1,0 +1,239 @@
+import { BaseService, type ServiceConfig } from '@codex/service-errors';
+
+/**
+ * Configuration for the dev-only Cloudflare Custom Domain provisioner.
+ *
+ * The service is a no-op outside the `dev` deployed environment, so the
+ * Cloudflare credentials are optional — missing creds just turn off the
+ * provisioning step rather than failing the org-create flow.
+ */
+export interface DevDomainServiceConfig extends ServiceConfig {
+  /** Cloudflare API token with `Workers Scripts: Edit` scope. */
+  cloudflareApiToken?: string;
+  /** Cloudflare account ID hosting the dev workers. */
+  cloudflareAccountId?: string;
+  /**
+   * The DNS zone name (e.g. `revelations.studio`). Dev hostnames are built
+   * as `{slug}.dev.{zoneName}`.
+   */
+  zoneName: string;
+  /**
+   * The name of the dev web worker that org subdomains should bind to.
+   * For Codex this is `codex-web-dev`.
+   */
+  webWorkerName: string;
+}
+
+interface CloudflareWorkerDomain {
+  id: string;
+  hostname: string;
+  service: string;
+}
+
+/**
+ * Provisions and removes Cloudflare Workers Custom Domains for dev orgs.
+ *
+ * In the deployed `dev` environment, the free Cloudflare Universal SSL
+ * does not auto-issue certs for hostnames at two levels deep (such as
+ * `studio-alpha.dev.revelations.studio`). Workers Custom Domains DO get
+ * per-hostname certs auto-issued at any depth, AND they bind the
+ * hostname to a specific worker for routing — so we use them to cover
+ * both TLS and routing in one call.
+ *
+ * The hook is fire-and-forget: org creation never blocks on (or fails
+ * because of) Cloudflare API hiccups. Errors are logged via the
+ * observability client and swallowed.
+ *
+ * Outside dev (production, staging, local development) every method is
+ * a no-op — production org subdomains are first-level under
+ * `revelations.studio` and are covered by the existing Universal SSL
+ * wildcard with no additional work needed.
+ */
+export class DevDomainService extends BaseService {
+  private readonly apiToken?: string;
+  private readonly accountId?: string;
+  private readonly zoneName: string;
+  private readonly webWorkerName: string;
+  private cachedZoneId?: string;
+
+  constructor(config: DevDomainServiceConfig) {
+    super(config);
+    this.apiToken = config.cloudflareApiToken;
+    this.accountId = config.cloudflareAccountId;
+    this.zoneName = config.zoneName;
+    this.webWorkerName = config.webWorkerName;
+  }
+
+  /**
+   * Ensure a Custom Domain exists for the given org slug bound to the
+   * web worker. Idempotent: if the domain already exists this is a
+   * silent no-op.
+   */
+  async ensureDevDomain(slug: string): Promise<void> {
+    if (!this.shouldRun(slug, 'ensureDevDomain')) return;
+    const hostname = this.hostnameFor(slug);
+    try {
+      const existing = await this.findDomain(hostname);
+      if (existing) {
+        this.obs.info('Dev custom domain already exists', { slug, hostname });
+        return;
+      }
+      const zoneId = await this.resolveZoneId();
+      await this.createDomain(hostname, this.webWorkerName, zoneId);
+      this.obs.info('Dev custom domain created', { slug, hostname });
+    } catch (error) {
+      this.logCloudflareFailure('ensureDevDomain', error, { slug, hostname });
+    }
+  }
+
+  /** Remove the Custom Domain for a given org slug, if it exists. */
+  async removeDevDomain(slug: string): Promise<void> {
+    if (!this.shouldRun(slug, 'removeDevDomain')) return;
+    const hostname = this.hostnameFor(slug);
+    try {
+      const existing = await this.findDomain(hostname);
+      if (!existing) return;
+      await this.deleteDomain(existing.id);
+      this.obs.info('Dev custom domain removed', { slug, hostname });
+    } catch (error) {
+      this.logCloudflareFailure('removeDevDomain', error, { slug, hostname });
+    }
+  }
+
+  /**
+   * Rename the Custom Domain when an org's slug changes. Removes the old
+   * binding and creates a new one. Skips work if the slug is unchanged.
+   */
+  async renameDevDomain(oldSlug: string, newSlug: string): Promise<void> {
+    if (oldSlug === newSlug) return;
+    if (!this.isDevEnvironment()) return;
+    await this.removeDevDomain(oldSlug);
+    await this.ensureDevDomain(newSlug);
+  }
+
+  // ----- helpers --------------------------------------------------------
+
+  private shouldRun(slug: string, methodName: string): boolean {
+    if (!this.isDevEnvironment()) return false;
+    if (!this.canCallCloudflare()) {
+      this.obs.warn(
+        `DevDomainService.${methodName} skipped — Cloudflare creds missing`,
+        {
+          slug,
+          hasToken: Boolean(this.apiToken),
+          hasAccountId: Boolean(this.accountId),
+        }
+      );
+      return false;
+    }
+    return true;
+  }
+
+  private isDevEnvironment(): boolean {
+    return this.environment === 'dev';
+  }
+
+  private canCallCloudflare(): boolean {
+    return Boolean(this.apiToken && this.accountId);
+  }
+
+  private hostnameFor(slug: string): string {
+    return `${slug}.dev.${this.zoneName}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiToken}`,
+      Accept: 'application/json',
+    };
+  }
+
+  private logCloudflareFailure(
+    method: string,
+    error: unknown,
+    context: Record<string, unknown>
+  ): void {
+    this.obs.warn(`DevDomainService.${method} failed`, {
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  private async resolveZoneId(): Promise<string> {
+    if (this.cachedZoneId) return this.cachedZoneId;
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/zones?name=${encodeURIComponent(this.zoneName)}`,
+      { headers: this.headers() }
+    );
+    const body = (await res.json()) as {
+      success: boolean;
+      result?: Array<{ id: string }>;
+      errors?: unknown;
+    };
+    const zoneId = body.result?.[0]?.id;
+    if (!body.success || !zoneId) {
+      throw new Error(
+        `Failed to resolve zone id for ${this.zoneName}: ${JSON.stringify(body.errors ?? body)}`
+      );
+    }
+    this.cachedZoneId = zoneId;
+    return zoneId;
+  }
+
+  private async findDomain(
+    hostname: string
+  ): Promise<CloudflareWorkerDomain | null> {
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/workers/domains`,
+      { headers: this.headers() }
+    );
+    const body = (await res.json()) as {
+      success: boolean;
+      result?: CloudflareWorkerDomain[];
+    };
+    if (!body.success || !body.result) return null;
+    return body.result.find((d) => d.hostname === hostname) ?? null;
+  }
+
+  private async createDomain(
+    hostname: string,
+    service: string,
+    zoneId: string
+  ): Promise<void> {
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/workers/domains`,
+      {
+        method: 'PUT',
+        headers: { ...this.headers(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          hostname,
+          service,
+          environment: 'production',
+          zone_id: zoneId,
+        }),
+      }
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Cloudflare custom-domain create failed (${res.status}): ${text.slice(0, 300)}`
+      );
+    }
+  }
+
+  private async deleteDomain(id: string): Promise<void> {
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/workers/domains/${id}`,
+      {
+        method: 'DELETE',
+        headers: this.headers(),
+      }
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Cloudflare custom-domain delete failed (${res.status}): ${text.slice(0, 300)}`
+      );
+    }
+  }
+}

--- a/packages/organization/src/services/index.ts
+++ b/packages/organization/src/services/index.ts
@@ -5,4 +5,10 @@
  * Provides both service classes and factory functions.
  */
 // Organization Service
+
+// Dev-only Cloudflare Custom Domain provisioner
+export {
+  DevDomainService,
+  type DevDomainServiceConfig,
+} from './dev-domain-service';
 export { OrganizationService } from './organization-service';

--- a/packages/shared-types/src/worker-types.ts
+++ b/packages/shared-types/src/worker-types.ts
@@ -94,6 +94,20 @@ export type Bindings = {
   R2_ACCOUNT_ID?: string;
 
   /**
+   * Cloudflare API token used by dev-only DevDomainService for
+   * Workers Custom Domain provisioning. Optional — when absent the
+   * service no-ops. Only the organization-api worker needs this binding;
+   * it's included on all workers' Bindings type for simplicity.
+   */
+  CLOUDFLARE_API_TOKEN?: string;
+
+  /**
+   * Cloudflare Account ID used by dev-only DevDomainService alongside
+   * CLOUDFLARE_API_TOKEN. Optional.
+   */
+  CLOUDFLARE_ACCOUNT_ID?: string;
+
+  /**
    * R2 API token Access Key ID
    */
   R2_ACCESS_KEY_ID?: string;

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -27,7 +27,7 @@ import {
   TemplateService,
 } from '@codex/notifications';
 import type { ObservabilityClient } from '@codex/observability';
-import { OrganizationService } from '@codex/organization';
+import { DevDomainService, OrganizationService } from '@codex/organization';
 import {
   BrandingSettingsService,
   ContactSettingsService,
@@ -94,6 +94,7 @@ export function createServiceRegistry(
   let _access: ContentAccessService | undefined;
   let _imageProcessing: ImageProcessingService | undefined;
   let _organization: OrganizationService | undefined;
+  let _devDomain: DevDomainService | undefined;
   let _settings: PlatformSettingsFacade | undefined;
   let _purchase: PurchaseService | undefined;
   let _feeConfig: FeeConfigService | undefined;
@@ -344,6 +345,32 @@ export function createServiceRegistry(
         });
       }
       return _organization;
+    },
+
+    /**
+     * Dev-only Cloudflare Custom Domain provisioner. No-op outside
+     * `ENVIRONMENT === 'dev'`. Reads CLOUDFLARE_API_TOKEN and
+     * CLOUDFLARE_ACCOUNT_ID from worker env bindings; missing creds
+     * turn the service off silently rather than failing org-create.
+     */
+    get devDomain() {
+      if (!_devDomain) {
+        _devDomain = new DevDomainService({
+          db: getSharedDb(),
+          environment: getEnvironment(),
+          cloudflareApiToken:
+            typeof env.CLOUDFLARE_API_TOKEN === 'string'
+              ? env.CLOUDFLARE_API_TOKEN
+              : undefined,
+          cloudflareAccountId:
+            typeof env.CLOUDFLARE_ACCOUNT_ID === 'string'
+              ? env.CLOUDFLARE_ACCOUNT_ID
+              : undefined,
+          zoneName: 'revelations.studio',
+          webWorkerName: 'codex-web-dev',
+        });
+      }
+      return _devDomain;
     },
 
     get settings() {

--- a/packages/worker-utils/src/procedure/types.ts
+++ b/packages/worker-utils/src/procedure/types.ts
@@ -25,7 +25,10 @@ import type {
   TemplateService,
 } from '@codex/notifications';
 import type { ObservabilityClient } from '@codex/observability';
-import type { OrganizationService } from '@codex/organization';
+import type {
+  DevDomainService,
+  OrganizationService,
+} from '@codex/organization';
 import type { PlatformSettingsFacade } from '@codex/platform-settings';
 import type { FeeConfigService, PurchaseService } from '@codex/purchase';
 import type {
@@ -125,6 +128,12 @@ export interface ServiceRegistry {
   // Organization domain
   organization: OrganizationService;
   settings: PlatformSettingsFacade;
+  /**
+   * Dev-only Cloudflare Custom Domain provisioner (Codex Phase 7).
+   * No-op outside `ENVIRONMENT === 'dev'`. Creates per-org HTTPS bindings
+   * for hostnames at two levels deep where Universal SSL doesn't reach.
+   */
+  devDomain: DevDomainService;
 
   // Commerce domain
   purchase: PurchaseService;

--- a/workers/admin-api/wrangler.jsonc
+++ b/workers/admin-api/wrangler.jsonc
@@ -201,8 +201,8 @@
       ],
       "routes": [
         {
-          "pattern": "admin-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "admin-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -145,8 +145,8 @@
       ],
       "routes": [
         {
-          "pattern": "auth.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "auth.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -217,8 +217,8 @@
       ],
       "routes": [
         {
-          "pattern": "content-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "content-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -170,8 +170,8 @@
       ],
       "routes": [
         {
-          "pattern": "ecom-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "ecom-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -209,8 +209,8 @@
       ],
       "routes": [
         {
-          "pattern": "identity-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "identity-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -242,8 +242,8 @@
       ],
       "routes": [
         {
-          "pattern": "media-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "media-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -153,8 +153,8 @@
       ],
       "routes": [
         {
-          "pattern": "notifications-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "notifications-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }

--- a/workers/organization-api/src/routes/organizations.ts
+++ b/workers/organization-api/src/routes/organizations.ts
@@ -73,6 +73,15 @@ app.post(
         ctx.user.id
       );
 
+      // Dev-only: provision a Cloudflare Custom Domain so the new org's
+      // `{slug}.dev.revelations.studio` hostname gets a per-hostname TLS
+      // cert + routing binding. Fire-and-forget — org creation must
+      // not block on or fail because of Cloudflare API hiccups. No-op
+      // outside the deployed `dev` environment.
+      ctx.executionCtx.waitUntil(
+        ctx.services.devDomain.ensureDevDomain(org.slug)
+      );
+
       return org;
     },
   })
@@ -557,6 +566,14 @@ app.patch(
         ctx.executionCtx.waitUntil(Promise.all(invalidations).catch(() => {}));
       }
 
+      // Dev-only: if the slug changed, swap the Cloudflare Custom Domain
+      // (delete old hostname binding + create new). No-op outside dev.
+      if (oldSlug && updated.slug !== oldSlug) {
+        ctx.executionCtx.waitUntil(
+          ctx.services.devDomain.renameDevDomain(oldSlug, updated.slug)
+        );
+      }
+
       return updated;
     },
   })
@@ -623,6 +640,13 @@ app.delete(
             Promise.all(invalidations).catch(() => {})
           );
         }
+
+        // Dev-only: tear down the Cloudflare Custom Domain that was
+        // provisioned at org-create time so the hostname is freed up.
+        // No-op outside dev.
+        ctx.executionCtx.waitUntil(
+          ctx.services.devDomain.removeDevDomain(org.slug)
+        );
       }
 
       return null;

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -210,8 +210,8 @@
       ],
       "routes": [
         {
-          "pattern": "organization-api.dev.revelations.studio/*",
-          "zone_name": "revelations.studio"
+          "pattern": "organization-api.dev.revelations.studio",
+          "custom_domain": true
         }
       ]
     }


### PR DESCRIPTION
## Summary

Closes the two remaining issues blocking the deployed dev environment from working like prod:

1. **Free Universal SSL only covers root + first-level subdomains** — dev hostnames at two levels deep (`studio-alpha.dev.revelations.studio`) had no certs.
2. **Wildcard zone route `*.dev.revelations.studio/*` shadowed Custom Domain bindings** — every API hostname served SvelteKit HTML instead of its actual worker.

Solution: Cloudflare Workers Custom Domains. They auto-provision per-hostname Universal SSL certs at *any* depth AND bind hostname→worker 1:1 with no shadowing. Free.

## Architecture (dev only — prod unchanged)

| Hostname | Mechanism | Bound to |
|---|---|---|
| `dev.revelations.studio` | zone_name route | codex-web-dev |
| `auth.dev.revelations.studio` | Custom Domain | auth-worker-dev |
| `content-api.dev.revelations.studio` (+ 6 others) | Custom Domain | their `-dev` worker |
| `studio-alpha.dev.revelations.studio` (+ 2 seeds) | Custom Domain (created by bootstrap workflow) | codex-web-dev |
| `<new-org>.dev.revelations.studio` | Custom Domain (created at runtime by DevDomainService hook) | codex-web-dev |

**No wildcard route on dev.** Each hostname has its own Custom Domain.

## Files changed

- **NEW** \`packages/organization/src/services/dev-domain-service.ts\` — \`DevDomainService\` (extends \`BaseService\`). \`ensureDevDomain\` / \`removeDevDomain\` / \`renameDevDomain\`. No-op outside \`ENVIRONMENT === 'dev'\`. All errors logged via \`obs.warn\` and swallowed.
- \`packages/organization\` barrels: export \`DevDomainService\`.
- \`packages/worker-utils/src/procedure/{service-registry,types}.ts\`: lazy \`devDomain\` getter + \`ServiceRegistry\` type entry.
- \`packages/shared-types/src/worker-types.ts\`: optional \`CLOUDFLARE_API_TOKEN\` + \`CLOUDFLARE_ACCOUNT_ID\` bindings.
- \`workers/organization-api/src/routes/organizations.ts\`: fire-and-forget hooks via \`ctx.executionCtx.waitUntil\` in POST (create) / PATCH (slug rename) / DELETE (soft-delete).
- \`workers/{auth,content-api,ecom-api,identity-api,admin-api,organization-api,notifications-api,media-api}/wrangler.jsonc\` env.dev: revert zone_name back to \`custom_domain: true\`.
- \`apps/web/wrangler.jsonc\` env.dev: REMOVE the \`*.dev.revelations.studio/*\` wildcard route (kept only \`dev.revelations.studio/*\` for the apex).
- \`.github/workflows/bootstrap-dev-infra.yml\`: new step idempotently creates Custom Domains for 8 API workers + 3 seed orgs.
- \`.github/scripts/upload-worker-secrets.sh\`: pass \`CLOUDFLARE_API_TOKEN\` + \`CLOUDFLARE_ACCOUNT_ID\` to organization-api worker secrets.

## Tests

- \`pnpm typecheck\` — 55/55 tasks green
- Local \`wrangler deploy --env dev --dry-run\` on auth worker — bindings parse, custom_domain route accepted

## Verification plan (post-merge)

1. Run \`gh workflow run \"Bootstrap Dev Infrastructure\"\` — creates Custom Domains for 11 hostnames.
2. Push to dev → \`deploy-dev.yml\` runs and re-binds idempotently.
3. Fetch \`https://auth.dev.revelations.studio/\` — verify response is from auth-worker, NOT SvelteKit HTML.
4. Create a fresh test org via \`POST /api/organizations\`. Wait ~3 min. Fetch new \`<slug>.dev.revelations.studio\` — should resolve and serve.

## Trade-offs

- Cert provisioning latency ~2-5 min after org create (acceptable for dev).
- Orgs created via raw DB insert won't get a custom domain — must go through the API.
- Cloudflare API call from a worker — token blast radius limited to Workers ops only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)