### PR TITLE
fix(ci): add db:seed + start missing workers for E2E Web Tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -90,6 +90,11 @@ jobs:
       organization-api: ${{ steps.filter.outputs.organization-api }}
       notifications-api: ${{ steps.filter.outputs.notifications-api }}
       admin-api: ${{ steps.filter.outputs.admin-api }}
+      # CI infrastructure changes (workflow yaml, generate-dev-vars script,
+      # seed steps, worker startup blocks). When this is true the test jobs
+      # MUST run even when no source file changed — otherwise a workflow
+      # fix is silently never exercised in CI.
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@v4
       - name: Filter changed packages
@@ -140,6 +145,9 @@ jobs:
               - 'workers/notifications-api/**'
             admin-api:
               - 'workers/admin-api/**'
+            workflows:
+              - '.github/workflows/testing.yml'
+              - '.github/scripts/generate-dev-vars.sh'
 
   test:
     needs: [changes, static-analysis]  # Both must pass before running tests
@@ -749,7 +757,8 @@ jobs:
       needs.worker-tests.result != 'failure' &&
       (needs.changes.outputs.web == 'true' ||
        needs.changes.outputs.auth-worker == 'true' ||
-       needs.changes.outputs.shared-types == 'true')
+       needs.changes.outputs.shared-types == 'true' ||
+       needs.changes.outputs.workflows == 'true')
     runs-on: ubuntu-latest
     environment: test
     outputs:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -825,6 +825,30 @@ jobs:
       - name: Build Storybook
         run: pnpm --filter web build-storybook
 
+      # Seed test database with users (viewer@test.com, creator@test.com, etc.)
+      # and seeded orgs (studio-alpha, studio-beta, of-blood-and-bones). The
+      # Playwright web specs depend on these — without seeding, fast-signin
+      # returns 500 INVALID_EMAIL_OR_PASSWORD and the entire loginAsSeedViewer
+      # path collapses (Codex-8yxy4).
+      #
+      # --force skips the interactive confirmation prompt.
+      # STRIPE_SECRET_KEY enables real Stripe test-mode subscription for
+      # viewer@test.com; without it the seed falls back to synthetic IDs +
+      # any checkout test would fail with 422.
+      - name: Seed test database
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+          DB_METHOD: NEON_BRANCH
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_MEDIA: ${{ vars.R2_BUCKET_MEDIA }}
+        run: |
+          echo "::add-mask::$DATABASE_URL"
+          echo "::add-mask::$STRIPE_SECRET_KEY"
+          pnpm db:seed -- --force
+
       # Generate .dev.vars.test files for workers to use in CI
       - name: Generate worker dev vars for E2E
         env:
@@ -911,6 +935,66 @@ jobs:
           DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
 
+      # The studio +layout.server.ts calls getMyMembership + getMyOrganizations
+      # via organization-api. Without it, role=null and the layout redirects
+      # to /?error=access_denied. Studio + analytics tests all break. Part of
+      # the Codex-8yxy4 fix.
+      - name: Start Organization API Worker in background
+        run: |
+          cd workers/organization-api
+          pnpm wrangler dev --env test --port 42071 --local &
+          echo $! > organization-api-worker.pid
+          timeout 60 bash -c 'until curl -f http://localhost:42071/health > /dev/null 2>&1; do sleep 1; done'
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+
+      # Studio layout's draft-count call routes through content-api. Content
+      # list, content detail, and any media-related test path requires it.
+      - name: Start Content API Worker in background
+        run: |
+          cd workers/content-api
+          pnpm wrangler dev --env test --port 4001 --local &
+          echo $! > content-api-worker.pid
+          timeout 60 bash -c 'until curl -f http://localhost:4001/health > /dev/null 2>&1; do sleep 1; done'
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+
+      # Analytics page calls admin-api for revenue / subscribers / followers /
+      # top-content. Without it the analytics zero-state tests time out
+      # waiting for .studio-layout because the query catches throw to empty
+      # data but the cascade still confuses the role guard.
+      - name: Start Admin API Worker in background
+        run: |
+          cd workers/admin-api
+          pnpm wrangler dev --env test --port 42073 --local &
+          echo $! > admin-api-worker.pid
+          timeout 60 bash -c 'until curl -f http://localhost:42073/health > /dev/null 2>&1; do sleep 1; done'
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+
+      # Notification preferences + email template specs route through this.
+      - name: Start Notifications API Worker in background
+        run: |
+          cd workers/notifications-api
+          pnpm wrangler dev --env test --port 42075 --local &
+          echo $! > notifications-api-worker.pid
+          timeout 60 bash -c 'until curl -f http://localhost:42075/health > /dev/null 2>&1; do sleep 1; done'
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+
+      # Media upload + transcoding callback specs route through this. Uses a
+      # mock RunPod endpoint per RUNPOD_DIRECT_URL in .dev.vars.test.
+      - name: Start Media API Worker in background
+        run: |
+          cd workers/media-api
+          pnpm wrangler dev --env test --port 4002 --local &
+          echo $! > media-api-worker.pid
+          timeout 60 bash -c 'until curl -f http://localhost:4002/health > /dev/null 2>&1; do sleep 1; done'
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+
       - name: Start Wrangler dev server in background
         run: |
           echo "::add-mask::$DATABASE_URL"
