### PR TITLE
feat(urls): WP-4 migrate URL builders + add buildOrgUrlFromEnv

### DIFF
--- a/apps/web/src/lib/utils/subdomain.ts
+++ b/apps/web/src/lib/utils/subdomain.ts
@@ -5,14 +5,17 @@
  * (`apps/web/src/routes/(auth)/+layout.server.ts`), and 30+ Svelte
  * components that import from `$lib/utils/subdomain`.
  *
- * The actual parsing lives in `@codex/urls.parseHost` — this file is a
- * thin re-export / adapter layer so the existing callers don't need to
- * change their imports. URL builders (buildOrgUrl, buildPlatformUrl,
- * buildCreatorsUrl, buildContentUrl) still live here pending WP-4
- * (Codex-fiveo) which will move them to @codex/urls.
+ * All parsing AND URL-building lives in `@codex/urls`. This file is a
+ * thin re-export / adapter layer so existing callers don't change imports.
  */
 
-import { parseHost } from '@codex/urls';
+import {
+  buildContentUrl as buildContentUrlInner,
+  buildCreatorsUrl as buildCreatorsUrlInner,
+  buildOrgUrl as buildOrgUrlInner,
+  buildPlatformUrl as buildPlatformUrlInner,
+  parseHost,
+} from '@codex/urls';
 import { RESERVED_SUBDOMAINS } from '$lib/constants';
 
 /**
@@ -41,79 +44,14 @@ type SubdomainContext =
   | { type: 'reserved'; subdomain: string };
 
 /**
- * Build a full URL on a different org subdomain.
- *
- * Cross-org navigation requires changing the hostname (different origin),
- * so we need a full URL rather than a root-relative path.
- *
- * @param currentUrl - The current page URL (used to derive protocol, port, and base domain)
- * @param slug - The org slug to navigate to
- * @param path - The path on the org subdomain (default: '/')
- * @returns Full URL string, e.g. "http://bruce-studio.lvh.me:3000/studio"
- *          or "http://bruce-studio.192.168.1.10.nip.io:3000/studio"
+ * URL builders re-exported from `@codex/urls` (WP-4 / Codex-fiveo).
+ * 30+ Svelte components import these via `$lib/utils/subdomain`; the
+ * re-export layer means consumers don't change imports.
  */
