### PR TITLE
fix(ci): upload WORKER_SHARED_SECRET to identity-api + notifications-api

### DIFF
--- a/.github/scripts/upload-worker-secrets.sh
+++ b/.github/scripts/upload-worker-secrets.sh
@@ -103,9 +103,12 @@ EOF
     ;;
 
   identity-api)
+    # WORKER_SHARED_SECRET required: identity-api exposes a worker-HMAC
+    # membership lookup endpoint that auth uses to resolve org context.
     SECRETS_JSON=$(cat <<EOF
 {
-  "DATABASE_URL":"${DATABASE_URL}"
+  "DATABASE_URL":"${DATABASE_URL}",
+  "WORKER_SHARED_SECRET":"${WORKER_SHARED_SECRET:-}"
 }
 EOF
 )
@@ -136,9 +139,13 @@ EOF
     ;;
 
   notifications-api)
+    # WORKER_SHARED_SECRET required: notifications-api accepts worker-HMAC
+    # signed /internal/send calls from other workers (auth → welcome email,
+    # org-api → invite email, etc).
     SECRETS_JSON=$(cat <<EOF
 {
-  "DATABASE_URL":"${DATABASE_URL}"
+  "DATABASE_URL":"${DATABASE_URL}",
+  "WORKER_SHARED_SECRET":"${WORKER_SHARED_SECRET:-}"
 }
 EOF
 )


### PR DESCRIPTION
Both workers refuse to boot without WORKER_SHARED_SECRET (they accept HMAC-signed worker-to-worker calls). The upload-worker-secrets.sh script wasn't echoing the secret into the bulk-set JSON for these cases. Latent bug exposed now that Phase 7 deploys reach the worker-boot step.