@@ -934,10 +1018,15 @@ jobs:
           echo "Waiting for workers to fully initialize..."
           sleep 5
           # Verify all critical endpoints are responsive
-          curl -f http://localhost:42069/health || exit 1
-          curl -f http://localhost:42074/health || exit 1
-          curl -f http://localhost:42072/health || exit 1
-          curl -f http://localhost:5173 || exit 1
+          curl -f http://localhost:42069/health || exit 1  # auth
+          curl -f http://localhost:42074/health || exit 1  # identity-api
+          curl -f http://localhost:42072/health || exit 1  # ecom-api
+          curl -f http://localhost:42071/health || exit 1  # organization-api
+          curl -f http://localhost:4001/health || exit 1   # content-api
+          curl -f http://localhost:42073/health || exit 1  # admin-api
+          curl -f http://localhost:42075/health || exit 1  # notifications-api
+          curl -f http://localhost:4002/health || exit 1   # media-api
+          curl -f http://localhost:5173 || exit 1          # apps/web
           echo "All workers ready"
 
       - name: Run E2E tests
@@ -1013,6 +1102,46 @@ jobs:
           if [ -f workers/ecom-api/ecom-api-worker.pid ]; then
             kill $(cat workers/ecom-api/ecom-api-worker.pid) || true
             rm workers/ecom-api/ecom-api-worker.pid
+          fi
+
+      - name: Stop Organization API Worker
+        if: always()
+        run: |
+          if [ -f workers/organization-api/organization-api-worker.pid ]; then
+            kill $(cat workers/organization-api/organization-api-worker.pid) || true
+            rm workers/organization-api/organization-api-worker.pid
+          fi
+
+      - name: Stop Content API Worker
+        if: always()
+        run: |
+          if [ -f workers/content-api/content-api-worker.pid ]; then
+            kill $(cat workers/content-api/content-api-worker.pid) || true
+            rm workers/content-api/content-api-worker.pid
+          fi
+
+      - name: Stop Admin API Worker
+        if: always()
+        run: |
+          if [ -f workers/admin-api/admin-api-worker.pid ]; then
+            kill $(cat workers/admin-api/admin-api-worker.pid) || true
+            rm workers/admin-api/admin-api-worker.pid
+          fi
+
+      - name: Stop Notifications API Worker
+        if: always()
+        run: |
+          if [ -f workers/notifications-api/notifications-api-worker.pid ]; then
+            kill $(cat workers/notifications-api/notifications-api-worker.pid) || true
+            rm workers/notifications-api/notifications-api-worker.pid
+          fi
+
+      - name: Stop Media API Worker
+        if: always()
+        run: |
+          if [ -f workers/media-api/media-api-worker.pid ]; then
+            kill $(cat workers/media-api/media-api-worker.pid) || true
+            rm workers/media-api/media-api-worker.pid
           fi
 
       # Upload generated snapshots for committing to repo


### PR DESCRIPTION
## Summary

**Closes Codex-8yxy4 — the CI bug cluster blocking PRs #261, #262, #263, #264.**

