### PR TITLE
refactor(e2e): consolidate auth helpers + add apps/web/e2e/CLAUDE.md (was #262)

### DIFF
--- a/apps/web/e2e/CLAUDE.md
+++ b/apps/web/e2e/CLAUDE.md
@@ -1,0 +1,226 @@
+# Web App E2E Tests (Playwright)
+
+End-to-end tests against the SvelteKit app, running against the full local stack (workers + dev server). Sibling to the API E2E suite at the repo root (`/e2e/`) which uses Vitest — these are different runners with different fixture systems; don't confuse them.
+
+**Stack:** Playwright 1.52, Node 22, BetterAuth + Neon test branch, lvh.me wildcard DNS.
+
+---
+
+## Strict Rules
+
+### Cookies & Auth
+- **MUST** POST to `lvh.me:42069` (NOT `localhost:42069`) when an HTTP call sets cookies — see [Cookie domain gotcha](#cookie-domain-gotcha)
+- **MUST** inject BOTH `better-auth.session_token` AND `codex-session` cookies — use `aliasSessionCookies()` from `helpers/auth-cookies.ts`
+- **MUST** scope cookies to `.lvh.me` (leading dot) so they propagate to every `*.lvh.me` subdomain
+- **NEVER** hand-roll the cookie aliasing logic — extend `helpers/auth-cookies.ts` if a new input shape needs support
+
+### Test Data
+- **NEVER** call `cleanupDatabase()` from `@codex/test-utils` in a Playwright spec — it deletes ALL orgs including the seeded `studio-alpha`/`studio-beta`/`creators`
+- **MUST** use unique slugs (`e2e-<purpose>-${timestamp}-${rand}`) for any spec that creates orgs
+- **MUST** be idempotent — assume the previous run left state behind; either run a teardown that restores starting state, or assert "at least one X" rather than "exactly one X"
+
+### Navigation
+- **MUST** use `expectClickNavigates()` from `helpers/spa-nav.ts` for studio routes (`ssr=false`) — `waitForURL` hangs
+- **MUST** use root-relative paths inside `page.goto()` once on an org subdomain — slug is in hostname, not path
+- **MUST** prefer `getByRole(...)` and structural class locators over `getByText(...)` — text drifts faster than roles or DOM structure
+
+### Locators (transitional)
+- **PREFER** `data-testid` for new tests where the underlying element will likely have copy changes (button labels, badges, tier names)
+- **AVOID** raw text matchers without a regex — `getByText('Cancel')` matches "Cancel Subscription", "Cancel Plan", etc.
+
+---
+
+## Cookie domain gotcha
+
+The auth worker emits `Set-Cookie: ...; Domain=.lvh.me; Path=/; HttpOnly; SameSite=Lax`. Chromium silently REJECTS the cookie unless the response host matches the cookie's Domain attribute.
+
+- ✅ POST to `http://lvh.me:42069/api/test/fast-signin` → cookie accepted
+- ❌ POST to `http://localhost:42069/api/test/fast-signin` → cookie silently dropped
+
+This is the single most expensive gotcha — it cost hours during PR #261's debug cycle. The symptom: `loginAsSeedViewer` returns successfully, but the next `page.goto('/library')` redirects to `/login` because no session cookie ever reached the browser.
+
+Health checks (`request.get('http://localhost:42069/health')`) are fine — they don't set cookies. Only cookie-setting endpoints need `lvh.me`.
+
+---
+
+## Dual-cookie injection
+
+Two cookie names exist for one session:
+
+| Cookie | Set by | Read by |
+|---|---|---|
+| `better-auth.session_token` | BetterAuth (auth worker) — its default name | The auth worker itself (and direct auth API calls) |
+| `codex-session` | Our SvelteKit layer (via `COOKIES.SESSION_NAME` in `@codex/constants`) | `hooks.server.ts` session validation |
+
+When you receive a Set-Cookie from `/api/test/fast-signin` or `/api/auth/sign-in/email`, the auth worker emits ONLY `better-auth.session_token`. SvelteKit reads `codex-session`. The two-cookie convergence happens via `aliasSessionCookies()` which detects `better-auth.session_token` and emits a `codex-session` alias with the same value.
+
+`★ Why the alias exists`: Historical — the platform was built before adopting BetterAuth and the cookie name was hardcoded in many places. Renaming the SvelteKit-side constant to match BetterAuth's default would be cleaner but the migration cost is high; the alias is the de-facto contract.
+
+---
+
+## Helper map
+
+```
+apps/web/e2e/helpers/
+├── auth-cookies.ts      Cookie alias + Set-Cookie parsers (the heart of e2e auth)
+├── seed-auth.ts         Login as a pre-seeded user via fast-signin
+├── spa-nav.ts           expectClickNavigates() for ssr=false routes
+├── studio.ts            registerSharedStudioUser, navigateToStudio, injectOrgCookies
+├── subscription.ts      Seeded creator login, fresh-owner-with-rate-bypass, Stripe cleanup
+└── agreements.ts        Owner ↔ creator topology helpers (revenue-share specs)
+```
+
+### Choosing an auth helper
+
+| Helper | When to use | Auth strategy | Cost |
+|---|---|---|---|
+| `loginAsSeedViewer` (seed-auth.ts) | Test needs `viewer@test.com` with the seeded `studio-alpha` subscription | `/api/test/fast-signin` | Fast (1 HTTP) |
+| `loginAsSeededCreator` (subscription.ts) | Test needs `creator@test.com` (Studio Alpha owner) | Real `/api/auth/sign-in/email` via form | Slow + rate-limited |
+| `captureSeededCreatorCookies` (subscription.ts) | Same as above but for `beforeAll` — share cookies across tests | Sign-in with synthetic CF-Connecting-IP | Fast, bypasses rate limit |
+| `registerSharedStudioUser` (studio.ts) | Test needs a fresh org with isolated state | `orgFixture.createOrgMember` (multi-step) | Slow, but isolated |
+| `createFreshOwnerWithBypass` (subscription.ts) | Same as above but rate-limit-immune | fast-register + synthetic-IP sign-in + direct DB org insert | Fastest fresh-org path |
+| `createOwnerAndCreator` (agreements.ts) | Two-actor negotiation tests | Two `createOrgMember` calls | Slowest, two users |
+
+**Rule of thumb**: prefer seed-user helpers (idempotency burden, but fast). Use fresh-org helpers when the test mutates state in ways that would corrupt the next run.
+
+---
+
+## Rate limits
+
+The auth worker enforces `RATE_LIMIT_PRESETS.auth` (5 req / 15 min per IP) on `/api/auth/sign-in/email`. On localhost the default IP fallback resolves to the string `"unknown"`, so **all parallel processes share one bucket** — easily exhausted by a single failed test run.
+
+Three escape hatches:
+
+1. **`/api/test/fast-signin`** — bypasses the form flow entirely. No rate limit. Used by `loginAsSeedViewer`.
+2. **Synthetic `CF-Connecting-IP` header** — per `defaultKeyGenerator` in `packages/security/src/rate-limit.ts:135-143`, the header is honoured for bucket keying. Used by `captureSeededCreatorCookies` and `createFreshOwnerWithBypass`.
+3. **Wait 15 minutes** — only useful in extreme cases; just use one of the above.
+
+---
+
+## Test fixtures (`fixtures/auth.ts`)
+
+`fixtures/auth.ts` extends Playwright's `test` with `authenticatedUser` and `authenticatedPage` fixtures. Used by specs that need a stock authenticated context without spec-local setup.
+
+**Health-check fixture**: All auth-dependent specs should skip cleanly when the auth worker isn't running — pattern:
+
+```typescript
+test.beforeAll(async ({ request }) => {
+  try {
+    const res = await request.get('http://localhost:42069/health');
+    if (!res.ok()) test.skip(true, 'Auth worker not running on port 42069');
+  } catch {
+    test.skip(true, 'Auth worker not running on port 42069');
+  }
+});
+```
+
+The localhost URL is OK here — `/health` doesn't set cookies. (Yes, it's inconsistent with the lvh.me rule. The rule applies only to cookie-setting endpoints.)
+
+---
+
+## SPA navigation (studio sub-tree)
+
+Studio routes have `export const ssr = false` (apps/web/src/routes/_org/[slug]/studio/+layout.ts) — the entire sub-tree is client-rendered. Three consequences:
+
+1. **`waitForURL` with default `waitUntil:'load'` hangs forever** — there is no real `load` event after the initial bundle loads; subsequent navigation is `history.pushState` only.
+2. **Playwright's synthetic `click()` doesn't always bubble** in a way SvelteKit's client router (delegated listener on `document`) picks up.
+3. **The desktop rail expands on hover**, so the actionability check fails mid-action: the link shifts, the click misses.
+
+The robust pattern (encoded in `helpers/spa-nav.ts` `expectClickNavigates`):
+
+```typescript
+await locator.hover();                           // Settle the rail
+await locator.evaluate((el: HTMLElement) => el.click());  // Native click bubbles
+await expect(page).toHaveURL(pattern);           // Poll URL — no wait events
+```
+
+---
+
+## Database hazards
+
+### `cleanupDatabase()` wipes everything
+
+`@codex/test-utils/src/database.ts` exports a `cleanupDatabase()` that deletes ALL rows from key tables — `organizations`, `users`, `subscriptions`, etc. If a Playwright spec calls this (directly or transitively), the seeded `studio-alpha`/`studio-beta` orgs vanish and every subsequent test in the suite breaks.
+
+Vitest integration tests CAN call `cleanupDatabase` (they run in `--concurrency=1` and re-seed in `beforeAll`). Playwright specs must NOT.
+
+### Shared Neon test branch
+
+CI uses one ephemeral Neon branch per workflow run. All Playwright tests in a single run share that branch. Memory: `feedback_e2e_vitest_forks_neon_contention` — workers capped at 2 max on the shared branch.
+
+### Re-seed between long runs
+
+The seed is not re-run between iterations of the full suite. Long debug loops accumulate test-created orgs; queries slow down (28min → 35min observed between iterations). If wall-clock starts climbing mid-session, run `pnpm db:seed` manually.
+
+---
+
+## Parallelism (current state)
+
+`playwright.config.ts`:
+```typescript
+workers: process.env.CI ? 1 : undefined,   // CI: 1 worker. Local: cores.
+```
+
+**Why**: auth-worker + shared Neon ephemeral branch + cookie-jar leakage across contexts caused a flake cluster (Codex-l13ai) that was the primary driver of PR #261. workers=1 is the conservative answer.
+
+**Triggers to revisit**:
+- Auth worker gets a Neon connection-pool bump (currently uses HTTP per-request)
+- All callers of `/api/auth/sign-in/email` migrate to `fast-signin` (eliminating rate-limit contention)
+- A measurement run on a feature branch shows ≥99% pass rate at workers=2 across 3 consecutive full-suite runs
+
+See WP-4 of beads epic `Codex-498na` for the planned measurement.
+
+---
+
+## Selector strategy
+
+PR #261 had 12 of 22 commits as text-locator drift fixes. The trend: button copy changes more often than DOM structure. The strategy:
+
+1. **First choice**: Structural class selectors with regex when stable — `.subscription-card`, `.studio-rail__item[href="/studio/content"]`, `.badge`. These survive copy changes entirely.
+2. **Second choice**: `getByRole('button', { name: /pattern/i })` with regex matching. Survives whitespace and minor copy edits but breaks if the button is replaced with a non-button (e.g. Melt UI Select replacing a native `<select>`).
+3. **For new tests**: prefer `data-testid` on elements likely to see copy churn (pricing tier buttons, subscription badges, propose-dialog radio labels). Wide data-testid coverage is WP-3 of beads epic `Codex-498na`.
+4. **Last resort**: text matchers with regex. Always include a regex (`/pattern/i`) — never a bare string.
+
+### Patterns that drifted in PR #261
+
+- `'Reactivate plan'` → `'Reactivate'` (subscription card)
+- `'Cancel'` → `'Cancel Subscription'` (account page)
+- `'Current Plan'` → `' Current Plan'` (leading whitespace from layout)
+- `<textarea>` → `<RichTextEditor>` Tiptap contenteditable (content form)
+- `<select>` → Melt UI Select (portalled options)
+- Toast `role="status"` → `role="alert"`
+
+---
+
+## Wall-clock & debugging tips
+
+- **First run cold-start**: ~30s for Playwright `webServer` boot. Subsequent runs in same session use `reuseExistingServer: true` and are instant.
+- **Long-running spec smell**: `pie-math` (1.4min, 3x propose+accept), `agreements terminate` (40-50s each), `subscription tests` (17-30s for login + state setup).
+- **Trace artifact**: `playwright-report/` — generated on every failure (`trace: 'on-first-retry'` default). Open with `pnpm exec playwright show-report`.
+- **Debug a single spec**: `pnpm --filter web exec playwright test apps/web/e2e/<file>.spec.ts --headed --debug`.
+
+---
+
+## Important files
+
+| Path | Purpose |
+|---|---|
+| `playwright.config.ts` | Test runner config, web server orchestration |
+| `e2e/fixtures/auth.ts` | `authenticatedUser` / `authenticatedPage` test fixtures |
+| `e2e/helpers/auth-cookies.ts` | `aliasSessionCookies`, `parseSetCookieHeaders`, `parseSetCookieStrings` |
+| `e2e/helpers/seed-auth.ts` | `loginAsSeedViewer`, `SEED_VIEWER` |
+| `e2e/helpers/spa-nav.ts` | `expectClickNavigates` |
+| `e2e/helpers/studio.ts` | `registerSharedStudioUser`, `injectOrgCookies`, `navigateToStudio` |
+| `e2e/helpers/subscription.ts` | Seeded creator login, rate-bypass helpers, Stripe cleanup |
+| `e2e/helpers/agreements.ts` | Two-actor topology for revenue-share negotiation specs |
+| `packages/test-utils/src/e2e/cookies.ts` | `parseCookieString` (Cookie REQUEST header parser) |
+| `packages/test-utils/src/e2e/fixtures/auth.fixture.ts` | API E2E auth fixture (vitest, NOT Playwright) |
+
+---
+
+## Related Docs
+
+- Web app overview: `apps/web/CLAUDE.md`
+- Caching invalidation strategy: `docs/caching-strategy.md`
+- API E2E suite (vitest): `e2e/CLAUDE.md` (if exists) and `packages/test-utils/CLAUDE.md`
+- Beads epic for this work: `Codex-498na` (PR #261 follow-up)

--- a/apps/web/e2e/account-subscription-cancel.spec.ts
+++ b/apps/web/e2e/account-subscription-cancel.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { loginAsSeedViewer } from './helpers/seed-auth';
 
 /**
  * Account Subscription Cancel Flow E2E Tests
@@ -32,66 +33,7 @@ import { expect, test } from '@playwright/test';
  *     auto-starts these when PLAYWRIGHT_BASE_URL is not set)
  */
 
-const SEED_USER = {
-  email: 'viewer@test.com',
-  password: 'Test1234!', // SEED_PASSWORD in packages/database/scripts/seed/constants.ts
-};
-
 const SEEDED_ORG_NAME = 'Studio Alpha';
-
-/**
- * Log in via the real login form + auth worker, then wait for the session
- * cookie to be set. We don't hit the auth worker directly because the task
- * constraints require "real session through the normal login flow".
- */
-async function loginAsSeedViewer(page: import('@playwright/test').Page) {
-  // Call fast-signin via lvh.me to satisfy cookie Domain=.lvh.me, then
-  // manually inject Set-Cookie headers into the page context — Playwright's
-  // request fixture cookie jar doesn't reliably merge into page.context().
-  const response = await page.request.post(
-    'http://lvh.me:42069/api/test/fast-signin',
-    {
-      headers: { 'Content-Type': 'application/json' },
-      data: { email: SEED_USER.email, password: SEED_USER.password },
-    }
-  );
-  if (!response.ok()) {
-    throw new Error(
-      `fast-signin failed: ${response.status()} ${await response.text()}`
-    );
-  }
-  // BetterAuth issues `better-auth.session_token`; SvelteKit reads
-  // `codex-session`. Inject both. Same pattern as `injectOrgCookies` in
-  // apps/web/e2e/helpers/studio.ts.
-  const setCookieHeaders = response
-    .headersArray()
-    .filter((h) => h.name.toLowerCase() === 'set-cookie');
-  const browserCookies = setCookieHeaders.flatMap((h) => {
-    const pair = h.value.split(';')[0];
-    if (!pair) return [];
-    const eq = pair.indexOf('=');
-    if (eq < 0) return [];
-    const name = pair.slice(0, eq).trim();
-    const value = pair.slice(eq + 1).trim();
-    const base = {
-      value,
-      domain: '.lvh.me',
-      path: '/',
-      httpOnly: true,
-      secure: false,
-      sameSite: 'Lax' as const,
-      expires: -1,
-    };
-    const cookies = [{ name, ...base }];
-    if (name === 'better-auth.session_token') {
-      cookies.push({ name: 'codex-session', ...base });
-    }
-    return cookies;
-  });
-  await page.context().addCookies(browserCookies);
-  await page.goto('/library');
-  await expect(page).toHaveURL(/\/library/, { timeout: 10_000 });
-}
 
 /**
  * Locate the subscription card for the seeded org by matching the org name.

--- a/apps/web/e2e/helpers/agreements.ts
+++ b/apps/web/e2e/helpers/agreements.ts
@@ -16,7 +16,6 @@
  * for the pie-math test.
  */
 
-import { COOKIES } from '@codex/constants';
 import type { OrgMemberContext } from '@codex/shared-types';
 import {
   authFixture,
@@ -24,6 +23,7 @@ import {
   parseCookieString,
 } from '@codex/test-utils/e2e';
 import type { BrowserContext, Page } from '@playwright/test';
+import { aliasSessionCookies } from './auth-cookies';
 
 export const E2E_BASE_PORT = 5173;
 const PASSWORD = 'Test123!@#';
@@ -36,44 +36,7 @@ export async function injectAgreementCookies(
   ctx: BrowserContext | Page,
   rawCookie: string
 ): Promise<void> {
-  const parsedCookies = parseCookieString(rawCookie);
-  const browserCookies: {
-    name: string;
-    value: string;
-    domain: string;
-    path: string;
-    httpOnly: boolean;
-    secure: boolean;
-    sameSite: 'Lax' | 'Strict' | 'None';
-    expires: number;
-  }[] = [];
-
-  for (const { name, value } of parsedCookies) {
-    browserCookies.push({
-      name,
-      value,
-      domain: '.lvh.me',
-      path: '/',
-      httpOnly: true,
-      secure: false,
-      sameSite: 'Lax',
-      expires: -1,
-    });
-
-    if (name === 'better-auth.session_token') {
-      browserCookies.push({
-        name: COOKIES.SESSION_NAME,
-        value,
-        domain: '.lvh.me',
-        path: '/',
-        httpOnly: true,
-        secure: false,
-        sameSite: 'Lax',
-        expires: -1,
-      });
-    }
-  }
-
+  const browserCookies = aliasSessionCookies(parseCookieString(rawCookie));
   const context = 'context' in ctx ? ctx.context() : ctx;
   await context.clearCookies();
   await context.addCookies(browserCookies);

--- a/apps/web/e2e/helpers/auth-cookies.ts
+++ b/apps/web/e2e/helpers/auth-cookies.ts
@@ -1,0 +1,101 @@
+/**
+ * Auth cookie helpers for Playwright E2E tests.
+ *
+ * Two input shapes converge here:
+ *   1. Cookie REQUEST-header strings (semicolon-separated `name1=val1; ...`)
+ *      — parsed by `parseCookieString` from `@codex/test-utils/e2e`. Used by
+ *      `helpers/studio.ts` `injectOrgCookies`.
+ *   2. Set-Cookie RESPONSE headers (from `page.request.post` returns)
+ *      — parsed by `parseSetCookieHeaders` below. Used by seed-user login.
+ *
+ * After parsing to `{ name, value }[]`, both inputs feed `aliasSessionCookies`,
+ * which adds the codex-session alias for BetterAuth's session_token cookie.
+ *
+ * See `apps/web/e2e/CLAUDE.md` for the dual-cookie rationale.
+ */
+
+import { COOKIES } from '@codex/constants';
+import type { APIResponse, BrowserContext } from '@playwright/test';
+
+export type BrowserCookie = Parameters<BrowserContext['addCookies']>[0][number];
+
+const COOKIE_DEFAULTS = {
+  domain: '.lvh.me',
+  path: '/',
+  httpOnly: true,
+  secure: false,
+  sameSite: 'Lax',
+  expires: -1,
+} as const satisfies Omit<BrowserCookie, 'name' | 'value'>;
+
+/**
+ * Convert `{ name, value }` pairs into Playwright-shaped BrowserCookies,
+ * adding the `codex-session` alias whenever `better-auth.session_token` is
+ * present. SvelteKit reads the session via `COOKIES.SESSION_NAME` while
+ * BetterAuth emits its default name — both must be set on `.lvh.me`.
+ */
+export function aliasSessionCookies(
+  parsed: Array<{ name: string; value: string }>,
+  overrides: Partial<typeof COOKIE_DEFAULTS> = {}
+): BrowserCookie[] {
+  const base = { ...COOKIE_DEFAULTS, ...overrides };
+  const cookies: BrowserCookie[] = [];
+  for (const { name, value } of parsed) {
+    cookies.push({ ...base, name, value });
+    if (name === 'better-auth.session_token') {
+      cookies.push({ ...base, name: COOKIES.SESSION_NAME, value });
+    }
+  }
+  return cookies;
+}
+
+/**
+ * Parse a single Set-Cookie response-header value into a `{ name, value }`
+ * pair (drops options: Domain, Path, Expires, etc.). Returns null when the
+ * header is malformed.
+ */
+function parseOneSetCookie(
+  setCookieValue: string
+): { name: string; value: string } | null {
+  const pair = setCookieValue.split(';')[0];
+  if (!pair) return null;
+  const eq = pair.indexOf('=');
+  if (eq < 0) return null;
+  return {
+    name: pair.slice(0, eq).trim(),
+    value: pair.slice(eq + 1).trim(),
+  };
+}
+
+/**
+ * Extract `{ name, value }` pairs from a Playwright APIResponse's Set-Cookie
+ * headers (from `page.request.*` calls).
+ *
+ * `aliasSessionCookies` re-applies a uniform `.lvh.me` scope so the cookies
+ * are accepted on every subdomain navigation (per the lvh.me note in
+ * apps/web/e2e/CLAUDE.md).
+ */
+export function parseSetCookieHeaders(
+  response: APIResponse
+): Array<{ name: string; value: string }> {
+  return response
+    .headersArray()
+    .filter((h) => h.name.toLowerCase() === 'set-cookie')
+    .map((h) => parseOneSetCookie(h.value))
+    .filter((x): x is { name: string; value: string } => x !== null);
+}
+
+/**
+ * Extract `{ name, value }` pairs from a list of raw Set-Cookie header
+ * values (e.g. from Node `fetch` `response.headers.getSetCookie()`).
+ *
+ * Companion to {@link parseSetCookieHeaders} for callers that use the global
+ * Node `fetch` instead of Playwright's `page.request`.
+ */
+export function parseSetCookieStrings(
+  setCookieHeaders: string[]
+): Array<{ name: string; value: string }> {
+  return setCookieHeaders
+    .map(parseOneSetCookie)
+    .filter((x): x is { name: string; value: string } => x !== null);
+}

--- a/apps/web/e2e/helpers/seed-auth.ts
+++ b/apps/web/e2e/helpers/seed-auth.ts
@@ -1,0 +1,73 @@
+/**
+ * Seed-user auth helper for Playwright E2E tests.
+ *
+ * Signs in as a pre-seeded test user (default: viewer@test.com from the seed
+ * script) via the `/api/test/fast-signin` endpoint on the auth worker. This
+ * bypasses the standard form-driven login flow AND the 5/15min rate limit
+ * that gates the real /api/auth/sign-in/email path.
+ *
+ * Two crucial details (see apps/web/e2e/CLAUDE.md for full rationale):
+ *   1. We POST to `lvh.me:42069`, NOT `localhost:42069`. The Set-Cookie
+ *      response has `Domain=.lvh.me` which Chromium silently rejects if the
+ *      response host doesn't match the cookie domain.
+ *   2. Playwright's `page.request` cookie jar does NOT always merge into
+ *      `page.context()` — we manually extract Set-Cookie headers and call
+ *      `addCookies()` so the browser session has the cookie on next nav.
+ */
+
+import { expect, type Page } from '@playwright/test';
+import { aliasSessionCookies, parseSetCookieHeaders } from './auth-cookies';
+
+export const SEED_VIEWER = {
+  email: 'viewer@test.com',
+  password: 'Test1234!',
+} as const;
+
+export interface LoginAsSeedOptions {
+  /** Override which seeded user to sign in as. Defaults to {@link SEED_VIEWER}. */
+  user?: { email: string; password: string };
+  /**
+   * URL to navigate to after the cookie is set, to confirm the session
+   * landed. Pass `null` to skip the post-login navigation (caller will
+   * navigate explicitly). Defaults to `/library`.
+   */
+  navigateTo?: string | null;
+  /**
+   * URL pattern asserted via `toHaveURL` after `navigateTo`. Defaults to
+   * `/\/library/` matching the default `navigateTo`. Ignored when
+   * `navigateTo` is null.
+   */
+  verifyUrlPattern?: RegExp;
+}
+
+export async function loginAsSeedViewer(
+  page: Page,
+  opts: LoginAsSeedOptions = {}
+): Promise<void> {
+  const user = opts.user ?? SEED_VIEWER;
+  const navigateTo =
+    opts.navigateTo === undefined ? '/library' : opts.navigateTo;
+  const verifyUrlPattern = opts.verifyUrlPattern ?? /\/library/;
+
+  const response = await page.request.post(
+    'http://lvh.me:42069/api/test/fast-signin',
+    {
+      headers: { 'Content-Type': 'application/json' },
+      data: { email: user.email, password: user.password },
+    }
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `fast-signin failed: ${response.status()} ${await response.text()}`
+    );
+  }
+
+  const parsed = parseSetCookieHeaders(response);
+  const browserCookies = aliasSessionCookies(parsed);
+  await page.context().addCookies(browserCookies);
+
+  if (navigateTo !== null) {
+    await page.goto(navigateTo);
+    await expect(page).toHaveURL(verifyUrlPattern, { timeout: 10_000 });
+  }
+}

--- a/apps/web/e2e/helpers/spa-nav.ts
+++ b/apps/web/e2e/helpers/spa-nav.ts
@@ -1,0 +1,42 @@
+/**
+ * SPA-navigation helpers for Playwright tests against client-rendered routes
+ * (e.g. studio sub-tree, which has `export const ssr = false`).
+ *
+ * Why this exists (see apps/web/e2e/CLAUDE.md):
+ *   - SvelteKit's client router listens for native anchor clicks via a
+ *     delegated listener on `document`. Playwright's synthetic `click()`
+ *     doesn't always bubble in a way the router picks up.
+ *   - Studio rail items reposition on hover (the rail expands), so the
+ *     Playwright actionability check sometimes fails mid-click.
+ *   - `waitForURL` with the default `waitUntil: 'load'` hangs forever on
+ *     `ssr=false` routes because there is no real `load` event — the
+ *     navigation is a `history.pushState` only.
+ *
+ * The robust pattern is: hover (to settle the rail), `evaluate(el => el.click())`
+ * (native click bubbles to the document listener), then poll the URL via
+ * `toHaveURL` rather than waiting on a navigation event.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export interface ExpectClickNavigatesOptions {
+  /** URL-match timeout in milliseconds. Defaults to 10_000. */
+  timeout?: number;
+  /**
+   * Hover the locator before clicking. Defaults to true — needed for studio
+   * rail items whose layout shifts on hover. Set false for stable elements.
+   */
+  hover?: boolean;
+}
+
+export async function expectClickNavigates(
+  page: Page,
+  locator: Locator,
+  pattern: RegExp,
+  opts: ExpectClickNavigatesOptions = {}
+): Promise<void> {
+  const { timeout = 10_000, hover = true } = opts;
+  if (hover) await locator.hover();
+  await locator.evaluate((el: HTMLElement) => el.click());
+  await expect(page).toHaveURL(pattern, { timeout });
+}

--- a/apps/web/e2e/helpers/studio.ts
+++ b/apps/web/e2e/helpers/studio.ts
@@ -5,7 +5,6 @@
  * and injecting auth cookies that work across subdomains.
  */
 
-import { COOKIES } from '@codex/constants';
 import type { OrgMemberContext, OrgMemberRole } from '@codex/shared-types';
 import {
   authFixture,
@@ -13,6 +12,7 @@ import {
   parseCookieString,
 } from '@codex/test-utils/e2e';
 import type { Page } from '@playwright/test';
+import { aliasSessionCookies } from './auth-cookies';
 
 const BASE_PORT = 5173;
 
@@ -92,45 +92,7 @@ export async function injectOrgCookies(
   page: Page,
   cookie: string
 ): Promise<void> {
-  const parsedCookies = parseCookieString(cookie);
-  const browserCookies: {
-    name: string;
-    value: string;
-    domain: string;
-    path: string;
-    httpOnly: boolean;
-    secure: boolean;
-    sameSite: 'Lax' | 'Strict' | 'None';
-    expires: number;
-  }[] = [];
-
-  for (const { name, value } of parsedCookies) {
-    browserCookies.push({
-      name,
-      value,
-      domain: '.lvh.me',
-      path: '/',
-      httpOnly: true,
-      secure: false,
-      sameSite: 'Lax',
-      expires: -1,
-    });
-
-    // Add the codex-session alias for session tokens
-    if (name === 'better-auth.session_token') {
-      browserCookies.push({
-        name: COOKIES.SESSION_NAME,
-        value,
-        domain: '.lvh.me',
-        path: '/',
-        httpOnly: true,
-        secure: false,
-        sameSite: 'Lax',
-        expires: -1,
-      });
-    }
-  }
-
+  const browserCookies = aliasSessionCookies(parseCookieString(cookie));
   await page.context().clearCookies();
   await page.context().addCookies(browserCookies);
 }

--- a/apps/web/e2e/helpers/subscription.ts
+++ b/apps/web/e2e/helpers/subscription.ts
@@ -9,6 +9,11 @@
  */
 
 import type { Page } from '@playwright/test';
+import {
+  aliasSessionCookies,
+  type BrowserCookie,
+  parseSetCookieStrings,
+} from './auth-cookies';
 
 /**
  * The seeded creator @ Studio Alpha (commerce.ts seed).
@@ -59,8 +64,12 @@ export function buildOrgUrl(
 }
 
 /**
- * Log in as the seeded creator via the real login form. Mirrors
- * `loginAsSeedViewer` in account-subscription-cancel.spec.ts:47-55.
+ * Log in as the seeded creator via the real login form.
+ *
+ * Sibling helper to `loginAsSeedViewer` (in `helpers/seed-auth.ts`) which
+ * signs in the seeded viewer via the fast-signin test endpoint. This one
+ * uses the real form-driven path because the original spec needed to
+ * exercise the form. Prefer the seed-auth helper for new tests.
  *
  * After a successful login the page is at `/library`. Cookies are
  * scoped to `lvh.me` (the parent domain) so they propagate to any
@@ -82,60 +91,17 @@ export async function loginAsSeededCreator(page: Page): Promise<void> {
   await page.waitForURL(/\/library/, { timeout: 30_000 });
 }
 
-/** Playwright-compatible cookie shape. */
-type BrowserCookie = {
-  name: string;
-  value: string;
-  domain: string;
-  path: string;
-  httpOnly: boolean;
-  secure: boolean;
-  sameSite: 'Lax' | 'Strict' | 'None';
-  expires: number;
-};
-
 /**
- * Parse a list of Set-Cookie response header strings into Playwright cookies.
+ * Convert raw Set-Cookie header values (from `headers.getSetCookie()`) into
+ * Playwright-shaped cookies scoped to `.lvh.me`, automatically adding the
+ * `codex-session` alias for BetterAuth's session token.
  *
- * Sets BOTH the explicit name and a `codex-session` alias when the cookie is
- * `better-auth.session_token` (mirrors `apps/web/e2e/helpers/studio.ts:152-163`).
- * Domain is `.lvh.me` (with leading dot) to match every `*.lvh.me` subdomain
- * unambiguously — Chromium treats no-dot domains as host-only, which would
- * mean cookies set on `lvh.me` are NOT sent to `studio-alpha.lvh.me`.
+ * Thin wrapper around the shared parser + aliaser in `./auth-cookies` so
+ * every E2E auth helper produces the same dual-cookie shape (see
+ * apps/web/e2e/CLAUDE.md for the rationale).
  */
-function parseSetCookieHeaders(setCookieHeaders: string[]): BrowserCookie[] {
-  const cookies: BrowserCookie[] = [];
-  for (const sc of setCookieHeaders) {
-    const firstSemi = sc.indexOf(';');
-    const nameValue = firstSemi > 0 ? sc.substring(0, firstSemi) : sc;
-    const eqIdx = nameValue.indexOf('=');
-    if (eqIdx <= 0) continue;
-    const cookieName = nameValue.substring(0, eqIdx).trim();
-    const cookieValue = nameValue.substring(eqIdx + 1).trim();
-    cookies.push({
-      name: cookieName,
-      value: cookieValue,
-      domain: '.lvh.me',
-      path: '/',
-      httpOnly: true,
-      secure: false,
-      sameSite: 'Lax',
-      expires: -1,
-    });
-    if (cookieName === 'better-auth.session_token') {
-      cookies.push({
-        name: 'codex-session',
-        value: cookieValue,
-        domain: '.lvh.me',
-        path: '/',
-        httpOnly: true,
-        secure: false,
-        sameSite: 'Lax',
-        expires: -1,
-      });
-    }
-  }
-  return cookies;
+function buildBrowserCookies(setCookieHeaders: string[]): BrowserCookie[] {
+  return aliasSessionCookies(parseSetCookieStrings(setCookieHeaders));
 }
 
 /**
@@ -182,7 +148,7 @@ export async function captureSeededCreatorCookies(): Promise<BrowserCookie[]> {
     );
   }
 
-  return parseSetCookieHeaders(response.headers.getSetCookie());
+  return buildBrowserCookies(response.headers.getSetCookie());
 }
 
 /**
@@ -274,8 +240,7 @@ export async function createFreshOwnerWithBypass(opts: {
     );
   }
 
-  const setCookieHeaders = signInRes.headers.getSetCookie();
-  const cookies = parseSetCookieHeaders(setCookieHeaders);
+  const cookies = buildBrowserCookies(signInRes.headers.getSetCookie());
 
   // Step 3: Create org + membership directly via DB (mirrors orgFixture).
   const [org] = await dbHttp

--- a/apps/web/e2e/studio/navigation.spec.ts
+++ b/apps/web/e2e/studio/navigation.spec.ts
@@ -1,5 +1,6 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { test } from '../fixtures/auth';
+import { expectClickNavigates } from '../helpers/spa-nav';
 import {
   cleanupSharedStudioAuth,
   injectSharedStudioAuth,
@@ -16,6 +17,20 @@ import {
  * Tests sidebar navigation, mobile drawer behavior, and settings tabs.
  * Owner role is used for full nav access (sees all sections).
  */
+
+// Each /studio link appears multiple times in the DOM (topbar brand, desktop
+// rail brand + nav item, mobile drawer brand + nav item). Scoping to the
+// desktop rail's nav-item class (`.studio-rail__item`) picks the canonical
+// sidebar link and avoids strict-mode multi-match violations.
+const railLink = (href: string) =>
+  `.studio-layout__rail--desktop .studio-rail__item[href="${href}"]`;
+
+// Studio uses `ssr = false` so SvelteKit navigates via History.pushState —
+// `waitForURL` would hang. Plus the rail expands on hover and shifts mid-
+// click. See helpers/spa-nav.ts and apps/web/e2e/CLAUDE.md for full notes.
+async function clickRailLink(page: Page, href: string, pattern: RegExp) {
+  return expectClickNavigates(page, page.locator(railLink(href)), pattern);
+}
 
 test.describe('Studio Navigation - Sidebar', () => {
   test.describe.configure({ mode: 'serial' });
@@ -49,13 +64,6 @@ test.describe('Studio Navigation - Sidebar', () => {
     await expect(page.locator('.studio-layout__main')).toBeVisible();
   });
 
-  // Each /studio link appears multiple times in the DOM (topbar brand, desktop
-  // rail brand + nav item, mobile drawer brand + nav item). Scoping to the
-  // desktop rail's nav-item class (`.studio-rail__item`) picks the canonical
-  // sidebar link and avoids strict-mode multi-match violations.
-  const railLink = (href: string) =>
-    `.studio-layout__rail--desktop .studio-rail__item[href="${href}"]`;
-
   test('sidebar shows all nav links for owner', async ({ page }) => {
     await navigateToStudio(page, sharedAuth.member.organization.slug);
 
@@ -81,38 +89,10 @@ test.describe('Studio Navigation - Sidebar', () => {
     await expect(dashboardLink).toHaveClass(/active/);
   });
 
-  // Studio uses `ssr = false` (client-rendered SPA); SvelteKit navigates via
-  // the History API without firing a real `load` event. `waitForURL`'s
-  // default `waitUntil: 'load'` therefore hangs forever — use `toHaveURL`
-  // polling instead.
-  //
-  // `force: true` bypasses Playwright's stability re-check, which fails when
-  // the desktop rail expands on hover during the actionability check: the
-  // link shifts mid-action and the click misses.
-  // Hover the rail to expand it (desktop rail collapses by default). Then
-  // trigger a native click via `evaluate(el => el.click())` — Playwright's
-  // synthetic click event doesn't bubble in a way that SvelteKit's
-  // client router picks up (the router listens on `document` for native
-  // anchor clicks via a delegated listener). Then poll the URL with
-  // `toHaveURL` — `waitForURL` with `waitUntil:'commit'` ALSO doesn't
-  // fire reliably here because the navigation is a History.pushState
-  // call, not a real document load. URL polling is the only path that
-  // works for studio's `ssr=false` SPA navigation.
-  async function clickRailAndExpect(
-    page: import('@playwright/test').Page,
-    href: string,
-    pattern: RegExp
-  ) {
-    const link = page.locator(railLink(href));
-    await link.hover();
-    await link.evaluate((el: HTMLElement) => el.click());
-    await expect(page).toHaveURL(pattern, { timeout: 10_000 });
-  }
-
   test('clicking Content nav link navigates correctly', async ({ page }) => {
     await navigateToStudio(page, sharedAuth.member.organization.slug);
 
-    await clickRailAndExpect(page, '/studio/content', /\/studio\/content/);
+    await clickRailLink(page, '/studio/content', /\/studio\/content/);
     await expect(page.locator(railLink('/studio/content'))).toHaveClass(
       /active/
     );
@@ -120,22 +100,22 @@ test.describe('Studio Navigation - Sidebar', () => {
 
   test('clicking Analytics nav link navigates correctly', async ({ page }) => {
     await navigateToStudio(page, sharedAuth.member.organization.slug);
-    await clickRailAndExpect(page, '/studio/analytics', /\/studio\/analytics/);
+    await clickRailLink(page, '/studio/analytics', /\/studio\/analytics/);
   });
 
   test('clicking Team nav link navigates correctly', async ({ page }) => {
     await navigateToStudio(page, sharedAuth.member.organization.slug);
-    await clickRailAndExpect(page, '/studio/team', /\/studio\/team/);
+    await clickRailLink(page, '/studio/team', /\/studio\/team/);
   });
 
   test('clicking Settings nav link navigates correctly', async ({ page }) => {
     await navigateToStudio(page, sharedAuth.member.organization.slug);
-    await clickRailAndExpect(page, '/studio/settings', /\/studio\/settings/);
+    await clickRailLink(page, '/studio/settings', /\/studio\/settings/);
   });
 
   test('clicking Billing nav link navigates correctly', async ({ page }) => {
     await navigateToStudio(page, sharedAuth.member.organization.slug);
-    await clickRailAndExpect(page, '/studio/billing', /\/studio\/billing/);
+    await clickRailLink(page, '/studio/billing', /\/studio\/billing/);
   });
 });
 
@@ -307,12 +287,6 @@ test.describe('Studio Navigation - Unauthenticated', () => {
 });
 
 test.describe('Studio Navigation - Role-Based Sidebar', () => {
-  // Same desktop-rail-scoped selector as the Sidebar describe above — the
-  // bare `a[href="..."]` would match topbar brand + drawer copies and trip
-  // Playwright's strict-mode multi-match guard.
-  const railLink = (href: string) =>
-    `.studio-layout__rail--desktop .studio-rail__item[href="${href}"]`;
-
   test('creator role does not see admin or owner sections', async ({
     page,
   }) => {

--- a/apps/web/e2e/subscription-cross-device.spec.ts
+++ b/apps/web/e2e/subscription-cross-device.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { loginAsSeedViewer } from './helpers/seed-auth';
 
 /**
  * Cross-Device Subscription Visibility-Change E2E Tests
@@ -31,68 +32,8 @@ import { expect, test } from '@playwright/test';
  *   - SvelteKit dev server on lvh.me:5173 (wildcard DNS → 127.0.0.1)
  */
 
-const SEED_USER = {
-  email: 'viewer@test.com',
-  password: 'Test1234!',
-};
-
 const SEEDED_ORG_SLUG = 'studio-alpha';
 const SEEDED_ORG_NAME = 'Studio Alpha';
-
-async function loginAsSeedViewer(page: import('@playwright/test').Page) {
-  // Use the test-only fast-signin endpoint via lvh.me (cookie Domain=.lvh.me).
-  // Extract Set-Cookie headers from the response and inject directly into
-  // the page's browser context — Playwright's `page.request` cookie jar
-  // does NOT always merge into `page`'s cookie storage reliably (depends
-  // on whether the response has `Secure` + the actual port-pair). Manual
-  // injection is the only reliable path.
-  const response = await page.request.post(
-    'http://lvh.me:42069/api/test/fast-signin',
-    {
-      headers: { 'Content-Type': 'application/json' },
-      data: { email: SEED_USER.email, password: SEED_USER.password },
-    }
-  );
-  if (!response.ok()) {
-    throw new Error(
-      `fast-signin failed: ${response.status()} ${await response.text()}`
-    );
-  }
-  // BetterAuth issues cookies under its default names (`better-auth.session_
-  // token` + `better-auth.session_data`). SvelteKit's hooks.server.ts reads
-  // the session via `COOKIES.SESSION_NAME` ("codex-session"). Inject BOTH:
-  // the original better-auth name (for direct auth-worker calls) AND a
-  // codex-session alias pointing at the same token value (for SvelteKit).
-  // Same pattern as `apps/web/e2e/helpers/studio.ts` `injectOrgCookies`.
-  const setCookieHeaders = response
-    .headersArray()
-    .filter((h) => h.name.toLowerCase() === 'set-cookie');
-  const browserCookies = setCookieHeaders.flatMap((h) => {
-    const pair = h.value.split(';')[0];
-    if (!pair) return [];
-    const eq = pair.indexOf('=');
-    if (eq < 0) return [];
-    const name = pair.slice(0, eq).trim();
-    const value = pair.slice(eq + 1).trim();
-    const base = {
-      value,
-      domain: '.lvh.me',
-      path: '/',
-      httpOnly: true,
-      secure: false,
-      sameSite: 'Lax' as const,
-      expires: -1,
-    };
-    const cookies = [{ name, ...base }];
-    if (name === 'better-auth.session_token') {
-      cookies.push({ name: 'codex-session', ...base });
-    }
-    return cookies;
-  });
-  await page.context().addCookies(browserCookies);
-  await page.goto('/library');
-  await expect(page).toHaveURL(/\/library/, { timeout: 10_000 });
-}
 
 function subscriptionCard(
   page: import('@playwright/test').Page,


### PR DESCRIPTION
## Summary

- Re-opened from #262 (auto-closed when its base branch was merged via cascade)
- Cherry-picked the single net-new commit `7393b594` onto current `dev`
- Resolved conflicts in `account-subscription-cancel.spec.ts` and `subscription-cross-device.spec.ts` by taking #262's side (the consolidation removes inline `loginAsSeedViewer` in favor of `./helpers/seed-auth`)

## Test plan
- [ ] CI passes static-analysis + worker tests + E2E API + E2E Web

🤖 Generated with [Claude Code](https://claude.com/claude-code)