### PR TITLE
feat(urls): WP-1 @codex/urls foundation + DEV_REMOTE rename

### DIFF
--- a/packages/constants/src/env.ts
+++ b/packages/constants/src/env.ts
@@ -15,7 +15,11 @@ export type ServiceName =
 export const ENV_NAMES = {
   PRODUCTION: 'production',
   STAGING: 'staging',
-  DEV: 'dev', // deployed long-lived dev branch (dev.revelations.studio)
+  // DEV_REMOTE is the deployed long-lived dev branch (dev.revelations.studio).
+  // Renamed from DEV to disambiguate from DEVELOPMENT (= local). The string
+  // value 'dev' is unchanged — this rename is identifier-only and does NOT
+  // require updating ENVIRONMENT bindings in any wrangler.jsonc.
+  DEV_REMOTE: 'dev',
   DEVELOPMENT: 'development',
   TEST: 'test',
 } as const;
@@ -88,7 +92,7 @@ export function isDev(env?: Env | boolean): boolean {
  */
 export function isDevRemote(env?: Env | boolean): boolean {
   if (typeof env !== 'object' || env === null) return false;
-  return env.ENVIRONMENT === ENV_NAMES.DEV;
+  return env.ENVIRONMENT === ENV_NAMES.DEV_REMOTE;
 }
 
 /**

--- a/packages/urls/CLAUDE.md
+++ b/packages/urls/CLAUDE.md
@@ -1,0 +1,115 @@
+# @codex/urls
+
+Centralized URL building, hostname parsing, and cookie/CORS domain helpers for the Codex platform.
+
+Owns the routing-related concerns that were previously duplicated across:
+
+- `apps/web/src/lib/utils/subdomain.ts` (hostname parsers + URL builders)
+- `packages/constants/src/{env,cookies}.ts` (service URLs + cookie config)
+- `workers/auth/src/auth-config.ts` (BetterAuth cookie domain + trustedOrigins)
+- `packages/organization/src/services/dev-domain-service.ts` (Phase 7 hostname)
+
+## Source of truth: `ENV_HOSTS`
+
+A 5-row table keyed by `EnvName`. Each row provides:
+
+- `scheme` — `http` (local) or `https` (deployed)
+- `port` — local-dev only (3000 for `development` / `test`)
+- `apiUrl(service)` — worker URL for a given service
+- `orgHost(slug)` — hostname (no scheme, no path) for a given org slug
+
+Adding a new env = one new row. Adding a new service = one new entry in `SERVICE_SUBDOMAIN`.
+
+## Public API
+
+### Hostname parsing
+
+```ts
+import { parseHost } from '@codex/urls';
+
+parseHost('studio-alpha.dev.revelations.studio');
+// → { env: 'dev', baseDomain: 'dev.revelations.studio',
+//     subdomain: 'studio-alpha', port: null, nipApex: null }
+
+parseHost('codex-staging.revelations.studio');
+// → { env: 'staging', baseDomain: 'revelations.studio',
+//     subdomain: 'codex-staging', port: null, nipApex: null }
+
+parseHost('bruce-studio.192.168.1.10.nip.io:3000');
+// → { env: 'development', baseDomain: '192.168.1.10.nip.io',
+//     subdomain: 'bruce-studio', port: '3000',
+//     nipApex: '192.168.1.10.nip.io' }
+```
+
+`env: null` is returned for unknown hosts (custom domains, IPs, etc.) — workers should pass env explicitly when building URLs from non-routable contexts.
+
+### URL building (WP-3 / WP-4 stubs)
+
+```ts
+import {
+  buildServiceUrl,         // WP-3 stub — throws until WP-3 lands
+  buildOrgUrl,             // WP-4 stub
+  buildOrgUrlFromEnv,      // WP-4 stub
+  buildPlatformUrl,        // WP-4 stub
+  buildCreatorsUrl,        // WP-4 stub
+  buildContentUrl,         // WP-4 stub
+} from '@codex/urls';
+```
+
+### CORS origins
+
+```ts
+import { corsOriginsFor } from '@codex/urls';
+
+corsOriginsFor('development');
+// → ['http://localhost:42069', 'http://lvh.me:3000',
+//    'http://lvh.me:5173', 'http://*.nip.io']
+```
+
+### Cookie domain (WP-5a stub)
+
+```ts
+import { cookieDomainFor } from '@codex/urls';
+// Throws "not implemented (WP-5a)" until WP-5a lands.
+```
+
+## ENV_HOSTS table
+
+| env | scheme | `orgHost(slug)` | `apiUrl('auth')` (example) |
+|---|---|---|---|
+| `production` | https | `{slug}.revelations.studio` | `https://auth.revelations.studio` |
+| `staging` | https | `{slug}-staging.revelations.studio` | `https://auth-staging.revelations.studio` |
+| `dev` | https | `{slug}.dev.revelations.studio` | `https://auth.dev.revelations.studio` |
+| `development` | http | `{slug}.lvh.me` | `http://localhost:42069` |
+| `test` | http | `{slug}.lvh.me` | `http://localhost:42069` |
+
+## Two-`dev` naming clarification
+
+`EnvName` has two values that both contain "dev":
+
+- **`dev`** — the deployed long-lived `dev.revelations.studio` environment. HTTPS, secure cookies, per-org Cloudflare Custom Domains via `DevDomainService`.
+- **`development`** — local development on the developer's machine. HTTP, non-secure cookies, lvh.me / nip.io / localhost.
+
+`ENV_NAMES.DEV_REMOTE` in `@codex/constants` is the matching constant for the `dev` env value. Avoid `'dev'` string literals; always use `ENV_NAMES.DEV_REMOTE`.
+
+## Strict rules
+
+- **Zero runtime deps** except `@codex/constants` (for `SERVICE_PORTS`)
+- **Never hardcode** hostname patterns elsewhere; always import from `ENV_HOSTS` or call `parseHost`
+- **Never duplicate** TLD-branch logic. Single source of truth in `parse-host.ts`.
+- `parseHost` returns `env: null` for unknown hosts — callers MUST pass env explicitly when building URLs from non-routable contexts.
+
+## Migration status (Codex-rscgk epic)
+
+- ✅ **WP-1** — package foundation + `ENV_HOSTS` + `parseHost` + `corsOriginsFor` + DEV_REMOTE rename
+- ⏳ **WP-2** — hostname parsers in `apps/web` become wrappers (Codex-qyjds)
+- ⏳ **WP-3** — `buildServiceUrl` replaces `getServiceUrl` + `DEFAULT_URLS` (Codex-4xbuw)
+- ⏳ **WP-4** — URL builders + `buildOrgUrlFromEnv` (Codex-fiveo)
+- ⏳ **WP-5a** — `cookieDomainFor` unification + byte-equal fixture (Codex-ora41)
+- ⏳ **WP-5b** — BetterAuth cross-subdomain integration test (Codex-7okxb)
+- ⏳ **WP-6** — `DevDomainService` rewire (Codex-0hxw4)
+- ⏳ **WP-7** — wrangler URL env-var cleanup (Codex-10hr1)
+- ⏳ **WP-8** — sitemap structural test (Codex-6wvam)
+- ⏳ **WP-9** — dev-deploy smoke gate in CI (Codex-ikum9)
+
+Plan: `~/.claude/plans/typed-honking-canyon.md`. Investigation: `docs/routing-centralization.md`.

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@codex/urls",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "vite build --config vite.config.urls",
+    "dev": "vite build --config vite.config.urls --watch",
+    "test": "vitest run --config vitest.config.urls.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint --write .",
+    "format": "biome format --write ."
+  },
+  "dependencies": {
+    "@codex/constants": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "vite": "^7.2.2"
+  }
+}

--- a/packages/urls/src/__tests__/cors-origins.test.ts
+++ b/packages/urls/src/__tests__/cors-origins.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { corsOriginsFor } from '../cors-origins';
+
+describe('corsOriginsFor', () => {
+  it('dev includes the dev apex + wildcard', () => {
+    const origins = corsOriginsFor('dev');
+    expect(origins).toContain('https://dev.revelations.studio');
+    expect(origins).toContain('https://*.dev.revelations.studio');
+  });
+
+  it('development includes lvh.me + nip.io + auth-worker self URL', () => {
+    const origins = corsOriginsFor('development');
+    expect(origins).toContain('http://lvh.me:3000');
+    expect(origins).toContain('http://localhost:42069');
+    expect(origins).toContain('http://lvh.me:5173');
+    expect(origins).toContain('http://*.nip.io');
+  });
+
+  it('staging includes -staging apex + wildcard', () => {
+    const origins = corsOriginsFor('staging');
+    expect(origins).toContain('https://codex-staging.revelations.studio');
+    expect(origins).toContain('https://*-staging.revelations.studio');
+  });
+
+  it('production returns empty (relies on env.WEB_APP_URL + env.API_URL)', () => {
+    expect(corsOriginsFor('production')).toEqual([]);
+  });
+
+  it('test returns empty (tests use exact origin)', () => {
+    expect(corsOriginsFor('test')).toEqual([]);
+  });
+
+  it('returns a new array each call (defensive — no shared mutable state)', () => {
+    const a = corsOriginsFor('development');
+    const b = corsOriginsFor('development');
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/urls/src/__tests__/env-hosts.test.ts
+++ b/packages/urls/src/__tests__/env-hosts.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { ENV_HOSTS, SERVICE_SUBDOMAIN } from '../env-hosts';
+import type { EnvName, ServiceName } from '../types';
+
+const ALL_ENVS: EnvName[] = [
+  'production',
+  'staging',
+  'dev',
+  'development',
+  'test',
+];
+
+const ALL_SERVICES: ServiceName[] = [
+  'auth',
+  'content',
+  'access',
+  'org',
+  'ecom',
+  'admin',
+  'identity',
+  'notifications',
+  'media',
+];
+
+describe('ENV_HOSTS', () => {
+  describe('completeness', () => {
+    it('has an entry for every EnvName', () => {
+      for (const env of ALL_ENVS) {
+        expect(ENV_HOSTS[env]).toBeDefined();
+      }
+    });
+
+    it('every env has scheme + apiUrl + orgHost', () => {
+      for (const env of ALL_ENVS) {
+        const host = ENV_HOSTS[env];
+        expect(host.scheme).toMatch(/^https?$/);
+        expect(typeof host.apiUrl).toBe('function');
+        expect(typeof host.orgHost).toBe('function');
+      }
+    });
+  });
+
+  describe('production', () => {
+    it('builds auth URL as auth.revelations.studio', () => {
+      expect(ENV_HOSTS.production.apiUrl('auth')).toBe(
+        'https://auth.revelations.studio'
+      );
+    });
+
+    it('builds content URL as content-api.revelations.studio', () => {
+      expect(ENV_HOSTS.production.apiUrl('content')).toBe(
+        'https://content-api.revelations.studio'
+      );
+    });
+
+    it('builds org subdomain hostname', () => {
+      expect(ENV_HOSTS.production.orgHost('yoga-studio')).toBe(
+        'yoga-studio.revelations.studio'
+      );
+    });
+  });
+
+  describe('staging (-staging suffix pattern)', () => {
+    it('builds auth URL with -staging suffix', () => {
+      expect(ENV_HOSTS.staging.apiUrl('auth')).toBe(
+        'https://auth-staging.revelations.studio'
+      );
+    });
+
+    it('builds org subdomain hostname with -staging suffix', () => {
+      expect(ENV_HOSTS.staging.orgHost('studio-alpha')).toBe(
+        'studio-alpha-staging.revelations.studio'
+      );
+    });
+  });
+
+  describe('dev (deployed dev.revelations.studio)', () => {
+    it('builds auth URL at dev.revelations.studio', () => {
+      expect(ENV_HOSTS.dev.apiUrl('auth')).toBe(
+        'https://auth.dev.revelations.studio'
+      );
+    });
+
+    it('builds org subdomain hostname two-deep', () => {
+      expect(ENV_HOSTS.dev.orgHost('studio-alpha')).toBe(
+        'studio-alpha.dev.revelations.studio'
+      );
+    });
+  });
+
+  describe('development (local)', () => {
+    it('uses http scheme and lvh.me apex', () => {
+      expect(ENV_HOSTS.development.scheme).toBe('http');
+      expect(ENV_HOSTS.development.port).toBe(3000);
+    });
+
+    it('builds auth URL on localhost with port from SERVICE_PORTS', () => {
+      expect(ENV_HOSTS.development.apiUrl('auth')).toBe(
+        'http://localhost:42069'
+      );
+    });
+
+    it('builds org subdomain on lvh.me', () => {
+      expect(ENV_HOSTS.development.orgHost('bruce-studio')).toBe(
+        'bruce-studio.lvh.me'
+      );
+    });
+  });
+
+  describe('test (mirrors development)', () => {
+    it('matches development scheme/port/apiUrl', () => {
+      expect(ENV_HOSTS.test.scheme).toBe('http');
+      expect(ENV_HOSTS.test.port).toBe(3000);
+      expect(ENV_HOSTS.test.apiUrl('auth')).toBe('http://localhost:42069');
+    });
+  });
+
+  describe('apiUrl coverage for every service in every env', () => {
+    it('every service yields a non-empty URL in every env', () => {
+      for (const env of ALL_ENVS) {
+        for (const service of ALL_SERVICES) {
+          const url = ENV_HOSTS[env].apiUrl(service);
+          expect(url).toMatch(/^https?:\/\/.+/);
+        }
+      }
+    });
+  });
+
+  describe('scheme + port invariants', () => {
+    it('https envs omit port (deployed only)', () => {
+      for (const env of ['production', 'staging', 'dev'] as const) {
+        expect(ENV_HOSTS[env].scheme).toBe('https');
+        expect(ENV_HOSTS[env].port).toBeUndefined();
+      }
+    });
+
+    it('http envs define a port (local only)', () => {
+      for (const env of ['development', 'test'] as const) {
+        expect(ENV_HOSTS[env].scheme).toBe('http');
+        expect(typeof ENV_HOSTS[env].port).toBe('number');
+      }
+    });
+  });
+});
+
+describe('SERVICE_SUBDOMAIN', () => {
+  it('has an entry for every ServiceName', () => {
+    for (const service of ALL_SERVICES) {
+      expect(SERVICE_SUBDOMAIN[service]).toBeDefined();
+      expect(typeof SERVICE_SUBDOMAIN[service]).toBe('string');
+    }
+  });
+
+  it('content and access share the same subdomain (content-api)', () => {
+    // They deploy to the same worker
+    expect(SERVICE_SUBDOMAIN.content).toBe(SERVICE_SUBDOMAIN.access);
+    expect(SERVICE_SUBDOMAIN.content).toBe('content-api');
+  });
+});

--- a/packages/urls/src/__tests__/parse-host.test.ts
+++ b/packages/urls/src/__tests__/parse-host.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import { parseHost } from '../parse-host';
+
+describe('parseHost', () => {
+  describe('lvh.me (development)', () => {
+    it('returns null subdomain on bare lvh.me', () => {
+      expect(parseHost('lvh.me')).toEqual({
+        env: 'development',
+        baseDomain: 'lvh.me',
+        subdomain: null,
+        port: null,
+        nipApex: null,
+      });
+    });
+
+    it('preserves port on bare lvh.me', () => {
+      expect(parseHost('lvh.me:3000')).toEqual({
+        env: 'development',
+        baseDomain: 'lvh.me',
+        subdomain: null,
+        port: '3000',
+        nipApex: null,
+      });
+    });
+
+    it('extracts org subdomain from {sub}.lvh.me', () => {
+      expect(parseHost('studio-alpha.lvh.me:3000')).toEqual({
+        env: 'development',
+        baseDomain: 'lvh.me',
+        subdomain: 'studio-alpha',
+        port: '3000',
+        nipApex: null,
+      });
+    });
+
+    it('extracts creators subdomain from creators.lvh.me', () => {
+      expect(parseHost('creators.lvh.me:3000').subdomain).toBe('creators');
+    });
+
+    it('rejects nested subdomain under lvh.me', () => {
+      expect(parseHost('foo.bar.lvh.me:3000').subdomain).toBeNull();
+    });
+  });
+
+  describe('nip.io (development, LAN testing)', () => {
+    it('returns nipApex with null subdomain on bare {ip}.nip.io', () => {
+      expect(parseHost('192.168.1.10.nip.io:3000')).toEqual({
+        env: 'development',
+        baseDomain: '192.168.1.10.nip.io',
+        subdomain: null,
+        port: '3000',
+        nipApex: '192.168.1.10.nip.io',
+      });
+    });
+
+    it('extracts subdomain from {sub}.{ip}.nip.io', () => {
+      expect(parseHost('studio-alpha.192.168.1.10.nip.io:3000')).toEqual({
+        env: 'development',
+        baseDomain: '192.168.1.10.nip.io',
+        subdomain: 'studio-alpha',
+        port: '3000',
+        nipApex: '192.168.1.10.nip.io',
+      });
+    });
+
+    it('rejects nested subdomain under nip.io', () => {
+      // foo.bar.192.168.1.10.nip.io — subdomain prefix has a dot
+      const info = parseHost('foo.bar.192.168.1.10.nip.io');
+      expect(info.subdomain).toBeNull();
+      expect(info.env).toBe('development');
+      expect(info.nipApex).toBe('192.168.1.10.nip.io');
+    });
+  });
+
+  describe('localhost (development)', () => {
+    it('returns null subdomain on bare localhost', () => {
+      expect(parseHost('localhost:3000')).toEqual({
+        env: 'development',
+        baseDomain: 'localhost',
+        subdomain: null,
+        port: '3000',
+        nipApex: null,
+      });
+    });
+
+    it('extracts subdomain from {sub}.localhost', () => {
+      expect(parseHost('test-org.localhost:3000').subdomain).toBe('test-org');
+    });
+  });
+
+  describe('dev.revelations.studio (deployed dev)', () => {
+    it('returns null subdomain on bare dev apex', () => {
+      expect(parseHost('dev.revelations.studio')).toEqual({
+        env: 'dev',
+        baseDomain: 'dev.revelations.studio',
+        subdomain: null,
+        port: null,
+        nipApex: null,
+      });
+    });
+
+    it('extracts org slug from {sub}.dev.revelations.studio', () => {
+      expect(parseHost('studio-alpha.dev.revelations.studio').subdomain).toBe(
+        'studio-alpha'
+      );
+    });
+
+    it('treats reserved subdomain as subdomain (auth.dev)', () => {
+      const info = parseHost('auth.dev.revelations.studio');
+      expect(info.env).toBe('dev');
+      expect(info.subdomain).toBe('auth');
+    });
+
+    it('rejects nested subdomain under dev apex', () => {
+      expect(
+        parseHost('foo.studio-alpha.dev.revelations.studio').subdomain
+      ).toBeNull();
+    });
+  });
+
+  describe('revelations.studio (production)', () => {
+    it('returns null subdomain on bare prod apex', () => {
+      expect(parseHost('revelations.studio')).toEqual({
+        env: 'production',
+        baseDomain: 'revelations.studio',
+        subdomain: null,
+        port: null,
+        nipApex: null,
+      });
+    });
+
+    it('extracts org slug from {sub}.revelations.studio', () => {
+      expect(parseHost('yoga-studio.revelations.studio').subdomain).toBe(
+        'yoga-studio'
+      );
+    });
+
+    it('treats www as subdomain (dispatcher decides platform)', () => {
+      expect(parseHost('www.revelations.studio').subdomain).toBe('www');
+      expect(parseHost('www.revelations.studio').env).toBe('production');
+    });
+  });
+
+  describe('staging (revelations.studio with -staging suffix)', () => {
+    it('detects staging env from -staging suffix', () => {
+      const info = parseHost('codex-staging.revelations.studio');
+      expect(info.env).toBe('staging');
+      // Subdomain is the LITERAL prefix (backward-compat with extractSubdomain)
+      expect(info.subdomain).toBe('codex-staging');
+      expect(info.baseDomain).toBe('revelations.studio');
+    });
+
+    it('detects staging for org-style hosts', () => {
+      const info = parseHost('studio-alpha-staging.revelations.studio');
+      expect(info.env).toBe('staging');
+      expect(info.subdomain).toBe('studio-alpha-staging');
+    });
+
+    it('detects staging for bare staging.revelations.studio', () => {
+      const info = parseHost('staging.revelations.studio');
+      expect(info.env).toBe('staging');
+      expect(info.subdomain).toBe('staging');
+    });
+
+    it('does NOT detect staging for unrelated subdomains', () => {
+      expect(parseHost('codex.revelations.studio').env).toBe('production');
+    });
+  });
+
+  describe('unknown hosts (env=null)', () => {
+    it('returns env=null for arbitrary custom domains', () => {
+      expect(parseHost('custom.example.com')).toEqual({
+        env: null,
+        baseDomain: 'custom.example.com',
+        subdomain: null,
+        port: null,
+        nipApex: null,
+      });
+    });
+
+    it('returns env=null but preserves port for IP literals', () => {
+      expect(parseHost('192.0.2.1:8080')).toEqual({
+        env: null,
+        baseDomain: '192.0.2.1',
+        subdomain: null,
+        port: '8080',
+        nipApex: null,
+      });
+    });
+  });
+
+  describe('port preservation across envs', () => {
+    it('preserves port on deployed dev hosts', () => {
+      expect(parseHost('studio-alpha.dev.revelations.studio:8443').port).toBe(
+        '8443'
+      );
+    });
+
+    it('preserves port on prod hosts', () => {
+      expect(parseHost('yoga-studio.revelations.studio:443').port).toBe('443');
+    });
+
+    it('preserves port on staging hosts', () => {
+      expect(parseHost('codex-staging.revelations.studio:443').port).toBe(
+        '443'
+      );
+    });
+  });
+
+  describe('priority ordering', () => {
+    it('matches dev.revelations.studio BEFORE prod (avoids regex collision)', () => {
+      // dev.revelations.studio ends with revelations.studio — must be checked first
+      expect(parseHost('dev.revelations.studio').env).toBe('dev');
+    });
+
+    it('matches lvh.me BEFORE generic fallback', () => {
+      expect(parseHost('lvh.me').env).toBe('development');
+    });
+  });
+
+  describe('malformed input — empty subdomain', () => {
+    // Backward-compat regression guard. The historical extractSubdomain
+    // rejected leading-dot hosts via `parts.length > 2`. The matchApex
+    // helper used by lvh.me / localhost / dev.revelations.studio must
+    // reject empty subdomains the same way.
+    it('rejects leading-dot host on lvh.me apex (.lvh.me)', () => {
+      expect(parseHost('.lvh.me').subdomain).toBeNull();
+    });
+
+    it('rejects leading-dot host on dev.revelations.studio apex', () => {
+      expect(parseHost('.dev.revelations.studio').subdomain).toBeNull();
+    });
+
+    it('rejects leading-dot host on localhost apex', () => {
+      expect(parseHost('.localhost:3000').subdomain).toBeNull();
+    });
+  });
+
+  describe('case insensitivity (DNS is case-insensitive per RFC 4343)', () => {
+    it('lowercases LVH.ME', () => {
+      expect(parseHost('LVH.ME').env).toBe('development');
+    });
+
+    it('lowercases mixed-case org subdomain', () => {
+      const info = parseHost('Studio-Alpha.Dev.Revelations.Studio');
+      expect(info.env).toBe('dev');
+      expect(info.subdomain).toBe('studio-alpha');
+      expect(info.baseDomain).toBe('dev.revelations.studio');
+    });
+
+    it('lowercases prod hostname', () => {
+      expect(parseHost('YOGA-STUDIO.REVELATIONS.STUDIO').subdomain).toBe(
+        'yoga-studio'
+      );
+    });
+  });
+});

--- a/packages/urls/src/build-url.ts
+++ b/packages/urls/src/build-url.ts
@@ -1,0 +1,79 @@
+import type { EnvName, HostInfo, ServiceName } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STUBS — filled in WP-3 (buildServiceUrl) and WP-4 (org/platform/content URL
+// builders). Signatures are stable so WP-2/3/4/5a can develop in parallel.
+// Throwing here surfaces an explicit error if any consumer reaches a stub
+// before its implementing WP has landed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a worker service URL. Reads env-var override first; falls back to
+ * `ENV_HOSTS[env].apiUrl(service)`.
+ *
+ * Replaces `getServiceUrl` from `@codex/constants/src/env.ts` (which becomes
+ * a re-export shim in WP-3).
+ */
+export function buildServiceUrl(
+  _service: ServiceName,
+  _env: EnvName | boolean | { ENVIRONMENT?: string; [k: string]: unknown }
+): string {
+  throw new Error('buildServiceUrl: not implemented (WP-3)');
+}
+
+/**
+ * Build a full URL on a specific org subdomain, derived from a parsed host.
+ * Preserves the current page's protocol and port (when present).
+ */
+export function buildOrgUrl(
+  _host: HostInfo,
+  _slug: string,
+  _path = '/'
+): string {
+  throw new Error('buildOrgUrl: not implemented (WP-4)');
+}
+
+/**
+ * Build an org subdomain URL from an env name (no request context required).
+ * Used by `DevDomainService` and any worker that needs an org URL without
+ * a `currentUrl` to derive from.
+ */
+export function buildOrgUrlFromEnv(
+  _env: EnvName,
+  _slug: string,
+  _path = '/'
+): string {
+  throw new Error('buildOrgUrlFromEnv: not implemented (WP-4)');
+}
+
+/**
+ * Build a platform URL (no subdomain, root of the apex).
+ */
+export function buildPlatformUrl(_host: HostInfo, _path = '/'): string {
+  throw new Error('buildPlatformUrl: not implemented (WP-4)');
+}
+
+/**
+ * Build a URL on the `creators` subdomain.
+ */
+export function buildCreatorsUrl(_host: HostInfo, _path = '/'): string {
+  throw new Error('buildCreatorsUrl: not implemented (WP-4)');
+}
+
+/**
+ * Build a URL to a content detail page, handling cross-org subdomain routing.
+ *
+ * - On the content's own org subdomain → root-relative `/content/{slug}`
+ * - On a different origin (platform, other org) → full URL via buildOrgUrl
+ * - Falls back to content ID if slug is unavailable
+ */
+export function buildContentUrl(
+  _host: HostInfo,
+  _content: {
+    slug?: string | null;
+    id: string;
+    organizationSlug?: string | null;
+  }
+): string {
+  throw new Error('buildContentUrl: not implemented (WP-4)');
+}

--- a/packages/urls/src/cookie-domain.ts
+++ b/packages/urls/src/cookie-domain.ts
@@ -1,0 +1,33 @@
+import type { EnvName } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STUB — filled in WP-5a. The byte-equal fixture matrix in
+// `__tests__/cookie-domain-fixtures.test.ts` (added by WP-5a) is the merge
+// gate that proves backward-compatibility with existing cookie domain
+// output. Until WP-5a lands, consumers continue using `getCookieConfig`
+// from `@codex/constants/src/cookies.ts` directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Derive the `Domain` cookie attribute for cross-subdomain auth.
+ *
+ * Two call modes:
+ *   1. **host-driven** (request-aware, defense-in-depth) — used by web app
+ *      `getCookieConfig` in `@codex/constants/src/cookies.ts`.
+ *   2. **env-driven** (worker startup, no request yet) — used by BetterAuth
+ *      `crossSubDomainCookies.domain` in `workers/auth/src/auth-config.ts`.
+ *
+ * When both are provided, `host` wins. Returns `undefined` when no
+ * cross-subdomain scope applies (localhost/127.0.0.1/test env).
+ *
+ * Replaces:
+ * - `getCookieConfig` host-branching logic in `@codex/constants/src/cookies.ts`
+ * - `getDevCookieDomain` in `workers/auth/src/auth-config.ts`
+ * - `crossSubDomainCookies.domain` ternary in `workers/auth/src/auth-config.ts`
+ */
+export function cookieDomainFor(_input: {
+  host?: string;
+  env?: EnvName | { ENVIRONMENT?: string; [k: string]: unknown };
+}): string | undefined {
+  throw new Error('cookieDomainFor: not implemented (WP-5a)');
+}

--- a/packages/urls/src/cors-origins.ts
+++ b/packages/urls/src/cors-origins.ts
@@ -1,0 +1,49 @@
+import type { EnvName } from './types';
+
+/**
+ * Returns the per-env list of trusted origins for BetterAuth's
+ * `trustedOrigins` config. Callers (currently `workers/auth/src/auth-config.ts`
+ * inline array) MUST additionally include the request-time origins
+ * (`env.WEB_APP_URL`, `env.API_URL`) — those are env-binding-driven and
+ * stay outside the static per-env list.
+ *
+ * Matches the existing inline array in `auth-config.ts:190-208`. Migration
+ * of the consumer is deferred (the inline array is touched in WP-1 only to
+ * rename `ENV_NAMES.DEV` → `ENV_NAMES.DEV_REMOTE`; full migration to
+ * `corsOriginsFor` is a follow-up bead).
+ */
+export function corsOriginsFor(env: EnvName): string[] {
+  switch (env) {
+    case 'dev':
+      // Deployed dev (long-lived dev.revelations.studio branch). Browser
+      // requests come from the platform apex AND from per-org subdomains
+      // (studio-alpha.dev.revelations.studio etc), so a wildcard is needed.
+      return [
+        'https://dev.revelations.studio',
+        'https://*.dev.revelations.studio',
+      ];
+    case 'development':
+      return [
+        // Auth worker's own URL for E2E tests
+        'http://localhost:42069',
+        // Dev app (cross-subdomain cookies)
+        'http://lvh.me:3000',
+        // Vite dev server
+        'http://lvh.me:5173',
+        // Phone/LAN testing (any {ip}.nip.io subdomain)
+        'http://*.nip.io',
+      ];
+    case 'staging':
+      return [
+        'https://codex-staging.revelations.studio',
+        'https://*-staging.revelations.studio',
+      ];
+    case 'production':
+      // Prod relies entirely on env.WEB_APP_URL + env.API_URL bindings
+      // (no static origins beyond those).
+      return [];
+    case 'test':
+      // Tests use exact origin per existing config.
+      return [];
+  }
+}

--- a/packages/urls/src/env-hosts.ts
+++ b/packages/urls/src/env-hosts.ts
@@ -1,0 +1,96 @@
+import { SERVICE_PORTS } from '@codex/constants';
+import type { EnvName, ServiceName } from './types';
+
+/**
+ * Service → subdomain prefix. The dot-separated apex follows from `ENV_HOSTS`.
+ *
+ * `content` and `access` share the same worker deployment (content-api).
+ */
+export const SERVICE_SUBDOMAIN: Record<ServiceName, string> = {
+  auth: 'auth',
+  content: 'content-api',
+  access: 'content-api',
+  org: 'organization-api',
+  ecom: 'ecom-api',
+  admin: 'admin-api',
+  identity: 'identity-api',
+  notifications: 'notifications-api',
+  media: 'media-api',
+};
+
+/**
+ * Service → local-dev port. Pulled from `@codex/constants.SERVICE_PORTS` so
+ * the port table stays the single source of truth. Re-exposed here as a
+ * `ServiceName`-keyed map for ergonomic lookup in `ENV_HOSTS.development.apiUrl`.
+ */
+const SERVICE_PORT_MAP: Record<ServiceName, number> = {
+  auth: SERVICE_PORTS.AUTH,
+  content: SERVICE_PORTS.CONTENT,
+  access: SERVICE_PORTS.ACCESS,
+  org: SERVICE_PORTS.ORGANIZATION,
+  ecom: SERVICE_PORTS.ECOMMERCE,
+  admin: SERVICE_PORTS.ADMIN,
+  identity: SERVICE_PORTS.IDENTITY,
+  notifications: SERVICE_PORTS.NOTIFICATIONS,
+  media: SERVICE_PORTS.MEDIA,
+};
+
+/**
+ * Per-env routing primitives. Source of truth for URL construction across
+ * the entire codebase — every consumer that needs a worker URL, an org
+ * hostname, or a platform scheme reads it from here.
+ */
+export interface EnvHost {
+  /** HTTP scheme for this env. Local envs use http; deployed envs use https. */
+  scheme: 'http' | 'https';
+  /** Port suffix for local envs only (omitted for deployed envs). */
+  port?: number;
+  /** Worker URL for a given service. */
+  apiUrl(service: ServiceName): string;
+  /** Hostname (no scheme, no path) for a given org slug. */
+  orgHost(slug: string): string;
+}
+
+/**
+ * The 5-row environment table. Replaces the 27-cell `DEFAULT_URLS` table in
+ * `@codex/constants/src/env.ts` (migrated to call `apiUrl(service)` in WP-3).
+ *
+ * Notes:
+ * - Staging uses a **suffix** pattern (`{slug}-staging.revelations.studio`),
+ *   NOT a depth pattern. The apex stays `revelations.studio`; the staging-ness
+ *   is encoded in the subdomain prefix. This matches the wrangler route
+ *   `*-staging.revelations.studio/*` pattern.
+ * - Dev uses per-org Cloudflare Custom Domains (provisioned by
+ *   `DevDomainService`), not a wildcard zone route. Cloudflare research
+ *   verdict to keep this asymmetry — see
+ *   `docs/routing-centralization/cloudflare-edge-cases.md`.
+ */
+export const ENV_HOSTS: Record<EnvName, EnvHost> = {
+  production: {
+    scheme: 'https',
+    apiUrl: (s) => `https://${SERVICE_SUBDOMAIN[s]}.revelations.studio`,
+    orgHost: (slug) => `${slug}.revelations.studio`,
+  },
+  staging: {
+    scheme: 'https',
+    apiUrl: (s) => `https://${SERVICE_SUBDOMAIN[s]}-staging.revelations.studio`,
+    orgHost: (slug) => `${slug}-staging.revelations.studio`,
+  },
+  dev: {
+    scheme: 'https',
+    apiUrl: (s) => `https://${SERVICE_SUBDOMAIN[s]}.dev.revelations.studio`,
+    orgHost: (slug) => `${slug}.dev.revelations.studio`,
+  },
+  development: {
+    scheme: 'http',
+    port: 3000,
+    apiUrl: (s) => `http://localhost:${SERVICE_PORT_MAP[s]}`,
+    orgHost: (slug) => `${slug}.lvh.me`,
+  },
+  test: {
+    scheme: 'http',
+    port: 3000,
+    apiUrl: (s) => `http://localhost:${SERVICE_PORT_MAP[s]}`,
+    orgHost: (slug) => `${slug}.lvh.me`,
+  },
+};

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -1,0 +1,20 @@
+// Stubs for WP-3 (buildServiceUrl) and WP-4 (URL builders).
+// Each throws an explicit "not implemented (WP-N)" error on call.
+export {
+  buildContentUrl,
+  buildCreatorsUrl,
+  buildOrgUrl,
+  buildOrgUrlFromEnv,
+  buildPlatformUrl,
+  buildServiceUrl,
+} from './build-url';
+// Stub for WP-5a (cookieDomainFor). Throws "not implemented (WP-5a)" on call.
+export { cookieDomainFor } from './cookie-domain';
+export { corsOriginsFor } from './cors-origins';
+export {
+  ENV_HOSTS,
+  type EnvHost,
+  SERVICE_SUBDOMAIN,
+} from './env-hosts';
+export { parseHost } from './parse-host';
+export type { EnvName, HostInfo, ServiceName } from './types';

--- a/packages/urls/src/parse-host.ts
+++ b/packages/urls/src/parse-host.ts
@@ -1,0 +1,119 @@
+import type { EnvName, HostInfo } from './types';
+
+/**
+ * Parse a hostname into structured route info.
+ *
+ * Detects env from TLD pattern. Returns `env: null` for unknown hosts
+ * (custom domains, IPs, etc.) — workers should pass env explicitly when
+ * building URLs from non-routable contexts.
+ *
+ * Backward-compat note: the `subdomain` field returns the LITERAL first-level
+ * label as `extractSubdomain` did historically. For staging hosts, that means
+ * the suffix `-staging` is preserved (e.g. `codex-staging.revelations.studio`
+ * yields `subdomain: 'codex-staging'`). The `env` field is the canonical
+ * env-detection signal.
+ */
+export function parseHost(host: string): HostInfo {
+  const colonIdx = host.indexOf(':');
+  // Normalize to lowercase. DNS hostnames are case-insensitive (RFC 4343),
+  // and routing-layer comparisons MUST behave the same regardless of how the
+  // request's Host header is cased. SvelteKit lowercases the URL.hostname
+  // before the reroute hook fires, but Hono passes raw Host through — so
+  // doing this once at the parse boundary future-proofs every consumer.
+  const hostNoPort = (
+    colonIdx >= 0 ? host.slice(0, colonIdx) : host
+  ).toLowerCase();
+  const port = colonIdx >= 0 ? host.slice(colonIdx + 1) : null;
+
+  // Single-apex envs: bare apex OR `{single-label}.apex`. Nested subdomains
+  // (more than one label before apex) collapse to `subdomain: null`. Order
+  // matters — `.dev.revelations.studio` MUST be checked before the broader
+  // `.revelations.studio` block below.
+  const apexMatch =
+    matchApex(hostNoPort, 'lvh.me', 'development') ??
+    matchApex(hostNoPort, 'localhost', 'development') ??
+    matchApex(hostNoPort, 'dev.revelations.studio', 'dev');
+  if (apexMatch) {
+    return { ...apexMatch, port, nipApex: null };
+  }
+
+  // nip.io — LAN testing via embedded IP. Pattern:
+  //   (subdomain.)?<a.b.c.d>.nip.io
+  if (hostNoPort.endsWith('nip.io')) {
+    const m = hostNoPort.match(/^(?:(.+?)\.)?(\d+\.\d+\.\d+\.\d+\.nip\.io)$/);
+    const nipApex = m?.[2];
+    if (m && nipApex) {
+      const sub = m[1];
+      const subClean = sub && !sub.includes('.') ? sub : null;
+      return {
+        env: 'development',
+        baseDomain: nipApex,
+        subdomain: subClean,
+        port,
+        nipApex,
+      };
+    }
+  }
+
+  // *.revelations.studio (prod + staging, both single-level).
+  // Staging uses suffix pattern (foo-staging.revelations.studio), NOT depth.
+  if (hostNoPort === 'revelations.studio') {
+    return {
+      env: 'production',
+      baseDomain: 'revelations.studio',
+      subdomain: null,
+      port,
+      nipApex: null,
+    };
+  }
+  const rsMatch = hostNoPort.match(/^([^.]+)\.revelations\.studio$/);
+  const rsSub = rsMatch?.[1];
+  if (rsSub) {
+    const isStaging = rsSub === 'staging' || rsSub.endsWith('-staging');
+    return {
+      env: isStaging ? 'staging' : 'production',
+      baseDomain: 'revelations.studio',
+      subdomain: rsSub,
+      port,
+      nipApex: null,
+    };
+  }
+
+  // Unknown host — env=null; callers must pass env explicitly to URL builders.
+  return {
+    env: null,
+    baseDomain: hostNoPort,
+    subdomain: null,
+    port,
+    nipApex: null,
+  };
+}
+
+/**
+ * Match a host against a single-apex env (bare apex OR one-label subdomain).
+ * Returns `null` when the host does not belong to this apex, so the caller
+ * can fall through to the next candidate.
+ */
+function matchApex(
+  hostNoPort: string,
+  apex: string,
+  env: EnvName
+): { env: EnvName; baseDomain: string; subdomain: string | null } | null {
+  if (hostNoPort === apex) {
+    return { env, baseDomain: apex, subdomain: null };
+  }
+  const suffix = `.${apex}`;
+  if (hostNoPort.endsWith(suffix)) {
+    const sub = hostNoPort.slice(0, -suffix.length);
+    // `sub` must be a non-empty single label. Reject empty (malformed
+    // leading-dot host like `.lvh.me`) and reject nested (multi-label
+    // like `foo.bar.lvh.me`). Matches the historical `extractSubdomain`
+    // semantics in apps/web/src/lib/utils/subdomain.ts.
+    return {
+      env,
+      baseDomain: apex,
+      subdomain: sub && !sub.includes('.') ? sub : null,
+    };
+  }
+  return null;
+}

--- a/packages/urls/src/types.ts
+++ b/packages/urls/src/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical env name. Distinguishes:
+ *  - `production`  — prod (revelations.studio wildcard zone route)
+ *  - `staging`     — staging (revelations.studio with `-staging` suffix)
+ *  - `dev`         — deployed long-lived dev (dev.revelations.studio with per-org
+ *                    Cloudflare Custom Domains; see DevDomainService)
+ *  - `development` — local development (lvh.me / nip.io / localhost)
+ *  - `test`        — automated tests (lvh.me with non-secure cookies)
+ *
+ * Note: `dev` and `development` are intentionally different — the deployed
+ * `dev` runs over HTTPS with secure cookies at dev.revelations.studio.
+ */
+export type EnvName = 'production' | 'staging' | 'dev' | 'development' | 'test';
+
+/**
+ * Backend service identifier. Must match `SERVICE_SUBDOMAIN` and
+ * `SERVICE_PORT_MAP` in `env-hosts.ts`. Mirrors `@codex/constants` `ServiceName`
+ * for compatibility but lives here as the routing-layer canonical type.
+ */
+export type ServiceName =
+  | 'auth'
+  | 'content'
+  | 'access'
+  | 'org'
+  | 'ecom'
+  | 'admin'
+  | 'identity'
+  | 'notifications'
+  | 'media';
+
+/**
+ * Structured result of `parseHost(host)`. Returns everything callers need to
+ * route, build URLs, or set cookies — without re-deriving any TLD-branch logic.
+ */
+export interface HostInfo {
+  /**
+   * Detected env from TLD. `null` when no match (custom domains, IPs, etc.) —
+   * workers should pass env explicitly in that case.
+   */
+  env: EnvName | null;
+  /**
+   * What goes AFTER an org slug. Used for URL construction and cookie domain.
+   * Examples: `lvh.me`, `dev.revelations.studio`, `revelations.studio`,
+   * `192.168.1.10.nip.io`, `localhost`.
+   */
+  baseDomain: string;
+  /**
+   * First label before `baseDomain`, or `null` on apex. For deployed dev,
+   * this is the org slug. For staging, this is the LITERAL prefix including
+   * any `-staging` suffix (e.g. `codex-staging`) — backward-compat with
+   * existing `extractSubdomain` behavior.
+   */
+  subdomain: string | null;
+  /** Port suffix or `null`. */
+  port: string | null;
+  /**
+   * For nip.io LAN testing — the extracted `192.168.1.10.nip.io` portion.
+   * `null` when not a nip.io host. Used by cookie domain logic to set
+   * `Domain=.{ip}.nip.io` for cross-subdomain mobile testing.
+   */
+  nipApex: string | null;
+}

--- a/packages/urls/tsconfig.json
+++ b/packages/urls/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig/package.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/urls/vite.config.urls.ts
+++ b/packages/urls/vite.config.urls.ts
@@ -1,0 +1,5 @@
+import { createPackageConfig } from '../../config/vite/package.config';
+
+export default createPackageConfig({
+  packageName: 'urls',
+});

--- a/packages/urls/vitest.config.urls.ts
+++ b/packages/urls/vitest.config.urls.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'urls',
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1147,6 +1147,19 @@ importers:
         specifier: ^4.0.2
         version: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@22.13.0)(@vitest/ui@4.0.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0)(tsx@4.20.6)(yaml@2.8.1)
 
