### PR TITLE
feat(e2e): add data-testid to drift-prone components + migrate tests (was #263)

### DIFF
--- a/apps/web/e2e/account-subscription-cancel.spec.ts
+++ b/apps/web/e2e/account-subscription-cancel.spec.ts
@@ -54,7 +54,7 @@ function subscriptionCard(
 async function reactivateIfCancelling(page: import('@playwright/test').Page) {
   const card = subscriptionCard(page);
   if ((await card.count()) === 0) return;
-  const reactivateBtn = card.getByRole('button', { name: /reactivate/i });
+  const reactivateBtn = card.getByTestId('subscription-reactivate-button');
   if ((await reactivateBtn.count()) === 0) return;
   if (!(await reactivateBtn.first().isVisible())) return;
 
@@ -132,17 +132,13 @@ test.describe
         .first();
       await expect(periodEndLocator).toBeVisible({ timeout: 5000 });
 
-      const cancelBtn = card.getByRole('button', {
-        name: /^Cancel Subscription$/i,
-      });
+      const cancelBtn = card.getByTestId('subscription-cancel-button');
       await cancelBtn.click();
 
       // Confirmation dialog opens — confirm submission.
-      // Melt UI dialog portals to <body>; the confirm button's text is the
+      // Melt UI dialog portals to <body>; the confirm button is the
       // destructive "Cancel at end of period" CTA.
-      const confirmBtn = page.getByRole('button', {
-        name: /^cancel at end of period$/i,
-      });
+      const confirmBtn = page.getByTestId('cancel-dialog-confirm-button');
       await expect(confirmBtn).toBeVisible({ timeout: 3000 });
       await confirmBtn.click();
 
@@ -186,13 +182,9 @@ test.describe
       const statusBadge = card.locator('.badge, [class*="badge"]').first();
       // Previous test may have left ACTIVE (afterEach reactivated it) — cancel again.
       if (!(await statusBadge.textContent())?.match(/Cancelling/i)) {
-        const cancelBtn = card.getByRole('button', {
-          name: /^Cancel Subscription$/i,
-        });
+        const cancelBtn = card.getByTestId('subscription-cancel-button');
         await cancelBtn.click();
-        const confirmBtn = page.getByRole('button', {
-          name: /^cancel at end of period$/i,
-        });
+        const confirmBtn = page.getByTestId('cancel-dialog-confirm-button');
         await expect(confirmBtn).toBeVisible({ timeout: 3000 });
         await confirmBtn.click();
         await expect(statusBadge).toHaveText(/Cancelling/i, { timeout: 5000 });
@@ -223,7 +215,9 @@ test.describe
       // The subscription might still be CANCELLING from prior test if afterEach
       // couldn't reactivate (e.g. test failure). If so, reactivate first via UI.
       if ((await statusBadge.textContent())?.match(/Cancelling/i)) {
-        const reactivateBtn = card.getByRole('button', { name: /reactivate/i });
+        const reactivateBtn = card.getByTestId(
+          'subscription-reactivate-button'
+        );
         await reactivateBtn.click();
         await expect(statusBadge).toHaveText(/Active/i, { timeout: 5000 });
       }
@@ -247,13 +241,9 @@ test.describe
         await route.continue();
       });
 
-      const cancelBtn = card.getByRole('button', {
-        name: /^Cancel Subscription$/i,
-      });
+      const cancelBtn = card.getByTestId('subscription-cancel-button');
       await cancelBtn.click();
-      const confirmBtn = page.getByRole('button', {
-        name: /^cancel at end of period$/i,
-      });
+      const confirmBtn = page.getByTestId('cancel-dialog-confirm-button');
       await expect(confirmBtn).toBeVisible({ timeout: 3000 });
       await confirmBtn.click();
 

--- a/apps/web/e2e/subscription-cross-device.spec.ts
+++ b/apps/web/e2e/subscription-cross-device.spec.ts
@@ -70,7 +70,9 @@ test.describe('Cross-device subscription sync via visibilitychange', () => {
       await cleanupPage.goto('/account/subscriptions');
       const card = subscriptionCard(cleanupPage);
       if ((await card.count()) > 0) {
-        const reactivateBtn = card.getByRole('button', { name: /reactivate/i });
+        const reactivateBtn = card.getByTestId(
+          'subscription-reactivate-button'
+        );
         if (
           (await reactivateBtn.count()) > 0 &&
           (await reactivateBtn.first().isVisible())
@@ -106,7 +108,7 @@ test.describe('Cross-device subscription sync via visibilitychange', () => {
     // If it's not active (e.g. the previous run left it cancelling and teardown
     // failed), reactivate first so the test starts from a known state.
     if (!(await badgeA.textContent())?.match(/Active/i)) {
-      const reactivateBtn = cardA.getByRole('button', { name: /reactivate/i });
+      const reactivateBtn = cardA.getByTestId('subscription-reactivate-button');
       await reactivateBtn.click();
       await expect(badgeA).toHaveText(/Active/i, { timeout: 5000 });
     }
@@ -140,26 +142,18 @@ test.describe('Cross-device subscription sync via visibilitychange', () => {
     await pageB.waitForLoadState('networkidle', { timeout: 15_000 });
 
     // Wait for the user's current-plan CTA to render on the org pricing
-    // page. The button text is "Current Plan" (with leading whitespace
-    // from the layout — match via `name: /current plan/i` which permits
-    // the substring match around the visible whitespace).
-    await expect(
-      pageB.getByRole('button', { name: /current plan/i }).first()
-    ).toBeVisible({ timeout: 15_000 });
+    // page (the disabled "Current Plan" button on the matched tier card).
+    await expect(pageB.getByTestId('tier-cta-current').first()).toBeVisible({
+      timeout: 15_000,
+    });
     // "Reactivate" must NOT be present yet — that CTA only shows once the
     // subscription is in the cancelling state.
-    await expect(
-      pageB.getByRole('button', { name: /reactivate/i })
-    ).toHaveCount(0);
+    await expect(pageB.getByTestId('tier-cta-reactivate')).toHaveCount(0);
 
     // ── Tab A: perform the cancel ──────────────────────────────────────────
-    const cancelBtn = cardA.getByRole('button', {
-      name: /^Cancel Subscription$/i,
-    });
+    const cancelBtn = cardA.getByTestId('subscription-cancel-button');
     await cancelBtn.click();
-    const confirmBtnA = pageA.getByRole('button', {
-      name: /^cancel at end of period$/i,
-    });
+    const confirmBtnA = pageA.getByTestId('cancel-dialog-confirm-button');
     await expect(confirmBtnA).toBeVisible({ timeout: 3000 });
     await confirmBtnA.click();
     await expect(badgeA).toHaveText(/Cancelling/i, { timeout: 10_000 });
@@ -183,9 +177,9 @@ test.describe('Cross-device subscription sync via visibilitychange', () => {
     // layout) means the dispatched visibilitychange will only trigger a
     // server load re-run on first fire — give the round-trip a generous
     // budget for KV propagation + Svelte effect resolution.
-    await expect(
-      pageB.getByRole('button', { name: /reactivate/i }).first()
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(pageB.getByTestId('tier-cta-reactivate').first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     await ctxA.close();
     await ctxB.close();

--- a/apps/web/src/lib/components/agreements/ProposeAgreementDialog.svelte
+++ b/apps/web/src/lib/components/agreements/ProposeAgreementDialog.svelte
@@ -208,7 +208,12 @@
       <p class="propose-form__field-hint">
         How long this rate is locked before either side can amend.
       </p>
-      <div class="propose-form__term-options" role="radiogroup" aria-label="Soft-lock term">
+      <div
+        class="propose-form__term-options"
+        role="radiogroup"
+        aria-label="Soft-lock term"
+        data-testid="propose-term-group"
+      >
         {#each termOptions as option (option.value)}
           <label class="propose-form__term-option">
             <input
@@ -218,6 +223,7 @@
               checked={termMonths === option.value}
               onchange={() => (termMonths = option.value)}
               disabled={submitting}
+              data-testid="propose-term-{option.value}"
             />
             <span>{option.label}</span>
           </label>
@@ -240,6 +246,7 @@
         maxlength="500"
         disabled={submitting}
         placeholder="e.g. Initial team agreement for season 1 content."
+        data-testid="propose-note-input"
       ></textarea>
       <span class="propose-form__char-count" aria-live="polite">
         {note.length} / 500

--- a/apps/web/src/routes/(auth)/login/+page.svelte
+++ b/apps/web/src/routes/(auth)/login/+page.svelte
@@ -36,13 +36,13 @@
 </svelte:head>
 
 <AuthLayout title={m.auth_signin_title()}>
-  <form method="POST" use:enhance={handleSubmit} class="auth-form">
+  <form method="POST" use:enhance={handleSubmit} class="auth-form" data-testid="login-form">
     {#if data.redirect}
       <input type="hidden" name="redirect" value={data.redirect} />
     {/if}
 
     {#if form?.error}
-      <div class="auth-error" role="alert">
+      <div class="auth-error" role="alert" data-testid="login-form-error">
         <p>{form.error}</p>
       </div>
     {/if}
@@ -56,6 +56,7 @@
         autocomplete="email"
         value={form?.email ?? ''}
         error={form?.errors?.email}
+        data-testid="login-email-input"
       />
     </div>
 
@@ -67,10 +68,11 @@
         type="password"
         autocomplete="current-password"
         error={form?.errors?.password}
+        data-testid="login-password-input"
       />
     </div>
 
-    <Button type="submit" {loading} class="auth-submit">
+    <Button type="submit" {loading} class="auth-submit" data-testid="login-submit-button">
       {loading ? m.common_loading() : m.auth_signin_button()}
     </Button>
 

--- a/apps/web/src/routes/(auth)/register/+page.svelte
+++ b/apps/web/src/routes/(auth)/register/+page.svelte
@@ -23,9 +23,9 @@
 </svelte:head>
 
 <AuthLayout title={m.auth_signup_title()}>
-  <form method="POST" use:enhance={handleSubmit} class="auth-form">
+  <form method="POST" use:enhance={handleSubmit} class="auth-form" data-testid="register-form">
     {#if form?.error}
-      <div class="auth-error" role="alert">
+      <div class="auth-error" role="alert" data-testid="register-form-error">
         <p>{form.error}</p>
       </div>
     {/if}
@@ -39,6 +39,7 @@
         autocomplete="name"
         value={form?.name ?? ''}
         error={form?.errors?.name}
+        data-testid="register-name-input"
       />
     </div>
 
@@ -51,6 +52,7 @@
         autocomplete="email"
         value={form?.email ?? ''}
         error={form?.errors?.email}
+        data-testid="register-email-input"
       />
     </div>
 
@@ -62,6 +64,7 @@
         type="password"
         autocomplete="new-password"
         error={form?.errors?.password}
+        data-testid="register-password-input"
       />
       <p class="auth-hint">At least 8 characters, one letter and one number.</p>
     </div>
@@ -74,10 +77,11 @@
         type="password"
         autocomplete="new-password"
         error={form?.errors?.confirmPassword}
+        data-testid="register-confirm-password-input"
       />
     </div>
 
-    <Button type="submit" {loading} class="auth-submit">
+    <Button type="submit" {loading} class="auth-submit" data-testid="register-submit-button">
       {loading ? m.common_loading() : m.auth_signup_button()}
     </Button>
   </form>

--- a/apps/web/src/routes/(platform)/account/subscriptions/+page.svelte
+++ b/apps/web/src/routes/(platform)/account/subscriptions/+page.svelte
@@ -292,7 +292,11 @@
       {#each subscriptions as sub (sub.id)}
         <Card.Root>
           <Card.Content>
-            <div class="subscription-card">
+            <div
+              class="subscription-card"
+              data-testid="subscription-card"
+              data-org-slug={sub.organization.slug}
+            >
               <div class="subscription-info">
                 <div class="subscription-org">
                   {#if sub.organization.logoUrl}
@@ -309,7 +313,7 @@
                     <span class="tier-name">{sub.tier.name}</span>
                   </div>
                 </div>
-                <Badge variant={statusVariant(sub.status)}>
+                <Badge variant={statusVariant(sub.status)} data-testid="subscription-status-badge">
                   {statusLabel(sub.status)}
                 </Badge>
               </div>
@@ -353,6 +357,7 @@
                 <Button
                   variant="ghost"
                   size="sm"
+                  data-testid="subscription-change-tier-button"
                   onclick={() => {
                     const orgUrl = buildOrgUrl(page.url, sub.organization.slug, '/pricing');
                     window.location.href = orgUrl;
@@ -364,6 +369,7 @@
                   <Button
                     variant="ghost"
                     size="sm"
+                    data-testid="subscription-cancel-button"
                     onclick={() => openCancelDialog(sub)}
                   >
                     {m.subscription_cancel()}
@@ -374,6 +380,7 @@
                     variant="primary"
                     size="sm"
                     loading={reactivatingIds.has(sub.id)}
+                    data-testid="subscription-reactivate-button"
                     onclick={() => handleReactivate(sub)}
                   >
                     {m.subscription_reactivate()}
@@ -384,6 +391,7 @@
                     variant="primary"
                     size="sm"
                     loading={resumingIds.has(sub.id)}
+                    data-testid="subscription-resume-button"
                     onclick={() => handleResume(sub)}
                   >
                     {m.subscription_resume()}
@@ -469,10 +477,19 @@
     </Dialog.Body>
 
     <Dialog.Footer>
-      <Button variant="ghost" onclick={() => { cancelDialogOpen = false; }}>
+      <Button
+        variant="ghost"
+        data-testid="cancel-dialog-dismiss-button"
+        onclick={() => { cancelDialogOpen = false; }}
+      >
         {m.monetisation_cancel()}
       </Button>
-      <Button variant="destructive" onclick={handleCancel} loading={cancelLoading}>
+      <Button
+        variant="destructive"
+        data-testid="cancel-dialog-confirm-button"
+        onclick={handleCancel}
+        loading={cancelLoading}
+      >
         {m.subscription_cancel_confirm()}
       </Button>
     </Dialog.Footer>

--- a/apps/web/src/routes/_org/[slug]/(space)/pricing/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/pricing/+page.svelte
@@ -1071,6 +1071,7 @@
                     onclick={() => handleSubscribe(tier)}
                     loading={checkoutLoading === tier.id}
                     class="tier-cta"
+                    data-testid="tier-cta-subscribe"
                     aria-label="Subscribe to {tier.name}"
                   >
                     {m.pricing_subscribe()}
@@ -1250,6 +1251,7 @@
       <Button
         onclick={() => handleSubscribe(recommendedTier)}
         loading={checkoutLoading === recommendedTier.id}
+        data-testid="pricing-sticky-subscribe"
         aria-label="Subscribe to {recommendedTier.name}"
       >
         {m.pricing_subscribe()}
@@ -1258,6 +1260,7 @@
         <button
           type="button"
           class="sticky-bar__dismiss"
+          data-testid="pricing-sticky-dismiss"
           onclick={() => { dismissedStickyCta = true; }}
           aria-label="Dismiss"
         >
@@ -1339,7 +1342,11 @@
     </Dialog.Body>
 
     <Dialog.Footer>
-      <Button variant="ghost" onclick={closeTierChangeDialog}>
+      <Button
+        variant="ghost"
+        data-testid="tier-change-dialog-cancel"
+        onclick={closeTierChangeDialog}
+      >
         Cancel
       </Button>
       {#if tierChangePreview && tierChangeDialogTier}
@@ -1356,6 +1363,7 @@
       {:else if tierChangePreviewError}
         <Button
           variant="primary"
+          data-testid="tier-change-dialog-retry"
           onclick={() => tierChangeDialogTier && openTierChangeDialog(tierChangeDialogTier)}
         >
           Try again


### PR DESCRIPTION
## Summary
- Re-opened from #263 (auto-closed when #262's branch merged via cascade)
- Cherry-picked single net-new commit `bc0ac34b` onto current `dev`
- Adds `data-testid` to drift-prone components (login, register, subscriptions, pricing, agreement dialog) and migrates 2 specs (account-subscription-cancel + subscription-cross-device) to use those testids

## Expected impact
- Should fix 2 of the 7 residual E2E failures on dev: `account-subscription-cancel.spec.ts:95` and `subscription-cross-device.spec.ts:93`

## Test plan
- [ ] CI passes static-analysis + worker tests + E2E API
- [ ] E2E Web Tests failure count drops from 7 → 5 or fewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)