### PR TITLE
fix(e2e): migrate missed getServiceUrl callers in e2e/ workspace

### DIFF
--- a/e2e/helpers/worker-urls.ts
+++ b/e2e/helpers/worker-urls.ts
@@ -1,17 +1,17 @@
 /**
  * Worker URLs for E2E tests.
  *
- * Re-exports from @codex/constants to maintain single source of truth for worker ports.
- * All workers use localhost URLs for local E2E testing.
+ * Re-exports from @codex/urls to maintain single source of truth for worker
+ * URLs. All workers use localhost URLs for local E2E testing.
  *
  * @module e2e/helpers/worker-urls
  */
 
-import { getServiceUrl } from '@codex/constants';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 
 /**
  * Worker URLs for E2E testing.
- * All URLs derived from @codex/constants SERVICE_PORTS.
+ * All URLs derived from @codex/urls ENV_HOSTS (development env).
  */
 export const WORKER_URLS = {
   auth: getServiceUrl('auth', true), // http://localhost:42069

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -25,6 +25,7 @@
     "@codex/observability": "workspace:*",
     "@codex/organization": "workspace:*",
     "@codex/purchase": "workspace:*",
-    "@codex/shared-types": "workspace:*"
+    "@codex/shared-types": "workspace:*",
+    "@codex/urls": "workspace:*"
   }
 }

--- a/e2e/tests/01-auth-flow.test.ts
+++ b/e2e/tests/01-auth-flow.test.ts
@@ -3,13 +3,13 @@
  * Tests user registration, login, session validation, and logout
  */
 
-import { getServiceUrl } from '@codex/constants';
 import { closeDbPool } from '@codex/database';
 import {
   authFixture,
   expectSuccessResponse,
   httpClient,
 } from '@codex/test-utils/e2e';
+import { buildServiceUrl as getServiceUrl } from '@codex/urls';
 import { afterAll, describe, expect, test } from 'vitest';
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       '@codex/shared-types':
         specifier: workspace:*
         version: link:../packages/shared-types
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../packages/urls
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.937.0


### PR DESCRIPTION
## Summary

**Hotfix for WP-3** (PR #249). The original caller audit for WP-3 grepped `apps/web/`, `workers/`, and `packages/` but missed the `e2e/` workspace package. Result: E2E tests crashed at import time with:

```
TypeError: (0 , getServiceUrl) is not a function
```

…because `@codex/constants` no longer exports `getServiceUrl` (it was relocated to `@codex/urls.buildServiceUrl` in WP-3).

### Files migrated

Same `import { buildServiceUrl as getServiceUrl } from '@codex/urls'` alias pattern as WP-3 — call-site code unchanged:

- `e2e/tests/01-auth-flow.test.ts`
- `e2e/helpers/worker-urls.ts` — the central `WORKER_URLS` table; was the import for 6 of the 10 failing test files
- `e2e/package.json` — added `@codex/urls: workspace:*` dep (the only missing consumer)

### Re-verification

Comprehensive monorepo grep now confirms **every** `getServiceUrl` import across the codebase correctly uses `@codex/urls`. Other `@codex/constants` imports (`PAGINATION`, `COOKIES`, `HEADERS`, `SERVICE_PORTS`, etc) are legitimate and remain — only `getServiceUrl` was relocated by WP-3.

## Test plan

- [x] Comprehensive grep: zero remaining `getServiceUrl from '@codex/constants'` imports
- [x] `pnpm install` clean
- [ ] CI E2E suite passes after merge (this PR's gate)

## Why this happened — and how to prevent recurrence

The caller audit agent for WP-3 was scoped to `apps/web/`, `workers/`, and `packages/`. The `e2e/` directory is its own workspace package (per `pnpm-workspace.yaml` `'e2e'` entry) and got missed. Future cross-cutting refactors must grep **every workspace** from `pnpm-workspace.yaml`, not assume the 3 obvious dirs are exhaustive. Saving as a memory rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)