+  packages/urls:
+    dependencies:
+      '@codex/constants':
+        specifier: workspace:*
+        version: link:../constants
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.2.2
+        version: 7.2.4(@types/node@22.13.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+
   packages/validation:
     dependencies:
       '@codex/constants':

--- a/workers/auth/src/auth-config.ts
+++ b/workers/auth/src/auth-config.ts
@@ -193,7 +193,7 @@ export function createAuthInstance(options: AuthConfigOptions) {
       // Deployed dev (long-lived dev.revelations.studio branch). Browser
       // requests come from the platform apex AND from per-org subdomains
       // (studio-alpha.dev.revelations.studio etc), so a wildcard is needed.
-      ...(env.ENVIRONMENT === ENV_NAMES.DEV
+      ...(env.ENVIRONMENT === ENV_NAMES.DEV_REMOTE
         ? [`https://${DOMAINS.DEV_REMOTE}`, `https://*.${DOMAINS.DEV_REMOTE}`]
         : []),
       // Local dev origins
@@ -219,7 +219,7 @@ export function createAuthInstance(options: AuthConfigOptions) {
             ? getDevCookieDomain(env) // .lvh.me or .{ip}.nip.io based on WEB_APP_URL
             : env.ENVIRONMENT === ENV_NAMES.TEST
               ? undefined // Tests use exact origin
-              : env.ENVIRONMENT === ENV_NAMES.DEV
+              : env.ENVIRONMENT === ENV_NAMES.DEV_REMOTE
                 ? `.${DOMAINS.DEV_REMOTE}` // .dev.revelations.studio
                 : `.${DOMAINS.PROD}`,
       },


### PR DESCRIPTION
## Summary

Foundation work for the routing centralization epic ([Codex-rscgk](https://github.com/brucemckayone/codex/issues?q=Codex-rscgk)). Introduces the new `@codex/urls` package owning hostname parsing, env detection, CORS origins, and the `ENV_HOSTS` table that downstream WPs (2 through 9) will consume.

**Bead:** Codex-bhmpt
**Plan:** `~/.claude/plans/typed-honking-canyon.md` (§6 WP-1)
**Investigation:** docs/routing-centralization.md (merged via #247)

### What's shipped

- **New `@codex/urls` package** — zero deps except `@codex/constants` (for `SERVICE_PORTS`)
  - `parseHost(host)` — single source of truth for hostname → `{env, baseDomain, subdomain, port, nipApex}`
  - `ENV_HOSTS` — 5-row table (`production`, `staging`, `dev`, `development`, `test`) with `scheme`, `port`, `apiUrl(service)`, `orgHost(slug)`
  - `corsOriginsFor(env)` — per-env BetterAuth `trustedOrigins` lookup (consumer migration deferred to follow-up)
  - `HostInfo`, `EnvName`, `ServiceName` types
- **`build-url.ts` and `cookie-domain.ts` ship as THROW STUBS** — signatures stable so WP-2/3/4/5a can develop in parallel against `@codex/urls`. Each throws an explicit `not implemented (WP-N)` pointing at its implementing WP.
- **`ENV_NAMES.DEV` → `DEV_REMOTE` rename** — VALUE stays `'dev'`; identifier-only change to resolve the two-`dev` confusion (`DEV_REMOTE` = deployed `dev.revelations.studio`; `DEVELOPMENT` = local). Three call sites migrated:
  - `packages/constants/src/env.ts` (`isDevRemote()`)
  - `workers/auth/src/auth-config.ts` (`trustedOrigins` + `crossSubDomainCookies.domain`)
- **`staging` added as first-class env** in `ENV_HOSTS` — fixes the latent foot-gun where forgotten staging URL env-vars would silently fall through to prod URLs in `pickDefaultUrl()`.

### Code-review findings applied

- **I1 (Important):** `matchApex` empty-string subdomain regression on `.lvh.me` — backward-compat fix; matches historical `extractSubdomain` semantics
- **I2 (Important):** `parseHost` case-normalization per RFC 4343 — future-proofs every consumer

## Test plan

- [x] `pnpm --filter @codex/urls test` — **58/58** pass (parse-host: 34, env-hosts: 18, cors-origins: 6)
- [x] `pnpm --filter @codex/urls typecheck` clean
- [x] `pnpm --filter @codex/constants test` — 56/56 pass (regression)
- [x] `pnpm --filter @codex/constants typecheck` clean
- [x] `pnpm --filter auth typecheck` clean
- [x] `pnpm biome check src/` clean across `@codex/urls`
- [x] `/simplify` applied: `matchApex` helper consolidates 3 duplicate apex-match branches; 5 new tests added
- [x] `/review` applied: I1 + I2 fixes
- [x] No new dead code (all exports in `index.ts` barrel are consumed or are intentional WP-N stubs)
- [x] No `as any`, no `@ts-ignore`, no hardcoded ports/URLs outside `ENV_HOSTS`

## Out of scope (downstream WPs)

This PR establishes the foundation. No downstream consumers are migrated yet:

- WP-2 (Codex-qyjds): `apps/web/src/lib/utils/subdomain.ts` becomes wrapper around `parseHost`
- WP-3 (Codex-4xbuw): `buildServiceUrl` replaces `getServiceUrl` + `DEFAULT_URLS`
- WP-4 (Codex-fiveo): URL builders + `buildOrgUrlFromEnv`
- WP-5a (Codex-ora41): `cookieDomainFor` unification + byte-equal fixture
- WP-5b (Codex-7okxb): BetterAuth integration test
- WP-6 (Codex-0hxw4): DevDomainService rewire
- WP-7 (Codex-10hr1): wrangler URL env-var cleanup
- WP-8 (Codex-6wvam): sitemap structural test
- WP-9 (Codex-ikum9): dev-deploy smoke gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)