### PR TITLE
fix(ci): retry Neon migrations for cold-branch resilience

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -163,8 +163,24 @@ jobs:
       - name: Build constants package
         run: pnpm --filter @codex/constants build
 
-      - name: Run dev database migrations
-        run: pnpm --filter @codex/database db:migrate
+      - name: Run dev database migrations (with retry)
+        run: |
+          # Neon free-tier auto-suspends inactive compute. The first
+          # migration attempt after a cold branch can be terminated mid-DDL
+          # with "administrator command" as Neon spins up the compute. Retry
+          # with backoff — by attempt 2 the branch is warm and the migration
+          # completes cleanly.
+          for attempt in 1 2 3; do
+            echo "Migration attempt $attempt/3..."
+            if pnpm --filter @codex/database db:migrate; then
+              echo "✅ Migrations applied"
+              exit 0
+            fi
+            echo "❌ Attempt $attempt failed; waiting 10s before retry..."
+            sleep 10
+          done
+          echo "❌ All 3 migration attempts failed"
+          exit 1
         env:
           DATABASE_URL: ${{ steps.neon.outputs.DATABASE_URL }}
           DB_METHOD: ${{ vars.DB_METHOD }}

--- a/.github/workflows/seed-dev-db.yml
+++ b/.github/workflows/seed-dev-db.yml
@@ -79,8 +79,18 @@ jobs:
       - name: Build required packages
         run: pnpm --filter @codex/database --filter @codex/constants build
 
-      - name: Run dev migrations (ensure schema is current)
-        run: pnpm --filter @codex/database db:migrate
+      - name: Run dev migrations (ensure schema is current, with retry)
+        run: |
+          for attempt in 1 2 3; do
+            echo "Migration attempt $attempt/3..."
+            if pnpm --filter @codex/database db:migrate; then
+              echo "✅ Migrations applied"
+              exit 0
+            fi
+            echo "❌ Attempt $attempt failed; waiting 10s before retry..."
+            sleep 10
+          done
+          exit 1
         env:
           DATABASE_URL: ${{ steps.neon.outputs.DATABASE_URL }}
           DB_METHOD: PRODUCTION


### PR DESCRIPTION
Neon free-tier auto-suspends compute; first DDL after wake gets killed by Neon's admin command. 3-attempt retry with 10s backoff makes the deploy resilient to cold-branch flakes.