### PR TITLE
ci(deploy): WP-9 strict post-deploy smoke gate (dev + production)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -374,47 +374,50 @@ jobs:
 
       # --- POST-DEPLOYMENT VERIFICATION ---
 
+      # After-deploy smoke gate (WP-9, Codex-ikum9). Catches silent 500s from
+      # broken bindings, missing env vars, or routing misconfig that
+      # wrangler-deploy alone cannot detect. Every worker exposes /health via
+      # createWorker() in @codex/worker-utils — a non-2xx response means the
+      # worker is alive but its DB/KV/R2 wiring is broken, which is exactly
+      # the silent-failure mode this gate exists to catch. Any non-2xx fails
+      # the workflow with a GitHub annotation pointing at the failing URL.
       - name: Smoke tests
         timeout-minutes: 5
         run: |
           echo "## 🚧 Dev Smoke Tests" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           FAILED=0
-          # A "healthy" worker is one that responds with ANY non-network
-          # HTTP status. We drop `curl -f` (which treats 4xx/5xx as failure)
-          # because Hono workers correctly return 404 from `/` when no
-          # route is defined — that's NOT a deploy failure, it just means
-          # the worker is alive and dispatching. We treat curl exit 0 (got
-          # a response) as success and any non-zero (network/TLS error) as
-          # failure. A 5xx body is reported but doesn't fail the deploy.
+          # Strict gate: only 2xx passes. `curl -f` returns non-zero on 4xx/5xx
+          # so any unhealthy worker fails the step. `--max-time 15` prevents
+          # indefinite hangs on DNS/TLS issues. GitHub annotations (::error::)
+          # surface the failure URL directly in the PR/checks UI.
           check_health() {
             local service_name=$1
             local url=$2
             local status
-            status=$(curl -L -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" 2>&1)
+            status=$(curl -L -s -o /tmp/body.txt -w '%{http_code}' --max-time 15 "$url" 2>&1)
             local exit_code=$?
-            if [ $exit_code -eq 0 ] && [ -n "$status" ] && [ "$status" != "000" ]; then
+            if [ $exit_code -eq 0 ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
               echo "✅ $service_name (HTTP $status)" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "❌ $service_name ($url) — curl exit=$exit_code status=$status" >> $GITHUB_STEP_SUMMARY
-              return 1
+              return 0
             fi
+            echo "::error title=Dev smoke failed::$service_name at $url returned HTTP $status (curl exit=$exit_code)"
+            echo "❌ $service_name ($url) — HTTP $status, curl exit=$exit_code" >> $GITHUB_STEP_SUMMARY
+            return 1
           }
           echo "⏳ Waiting 30s for propagation..."
           sleep 30
-          # Hit `/` rather than `/health` — `/health` isn't reliably wired
-          # on every worker (it may be gated by middleware or simply absent).
-          # `/` reaching the worker proves the worker is live and the custom
-          # domain binding is working, which is what we actually want to
-          # smoke-test post-deploy.
-          check_health "Media API" "https://media-api.dev.revelations.studio/" || FAILED=1
-          check_health "Ecom API" "https://ecom-api.dev.revelations.studio/" || FAILED=1
-          check_health "Content API" "https://content-api.dev.revelations.studio/" || FAILED=1
-          check_health "Identity API" "https://identity-api.dev.revelations.studio/" || FAILED=1
-          check_health "Organization API" "https://organization-api.dev.revelations.studio/" || FAILED=1
-          check_health "Notifications API" "https://notifications-api.dev.revelations.studio/" || FAILED=1
-          check_health "Admin API" "https://admin-api.dev.revelations.studio/" || FAILED=1
-          check_health "Auth Worker" "https://auth.dev.revelations.studio/" || FAILED=1
+          # Hit /health on each worker — JSON body contains DB/KV/R2 wiring
+          # status. Web app hits / (no /health route on SvelteKit). All URLs
+          # confirmed reachable via manual probe pre-merge (Codex-ikum9).
+          check_health "Media API" "https://media-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Ecom API" "https://ecom-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Content API" "https://content-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Identity API" "https://identity-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Organization API" "https://organization-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Notifications API" "https://notifications-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Admin API" "https://admin-api.dev.revelations.studio/health" || FAILED=1
+          check_health "Auth Worker" "https://auth.dev.revelations.studio/health" || FAILED=1
           check_health "Web App" "https://dev.revelations.studio/" || FAILED=1
           if [ $FAILED -eq 0 ]; then
             echo "✅ **All dev services passed smoke tests**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -351,6 +351,13 @@ jobs:
 
       # --- POST-DEPLOYMENT VERIFICATION ---
 
+      # After-deploy smoke gate (WP-9, Codex-ikum9). Catches silent 500s from
+      # broken bindings, missing env vars, or routing misconfig that
+      # wrangler-deploy alone cannot detect. Every worker exposes /health via
+      # createWorker() in @codex/worker-utils — a non-2xx response means the
+      # worker is alive but its DB/KV/R2 wiring is broken, which is exactly
+      # the silent-failure mode this gate exists to catch. Any non-2xx fails
+      # the workflow with a GitHub annotation pointing at the failing URL.
       - name: Comprehensive smoke tests
         timeout-minutes: 5
         run: |
@@ -361,20 +368,22 @@ jobs:
 
           FAILED=0
 
-          # Function to check health
+          # Strict gate: only 2xx passes. `--max-time 15` prevents indefinite
+          # hangs on DNS/TLS issues. GitHub annotations (::error::) surface the
+          # failure URL directly in the PR/checks UI so on-call can act fast.
           check_health() {
             local service_name=$1
             local url=$2
-            echo "Testing $service_name ($url)..."
-
-            # Use curl to get status code, follow redirects, match 200
-            if curl -L -f -s "$url" > /dev/null 2>&1; then
-              echo "✅ $service_name" >> $GITHUB_STEP_SUMMARY
+            local status
+            status=$(curl -L -s -o /tmp/body.txt -w '%{http_code}' --max-time 15 "$url" 2>&1)
+            local exit_code=$?
+            if [ $exit_code -eq 0 ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+              echo "✅ $service_name (HTTP $status)" >> $GITHUB_STEP_SUMMARY
               return 0
-            else
-              echo "❌ $service_name ($url)" >> $GITHUB_STEP_SUMMARY
-              return 1
             fi
+            echo "::error title=Production smoke failed::$service_name at $url returned HTTP $status (curl exit=$exit_code)"
+            echo "❌ $service_name ($url) — HTTP $status, curl exit=$exit_code" >> $GITHUB_STEP_SUMMARY
+            return 1
           }
 
           # Wait for propagation (initial delay)
@@ -399,7 +408,7 @@ jobs:
             exit 0
           else
             echo "❌ **Some services failed smoke tests**" >> $GITHUB_STEP_SUMMARY
-            # Don't fail the build immediately, allow notification to run
+            # Fail the deploy so on-call sees the alert immediately
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

WP-9 of the routing-centralization epic (Codex-rscgk). Closes the silent-500 hole where \`wrangler deploy\` succeeds but a worker's bindings (DB / KV / R2) are broken, so the deploy is reported green but every request returns 500.

The dev smoke step previously hit \`/\` and accepted *any* HTTP response (including 5xx) as "alive" — that masked exactly the failure mode we cared about. This PR:

- **deploy-dev.yml**: switches to \`/health\` per worker (registered uniformly via \`createWorker()\` in \`@codex/worker-utils\`, body reports DB/KV/R2 wiring status) and enforces strict 2xx; non-2xx fails the workflow with a \`::error::\` annotation.
- **deploy-production.yml**: keeps the existing \`/health\` URLs but tightens the response check and surfaces failures as GH annotations with the failing URL + HTTP code.

Refs: Codex-ikum9

## Workers covered by smoke

| Worker | Dev URL | Prod URL |
|---|---|---|
| auth | https://auth.dev.revelations.studio/health | https://auth.revelations.studio/health |
| content-api | https://content-api.dev.revelations.studio/health | https://content-api.revelations.studio/health |
| organization-api | https://organization-api.dev.revelations.studio/health | https://organization-api.revelations.studio/health |
| ecom-api | https://ecom-api.dev.revelations.studio/health | https://ecom-api.revelations.studio/health |
| admin-api | https://admin-api.dev.revelations.studio/health | https://admin-api.revelations.studio/health |
| identity-api | https://identity-api.dev.revelations.studio/health | https://identity-api.revelations.studio/health |
| notifications-api | https://notifications-api.dev.revelations.studio/health | https://notifications-api.revelations.studio/health |
| media-api | https://media-api.dev.revelations.studio/health | https://media-api.revelations.studio/health |
| web | https://dev.revelations.studio/ | https://revelations.studio/ |

**Skipped: dev-cdn** — local development only (Miniflare R2 proxy, port 4100), no deployed env URL.

## Pre-merge URL probe results

All endpoints probed locally 2026-05-22 — every probe returned HTTP 200 with a valid \`{"status":"healthy",...}\` JSON body confirming DB/KV/R2 wiring.

\`\`\`
=== Dev ===
media-api.dev.revelations.studio/health             HTTP=200 TIME=0.40s
ecom-api.dev.revelations.studio/health              HTTP=200 TIME=0.39s
content-api.dev.revelations.studio/health           HTTP=200 TIME=0.72s
identity-api.dev.revelations.studio/health          HTTP=200 TIME=0.46s
organization-api.dev.revelations.studio/health      HTTP=200 TIME=0.50s
notifications-api.dev.revelations.studio/health     HTTP=200 TIME=0.41s
admin-api.dev.revelations.studio/health             HTTP=200 TIME=0.64s
auth.dev.revelations.studio/health                  HTTP=200 TIME=0.63s
dev.revelations.studio/                             HTTP=200 TIME=0.46s

=== Production ===
media-api.revelations.studio/health                 HTTP=200 TIME=0.36s
ecom-api.revelations.studio/health                  HTTP=200 TIME=0.96s
content-api.revelations.studio/health               HTTP=200 TIME=0.76s
identity-api.revelations.studio/health              HTTP=200 TIME=0.31s
organization-api.revelations.studio/health          HTTP=200 TIME=0.35s
notifications-api.revelations.studio/health         HTTP=200 TIME=0.33s
admin-api.revelations.studio/health                 HTTP=200 TIME=0.36s
auth.revelations.studio/health                      HTTP=200 TIME=0.47s
revelations.studio/                                 HTTP=200 TIME=0.25s
\`\`\`

Sample healthy body:
\`\`\`json
{"status":"healthy","service":"content-api","version":"1.0.0","timestamp":"2026-05-22T17:08:33.472Z","checks":{"database":{"status":"ok"},"kv":{"status":"ok"},"r2":{"status":"ok"}}}
\`\`\`

## Notes

- Smoke gate validation (intentional break test — e.g. revoke a secret to confirm 500 → gate fails red) is a follow-up after merge. Doing it pre-merge would require deliberately breaking a live dev worker, which is not worth the disruption.
- Bonus production smoke gate shipped: **Y**.
- No follow-up beads required — every existing worker has \`/health\` wired via \`createWorker()\`, no auth-gating issues, no missing endpoints.

## Test plan

- [ ] Merge to \`dev\` → next dev deploy run shows the new smoke step with HTTP-2xx accept band and GH annotation on failure
- [ ] Follow-up (post-merge): intentionally inject a broken secret on a dev worker, confirm gate flips red

🤖 Generated with [Claude Code](https://claude.com/claude-code)