The E2E Web Tests CI job has been failing for days. \`gh run view\` on PR #261 from 2026-05-25T11:07Z shows **31 failed, 130 passed (47 min)**. Local runs are 100% green on the same code. Two distinct failure clusters with one shared root cause: CI's runtime environment diverges from local.

## Root cause (two clusters, one fix surface)

### Cluster A — \`fast-signin\` returns 500 \`INVALID_EMAIL_OR_PASSWORD\`

\`\`\`
Error: fast-signin failed: 500 {"error":"Sign-in failed",
  "details":"{\"code\":\"INVALID_EMAIL_OR_PASSWORD\"}"}
\`\`\`

The CI workflow runs migrations against the ephemeral Neon branch — but **never seeds**. Without \`pnpm db:seed\`, \`viewer@test.com / Test1234!\` doesn't exist. Every spec using \`loginAsSeedViewer\` 500s on first call.

### Cluster B — \`.studio-layout\` timeout on studio specs

Studio specs use \`registerSharedStudioUser\` (fresh user, no seed dep) yet fail at \`waitForSelector('.studio-layout', 30s)\`. The CI job started only **4 services** (auth, identity-api, ecom-api, apps/web). Local config starts **7+**.

Trace:
1. Test creates fresh org via fresh user (works, uses DB directly)
2. \`navigateToStudioPage('/studio/analytics')\`
3. Studio \`+layout.server.ts\` calls \`getMyMembership(org.id)\` → routes to \`organization-api\` (port 42071) — **not running in CI**
4. \`.catch()\` returns \`{ role: null }\`
5. \`if (!role) redirect(302, '/?error=access_denied')\`
6. \`.studio-layout\` never renders → 30s timeout

## Fix

Three changes to \`.github/workflows/testing.yml\` \`e2e-tests\` job:

### 1. Add seed step after build

\`\`\`yaml
- name: Seed test database
  env:
    DATABASE_URL: \${{ steps.create-branch.outputs.db_url_with_pooler }}
    DB_METHOD: NEON_BRANCH
    STRIPE_SECRET_KEY: \${{ secrets.STRIPE_SECRET_KEY }}
    R2_*: <as needed>
  run: pnpm db:seed -- --force
\`\`\`

The \`--force\` flag skips the interactive confirm prompt. The seed script reads \`.env.dev\` via \`dotenv\` (silent no-op in CI since the file doesn't exist) and uses \`process.env.DATABASE_URL\`.

### 2. Start the 5 missing workers

| Worker | Port | Why needed |
|---|---|---|
| organization-api | 42071 | studio layout \`getMyMembership\` + \`getMyOrganizations\` |
| content-api | 4001 | studio layout draft count + content list |
| admin-api | 42073 | analytics page revenue/subscribers/followers queries |
| notifications-api | 42075 | notification preference + email template specs |
| media-api | 4002 | upload + transcoding callback specs |

Each follows the existing auth/identity/ecom pattern: \`cd workers/<dir> && pnpm wrangler dev --env test --port <port> --local &\`, save PID, wait for \`/health\`.

### 3. Health-check + cleanup parity

Expand "Wait for workers to stabilize" curl checks to all 8 endpoints. Add 5 matching "Stop X Worker" cleanup steps (with \`if: always()\`).

## Verification

- \`testing.yml\` validates as YAML (js-yaml load succeeds)
- \`e2e-tests\` job goes from ~30 steps to 41 steps
- 8 worker Start steps total (was 3)
- Diff: **+133 / −4** on \`testing.yml\` — surgical, low blast radius

## Unblocks the stacked PR chain

```
dev
 └─ #261 fix/e2e-l13ai-form-drift     (parent — has CI failures)
    └─ #262 fix/e2e-helper-consolidation  (WP-1+WP-2)
       └─ #263 feat/e2e-data-testid-wide  (WP-3)
          └─ #264 feat/e2e-workers-2      (WP-4)
```

After this PR lands on \`dev\`, the 4 stacked PRs need to rebase to pick up the new workflow. CI then runs against:
- ✅ Seeded DB (Cluster A fix)
- ✅ All required workers (Cluster B fix)

WP-4's \`workers=2\` measurement runs naturally once CI is reliable.

## Caveats / things to monitor

- Each CI run now creates real Stripe test-mode subscriptions. They accumulate in the Stripe test account; the \`archiveTestStripeProducts\` helper exists but isn't invoked here. May warrant a periodic cleanup job.
- 8 wrangler dev instances will consume more memory on the GH-hosted runner (~200MB each = 1.6GB total). Runners have 7GB so should be fine.
- The seed step adds ~30-60s to CI wall-clock (depending on Stripe API latency).

## Test plan

- [x] YAML validates locally (\`js-yaml\` round-trip succeeds)
- [x] All 8 worker startup steps follow the same pattern
- [x] Pid-file naming consistent (\`<worker>-worker.pid\`)
- [x] Cleanup steps mirror start steps with \`if: always()\`
- [ ] CI E2E Web Tests goes green on this PR (the proof)
- [ ] Stacked PRs rebase + go green after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)