### PR TITLE
feat(urls): WP-3 migrate buildServiceUrl + add staging env

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "@codex/shared-types": "workspace:*",
     "@codex/subscription": "workspace:*",
     "@codex/test-utils": "workspace:*",
+    "@codex/urls": "workspace:*",
     "@codex/validation": "workspace:*",
     "@inlang/paraglide-sveltekit": "^0.15.0",
     "@melt-ui/svelte": "^0.86.6",

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -30,13 +30,7 @@ import type {
   AgreementProposal,
   CreatorOrganizationAgreement,
 } from '@codex/agreements';
-import {
-  COOKIES,
-  getServiceUrl,
-  HEADERS,
-  MIME_TYPES,
-  type ServiceName,
-} from '@codex/constants';
+import { COOKIES, HEADERS, MIME_TYPES } from '@codex/constants';
 import type { MediaItem } from '@codex/database/schema';
 import type { AvatarUploadResponse } from '@codex/identity';
 import type { NotificationPreferencesResponse } from '@codex/notifications';
@@ -65,6 +59,10 @@ import type {
   PayoutWithCreator,
   SubscriberListItem,
 } from '@codex/subscription';
+import {
+  buildServiceUrl as getServiceUrl,
+  type ServiceName,
+} from '@codex/urls';
 import type {
   CancelSubscriptionInput,
   ChangeTierInput,

--- a/apps/web/src/routes/(auth)/verify-email/+page.server.ts
+++ b/apps/web/src/routes/(auth)/verify-email/+page.server.ts
@@ -1,4 +1,5 @@
-import { COOKIES, getCookieConfig, getServiceUrl } from '@codex/constants';
+import { COOKIES, getCookieConfig } from '@codex/constants';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import { logger } from '$lib/observability';
 import {
   extractSessionToken,

--- a/apps/web/src/routes/api/unsubscribe/[token]/+server.ts
+++ b/apps/web/src/routes/api/unsubscribe/[token]/+server.ts
@@ -1,4 +1,4 @@
-import { getServiceUrl } from '@codex/constants';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 

--- a/apps/web/src/routes/unsubscribe/[token]/+page.server.ts
+++ b/apps/web/src/routes/unsubscribe/[token]/+page.server.ts
@@ -1,4 +1,4 @@
-import { getServiceUrl } from '@codex/constants';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, platform }) => {

--- a/packages/constants/src/env.test.ts
+++ b/packages/constants/src/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type Env, getServiceUrl, isDev, validateServiceUrl } from './env';
+import { isDev, validateServiceUrl } from './env';
 
 describe('isDev', () => {
   it('returns true for boolean true', () => {
@@ -34,87 +34,9 @@ describe('isDev', () => {
   });
 });
 
-describe('getServiceUrl', () => {
-  it('returns dev URL in dev mode', () => {
-    const url = getServiceUrl('auth', true);
-    expect(url).toContain('localhost');
-  });
-
-  it('returns prod URL in prod mode', () => {
-    const url = getServiceUrl('auth', false);
-    expect(url).toContain('revelations.studio');
-  });
-
-  it('uses environment binding if provided', () => {
-    const env: Env = {
-      AUTH_WORKER_URL: 'https://custom.example.com',
-      MODE: 'production',
-    };
-    const url = getServiceUrl('auth', env);
-    expect(url).toBe('https://custom.example.com');
-  });
-
-  it('validates environment URLs in production', () => {
-    const env: Env = {
-      AUTH_WORKER_URL: 'http://insecure.example.com',
-      MODE: 'production',
-    };
-    expect(() => getServiceUrl('auth', env)).toThrow('HTTPS is required');
-  });
-
-  it('allows HTTP in dev mode', () => {
-    const env: Env = {
-      AUTH_WORKER_URL: 'http://localhost:3000',
-      dev: true,
-    };
-    const url = getServiceUrl('auth', env);
-    expect(url).toBe('http://localhost:3000');
-  });
-
-  it('returns all service URLs in dev mode', () => {
-    const services = [
-      'auth',
-      'content',
-      'access',
-      'org',
-      'ecom',
-      'admin',
-      'identity',
-      'notifications',
-      'media',
-    ] as const;
-
-    for (const service of services) {
-      const url = getServiceUrl(service, true);
-      expect(url).toContain('localhost');
-    }
-  });
-
-  it('returns all service URLs in prod mode', () => {
-    const services = [
-      'auth',
-      'content',
-      'access',
-      'org',
-      'ecom',
-      'admin',
-      'identity',
-      'notifications',
-      'media',
-    ] as const;
-
-    for (const service of services) {
-      const url = getServiceUrl(service, false);
-      expect(url).toMatch(/^https:\/\/.*revelations\.studio$/);
-    }
-  });
-  it('throws for unknown service', () => {
-    // @ts-expect-error - Testing invalid input
-    expect(() => getServiceUrl('unknown-service', true)).toThrow(
-      'Unknown service: unknown-service'
-    );
-  });
-});
+// `getServiceUrl` tests moved to packages/urls/src/__tests__/build-service-url.test.ts
+// as part of WP-3 (Codex-4xbuw) — the function was relocated to @codex/urls
+// to centralize routing-layer logic. See plan: ~/.claude/plans/typed-honking-canyon.md
 
 describe('validateServiceUrl', () => {
   it('allows http URLs', () => {

--- a/packages/constants/src/env.ts
+++ b/packages/constants/src/env.ts
@@ -1,16 +1,4 @@
 import { ERROR_CODES, UrlValidationError } from './errors';
-import { SERVICE_PORTS } from './urls';
-
-export type ServiceName =
-  | 'auth'
-  | 'content'
-  | 'access'
-  | 'org'
-  | 'ecom'
-  | 'admin'
-  | 'identity'
-  | 'notifications'
-  | 'media';
 
 export const ENV_NAMES = {
   PRODUCTION: 'production',
@@ -108,6 +96,10 @@ export function isDevRemote(env?: Env | boolean): boolean {
  * - Rejects javascript:, data:, file:, ftp: and other dangerous protocols
  * - Enforces HTTPS in production when requireHttps is true
  * - Blocks private IP ranges and cloud metadata services
+ *
+ * Called by `@codex/urls.buildServiceUrl` for env-var override URLs. The
+ * URL-builder defaults (`ENV_HOSTS`) are NOT validated — they're
+ * code-controlled, not env-controlled, so no SSRF surface.
  */
 export function validateServiceUrl(
   url: string,
@@ -165,7 +157,7 @@ export function validateServiceUrl(
   //
   // NOTE: DNS rebinding attacks (where evil.com → 127.0.0.1) are mitigated because:
   // - Service URLs come from trusted env vars or hardcoded defaults
-  // - No user-controlled URLs are passed to getServiceUrl()
+  // - No user-controlled URLs are passed to buildServiceUrl()
   // - Cloudflare Workers restrict outbound requests to known origins
   //
   // We allow localhost/127.0.0.1 ONLY if requireHttps is false (dev mode implication).
@@ -188,149 +180,4 @@ export function validateServiceUrl(
   }
 
   return url;
-}
-
-const DEFAULT_URLS = {
-  auth: {
-    prod: 'https://auth.revelations.studio',
-    devRemote: 'https://auth.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.AUTH}`,
-  },
-  content: {
-    prod: 'https://content-api.revelations.studio',
-    devRemote: 'https://content-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.CONTENT}`,
-  },
-  access: {
-    prod: 'https://content-api.revelations.studio',
-    devRemote: 'https://content-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.ACCESS}`,
-  },
-  org: {
-    prod: 'https://organization-api.revelations.studio',
-    devRemote: 'https://organization-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.ORGANIZATION}`,
-  },
-  ecom: {
-    prod: 'https://ecom-api.revelations.studio',
-    devRemote: 'https://ecom-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.ECOMMERCE}`,
-  },
-  admin: {
-    prod: 'https://admin-api.revelations.studio',
-    devRemote: 'https://admin-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.ADMIN}`,
-  },
-  identity: {
-    prod: 'https://identity-api.revelations.studio',
-    devRemote: 'https://identity-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.IDENTITY}`,
-  },
-  notifications: {
-    prod: 'https://notifications-api.revelations.studio',
-    devRemote: 'https://notifications-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.NOTIFICATIONS}`,
-  },
-  media: {
-    prod: 'https://media-api.revelations.studio',
-    devRemote: 'https://media-api.dev.revelations.studio',
-    dev: `http://localhost:${SERVICE_PORTS.MEDIA}`,
-  },
-} as const;
-
-type ServiceUrls = (typeof DEFAULT_URLS)[keyof typeof DEFAULT_URLS];
-
-function pickDefaultUrl(urls: ServiceUrls, env?: Env | boolean): string {
-  if (isDevRemote(env)) return urls.devRemote;
-  return isDev(env) ? urls.dev : urls.prod;
-}
-
-export function getServiceUrl(
-  service: ServiceName,
-  env?: Env | boolean
-): string {
-  const devMode = isDev(env);
-  const bindings = typeof env === 'object' ? env : {};
-
-  /**
-   * Resolve an environment variable from bindings or process.env
-   */
-  const getEnvVar = (key: string): string | undefined => {
-    // 1. Check bindings (Cloudflare/SvelteKit platform.env)
-    if (bindings[key]) return bindings[key] as string;
-
-    // 2. Check Node.js process.env (for local development and E2E tests)
-    if (typeof process !== 'undefined' && process.env[key]) {
-      return process.env[key];
-    }
-
-    return undefined;
-  };
-
-  // Helper to validate and return URL from env or use default
-  const getValidatedUrl = (
-    envUrl: string | undefined,
-    defaultUrl: string
-  ): string => {
-    if (envUrl) {
-      return validateServiceUrl(envUrl, !devMode);
-    }
-    return defaultUrl;
-  };
-
-  switch (service) {
-    case 'auth':
-      return getValidatedUrl(
-        getEnvVar('AUTH_WORKER_URL'),
-        pickDefaultUrl(DEFAULT_URLS.auth, env)
-      );
-    case 'content':
-      return getValidatedUrl(
-        getEnvVar('API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.content, env)
-      );
-    case 'access':
-      return getValidatedUrl(
-        getEnvVar('API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.access, env)
-      );
-    case 'org':
-      return getValidatedUrl(
-        getEnvVar('ORG_API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.org, env)
-      );
-    case 'ecom':
-      return getValidatedUrl(
-        getEnvVar('ECOM_API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.ecom, env)
-      );
-    case 'admin':
-      return getValidatedUrl(
-        getEnvVar('ADMIN_API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.admin, env)
-      );
-    case 'identity':
-      return getValidatedUrl(
-        getEnvVar('IDENTITY_API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.identity, env)
-      );
-    case 'notifications':
-      return getValidatedUrl(
-        getEnvVar('NOTIFICATIONS_API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.notifications, env)
-      );
-    case 'media':
-      return getValidatedUrl(
-        getEnvVar('MEDIA_API_URL'),
-        pickDefaultUrl(DEFAULT_URLS.media, env)
-      );
-    default: {
-      // Runtime fallback for unknown services
-      const defaults = DEFAULT_URLS[service as keyof typeof DEFAULT_URLS];
-      if (defaults) {
-        return pickDefaultUrl(defaults, env);
-      }
-      throw new Error(`Unknown service: ${service}`);
-    }
-  }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -25,6 +25,7 @@
     "@codex/constants": "workspace:*",
     "@codex/database": "workspace:*",
     "@codex/shared-types": "workspace:*",
+    "@codex/urls": "workspace:*",
     "@neondatabase/serverless": "^0.10.4",
     "drizzle-orm": "0.44.7",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/test-utils/src/e2e/fixtures/auth.fixture.ts
+++ b/packages/test-utils/src/e2e/fixtures/auth.fixture.ts
@@ -1,4 +1,4 @@
-import { getServiceUrl } from '@codex/constants';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import { httpClient } from '../helpers/http-client';
 import type { RegisteredUser } from '../helpers/types';
 

--- a/packages/urls/src/__tests__/build-service-url.test.ts
+++ b/packages/urls/src/__tests__/build-service-url.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildServiceUrl } from '../build-url';
+import type { EnvName, ServiceName } from '../types';
+
+const ALL_SERVICES: ServiceName[] = [
+  'auth',
+  'content',
+  'access',
+  'org',
+  'ecom',
+  'admin',
+  'identity',
+  'notifications',
+  'media',
+];
+
+describe('buildServiceUrl', () => {
+  // Save + restore process.env across tests so env-var override fallbacks
+  // don't bleed between cases.
+  let originalEnv: NodeJS.ProcessEnv;
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('EnvName string resolution', () => {
+    it('production yields auth.revelations.studio for auth', () => {
+      expect(buildServiceUrl('auth', 'production')).toBe(
+        'https://auth.revelations.studio'
+      );
+    });
+
+    it('staging yields auth-staging.revelations.studio for auth', () => {
+      expect(buildServiceUrl('auth', 'staging')).toBe(
+        'https://auth-staging.revelations.studio'
+      );
+    });
+
+    it('dev (deployed) yields auth.dev.revelations.studio for auth', () => {
+      expect(buildServiceUrl('auth', 'dev')).toBe(
+        'https://auth.dev.revelations.studio'
+      );
+    });
+
+    it('development yields http://localhost:42069 for auth', () => {
+      expect(buildServiceUrl('auth', 'development')).toBe(
+        'http://localhost:42069'
+      );
+    });
+
+    it('test yields the same URL as development', () => {
+      expect(buildServiceUrl('auth', 'test')).toBe(
+        buildServiceUrl('auth', 'development')
+      );
+    });
+  });
+
+  describe('boolean env (backward-compat with old getServiceUrl)', () => {
+    it('true resolves to development', () => {
+      expect(buildServiceUrl('auth', true)).toBe('http://localhost:42069');
+    });
+
+    it('false resolves to production', () => {
+      expect(buildServiceUrl('auth', false)).toBe(
+        'https://auth.revelations.studio'
+      );
+    });
+  });
+
+  describe('Env object resolution', () => {
+    it('reads ENVIRONMENT="production"', () => {
+      expect(buildServiceUrl('org', { ENVIRONMENT: 'production' })).toBe(
+        'https://organization-api.revelations.studio'
+      );
+    });
+
+    it('reads ENVIRONMENT="staging"', () => {
+      expect(buildServiceUrl('org', { ENVIRONMENT: 'staging' })).toBe(
+        'https://organization-api-staging.revelations.studio'
+      );
+    });
+
+    it('reads ENVIRONMENT="dev"', () => {
+      expect(buildServiceUrl('org', { ENVIRONMENT: 'dev' })).toBe(
+        'https://organization-api.dev.revelations.studio'
+      );
+    });
+
+    it('reads ENVIRONMENT="development"', () => {
+      expect(buildServiceUrl('org', { ENVIRONMENT: 'development' })).toBe(
+        'http://localhost:42071'
+      );
+    });
+
+    it('reads ENVIRONMENT="test"', () => {
+      expect(buildServiceUrl('org', { ENVIRONMENT: 'test' })).toBe(
+        'http://localhost:42071'
+      );
+    });
+
+    it('MODE=development falls through when ENVIRONMENT absent', () => {
+      expect(buildServiceUrl('auth', { MODE: 'development' })).toBe(
+        'http://localhost:42069'
+      );
+    });
+
+    it('MODE=production falls through when ENVIRONMENT absent', () => {
+      expect(buildServiceUrl('auth', { MODE: 'production' })).toBe(
+        'https://auth.revelations.studio'
+      );
+    });
+
+    it('dev=true falls through when ENVIRONMENT and MODE absent', () => {
+      expect(buildServiceUrl('auth', { dev: true })).toBe(
+        'http://localhost:42069'
+      );
+    });
+
+    it('dev=false does NOT force production (falls through to NODE_ENV)', () => {
+      // dev: false is treated as absent — only `dev: true` selects development.
+      // Under vitest NODE_ENV=test, the fallback path picks development.
+      process.env.NODE_ENV = 'test';
+      expect(buildServiceUrl('auth', { dev: false })).toBe(
+        'http://localhost:42069'
+      );
+    });
+
+    it('empty Env defaults to production when NODE_ENV is absent (safe-by-default)', () => {
+      // Vitest sets NODE_ENV='test' by default; clear it to test the true
+      // empty-Env fallback. In a real deployment Cloudflare Workers don't
+      // expose process.env.NODE_ENV at all. `delete` is required because
+      // assigning `undefined` to process.env.X coerces to the STRING
+      // 'undefined' (Node.js process.env behavior).
+      delete process.env.NODE_ENV;
+      expect(buildServiceUrl('auth', {})).toBe(
+        'https://auth.revelations.studio'
+      );
+    });
+
+    it('ENVIRONMENT strictly wins over MODE (intentional precedence)', () => {
+      // Resolves to development (env.ENVIRONMENT='development') even though
+      // env.MODE='production' would suggest otherwise. The new precedence
+      // is documented on resolveEnvName's JSDoc; this test pins it so any
+      // future precedence change is caught.
+      expect(
+        buildServiceUrl('auth', {
+          ENVIRONMENT: 'development',
+          MODE: 'production',
+        })
+      ).toBe('http://localhost:42069');
+    });
+
+    it('ENVIRONMENT strictly wins over dev:true', () => {
+      // env.dev:true would normally select development, but explicit
+      // ENVIRONMENT='production' takes precedence.
+      expect(
+        buildServiceUrl('auth', { ENVIRONMENT: 'production', dev: true })
+      ).toBe('https://auth.revelations.studio');
+    });
+
+    it('empty Env returns development URL when NODE_ENV=test (vitest default)', () => {
+      // Documents the legitimate fallback path: when running under vitest,
+      // an empty Env defaults to 'development'. This matches the historical
+      // getServiceUrl behavior — backward-compat verified.
+      process.env.NODE_ENV = 'test';
+      expect(buildServiceUrl('auth', {})).toBe('http://localhost:42069');
+    });
+  });
+
+  describe('undefined env fallback', () => {
+    it('respects NODE_ENV=test → development', () => {
+      process.env.NODE_ENV = 'test';
+      expect(buildServiceUrl('auth')).toBe('http://localhost:42069');
+    });
+
+    it('respects NODE_ENV=production → production', () => {
+      process.env.NODE_ENV = 'production';
+      expect(buildServiceUrl('auth')).toBe('https://auth.revelations.studio');
+    });
+  });
+
+  describe('env-var override (Cloudflare bindings)', () => {
+    it('AUTH_WORKER_URL override wins over ENV_HOSTS default', () => {
+      const url = buildServiceUrl('auth', {
+        ENVIRONMENT: 'production',
+        AUTH_WORKER_URL: 'https://custom-auth.example.com',
+      });
+      expect(url).toBe('https://custom-auth.example.com');
+    });
+
+    it('API_URL override applies to content service', () => {
+      const url = buildServiceUrl('content', {
+        ENVIRONMENT: 'production',
+        API_URL: 'https://custom-content.example.com',
+      });
+      expect(url).toBe('https://custom-content.example.com');
+    });
+
+    it('API_URL override applies to access service (shared deployment)', () => {
+      const url = buildServiceUrl('access', {
+        ENVIRONMENT: 'production',
+        API_URL: 'https://custom-content.example.com',
+      });
+      expect(url).toBe('https://custom-content.example.com');
+    });
+
+    it('per-service URL override applies (ORG_API_URL → org)', () => {
+      const url = buildServiceUrl('org', {
+        ENVIRONMENT: 'staging',
+        ORG_API_URL: 'https://custom-org.example.com',
+      });
+      expect(url).toBe('https://custom-org.example.com');
+    });
+
+    it('override falls through to default when env value is empty string', () => {
+      expect(
+        buildServiceUrl('auth', {
+          ENVIRONMENT: 'production',
+          AUTH_WORKER_URL: '',
+        })
+      ).toBe('https://auth.revelations.studio');
+    });
+
+    it('reads override from process.env when bindings lack the key', () => {
+      // Bindings-first, process.env-fallback path. Cloudflare Workers don't
+      // expose process.env, but local dev + E2E tests rely on this fallback
+      // when the binding isn't materialized into the env object.
+      process.env.AUTH_WORKER_URL = 'https://from-process-env.example.com';
+      const url = buildServiceUrl('auth', { ENVIRONMENT: 'production' });
+      expect(url).toBe('https://from-process-env.example.com');
+    });
+  });
+
+  describe('SSRF validation on env-var overrides', () => {
+    it('rejects javascript: URL in deployed env', () => {
+      expect(() =>
+        buildServiceUrl('auth', {
+          ENVIRONMENT: 'production',
+          AUTH_WORKER_URL: 'javascript:alert(1)',
+        })
+      ).toThrow();
+    });
+
+    it('rejects http:// in deployed env (requireHttps)', () => {
+      expect(() =>
+        buildServiceUrl('auth', {
+          ENVIRONMENT: 'production',
+          AUTH_WORKER_URL: 'http://insecure.example.com',
+        })
+      ).toThrow();
+    });
+
+    it('allows http:// in development env (requireHttps=false)', () => {
+      const url = buildServiceUrl('auth', {
+        ENVIRONMENT: 'development',
+        AUTH_WORKER_URL: 'http://localhost:9000',
+      });
+      expect(url).toBe('http://localhost:9000');
+    });
+
+    it('rejects private IP in deployed env (SSRF)', () => {
+      expect(() =>
+        buildServiceUrl('auth', {
+          ENVIRONMENT: 'production',
+          AUTH_WORKER_URL: 'https://10.0.0.1',
+        })
+      ).toThrow();
+    });
+
+    it('rejects cloud metadata service URL', () => {
+      expect(() =>
+        buildServiceUrl('auth', {
+          ENVIRONMENT: 'production',
+          AUTH_WORKER_URL: 'https://169.254.169.254',
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('default URLs are NOT validated (code-controlled, no SSRF surface)', () => {
+    it('localhost defaults work in development without SSRF errors', () => {
+      // ENV_HOSTS.development.apiUrl('auth') returns 'http://localhost:42069'.
+      // The historical getServiceUrl also skipped validation on defaults.
+      expect(buildServiceUrl('auth', 'development')).toBe(
+        'http://localhost:42069'
+      );
+    });
+  });
+
+  describe('coverage matrix (every service × every env)', () => {
+    const ALL_ENVS: EnvName[] = [
+      'production',
+      'staging',
+      'dev',
+      'development',
+      'test',
+    ];
+
+    it('every combination produces a non-empty https://… or http://… URL', () => {
+      for (const env of ALL_ENVS) {
+        for (const service of ALL_SERVICES) {
+          const url = buildServiceUrl(service, env);
+          expect(url).toMatch(/^https?:\/\/.+/);
+        }
+      }
+    });
+  });
+});

--- a/packages/urls/src/build-url.ts
+++ b/packages/urls/src/build-url.ts
@@ -1,25 +1,141 @@
+import { type Env, validateServiceUrl } from '@codex/constants';
+import { ENV_HOSTS } from './env-hosts';
 import type { EnvName, HostInfo, ServiceName } from './types';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// STUBS — filled in WP-3 (buildServiceUrl) and WP-4 (org/platform/content URL
-// builders). Signatures are stable so WP-2/3/4/5a can develop in parallel.
-// Throwing here surfaces an explicit error if any consumer reaches a stub
-// before its implementing WP has landed.
-// ─────────────────────────────────────────────────────────────────────────────
+/**
+ * Per-service env-var override key. Workers + apps/web have always supported
+ * overriding the default URL via these bindings (e.g. for pointing local dev
+ * at a remote staging worker). Migration of the wrangler env-var declarations
+ * is WP-7 — until then these overrides remain functional.
+ *
+ * `content` and `access` share `API_URL` because they deploy to the same
+ * content-api worker.
+ */
+const SERVICE_ENV_VAR: Record<ServiceName, string> = {
+  auth: 'AUTH_WORKER_URL',
+  content: 'API_URL',
+  access: 'API_URL',
+  org: 'ORG_API_URL',
+  ecom: 'ECOM_API_URL',
+  admin: 'ADMIN_API_URL',
+  identity: 'IDENTITY_API_URL',
+  notifications: 'NOTIFICATIONS_API_URL',
+  media: 'MEDIA_API_URL',
+};
 
 /**
  * Build a worker service URL. Reads env-var override first; falls back to
  * `ENV_HOSTS[env].apiUrl(service)`.
  *
- * Replaces `getServiceUrl` from `@codex/constants/src/env.ts` (which becomes
- * a re-export shim in WP-3).
+ * Replaces `getServiceUrl` from `@codex/constants/src/env.ts`. Migration of
+ * the 7 caller files happens in this same WP (WP-3) — `getServiceUrl` is
+ * removed from `@codex/constants` rather than kept as a shim, because
+ * `@codex/urls` already depends on `@codex/constants` and a shim would
+ * create a module-load cycle.
+ *
+ * Security: env-var overrides are passed through `validateServiceUrl()`
+ * (SSRF protection: blocks `javascript:`, `data:`, cloud metadata, private
+ * IPs in non-dev). `ENV_HOSTS` defaults are NOT validated — they're
+ * code-controlled, not env-controlled, so no SSRF surface.
  */
 export function buildServiceUrl(
-  _service: ServiceName,
-  _env: EnvName | boolean | { ENVIRONMENT?: string; [k: string]: unknown }
+  service: ServiceName,
+  env?: EnvName | boolean | Env
 ): string {
-  throw new Error('buildServiceUrl: not implemented (WP-3)');
+  const bindings: Record<string, unknown> =
+    env && typeof env === 'object' ? env : {};
+  const envName = resolveEnvName(env, bindings);
+
+  const overrideUrl = readEnvVar(bindings, SERVICE_ENV_VAR[service]);
+  if (overrideUrl) {
+    return validateServiceUrl(overrideUrl, isDeployedEnv(envName));
+  }
+
+  return ENV_HOSTS[envName].apiUrl(service);
 }
+
+/**
+ * Resolve the canonical `EnvName` from the loose `env` parameter shape
+ * accepted by `buildServiceUrl` (and historically by `getServiceUrl`).
+ *
+ * Precedence:
+ *   1. `EnvName` string literal (`'production'` / `'staging'` / `'dev'` / ...)
+ *   2. `boolean` — true = development, false = production
+ *   3. `Env` object —
+ *      a. `ENVIRONMENT` binding STRICTLY wins when set to a valid EnvName.
+ *         This is a deliberate divergence from the legacy `isDev()` which
+ *         treated `MODE === 'production'` as a hard override — wrangler
+ *         configs co-set ENVIRONMENT and MODE, so the precedence flip is
+ *         benign in practice but documented + tested here for durability.
+ *      b. `MODE` (only consulted when ENVIRONMENT is absent or invalid)
+ *      c. `dev: true` (only consulted when ENVIRONMENT + MODE are absent)
+ *   4. Fallback: `process.env.NODE_ENV` for Node.js test runners
+ *   5. Default: `'production'` (safe-by-default — defaults to https / strict)
+ *
+ * `bindings` is the same `Env`-as-Record view already materialized by the
+ * caller — passed in to avoid re-typing the object twice.
+ */
+function resolveEnvName(
+  env: EnvName | boolean | Env | undefined,
+  bindings: Record<string, unknown>
+): EnvName {
+  if (typeof env === 'string') return env;
+  if (typeof env === 'boolean') return env ? 'development' : 'production';
+
+  const environment = bindings.ENVIRONMENT;
+  if (typeof environment === 'string' && isEnvName(environment)) {
+    return environment;
+  }
+  const mode = bindings.MODE;
+  if (mode === 'production') return 'production';
+  if (mode === 'development') return 'development';
+  if (bindings.dev === true) return 'development';
+
+  if (typeof process !== 'undefined') {
+    const nodeEnv = process.env?.NODE_ENV;
+    if (nodeEnv === 'production') return 'production';
+    if (nodeEnv === 'development' || nodeEnv === 'test') return 'development';
+  }
+
+  return 'production';
+}
+
+function isEnvName(value: string): value is EnvName {
+  return (
+    value === 'production' ||
+    value === 'staging' ||
+    value === 'dev' ||
+    value === 'development' ||
+    value === 'test'
+  );
+}
+
+/** Deployed envs require HTTPS on env-var overrides. */
+function isDeployedEnv(env: EnvName): boolean {
+  return env === 'production' || env === 'staging' || env === 'dev';
+}
+
+/**
+ * Read an env-var override from Cloudflare bindings (passed as object) or
+ * Node.js `process.env` (for local dev + E2E tests).
+ */
+function readEnvVar(
+  bindings: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const fromBindings = bindings[key];
+  if (typeof fromBindings === 'string' && fromBindings) return fromBindings;
+  if (typeof process !== 'undefined') {
+    const fromProcess = process.env?.[key];
+    if (fromProcess) return fromProcess;
+  }
+  return undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STUBS — filled in WP-4 (URL builders for org / platform / content).
+// Signatures are stable so WP-4/5a can develop in parallel.
+// ─────────────────────────────────────────────────────────────────────────────
 
 /**
  * Build a full URL on a specific org subdomain, derived from a parsed host.

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -52,6 +52,7 @@
     "@codex/service-errors": "workspace:*",
     "@codex/shared-types": "workspace:*",
     "@codex/transcoding": "workspace:*",
+    "@codex/urls": "workspace:*",
     "@codex/validation": "workspace:*",
     "drizzle-orm": "0.44.7",
     "hono": "^4.7.8",

--- a/packages/worker-utils/src/email/__tests__/send-email.test.ts
+++ b/packages/worker-utils/src/email/__tests__/send-email.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock dependencies before import
-vi.mock('@codex/constants', () => ({
-  getServiceUrl: vi.fn().mockReturnValue('http://localhost:42075'),
+vi.mock('@codex/urls', () => ({
+  buildServiceUrl: vi.fn().mockReturnValue('http://localhost:42075'),
 }));
 
 vi.mock('@codex/security', () => ({
   workerFetch: vi.fn().mockResolvedValue(new Response('{}', { status: 200 })),
 }));
 
-import { getServiceUrl } from '@codex/constants';
 import { workerFetch } from '@codex/security';
 import type { Bindings } from '@codex/shared-types';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import { sendEmailToWorker } from '../send-email';
 
 describe('sendEmailToWorker', () => {

--- a/packages/worker-utils/src/email/send-email.ts
+++ b/packages/worker-utils/src/email/send-email.ts
@@ -13,9 +13,9 @@
  *   });
  */
 
-import { getServiceUrl } from '@codex/constants';
 import { workerFetch } from '@codex/security';
 import type { Bindings } from '@codex/shared-types';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import type { InternalSendEmailInput } from '@codex/validation';
 
 export type SendEmailToWorkerParams = Omit<InternalSendEmailInput, 'data'> & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@codex/test-utils':
         specifier: workspace:*
         version: link:../../packages/test-utils
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../../packages/urls
       '@codex/validation':
         specifier: workspace:*
         version: link:../../packages/validation
@@ -1078,6 +1081,9 @@ importers:
       '@codex/shared-types':
         specifier: workspace:*
         version: link:../shared-types
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../urls
       '@neondatabase/serverless':
         specifier: ^0.10.4
         version: 0.10.4
@@ -1250,6 +1256,9 @@ importers:
       '@codex/transcoding':
         specifier: workspace:*
         version: link:../transcoding
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../urls
       '@codex/validation':
         specifier: workspace:*
         version: link:../validation
@@ -1354,6 +1363,9 @@ importers:
       '@codex/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../../packages/urls
       '@codex/validation':
         specifier: workspace:*
         version: link:../../packages/validation
@@ -1719,6 +1731,9 @@ importers:
       '@codex/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../../packages/urls
       '@codex/validation':
         specifier: workspace:*
         version: link:../../packages/validation

--- a/workers/auth/package.json
+++ b/workers/auth/package.json
@@ -22,6 +22,7 @@
     "@codex/security": "workspace:*",
     "@codex/service-errors": "workspace:*",
     "@codex/shared-types": "workspace:*",
+    "@codex/urls": "workspace:*",
     "@codex/validation": "workspace:*",
     "@codex/worker-utils": "workspace:*",
     "better-auth": "^1.4.11",

--- a/workers/auth/src/email.ts
+++ b/workers/auth/src/email.ts
@@ -9,9 +9,9 @@
  * In production, Resend delivers real emails.
  */
 
-import { getServiceUrl } from '@codex/constants';
 import { and, type Database, eq, schema } from '@codex/database';
 import { workerFetch } from '@codex/security';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import { sendEmailToWorker } from '@codex/worker-utils';
 import type { AuthBindings } from './types';
 

--- a/workers/notifications-api/package.json
+++ b/workers/notifications-api/package.json
@@ -26,6 +26,7 @@
     "@codex/platform-settings": "workspace:*",
     "@codex/security": "workspace:*",
     "@codex/shared-types": "workspace:*",
+    "@codex/urls": "workspace:*",
     "@codex/validation": "workspace:*",
     "@codex/worker-utils": "workspace:*",
     "drizzle-orm": "^0.44.2",

--- a/workers/notifications-api/src/handlers/agreement-expiring-sweep.ts
+++ b/workers/notifications-api/src/handlers/agreement-expiring-sweep.ts
@@ -23,11 +23,11 @@ import {
   AgreementService,
   creatorShareFromLegacyOrgFee,
 } from '@codex/agreements';
-import { getServiceUrl } from '@codex/constants';
 import { createDbClient, type Database } from '@codex/database';
 import { ObservabilityClient } from '@codex/observability';
 import { workerFetch } from '@codex/security';
 import type { Bindings } from '@codex/shared-types';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 
 /**
  * Default warning lead time — fire the email when an agreement is within


### PR DESCRIPTION
## Summary

Migrates `getServiceUrl` from `@codex/constants/env.ts` to `@codex/urls` as `buildServiceUrl` with **first-class `staging` env support**. The 27-cell `DEFAULT_URLS` table is gone; `ENV_HOSTS` (from WP-1) is now the single source of truth for service URLs.

**Bead:** Codex-4xbuw (parent epic [Codex-rscgk](https://github.com/brucemckayone/codex/pull/248#:~:text=Codex%2Drscgk))
**Plan:** `~/.claude/plans/typed-honking-canyon.md` (§6 WP-3)

### What changed

- **`@codex/urls/src/build-url.ts`** — `buildServiceUrl` fully implemented:
  - Env-var override path (`AUTH_WORKER_URL`, `API_URL`, etc) wins; falls back to `ENV_HOSTS[envName].apiUrl(service)`
  - `resolveEnvName` precedence: `EnvName` literal → boolean → `ENVIRONMENT` (strictly wins over MODE/dev) → MODE → dev → NODE_ENV → `'production'`
  - **Intentional divergence from legacy `isDev()`**: `ENVIRONMENT` strictly wins. Documented in JSDoc + pinned by 2 tests. Wrangler configs co-set `ENVIRONMENT` and `MODE`, so benign in practice; pinned for durability.
  - `validateServiceUrl` gates env-var overrides (SSRF protection preserved); `ENV_HOSTS` defaults skip validation (code-controlled, no SSRF surface)
  - `buildOrgUrl` / `buildOrgUrlFromEnv` / `buildPlatformUrl` / `buildCreatorsUrl` / `buildContentUrl` **remain throw stubs** for WP-4
- **`@codex/constants/src/env.ts`** — removed `DEFAULT_URLS`, `ServiceUrls` type, `pickDefaultUrl`, `getServiceUrl`, `ServiceName`. Kept `ENV_NAMES`, `Env`, `INFRA_KEYS`, `isDev`, `isDevRemote`, `validateServiceUrl`.
- **8 callers migrated** to `import { buildServiceUrl as getServiceUrl } from '@codex/urls'` (1-line import swap, call-site code unchanged):
  - `apps/web/src/lib/server/api.ts` (heaviest consumer)
  - 3 apps/web routes (verify-email, unsubscribe × 2)
  - `workers/auth/src/email.ts`
  - `workers/notifications-api/src/handlers/agreement-expiring-sweep.ts`
  - `packages/test-utils/src/e2e/fixtures/auth.fixture.ts`
  - `packages/worker-utils/src/email/send-email.ts` ← **caught by reviewer**; would have made full worker-utils typecheck red

### Decision recorded (plan §10 Open Question)

`getServiceUrl` is NOT kept as a re-export shim in `@codex/constants`. Reason: `@codex/urls` already imports from `@codex/constants` (for `validateServiceUrl` + `Env` type), so a shim would create a module-load cycle. Callers migrate to `buildServiceUrl as getServiceUrl` instead.

## Test plan

- [x] `pnpm --filter @codex/urls test` — **93/93** pass (35 new `buildServiceUrl` tests covering env resolution matrix, SSRF rejection, override paths, ENVIRONMENT-wins-over-MODE precedence)
- [x] `pnpm --filter @codex/constants test` — 48/48 pass (8 `getServiceUrl` tests removed; function moved)
- [x] `pnpm --filter @codex/worker-utils test` — 89/89 pass (12 skipped, pre-existing)
- [x] `pnpm --filter web test` — 769/769 pass
- [x] `pnpm --filter auth test` — 53/53 pass
- [x] `pnpm --filter notifications-api test` — 47/47 pass
- [x] `pnpm typecheck` clean across all affected packages
- [x] `pnpm biome check` clean across diff
- [x] `/simplify` applied: `resolveEnvName` shares `bindings` materialization with main path (+3 tests)
- [x] `/review` applied: Critical (worker-utils caller miss) + Important (biome import order, ENVIRONMENT-vs-MODE precedence pin)

## Unblocks (downstream WPs)

- **WP-4 (Codex-fiveo)**: URL builders + `buildOrgUrlFromEnv` — depends on `ENV_HOSTS` apex established here
- **WP-7 (Codex-10hr1)**: wrangler URL env-var cleanup — depends on `buildServiceUrl` resolving correctly without env-var declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)