-export function buildOrgUrl(currentUrl: URL, slug: string, path = '/'): string {
-  const baseDomain = deriveBaseDomain(currentUrl.hostname);
-  const port = currentUrl.port;
-  const portSuffix = port ? `:${port}` : '';
-  return `${currentUrl.protocol}//${slug}.${baseDomain}${portSuffix}${path}`;
-}
-
-/**
- * Derive the base apex domain (everything AFTER an org slug). Thin
- * wrapper over `@codex/urls.parseHost` — the builder family below uses
- * this internally. WP-4 will inline `parseHost` directly into each
- * builder and remove this helper.
- */
-function deriveBaseDomain(host: string): string {
-  return parseHost(host).baseDomain;
-}
-
-/**
- * Build a URL to the creators subdomain.
- * E.g., buildCreatorsUrl(currentUrl, '/studio') → 'http://creators.lvh.me:3000/studio'
- */
-export function buildCreatorsUrl(currentUrl: URL, path = '/'): string {
-  return buildOrgUrl(currentUrl, 'creators', path);
-}
-
-/**
- * Build a URL to the root platform domain (no subdomain).
- * E.g., buildPlatformUrl(currentUrl, '/library') → 'http://lvh.me:3000/library'
- */
-export function buildPlatformUrl(currentUrl: URL, path = '/'): string {
-  const baseDomain = deriveBaseDomain(currentUrl.hostname);
-  const port = currentUrl.port;
-  const portSuffix = port ? `:${port}` : '';
-  return `${currentUrl.protocol}//${baseDomain}${portSuffix}${path}`;
-}
-
-/**
- * Build a URL to a content detail page, handling cross-org subdomain routing.
- *
- * - On the content's own org subdomain → root-relative `/content/{slug}`
- * - On a different origin (platform, other org) → full URL via buildOrgUrl()
- * - Falls back to content ID if slug is unavailable
- */
-export function buildContentUrl(
-  currentUrl: URL,
-  content: {
-    slug?: string | null;
-    id: string;
-    organizationSlug?: string | null;
-  }
-): string {
-  const contentPath = `/content/${content.slug ?? content.id}`;
-
-  if (content.organizationSlug) {
-    const currentSubdomain = extractSubdomain(currentUrl.hostname);
-    if (currentSubdomain !== content.organizationSlug) {
-      return buildOrgUrl(currentUrl, content.organizationSlug, contentPath);
-    }
-  }
-
-  return contentPath;
-}
+export const buildOrgUrl = buildOrgUrlInner;
+export const buildCreatorsUrl = buildCreatorsUrlInner;
+export const buildPlatformUrl = buildPlatformUrlInner;
+export const buildContentUrl = buildContentUrlInner;
 
 /**
  * Determine the context type from a hostname.

--- a/packages/urls/src/__tests__/build-url-builders.test.ts
+++ b/packages/urls/src/__tests__/build-url-builders.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for the URL builder family in @codex/urls/build-url.ts:
+ *   - buildOrgUrl(currentUrl, slug, path?)
+ *   - buildOrgUrlFromEnv(env, slug, path?)  ← NEW worker-side variant
+ *   - buildPlatformUrl(currentUrl, path?)
+ *   - buildCreatorsUrl(currentUrl, path?)
+ *   - buildContentUrl(currentUrl, content)
+ *
+ * Test contract: must produce identical output to the historical
+ * apps/web/src/lib/utils/subdomain.ts builders. Existing 35-test
+ * subdomain.test.ts suite is the byte-equality gate; this file adds
+ * the @codex/urls-specific coverage for new behaviours (buildOrgUrlFromEnv,
+ * staging URLs, etc).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildContentUrl,
+  buildCreatorsUrl,
+  buildOrgUrl,
+  buildOrgUrlFromEnv,
+  buildPlatformUrl,
+} from '../build-url';
+
+describe('buildOrgUrl (URL-based)', () => {
+  it('builds cross-org URL on lvh.me dev', () => {
+    expect(
+      buildOrgUrl(
+        new URL('http://lvh.me:3000/explore'),
+        'bruce-studio',
+        '/studio'
+      )
+    ).toBe('http://bruce-studio.lvh.me:3000/studio');
+  });
+
+  it('builds cross-org URL on production', () => {
+    expect(
+      buildOrgUrl(
+        new URL('https://revelations.studio/discover'),
+        'yoga-studio',
+        '/explore'
+      )
+    ).toBe('https://yoga-studio.revelations.studio/explore');
+  });
+
+  it('stays on deployed dev when navigating from a dev org subdomain', () => {
+    // Regression: must NOT leak to prod (studio-beta.revelations.studio)
+    expect(
+      buildOrgUrl(
+        new URL('https://studio-alpha.dev.revelations.studio/library'),
+        'studio-beta',
+        '/explore'
+      )
+    ).toBe('https://studio-beta.dev.revelations.studio/explore');
+  });
+
+  it('preserves protocol (https stays https)', () => {
+    expect(buildOrgUrl(new URL('https://lvh.me:3000/'), 'bruce-studio')).toBe(
+      'https://bruce-studio.lvh.me:3000/'
+    );
+  });
+
+  it('preserves port from the current URL', () => {
+    expect(
+      buildOrgUrl(new URL('http://studio-alpha.lvh.me:4173/'), 'bruce-studio')
+    ).toBe('http://bruce-studio.lvh.me:4173/');
+  });
+
+  it('defaults path to "/"', () => {
+    expect(buildOrgUrl(new URL('http://lvh.me:3000/'), 'bruce-studio')).toBe(
+      'http://bruce-studio.lvh.me:3000/'
+    );
+  });
+
+  it('builds URL on localhost', () => {
+    expect(
+      buildOrgUrl(
+        new URL('http://test-org.localhost:3000/'),
+        'other-org',
+        '/studio'
+      )
+    ).toBe('http://other-org.localhost:3000/studio');
+  });
+});
+
+describe('buildOrgUrlFromEnv (worker-side, no URL context)', () => {
+  it('builds dev URL', () => {
+    expect(buildOrgUrlFromEnv('dev', 'studio-alpha')).toBe(
+      'https://studio-alpha.dev.revelations.studio/'
+    );
+  });
+
+  it('builds dev URL with path', () => {
+    expect(buildOrgUrlFromEnv('dev', 'studio-alpha', '/explore')).toBe(
+      'https://studio-alpha.dev.revelations.studio/explore'
+    );
+  });
+
+  it('builds production URL', () => {
+    expect(buildOrgUrlFromEnv('production', 'yoga-studio')).toBe(
+      'https://yoga-studio.revelations.studio/'
+    );
+  });
+
+  it('builds staging URL with -staging suffix pattern', () => {
+    expect(buildOrgUrlFromEnv('staging', 'studio-alpha')).toBe(
+      'https://studio-alpha-staging.revelations.studio/'
+    );
+  });
+
+  it('builds development URL on lvh.me:3000', () => {
+    expect(buildOrgUrlFromEnv('development', 'bruce-studio')).toBe(
+      'http://bruce-studio.lvh.me:3000/'
+    );
+  });
+
+  it('builds test URL identical to development (same row in ENV_HOSTS)', () => {
+    expect(buildOrgUrlFromEnv('test', 'bruce-studio')).toBe(
+      buildOrgUrlFromEnv('development', 'bruce-studio')
+    );
+  });
+
+  it('defaults path to "/"', () => {
+    const url = buildOrgUrlFromEnv('production', 'yoga-studio');
+    expect(url.endsWith('/')).toBe(true);
+  });
+
+  it('preserves path including query strings', () => {
+    expect(
+      buildOrgUrlFromEnv('dev', 'studio-alpha', '/content/foo?ref=share')
+    ).toBe('https://studio-alpha.dev.revelations.studio/content/foo?ref=share');
+  });
+});
+
+describe('buildPlatformUrl (URL-based)', () => {
+  it('strips subdomain to platform apex on prod', () => {
+    expect(
+      buildPlatformUrl(
+        new URL('https://yoga-studio.revelations.studio/foo'),
+        '/about'
+      )
+    ).toBe('https://revelations.studio/about');
+  });
+
+  it('strips subdomain to lvh.me on local dev', () => {
+    expect(
+      buildPlatformUrl(new URL('http://bruce-studio.lvh.me:3000/'), '/library')
+    ).toBe('http://lvh.me:3000/library');
+  });
+
+  it('preserves dev.revelations.studio apex on deployed dev', () => {
+    expect(
+      buildPlatformUrl(
+        new URL('https://studio-alpha.dev.revelations.studio/'),
+        '/discover'
+      )
+    ).toBe('https://dev.revelations.studio/discover');
+  });
+
+  it('defaults path to "/"', () => {
+    expect(buildPlatformUrl(new URL('http://lvh.me:3000/'))).toBe(
+      'http://lvh.me:3000/'
+    );
+  });
+});
+
+describe('buildCreatorsUrl (URL-based)', () => {
+  it('builds creators subdomain on lvh.me', () => {
+    expect(
+      buildCreatorsUrl(new URL('http://lvh.me:3000/'), '/profile/bruce')
+    ).toBe('http://creators.lvh.me:3000/profile/bruce');
+  });
+
+  it('builds creators subdomain on production', () => {
+    expect(
+      buildCreatorsUrl(
+        new URL('https://revelations.studio/discover'),
+        '/profile/jane'
+      )
+    ).toBe('https://creators.revelations.studio/profile/jane');
+  });
+
+  it('builds creators URL on deployed dev', () => {
+    expect(
+      buildCreatorsUrl(
+        new URL('https://studio-alpha.dev.revelations.studio/explore'),
+        '/profile/alex'
+      )
+    ).toBe('https://creators.dev.revelations.studio/profile/alex');
+  });
+
+  it('defaults path to "/"', () => {
+    expect(buildCreatorsUrl(new URL('http://lvh.me:3000/'))).toBe(
+      'http://creators.lvh.me:3000/'
+    );
+  });
+});
+
+describe('buildContentUrl (cross-org-aware)', () => {
+  it('returns root-relative path when content is on current org subdomain', () => {
+    expect(
+      buildContentUrl(new URL('http://yoga-studio.lvh.me:3000/'), {
+        id: 'content-123',
+        slug: 'morning-flow',
+        organizationSlug: 'yoga-studio',
+      })
+    ).toBe('/content/morning-flow');
+  });
+
+  it('returns full cross-org URL when content is on another org', () => {
+    expect(
+      buildContentUrl(new URL('http://yoga-studio.lvh.me:3000/'), {
+        id: 'content-456',
+        slug: 'cooking-101',
+        organizationSlug: 'cooking-school',
+      })
+    ).toBe('http://cooking-school.lvh.me:3000/content/cooking-101');
+  });
+
+  it('returns full URL when current page is on the platform apex', () => {
+    expect(
+      buildContentUrl(new URL('http://lvh.me:3000/discover'), {
+        id: 'content-789',
+        slug: 'jazz-intro',
+        organizationSlug: 'music-school',
+      })
+    ).toBe('http://music-school.lvh.me:3000/content/jazz-intro');
+  });
+
+  it('falls back to content ID when slug is null', () => {
+    expect(
+      buildContentUrl(new URL('http://yoga-studio.lvh.me:3000/'), {
+        id: 'content-abc',
+        slug: null,
+        organizationSlug: 'yoga-studio',
+      })
+    ).toBe('/content/content-abc');
+  });
+
+  it('falls back to content ID when slug is missing', () => {
+    expect(
+      buildContentUrl(new URL('http://yoga-studio.lvh.me:3000/'), {
+        id: 'content-def',
+        organizationSlug: 'yoga-studio',
+      })
+    ).toBe('/content/content-def');
+  });
+
+  it('returns root-relative path when organizationSlug is missing', () => {
+    expect(
+      buildContentUrl(new URL('http://lvh.me:3000/'), {
+        id: 'content-xyz',
+        slug: 'standalone',
+      })
+    ).toBe('/content/standalone');
+  });
+
+  it('handles deployed dev cross-org navigation', () => {
+    expect(
+      buildContentUrl(new URL('https://studio-alpha.dev.revelations.studio/'), {
+        id: 'content-1',
+        slug: 'first-video',
+        organizationSlug: 'studio-beta',
+      })
+    ).toBe('https://studio-beta.dev.revelations.studio/content/first-video');
+  });
+});

--- a/packages/urls/src/build-url.ts
+++ b/packages/urls/src/build-url.ts
@@ -1,6 +1,7 @@
 import { type Env, validateServiceUrl } from '@codex/constants';
 import { ENV_HOSTS } from './env-hosts';
-import type { EnvName, HostInfo, ServiceName } from './types';
+import { parseHost } from './parse-host';
+import type { EnvName, ServiceName } from './types';
 
 /**
  * Per-service env-var override key. Workers + apps/web have always supported
@@ -133,63 +134,106 @@ function readEnvVar(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// STUBS — filled in WP-4 (URL builders for org / platform / content).
-// Signatures are stable so WP-4/5a can develop in parallel.
+// URL builders — derive scheme/baseDomain/port from the request URL.
+//
+// Signatures take `URL` (not `HostInfo`) so existing apps/web callers using
+// `page.url` migrate with zero call-site change. The handler internally calls
+// `parseHost` to extract the baseDomain that goes after the org slug.
+//
+// `buildOrgUrlFromEnv` is the worker-side variant — for callers like
+// `DevDomainService` that don't have a request URL. It derives scheme + port
+// + baseDomain entirely from `ENV_HOSTS[env]`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Build a full URL on a specific org subdomain, derived from a parsed host.
- * Preserves the current page's protocol and port (when present).
+ * Build a full URL on a different org subdomain, preserving the current
+ * page's protocol and port. Used when the user navigates from one org's
+ * subdomain to another (different origin → needs a full URL, not a path).
+ *
+ * @example
+ * buildOrgUrl(new URL('http://lvh.me:3000/'), 'bruce-studio', '/studio')
+ * // → 'http://bruce-studio.lvh.me:3000/studio'
+ *
+ * @example
+ * buildOrgUrl(new URL('https://yoga-studio.revelations.studio/'), 'cooking-school')
+ * // → 'https://cooking-school.revelations.studio/'
  */
