### PR TITLE
fix(notifications): widen 'reaches handler' test to accept 404

### DIFF
--- a/workers/notifications-api/src/routes/__tests__/internal.test.ts
+++ b/workers/notifications-api/src/routes/__tests__/internal.test.ts
@@ -190,12 +190,14 @@ describe('Internal Send Route', () => {
       });
 
       // Auth passes and input validates — handler executes.
-      // Without a real database, the service layer will error (500),
-      // or it may succeed if mock/console provider is configured.
-      // The key assertion: it is NOT 401 (auth passed) and NOT 400 (validation passed).
+      // Acceptable post-handler statuses (the test is flow-through, not behaviour):
+      //   200 — template seeded, mock provider rendered + sent
+      //   404 — fresh CI DB has migrations but no template seed; service throws NotFoundError
+      //   500 — DB unreachable or other handler-layer error
+      // The key assertion: NOT 401 (auth passed) and NOT 400 (validation passed).
       expect(response.status).not.toBe(401);
       expect(response.status).not.toBe(400);
-      expect([200, 500]).toContain(response.status);
+      expect([200, 404, 500]).toContain(response.status);
     });
   });
 });


### PR DESCRIPTION
## Summary

PR #244's fix unmasked a latent test brittleness. The 'accepts valid request with HMAC auth and reaches handler' test asserted post-handler status in `[200, 500]`. With the auth layer now working (PR #244), the handler actually runs against the fresh Neon ephemeral DB — which has migrations but no template seed. The service throws `NotFoundError` → 404.

The test's intent is flow-through (auth passes, validation passes, handler runs). 404 is a legitimate handler response — handler executed, service ran, template wasn't found. Widening the assertion to `[200, 404, 500]` preserves intent and matches CI reality without seeding test data.

## Why 404 was hidden before

PR #243 baseline: every request 500'd at the auth layer (worker-shared-secret missing). The `[200, 500].toContain(500)` assertion masked the template-not-found case completely. Once PR #244 fixed the secret, this surfaced.

## Why we don't seed instead

The test's name and comment both say 'reaches handler' — it's about flow control, not behaviour. Seeding adds setup complexity for what is genuinely a flow-through smoke test. Behaviour tests live in the service-layer unit tests.

## Test plan

- [x] Local: `pnpm --filter notifications-api test -- src/routes/__tests__/internal.test.ts` — 47/47 pass (gets 200 because local DB has template seed)
- [ ] CI: PR #244-fixed CI lifecycle should pass this test on a clean Neon branch (will get 404)
- [ ] After merge to dev: PR #243's `Notifications API Tests` matrix should turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)