### PR TITLE
feat(urls): WP-6 DevDomainService rewire + C5 unit tests

### DIFF
--- a/packages/organization/package.json
+++ b/packages/organization/package.json
@@ -38,6 +38,7 @@
     "@codex/database": "workspace:*",
     "@codex/service-errors": "workspace:*",
     "@codex/shared-types": "workspace:*",
+    "@codex/urls": "workspace:*",
     "@codex/validation": "workspace:*",
     "drizzle-orm": "0.44.7"
   },

--- a/packages/organization/src/services/__tests__/dev-domain-service.test.ts
+++ b/packages/organization/src/services/__tests__/dev-domain-service.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Unit tests for DevDomainService — closes the C5 coverage gap identified
+ * in the routing-centralization epic's test audit (Codex-rscgk).
+ *
+ * Before WP-6, DevDomainService had ZERO unit-test coverage. These tests:
+ *  - Pin the hostname format (snapshot via `ENV_HOSTS.dev.orgHost` alignment)
+ *  - Cover ensureDevDomain / removeDevDomain / renameDevDomain happy paths
+ *  - Verify the no-op guards (env=dev required, Cloudflare creds required)
+ *  - Verify error handling (Cloudflare 5xx logged + swallowed, not thrown)
+ *  - Mock the Cloudflare Workers Domains API via global fetch
+ *
+ * The service is fire-and-forget: org create/rename/delete operations
+ * MUST NOT throw because of Cloudflare API hiccups. These tests enforce
+ * that contract for every failure mode (network throw, non-2xx response,
+ * malformed JSON body).
+ *
+ * Implementation note on the obs mock: BaseService's constructor
+ * unconditionally creates its own ObservabilityClient — there's no
+ * obs-injection path through config, and `vi.mock`'s lazy-factory
+ * `vi.fn()` calls don't reliably register with vitest's spy matcher
+ * (you get "Function info is not a spy" on `toHaveBeenCalledWith`).
+ *
+ * Workaround: let BaseService build the real client, then overwrite
+ * `svc.obs` with a fresh `{ info, warn, error }` mock right after
+ * construction. `protected obs` is mutable (no `readonly`), so the
+ * service's internal `this.obs.info(...)` calls land on the mock.
+ */
+
+import { ENV_HOSTS } from '@codex/urls';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DevDomainService } from '../dev-domain-service';
+
+interface MockObs {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+}
+
+function mockFetchOk(body: unknown): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response);
+}
+
+function mockFetchFail(
+  status: number,
+  body: string = '{}'
+): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  } as unknown as Response);
+}
+
+interface MakeServiceOpts {
+  environment?: string;
+  apiToken?: string;
+  accountId?: string;
+}
+
+function makeService(opts: MakeServiceOpts = {}): {
+  svc: DevDomainService;
+  obs: MockObs;
+} {
+  const svc = new DevDomainService({
+    // DevDomainService doesn't query the DB — undefined is safe.
+    db: undefined as never,
+    environment: opts.environment ?? 'dev',
+    // `in` check (not `??`) so callers can pass `apiToken: undefined`
+    // explicitly to simulate "no creds" — `??` collapses explicit
+    // undefined to the default, masking the missing-creds branch.
+    cloudflareApiToken: 'apiToken' in opts ? opts.apiToken : 'test-token',
+    cloudflareAccountId:
+      'accountId' in opts ? opts.accountId : 'test-account-id',
+    webWorkerName: 'codex-web-dev',
+  });
+  // Overwrite the real ObservabilityClient created by BaseService with
+  // a fresh mock. `obs` is `protected` (not `readonly`), so subsequent
+  // `this.obs.info(...)` calls inside the service hit our mock.
+  const obs: MockObs = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  (svc as unknown as { obs: MockObs }).obs = obs;
+  return { svc, obs };
+}
+
+describe('DevDomainService — hostname derivation (snapshot)', () => {
+  it('hostnameFor produces ENV_HOSTS.dev.orgHost output for every slug shape', () => {
+    // Pins THREE invariants at once for the WP-6 rewire:
+    //   1. `DevDomainService.hostnameFor(slug)` (private, crossed via cast)
+    //      returns `{slug}.dev.revelations.studio` — the OLD template's
+    //      byte-equal output.
+    //   2. That output equals `ENV_HOSTS.dev.orgHost(slug)` — proving the
+    //      service is actually delegating to the centralized builder.
+    //   3. The builder is stable across slug shapes (single char,
+    //      reserved-ish words, multi-hyphen).
+    // A future refactor that accidentally swapped `ENV_HOSTS.dev` for
+    // `ENV_HOSTS.production` would orphan every dev custom domain — this
+    // test catches that drift before it ships.
+    const { svc } = makeService();
+    const hostnameFor = (
+      svc as unknown as { hostnameFor(slug: string): string }
+    ).hostnameFor.bind(svc);
+    const slugs = [
+      'studio-alpha',
+      'yoga-school',
+      'cooking-101',
+      'a',
+      'creators',
+      'admin',
+      'multi-hyphen-slug-here',
+    ];
+    for (const slug of slugs) {
+      const expected = `${slug}.dev.revelations.studio`;
+      expect(hostnameFor(slug)).toBe(expected);
+      expect(hostnameFor(slug)).toBe(ENV_HOSTS.dev.orgHost(slug));
+    }
+  });
+});
+
+describe('DevDomainService — guards (shouldRun)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('ensureDevDomain is a no-op outside dev env', async () => {
+    const fetchMock = mockFetchOk({});
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService({ environment: 'production' });
+    await svc.ensureDevDomain('studio-alpha');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(obs.info).not.toHaveBeenCalled();
+  });
+
+  it('removeDevDomain is a no-op outside dev env', async () => {
+    const fetchMock = mockFetchOk({});
+    globalThis.fetch = fetchMock as never;
+
+    const { svc } = makeService({ environment: 'development' });
+    await svc.removeDevDomain('studio-alpha');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('renameDevDomain is a no-op outside dev env', async () => {
+    const fetchMock = mockFetchOk({});
+    globalThis.fetch = fetchMock as never;
+
+    const { svc } = makeService({ environment: 'staging' });
+    await svc.renameDevDomain('old-slug', 'new-slug');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('ensureDevDomain warns and no-ops when API token missing', async () => {
+    const fetchMock = mockFetchOk({});
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService({ apiToken: undefined });
+    await svc.ensureDevDomain('studio-alpha');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(obs.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cloudflare creds missing'),
+      expect.objectContaining({ slug: 'studio-alpha' })
+    );
+  });
+
+  it('ensureDevDomain warns and no-ops when account ID missing', async () => {
+    const fetchMock = mockFetchOk({});
+    globalThis.fetch = fetchMock as never;
+
+    const { svc } = makeService({ accountId: undefined });
+    await svc.ensureDevDomain('studio-alpha');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('renameDevDomain with equal slugs is a no-op (even in dev env)', async () => {
+    const fetchMock = mockFetchOk({});
+    globalThis.fetch = fetchMock as never;
+
+    const { svc } = makeService();
+    await svc.renameDevDomain('same-slug', 'same-slug');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('DevDomainService — ensureDevDomain (happy paths)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('creates the Custom Domain when none exists', async () => {
+    // First call: findDomain (list) → empty array (no match)
+    // Second call: resolveZoneId → returns id
+    // Third call: createDomain → 200 OK
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: [] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: [{ id: 'zone-abc-123' }],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      } as Response);
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await svc.ensureDevDomain('studio-alpha');
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(obs.info).toHaveBeenCalledWith(
+      'Dev custom domain created',
+      expect.objectContaining({
+        slug: 'studio-alpha',
+        hostname: 'studio-alpha.dev.revelations.studio',
+      })
+    );
+  });
+
+  it('is idempotent — no-op when domain already exists', async () => {
+    // findDomain returns the existing domain → skip create
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        result: [
+          {
+            id: 'existing-domain-id',
+            hostname: 'studio-alpha.dev.revelations.studio',
+            service: 'codex-web-dev',
+          },
+        ],
+      }),
+    } as Response);
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await svc.ensureDevDomain('studio-alpha');
+
+    // Only ONE call (findDomain) — no create, no zone-id resolve
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(obs.info).toHaveBeenCalledWith(
+      'Dev custom domain already exists',
+      expect.objectContaining({ slug: 'studio-alpha' })
+    );
+  });
+});
+
+describe('DevDomainService — removeDevDomain', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('deletes the Custom Domain when it exists', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: [
+            {
+              id: 'domain-to-delete',
+              hostname: 'studio-alpha.dev.revelations.studio',
+              service: 'codex-web-dev',
+            },
+          ],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      } as Response);
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await svc.removeDevDomain('studio-alpha');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(obs.info).toHaveBeenCalledWith(
+      'Dev custom domain removed',
+      expect.objectContaining({ slug: 'studio-alpha' })
+    );
+  });
+
+  it('no-ops silently when the domain does not exist', async () => {
+    const fetchMock = mockFetchOk({ success: true, result: [] });
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await svc.removeDevDomain('studio-alpha');
+
+    // Only ONE call (findDomain) — no delete
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(obs.info).not.toHaveBeenCalled();
+  });
+});
+
+describe('DevDomainService — renameDevDomain', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('removes old slug and creates new slug', async () => {
+    // removeDevDomain: findDomain → result (exists), then delete → ok
+    // ensureDevDomain: findDomain → empty, resolveZoneId → id, create → ok
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: [
+            {
+              id: 'old-domain-id',
+              hostname: 'old-slug.dev.revelations.studio',
+              service: 'codex-web-dev',
+            },
+          ],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: [] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: [{ id: 'zone-abc-123' }],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      } as Response);
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await svc.renameDevDomain('old-slug', 'new-slug');
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(obs.info).toHaveBeenCalledWith(
+      'Dev custom domain removed',
+      expect.objectContaining({ slug: 'old-slug' })
+    );
+    expect(obs.info).toHaveBeenCalledWith(
+      'Dev custom domain created',
+      expect.objectContaining({ slug: 'new-slug' })
+    );
+  });
+});
+
+describe('DevDomainService — error handling (logged + swallowed)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('ensureDevDomain swallows network errors (does not throw)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('Network down'));
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    // MUST NOT throw — org creation cannot depend on Cloudflare being up
+    await expect(svc.ensureDevDomain('studio-alpha')).resolves.toBeUndefined();
+    expect(obs.warn).toHaveBeenCalledWith(
+      expect.stringContaining('ensureDevDomain failed'),
+      expect.objectContaining({
+        slug: 'studio-alpha',
+        hostname: 'studio-alpha.dev.revelations.studio',
+        error: 'Network down',
+      })
+    );
+  });
+
+  it('ensureDevDomain swallows Cloudflare 5xx (logged not thrown)', async () => {
+    const fetchMock = vi
+      .fn()
+      // findDomain: empty result
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: [] }),
+      } as Response)
+      // resolveZoneId: success
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: [{ id: 'zone-1' }] }),
+      } as Response)
+      // createDomain: 502
+      .mockResolvedValueOnce(mockFetchFail(502, '{"error":"bad gateway"}')());
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await expect(svc.ensureDevDomain('studio-alpha')).resolves.toBeUndefined();
+    expect(obs.warn).toHaveBeenCalledWith(
+      expect.stringContaining('ensureDevDomain failed'),
+      expect.objectContaining({ slug: 'studio-alpha' })
+    );
+  });
+
+  it('removeDevDomain swallows Cloudflare delete failures', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: [
+            {
+              id: 'd1',
+              hostname: 'studio-alpha.dev.revelations.studio',
+              service: 'codex-web-dev',
+            },
+          ],
+        }),
+      } as Response)
+      .mockResolvedValueOnce(mockFetchFail(500, 'Internal Server Error')());
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await expect(svc.removeDevDomain('studio-alpha')).resolves.toBeUndefined();
+    expect(obs.warn).toHaveBeenCalledWith(
+      expect.stringContaining('removeDevDomain failed'),
+      expect.objectContaining({ slug: 'studio-alpha' })
+    );
+  });
+
+  it('ensureDevDomain handles malformed zone-list response', async () => {
+    const fetchMock = vi
+      .fn()
+      // findDomain: empty
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: [] }),
+      } as Response)
+      // resolveZoneId: success=false (Cloudflare returned an error envelope)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: false,
+          errors: [{ message: 'Authentication failed' }],
+        }),
+      } as Response);
+    globalThis.fetch = fetchMock as never;
+
+    const { svc, obs } = makeService();
+    await expect(svc.ensureDevDomain('studio-alpha')).resolves.toBeUndefined();
+    expect(obs.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/organization/src/services/dev-domain-service.ts
+++ b/packages/organization/src/services/dev-domain-service.ts
@@ -1,4 +1,6 @@
+import { DOMAINS } from '@codex/constants';
 import { BaseService, type ServiceConfig } from '@codex/service-errors';
+import { ENV_HOSTS } from '@codex/urls';
 
 /**
  * Configuration for the dev-only Cloudflare Custom Domain provisioner.
@@ -6,17 +8,19 @@ import { BaseService, type ServiceConfig } from '@codex/service-errors';
  * The service is a no-op outside the `dev` deployed environment, so the
  * Cloudflare credentials are optional — missing creds just turn off the
  * provisioning step rather than failing the org-create flow.
+ *
+ * WP-6 (Codex-0hxw4) removed the `zoneName` config injection — the value
+ * was always `DOMAINS.PROD` (`revelations.studio`), the single DNS zone
+ * for the entire prod/staging/dev hierarchy. The hostname pattern is now
+ * derived from `ENV_HOSTS.dev.orgHost(slug)` instead of string-templated
+ * from injected config, keeping the dev domain string in lockstep with
+ * the rest of the routing centralization.
  */
 export interface DevDomainServiceConfig extends ServiceConfig {
   /** Cloudflare API token with `Workers Scripts: Edit` scope. */
   cloudflareApiToken?: string;
   /** Cloudflare account ID hosting the dev workers. */
   cloudflareAccountId?: string;
-  /**
-   * The DNS zone name (e.g. `revelations.studio`). Dev hostnames are built
-   * as `{slug}.dev.{zoneName}`.
-   */
-  zoneName: string;
   /**
    * The name of the dev web worker that org subdomains should bind to.
    * For Codex this is `codex-web-dev`.
@@ -29,6 +33,15 @@ interface CloudflareWorkerDomain {
   hostname: string;
   service: string;
 }
+
+/**
+ * The Cloudflare DNS zone hosting the dev hierarchy. `revelations.studio`
+ * is the single parent zone for prod (`revelations.studio`), staging
+ * (`*-staging.revelations.studio`), AND dev (`*.dev.revelations.studio`).
+ * Sourced from `DOMAINS.PROD` so any future zone rename stays consistent
+ * with the rest of `@codex/constants`.
+ */
+const CLOUDFLARE_ZONE_NAME = DOMAINS.PROD;
 
 /**
  * Provisions and removes Cloudflare Workers Custom Domains for dev orgs.
@@ -52,7 +65,6 @@ interface CloudflareWorkerDomain {
 export class DevDomainService extends BaseService {
   private readonly apiToken?: string;
   private readonly accountId?: string;
-  private readonly zoneName: string;
   private readonly webWorkerName: string;
   private cachedZoneId?: string;
 
@@ -60,7 +72,6 @@ export class DevDomainService extends BaseService {
     super(config);
     this.apiToken = config.cloudflareApiToken;
     this.accountId = config.cloudflareAccountId;
-    this.zoneName = config.zoneName;
     this.webWorkerName = config.webWorkerName;
   }
 
@@ -137,8 +148,15 @@ export class DevDomainService extends BaseService {
     return Boolean(this.apiToken && this.accountId);
   }
 
+  /**
+   * The Cloudflare Custom Domain hostname for a given org slug. Sourced
+   * from `ENV_HOSTS.dev.orgHost` (since WP-6 / Codex-0hxw4) so the
+   * pattern stays in lockstep with the rest of the routing layer —
+   * change `ENV_HOSTS.dev.orgHost` in one place to update every hostname
+   * derivation in the codebase.
+   */
   private hostnameFor(slug: string): string {
-    return `${slug}.dev.${this.zoneName}`;
+    return ENV_HOSTS.dev.orgHost(slug);
   }
 
   private headers(): Record<string, string> {
@@ -162,7 +180,7 @@ export class DevDomainService extends BaseService {
   private async resolveZoneId(): Promise<string> {
     if (this.cachedZoneId) return this.cachedZoneId;
     const res = await fetch(
-      `https://api.cloudflare.com/client/v4/zones?name=${encodeURIComponent(this.zoneName)}`,
+      `https://api.cloudflare.com/client/v4/zones?name=${encodeURIComponent(CLOUDFLARE_ZONE_NAME)}`,
       { headers: this.headers() }
     );
     const body = (await res.json()) as {
@@ -173,7 +191,7 @@ export class DevDomainService extends BaseService {
     const zoneId = body.result?.[0]?.id;
     if (!body.success || !zoneId) {
       throw new Error(
-        `Failed to resolve zone id for ${this.zoneName}: ${JSON.stringify(body.errors ?? body)}`
+        `Failed to resolve zone id for ${CLOUDFLARE_ZONE_NAME}: ${JSON.stringify(body.errors ?? body)}`
       );
     }
     this.cachedZoneId = zoneId;

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -366,7 +366,9 @@ export function createServiceRegistry(
             typeof env.CLOUDFLARE_ACCOUNT_ID === 'string'
               ? env.CLOUDFLARE_ACCOUNT_ID
               : undefined,
-          zoneName: 'revelations.studio',
+          // zoneName removed in WP-6 — DevDomainService now derives the
+          // hostname from ENV_HOSTS.dev.orgHost and the Cloudflare zone
+          // name internally (always `revelations.studio`).
           webWorkerName: 'codex-web-dev',
         });
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -835,6 +835,9 @@ importers:
       '@codex/shared-types':
         specifier: workspace:*
         version: link:../shared-types
+      '@codex/urls':
+        specifier: workspace:*
+        version: link:../urls
       '@codex/validation':
         specifier: workspace:*
         version: link:../validation


### PR DESCRIPTION
## Summary

Phase 7 of the routing-centralization epic (Codex-rscgk) — eliminates the last hardcoded dev-zone string in `DevDomainService` by:
- Delegating hostname derivation to `ENV_HOSTS.dev.orgHost` from `@codex/urls` (byte-equal output: `{slug}.dev.revelations.studio`).
- Sourcing the Cloudflare DNS zone from `DOMAINS.PROD` in `@codex/constants` (was always this value — just removing the indirection).
- Removing `zoneName` config injection from `DevDomainServiceConfig` and the service-registry call site (`packages/worker-utils/src/procedure/service-registry.ts`).
- Closes Codex-0hxw4.

## Changes

| File | Change |
|---|---|
| `packages/organization/src/services/dev-domain-service.ts` | Drops `zoneName` field/config; `hostnameFor` → `ENV_HOSTS.dev.orgHost`; `CLOUDFLARE_ZONE_NAME = DOMAINS.PROD` module constant |
| `packages/worker-utils/src/procedure/service-registry.ts` | Removes `zoneName` from DevDomainService instantiation |
| `packages/organization/package.json` | Adds `@codex/urls: workspace:*` |
| `packages/organization/src/services/__tests__/dev-domain-service.test.ts` | **NEW** — 16 unit tests closing C5 coverage gap |
| `pnpm-lock.yaml` | Auto-updated for new workspace dep |

## Test coverage (C5 gap closure)

DevDomainService had **zero** unit tests before this PR. Adds 16 tests covering:

- **Hostname snapshot** (1) — Invokes `hostnameFor` through the private-crossing cast for 7 slug shapes (single char, multi-hyphen, reserved-ish words), pins byte-equal output AND delegation to `ENV_HOSTS.dev.orgHost`. Catches accidental refactor to `ENV_HOSTS.production.orgHost`.
- **Guards** (6) — `ensureDevDomain`/`removeDevDomain`/`renameDevDomain` no-op outside `dev` env; warn-and-no-op on missing creds; equal-slug rename short-circuit.
- **Happy paths** (4) — `ensureDevDomain` creates when absent + idempotent when present; `removeDevDomain` deletes when present + silent no-op when absent; `renameDevDomain` removes-then-creates.
- **Error swallowing** (4) — Network throw, Cloudflare 5xx, delete failure, malformed zone-list response — all logged via `obs.warn` and SWALLOWED (never thrown). Enforces the fire-and-forget contract that org create/rename/delete cannot block on Cloudflare API hiccups.

## Notes for reviewers

- The `(svc as unknown as { obs: MockObs }).obs = obs` post-construction mutation in the test helper is intentional. BaseService's constructor unconditionally creates its own `ObservabilityClient` (no DI path), and `vi.mock` factory + lazy `vi.fn()` doesn't reliably register as a spy with vitest's `toHaveBeenCalled*` matcher. Direct property assignment is the cleanest workaround given `protected obs` is mutable. JSDoc on the helper explains this.
- The `'apiToken' in opts ? opts.apiToken : 'test-token'` pattern (vs `??`) preserves explicit-undefined for negative-path tests — `??` collapses explicit undefined to defaults, masking the missing-creds branch.
- Pre-existing nit (out of scope): `findDomain` lists ALL workers/domains without pagination — if the dev Cloudflare account ever exceeds one page, idempotency could break. Worth a follow-up bead, but not part of WP-6.

## Test plan

- [x] `pnpm --filter @codex/organization test` — 99 passed | 1 skipped (denoise-proof, unrelated)
- [x] `pnpm --filter @codex/urls test` — 192 passed
- [x] `pnpm --filter @codex/worker-utils test` — 89 passed | 12 skipped | 1 todo
- [x] `pnpm --filter @codex/constants test` — 23 passed
- [x] `pnpm --filter @codex/organization typecheck` — clean
- [x] `pnpm --filter @codex/worker-utils typecheck` — clean
- [x] `pnpm --filter @codex/urls typecheck` — clean
- [x] `pnpm biome check` on diff — clean
- [x] Code review (pr-review-toolkit:code-reviewer) — SHOULD-fix items addressed: strengthened snapshot to invoke service path, swapped JSDoc ordering for class vs zone-const.

## Epic context

- Epic: Codex-rscgk (routing centralization)
- Predecessor WPs: 1, 2, 3, 4, 5a, 7, 8 already merged on `dev`
- Remaining after this: WP-5b (BetterAuth integration test), WP-9 (deploy smoke gate)
- Plan: `~/.claude/plans/typed-honking-canyon.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)