### PR TITLE
chore(urls): WP-7 eliminate wrangler URL env-vars in apps/web

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -26,21 +26,22 @@
   ],
 
   // Environment configurations
+  //
+  // URL env-var declarations (AUTH_WORKER_URL, API_URL, ORG_API_URL etc) were
+  // removed in WP-7 (Codex-10hr1). They were redundant with the @codex/urls
+  // ENV_HOSTS defaults — `buildServiceUrl` now derives every worker URL from
+  // the `ENVIRONMENT` binding alone. Adding a new env or service is a one-row
+  // change in `packages/urls/src/env-hosts.ts`, not 9 wrangler lines × 4 envs.
+  //
+  // Override mechanism preserved: setting `AUTH_WORKER_URL` (etc) here would
+  // still override the ENV_HOSTS default. We just don't need the overrides
+  // when the value matches what ENV_HOSTS would compute.
   "env": {
     // Test environment (E2E tests)
     "test": {
       "name": "codex-web-test",
       "vars": {
-        "ENVIRONMENT": "test",
-        "AUTH_WORKER_URL": "http://localhost:42069",
-        "API_URL": "http://localhost:4001",
-        "CONTENT_API_URL": "http://localhost:4001",
-        "ORG_API_URL": "http://localhost:42071",
-        "ECOM_API_URL": "http://localhost:42072",
-        "MEDIA_API_URL": "http://localhost:4002",
-        "IDENTITY_API_URL": "http://localhost:42074",
-        "ADMIN_API_URL": "http://localhost:42073",
-        "NOTIFICATIONS_API_URL": "http://localhost:42075"
+        "ENVIRONMENT": "test"
       },
       "kv_namespaces": [
         {
@@ -54,16 +55,7 @@
     "production": {
       "name": "codex-web-production",
       "vars": {
-        "ENVIRONMENT": "production",
-        "AUTH_WORKER_URL": "https://auth.revelations.studio",
-        "API_URL": "https://content-api.revelations.studio",
-        "CONTENT_API_URL": "https://content-api.revelations.studio",
-        "ORG_API_URL": "https://organization-api.revelations.studio",
-        "ECOM_API_URL": "https://ecom-api.revelations.studio",
-        "MEDIA_API_URL": "https://media-api.revelations.studio",
-        "IDENTITY_API_URL": "https://identity-api.revelations.studio",
-        "ADMIN_API_URL": "https://admin-api.revelations.studio",
-        "NOTIFICATIONS_API_URL": "https://notifications-api.revelations.studio"
+        "ENVIRONMENT": "production"
       },
       "routes": [
         // Specific routes first (for priority)
@@ -97,16 +89,7 @@
     "staging": {
       "name": "codex-web-staging",
       "vars": {
-        "ENVIRONMENT": "staging",
-        "AUTH_WORKER_URL": "https://auth-staging.revelations.studio",
-        "API_URL": "https://content-api-staging.revelations.studio",
-        "CONTENT_API_URL": "https://content-api-staging.revelations.studio",
-        "ORG_API_URL": "https://organization-api-staging.revelations.studio",
-        "ECOM_API_URL": "https://ecom-api-staging.revelations.studio",
-        "MEDIA_API_URL": "https://media-api-staging.revelations.studio",
-        "IDENTITY_API_URL": "https://identity-api-staging.revelations.studio",
-        "ADMIN_API_URL": "https://admin-api-staging.revelations.studio",
-        "NOTIFICATIONS_API_URL": "https://notifications-api-staging.revelations.studio"
+        "ENVIRONMENT": "staging"
       },
       "routes": [
         // Specific routes first (for priority)
@@ -135,16 +118,7 @@
     "dev": {
       "name": "codex-web-dev",
       "vars": {
-        "ENVIRONMENT": "dev",
-        "AUTH_WORKER_URL": "https://auth.dev.revelations.studio",
-        "API_URL": "https://content-api.dev.revelations.studio",
-        "CONTENT_API_URL": "https://content-api.dev.revelations.studio",
-        "ORG_API_URL": "https://organization-api.dev.revelations.studio",
-        "ECOM_API_URL": "https://ecom-api.dev.revelations.studio",
-        "MEDIA_API_URL": "https://media-api.dev.revelations.studio",
-        "IDENTITY_API_URL": "https://identity-api.dev.revelations.studio",
-        "ADMIN_API_URL": "https://admin-api.dev.revelations.studio",
-        "NOTIFICATIONS_API_URL": "https://notifications-api.dev.revelations.studio"
+        "ENVIRONMENT": "dev"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## Summary

Removes 36 URL env-var declarations from `apps/web/wrangler.jsonc` across the 4 env blocks (test/production/staging/dev). Each value was redundant with the `@codex/urls` `ENV_HOSTS` default for its env — verified by audit cross-check before removal.

**Bead:** Codex-10hr1 (parent epic Codex-rscgk)
**Plan:** `~/.claude/plans/typed-honking-canyon.md` (§6 WP-7)
**Follow-up:** Codex-b5iuc (worker-side cleanup, P3)

## Scope narrowed from plan §6

The plan called for removing URL env-vars from **all 8** wrangler.jsonc files. The mandatory audit step (plan §6 WP-7 precondition) revealed worker-side env-vars have **non-URL-building** uses:

- `workers/auth/src/auth-config.ts:192` — `env.API_URL` in `trustedOrigins` (CORS allowlist)
- `workers/media-api/src/index.ts:241` — `env.API_URL` as RunPod webhook URL
- `workers/content-api/src/routes/media.ts:257` — `env.MEDIA_API_URL` for worker-to-worker calls
- `packages/worker-utils/src/procedure/service-registry.ts:702` — `env.API_URL` as transcoding webhook base URL

Removing those would silently break CORS, RunPod callbacks, and service-to-service calls. Worker-side cleanup deferred to **Codex-b5iuc** (P3 housekeeping) for per-file migration + per-caller code changes.

## Why apps/web is safe

All 9 URL env-vars in `apps/web/wrangler.jsonc` are consumed **ONLY** by `buildServiceUrl` via the `SERVICE_ENV_VAR` map. They all match `ENV_HOSTS` defaults — removal is byte-equal at runtime.

| Env var | Was → | Now (from ENV_HOSTS) |
|---|---|---|
| `AUTH_WORKER_URL` (production) | `https://auth.revelations.studio` | `ENV_HOSTS.production.apiUrl('auth')` ✓ |
| `API_URL` (test) | `http://localhost:4001` | `ENV_HOSTS.test.apiUrl('content')` ✓ |
| ...all 9 services × 4 envs | matches | matches |

`CONTENT_API_URL` was already dead code — `SERVICE_ENV_VAR` maps `content`→`API_URL`, never reading `CONTENT_API_URL`. Removed in this PR with the rest.

## What stays in apps/web/wrangler.jsonc

- `ENVIRONMENT` binding per env (drives `buildServiceUrl` env resolution)
- routes (zone wildcards + custom domains)
- KV namespaces, R2 bindings

Adding a new env or service now = **one row** in `ENV_HOSTS`, not 9 wrangler lines × N envs.

## Test plan

- [x] `pnpm --filter web test` — **769/769** pass
- [x] `pnpm --filter web typecheck` clean
- [x] Audit cross-check: all 9 × 4 = 36 declared URLs verified against `ENV_HOSTS[env].apiUrl(service)` outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)