-export function buildOrgUrl(
-  _host: HostInfo,
-  _slug: string,
-  _path = '/'
-): string {
-  throw new Error('buildOrgUrl: not implemented (WP-4)');
+export function buildOrgUrl(currentUrl: URL, slug: string, path = '/'): string {
+  const { baseDomain } = parseHost(currentUrl.hostname);
+  const portSuffix = currentUrl.port ? `:${currentUrl.port}` : '';
+  return `${currentUrl.protocol}//${slug}.${baseDomain}${portSuffix}${path}`;
 }
 
 /**
- * Build an org subdomain URL from an env name (no request context required).
- * Used by `DevDomainService` and any worker that needs an org URL without
- * a `currentUrl` to derive from.
+ * Build an org subdomain URL from an `EnvName` (no request context required).
+ * Used by `DevDomainService` (Codex-0hxw4, WP-6) and any worker that needs
+ * an org URL without a `currentUrl` to derive from.
+ *
+ * @example
+ * buildOrgUrlFromEnv('dev', 'studio-alpha')
+ * // → 'https://studio-alpha.dev.revelations.studio/'
+ *
+ * @example
+ * buildOrgUrlFromEnv('development', 'bruce-studio', '/studio')
+ * // → 'http://bruce-studio.lvh.me:3000/studio'
  */
 export function buildOrgUrlFromEnv(
-  _env: EnvName,
-  _slug: string,
-  _path = '/'
+  env: EnvName,
+  slug: string,
+  path = '/'
 ): string {
-  throw new Error('buildOrgUrlFromEnv: not implemented (WP-4)');
+  const cfg = ENV_HOSTS[env];
+  const portSuffix = cfg.port ? `:${cfg.port}` : '';
+  return `${cfg.scheme}://${cfg.orgHost(slug)}${portSuffix}${path}`;
 }
 
 /**
- * Build a platform URL (no subdomain, root of the apex).
+ * Build a platform URL — strips the subdomain, keeps the rest of the origin.
+ * E.g. `https://yoga-studio.revelations.studio/foo` → `https://revelations.studio/path`.
  */
-export function buildPlatformUrl(_host: HostInfo, _path = '/'): string {
-  throw new Error('buildPlatformUrl: not implemented (WP-4)');
+export function buildPlatformUrl(currentUrl: URL, path = '/'): string {
+  const { baseDomain } = parseHost(currentUrl.hostname);
+  const portSuffix = currentUrl.port ? `:${currentUrl.port}` : '';
+  return `${currentUrl.protocol}//${baseDomain}${portSuffix}${path}`;
 }
 
 /**
- * Build a URL on the `creators` subdomain.
+ * Build a URL on the `creators` subdomain. Thin wrapper over `buildOrgUrl`
+ * with `slug='creators'` — kept as a named export for ergonomics and
+ * grep-ability at call sites.
  */
-export function buildCreatorsUrl(_host: HostInfo, _path = '/'): string {
-  throw new Error('buildCreatorsUrl: not implemented (WP-4)');
+export function buildCreatorsUrl(currentUrl: URL, path = '/'): string {
+  return buildOrgUrl(currentUrl, 'creators', path);
 }
 
 /**
  * Build a URL to a content detail page, handling cross-org subdomain routing.
  *
  * - On the content's own org subdomain → root-relative `/content/{slug}`
- * - On a different origin (platform, other org) → full URL via buildOrgUrl
- * - Falls back to content ID if slug is unavailable
+ * - On a different origin (platform, other org) → full URL via `buildOrgUrl`
+ * - Falls back to content ID when `slug` is missing
+ *
+ * Codex-ga4d (closed Apr 2026) introduced this helper; 10+ Svelte components
+ * adopted it. WP-4 moves the implementation to `@codex/urls` while preserving
+ * the existing call-site contract via the `apps/web/src/lib/utils/subdomain.ts`
+ * re-export wrapper.
  */
 export function buildContentUrl(
-  _host: HostInfo,
-  _content: {
+  currentUrl: URL,
+  content: {
     slug?: string | null;
     id: string;
     organizationSlug?: string | null;
   }
 ): string {
-  throw new Error('buildContentUrl: not implemented (WP-4)');
+  const contentPath = `/content/${content.slug ?? content.id}`;
+
+  if (content.organizationSlug) {
+    const { subdomain } = parseHost(currentUrl.hostname);
+    if (subdomain !== content.organizationSlug) {
+      return buildOrgUrl(currentUrl, content.organizationSlug, contentPath);
+    }
+  }
+
+  return contentPath;
 }


### PR DESCRIPTION
## Summary

Replaces the 5 throw-stubs in `@codex/urls/build-url.ts` with full implementations, adds NEW `buildOrgUrlFromEnv` for worker-side callers, and migrates `apps/web/src/lib/utils/subdomain.ts` builders to thin re-exports.

**Bead:** Codex-fiveo (parent epic Codex-rscgk)
**Plan:** `~/.claude/plans/typed-honking-canyon.md` (§6 WP-4)

### Signature design

URL builders take `URL` (not `HostInfo` from the original stubs) — matches existing `apps/web` caller signature exactly so the 10+ Svelte components using `buildContentUrl(page.url, content)` etc keep working with **zero call-site change**. Internally each builder calls `parseHost` to extract `baseDomain`.

The new `buildOrgUrlFromEnv(env, slug, path?)` variant is for worker-side callers (like `DevDomainService`) that don't have a request URL — derives scheme + baseDomain + port entirely from `ENV_HOSTS[env]`. Intentional dead-code-by-design until WP-6 consumes it.

### What's shipped

- **`buildOrgUrl(currentUrl, slug, path?)`** — cross-org navigation, preserves protocol/port from current URL
- **`buildOrgUrlFromEnv(env, slug, path?)`** — NEW worker-callable variant
- **`buildPlatformUrl(currentUrl, path?)`** — strips subdomain to apex
- **`buildCreatorsUrl(currentUrl, path?)`** — wraps `buildOrgUrl` with `slug='creators'`
- **`buildContentUrl(currentUrl, content)`** — cross-org-aware; root-relative path when on content's own org, full URL otherwise

`apps/web/src/lib/utils/subdomain.ts` builders become re-exports (net **-94 LOC** in that file); `deriveBaseDomain` helper removed (no longer needed — `@codex/urls` builders use `parseHost` internally). Parser wrappers from WP-2 kept unchanged.

## Test plan

- [x] `pnpm --filter @codex/urls test` — **123/123** pass (30 new builder tests across URL-based and env-based paths × all 5 EnvName values)
- [x] `pnpm --filter web test` — 769/769 pass (existing `subdomain.test.ts` byte-equality contract holds through 2 layers of indirection)
- [x] `pnpm --filter @codex/urls typecheck` clean
- [x] `pnpm --filter web typecheck` clean
- [x] `/review` applied: **no Critical or Important findings**

## Unblocks downstream

- **WP-6 (Codex-0hxw4)**: DevDomainService rewire — consumes `buildOrgUrlFromEnv`

## Known limitations preserved

- `buildPlatformUrl` for staging hosts (e.g. `yoga-studio-staging.revelations.studio`) returns `revelations.studio` apex, NOT `codex-staging.revelations.studio` — preserved historical behaviour, flagged in plan §6 as a known limitation (not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)