### PR TITLE
feat(connect): single-account Connect schema (WP1 Codex-69t7c.1)

### DIFF
--- a/packages/database/scripts/seed/commerce.ts
+++ b/packages/database/scripts/seed/commerce.ts
@@ -877,9 +877,10 @@ export async function seedCommerce(db: typeof DbClient) {
         });
 
       // Heal stale rows on re-seed: if an earlier seed run (or a failed live
-      // onboarding attempt by the org owner in dev) left an inactive row for
-      // (userId, orgId), upsert points it at the freshly-activated Stripe
-      // account so subscription checkout passes the readiness gate.
+      // onboarding attempt in dev) left an inactive row for this user, upsert
+      // points it at the freshly-activated Stripe account so subscription
+      // checkout passes the readiness gate. One account per user (Codex-69t7c)
+      // → conflict target is userId alone.
       await db
         .insert(schema.stripeConnectAccounts)
         .values({
@@ -895,10 +896,7 @@ export async function seedCommerce(db: typeof DbClient) {
           updatedAt: now,
         })
         .onConflictDoUpdate({
-          target: [
-            schema.stripeConnectAccounts.userId,
-            schema.stripeConnectAccounts.organizationId,
-          ],
+          target: [schema.stripeConnectAccounts.userId],
           set: {
             stripeAccountId: accountId,
             status: chargesEnabled ? 'active' : 'onboarding',

--- a/packages/database/src/migrations/0074_hot_goliath.sql
+++ b/packages/database/src/migrations/0074_hot_goliath.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "stripe_connect_accounts" DROP CONSTRAINT "uq_stripe_connect_user_org";--> statement-breakpoint
+ALTER TABLE "stripe_connect_accounts" DROP CONSTRAINT "stripe_connect_accounts_organization_id_organizations_id_fk";
+--> statement-breakpoint
+DROP INDEX "idx_stripe_connect_user_id";--> statement-breakpoint
+ALTER TABLE "purchases" ALTER COLUMN "organization_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_connect_accounts" ALTER COLUMN "organization_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_connect_accounts" ADD CONSTRAINT "stripe_connect_accounts_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stripe_connect_accounts" ADD CONSTRAINT "uq_stripe_connect_user" UNIQUE("user_id");

--- a/packages/database/src/migrations/meta/0074_snapshot.json
+++ b/packages/database/src/migrations/meta/0074_snapshot.json
@@ -1,0 +1,6658 @@
+{
+  "id": "c0e46ada-c2fb-413a-823d-9510a9dbdaca",
+  "prevId": "119f92ed-7985-4072-a185-334ad853fe45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_username": {
+          "name": "idx_unique_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_users_stripe_customer_id": {
+          "name": "idx_unique_users_stripe_customer_id",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"stripe_customer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body": {
+          "name": "content_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body_json": {
+          "name": "content_body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "shader_preset": {
+          "name": "shader_preset",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shader_config": {
+          "name": "shader_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_tier_id": {
+          "name": "minimum_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_creator_id": {
+          "name": "idx_content_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_organization_id": {
+          "name": "idx_content_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_media_item_id": {
+          "name": "idx_content_media_item_id",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_slug_org": {
+          "name": "idx_content_slug_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_status": {
+          "name": "idx_content_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_published_at": {
+          "name": "idx_content_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_category": {
+          "name": "idx_content_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_minimum_tier": {
+          "name": "idx_content_minimum_tier",
+          "columns": [
+            {
+              "expression": "minimum_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_published": {
+          "name": "idx_content_org_published",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_creator_org_published": {
+          "name": "idx_content_creator_org_published",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_featured": {
+          "name": "idx_content_org_featured",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"featured\" = true AND \"content\".\"status\" = 'published' AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_per_org": {
+          "name": "idx_unique_content_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NOT NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_personal": {
+          "name": "idx_unique_content_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_type": {
+          "name": "idx_content_access_type",
+          "columns": [
+            {
+              "expression": "access_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_creator_id_users_id_fk": {
+          "name": "content_creator_id_users_id_fk",
+          "tableFrom": "content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_organization_id_organizations_id_fk": {
+          "name": "content_organization_id_organizations_id_fk",
+          "tableFrom": "content",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_media_item_id_media_items_id_fk": {
+          "name": "content_media_item_id_media_items_id_fk",
+          "tableFrom": "content",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_minimum_tier_id_subscription_tiers_id_fk": {
+          "name": "content_minimum_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "content",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "minimum_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_content_status": {
+          "name": "check_content_status",
+          "value": "\"content\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_content_access_type": {
+          "name": "check_content_access_type",
+          "value": "\"content\".\"access_type\" IN ('free', 'paid', 'followers', 'subscribers', 'team')"
+        },
+        "check_content_type": {
+          "name": "check_content_type",
+          "value": "\"content\".\"content_type\" IN ('video', 'audio', 'written')"
+        },
+        "check_price_non_negative": {
+          "name": "check_price_non_negative",
+          "value": "\"content\".\"price_cents\" IS NULL OR \"content\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_master_playlist_key": {
+          "name": "hls_master_playlist_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_preview_key": {
+          "name": "hls_preview_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_key": {
+          "name": "waveform_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_image_key": {
+          "name": "waveform_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runpod_job_id": {
+          "name": "runpod_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_error": {
+          "name": "transcoding_error",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_attempts": {
+          "name": "transcoding_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transcoding_priority": {
+          "name": "transcoding_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "transcoding_progress": {
+          "name": "transcoding_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_step": {
+          "name": "transcoding_step",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_key": {
+          "name": "mezzanine_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_status": {
+          "name": "mezzanine_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_variants": {
+          "name": "ready_variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_integrated": {
+          "name": "loudness_integrated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_peak": {
+          "name": "loudness_peak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_range": {
+          "name": "loudness_range",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_creator_id": {
+          "name": "idx_media_items_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_status": {
+          "name": "idx_media_items_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_type": {
+          "name": "idx_media_items_type",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_runpod_job_id": {
+          "name": "idx_media_items_runpod_job_id",
+          "columns": [
+            {
+              "expression": "runpod_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_transcoding_status": {
+          "name": "idx_media_items_transcoding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcoding_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_items_creator_id_users_id_fk": {
+          "name": "media_items_creator_id_users_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_media_status": {
+          "name": "check_media_status",
+          "value": "\"media_items\".\"status\" IN ('uploading', 'uploaded', 'transcoding', 'ready', 'failed')"
+        },
+        "check_media_type": {
+          "name": "check_media_type",
+          "value": "\"media_items\".\"media_type\" IN ('video', 'audio')"
+        },
+        "check_mezzanine_status": {
+          "name": "check_mezzanine_status",
+          "value": "\"media_items\".\"mezzanine_status\" IS NULL OR \"media_items\".\"mezzanine_status\" IN ('pending', 'processing', 'ready', 'failed')"
+        },
+        "check_transcoding_priority": {
+          "name": "check_transcoding_priority",
+          "value": "\"media_items\".\"transcoding_priority\" >= 0 AND \"media_items\".\"transcoding_priority\" <= 4"
+        },
+        "check_max_transcoding_attempts": {
+          "name": "check_max_transcoding_attempts",
+          "value": "\"media_items\".\"transcoding_attempts\" >= 0 AND \"media_items\".\"transcoding_attempts\" <= 3"
+        },
+        "check_transcoding_progress_range": {
+          "name": "check_transcoding_progress_range",
+          "value": "\"media_items\".\"transcoding_progress\" IS NULL OR (\"media_items\".\"transcoding_progress\" >= 0 AND \"media_items\".\"transcoding_progress\" <= 100)"
+        },
+        "status_ready_requires_keys": {
+          "name": "status_ready_requires_keys",
+          "value": "\"media_items\".\"status\" != 'ready' OR (\n        \"media_items\".\"hls_master_playlist_key\" IS NOT NULL\n        AND \"media_items\".\"duration_seconds\" IS NOT NULL\n        AND (\n          (\"media_items\".\"media_type\" = 'video' AND \"media_items\".\"thumbnail_key\" IS NOT NULL)\n          OR (\"media_items\".\"media_type\" = 'audio' AND \"media_items\".\"waveform_key\" IS NOT NULL)\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_membership": {
+          "name": "idx_unique_org_membership",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_id": {
+          "name": "idx_org_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_user_id": {
+          "name": "idx_org_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_role": {
+          "name": "idx_org_memberships_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_status": {
+          "name": "idx_org_memberships_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_active_role": {
+          "name": "idx_org_memberships_org_active_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organization_memberships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_membership_role": {
+          "name": "check_membership_role",
+          "value": "\"organization_memberships\".\"role\" IN ('owner', 'admin', 'creator', 'subscriber', 'member')"
+        },
+        "check_membership_status": {
+          "name": "check_membership_status",
+          "value": "\"organization_memberships\".\"status\" IN ('active', 'inactive', 'invited')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agreement_proposals": {
+      "name": "agreement_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_proposal_id": {
+          "name": "parent_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_role": {
+          "name": "proposed_by_role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_creator_share_percent": {
+          "name": "proposed_creator_share_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_term_months": {
+          "name": "proposed_term_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_effective_from": {
+          "name": "proposed_effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agreement_proposals_thread": {
+          "name": "idx_agreement_proposals_thread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_creator_status": {
+          "name": "idx_agreement_proposals_creator_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_org_status": {
+          "name": "idx_agreement_proposals_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agreement_proposals_organization_id_organizations_id_fk": {
+          "name": "agreement_proposals_organization_id_organizations_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_creator_id_users_id_fk": {
+          "name": "agreement_proposals_creator_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk": {
+          "name": "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "parent_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_proposed_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_proposed_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_responded_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_responded_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_agreement_proposals_revenue_type": {
+          "name": "check_agreement_proposals_revenue_type",
+          "value": "\"agreement_proposals\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_agreement_proposals_proposed_by_role": {
+          "name": "check_agreement_proposals_proposed_by_role",
+          "value": "\"agreement_proposals\".\"proposed_by_role\" IN ('owner', 'creator')"
+        },
+        "check_agreement_proposals_status": {
+          "name": "check_agreement_proposals_status",
+          "value": "\"agreement_proposals\".\"status\" IN ('open', 'accepted', 'declined', 'countered', 'withdrawn', 'superseded')"
+        },
+        "check_agreement_proposals_share_bps": {
+          "name": "check_agreement_proposals_share_bps",
+          "value": "\"agreement_proposals\".\"proposed_creator_share_percent\" >= 0 AND \"agreement_proposals\".\"proposed_creator_share_percent\" <= 10000"
+        },
+        "check_agreement_proposals_round_positive": {
+          "name": "check_agreement_proposals_round_positive",
+          "value": "\"agreement_proposals\".\"round_number\" >= 1"
+        },
+        "check_agreement_proposals_term_positive": {
+          "name": "check_agreement_proposals_term_positive",
+          "value": "\"agreement_proposals\".\"proposed_term_months\" IS NULL OR \"agreement_proposals\".\"proposed_term_months\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_access": {
+      "name": "content_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_access_user_id": {
+          "name": "idx_content_access_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_content_id": {
+          "name": "idx_content_access_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_organization_id": {
+          "name": "idx_content_access_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_access_user_id_users_id_fk": {
+          "name": "content_access_user_id_users_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_content_id_content_id_fk": {
+          "name": "content_access_content_id_content_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_organization_id_organizations_id_fk": {
+          "name": "content_access_organization_id_organizations_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_access_user_content_unique": {
+          "name": "content_access_user_content_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_access_type": {
+          "name": "check_access_type",
+          "value": "\"content_access\".\"access_type\" IN ('purchased', 'subscription', 'complimentary', 'preview')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_organization_agreements": {
+      "name": "creator_organization_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_fee_percentage": {
+          "name": "organization_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_by_user_id": {
+          "name": "terminated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_proposal_id": {
+          "name": "current_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiring_soon_email_sent_at": {
+          "name": "expiring_soon_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_creator_org_agreement_creator_id": {
+          "name": "idx_creator_org_agreement_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_org_id": {
+          "name": "idx_creator_org_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_effective": {
+          "name": "idx_creator_org_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_active_lookup": {
+          "name": "idx_creator_org_agreement_active_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_creator_org_agreement_active_per_type": {
+          "name": "uq_creator_org_agreement_active_per_type",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"creator_organization_agreements\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_organization_agreements_creator_id_users_id_fk": {
+          "name": "creator_organization_agreements_creator_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_organization_id_organizations_id_fk": {
+          "name": "creator_organization_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_terminated_by_user_id_users_id_fk": {
+          "name": "creator_organization_agreements_terminated_by_user_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "terminated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk": {
+          "name": "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "current_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "creator_org_agreement_unique": {
+          "name": "creator_org_agreement_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "organization_id",
+            "effective_from",
+            "revenue_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_org_fee_percentage": {
+          "name": "check_org_fee_percentage",
+          "value": "\"creator_organization_agreements\".\"organization_fee_percentage\" >= 0 AND \"creator_organization_agreements\".\"organization_fee_percentage\" <= 10000"
+        },
+        "check_creator_org_agreement_revenue_type": {
+          "name": "check_creator_org_agreement_revenue_type",
+          "value": "\"creator_organization_agreements\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_creator_org_agreement_status": {
+          "name": "check_creator_org_agreement_status",
+          "value": "\"creator_organization_agreements\".\"status\" IN ('active', 'terminated', 'expired')"
+        },
+        "check_creator_org_agreement_terminated_shape": {
+          "name": "check_creator_org_agreement_terminated_shape",
+          "value": "(\"creator_organization_agreements\".\"status\" = 'terminated') = (\"creator_organization_agreements\".\"terminated_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_platform_agreements": {
+      "name": "organization_platform_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_platform_agreement_org_id": {
+          "name": "idx_org_platform_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_platform_agreement_effective": {
+          "name": "idx_org_platform_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_platform_agreements_organization_id_organizations_id_fk": {
+          "name": "organization_platform_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "organization_platform_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percentage": {
+          "name": "check_org_platform_fee_percentage",
+          "value": "\"organization_platform_agreements\".\"platform_fee_percentage\" >= 0 AND \"organization_platform_agreements\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_fee_config": {
+      "name": "platform_fee_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_fee_config_effective": {
+          "name": "idx_platform_fee_config_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_platform_fee_percentage": {
+          "name": "check_platform_fee_percentage",
+          "value": "\"platform_fee_config\".\"platform_fee_percentage\" >= 0 AND \"platform_fee_config\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platform_agreement_id": {
+          "name": "platform_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_org_agreement_id": {
+          "name": "creator_org_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount_cents": {
+          "name": "refund_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispute_reason": {
+          "name": "dispute_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_dispute_id": {
+          "name": "stripe_dispute_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_purchases_customer_id": {
+          "name": "idx_purchases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_content_id": {
+          "name": "idx_purchases_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_organization_id": {
+          "name": "idx_purchases_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_stripe_payment_intent": {
+          "name": "idx_purchases_stripe_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_created_at": {
+          "name": "idx_purchases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_purchased_at": {
+          "name": "idx_purchases_purchased_at",
+          "columns": [
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_platform_agreement": {
+          "name": "idx_purchases_platform_agreement",
+          "columns": [
+            {
+              "expression": "platform_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_creator_org_agreement": {
+          "name": "idx_purchases_creator_org_agreement",
+          "columns": [
+            {
+              "expression": "creator_org_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_purchased": {
+          "name": "idx_purchases_customer_purchased",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_status_content": {
+          "name": "idx_purchases_customer_status_content",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_created": {
+          "name": "idx_purchases_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_purchased": {
+          "name": "idx_purchases_org_status_purchased",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "purchases_customer_id_users_id_fk": {
+          "name": "purchases_customer_id_users_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchases_content_id_content_id_fk": {
+          "name": "purchases_content_id_content_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_organization_id_organizations_id_fk": {
+          "name": "purchases_organization_id_organizations_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_platform_agreement_id_organization_platform_agreements_id_fk": {
+          "name": "purchases_platform_agreement_id_organization_platform_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organization_platform_agreements",
+          "columnsFrom": [
+            "platform_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk": {
+          "name": "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "creator_organization_agreements",
+          "columnsFrom": [
+            "creator_org_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchases_stripe_payment_intent_id_unique": {
+          "name": "purchases_stripe_payment_intent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_payment_intent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_purchase_status": {
+          "name": "check_purchase_status",
+          "value": "\"purchases\".\"status\" IN ('pending', 'completed', 'refunded', 'failed')"
+        },
+        "check_amount_positive": {
+          "name": "check_amount_positive",
+          "value": "\"purchases\".\"amount_paid_cents\" >= 0"
+        },
+        "check_platform_fee_positive": {
+          "name": "check_platform_fee_positive",
+          "value": "\"purchases\".\"platform_fee_cents\" >= 0"
+        },
+        "check_org_fee_positive": {
+          "name": "check_org_fee_positive",
+          "value": "\"purchases\".\"organization_fee_cents\" >= 0"
+        },
+        "check_creator_payout_positive": {
+          "name": "check_creator_payout_positive",
+          "value": "\"purchases\".\"creator_payout_cents\" >= 0"
+        },
+        "check_revenue_split_equals_total": {
+          "name": "check_revenue_split_equals_total",
+          "value": "\"purchases\".\"amount_paid_cents\" = \"purchases\".\"platform_fee_cents\" + \"purchases\".\"organization_fee_cents\" + \"purchases\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_audit_log": {
+      "name": "fee_config_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_creator_id": {
+          "name": "scope_creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_config_audit_scope": {
+          "name": "idx_fee_config_audit_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_org": {
+          "name": "idx_fee_config_audit_org",
+          "columns": [
+            {
+              "expression": "scope_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_creator": {
+          "name": "idx_fee_config_audit_creator",
+          "columns": [
+            {
+              "expression": "scope_creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_changed_by": {
+          "name": "idx_fee_config_audit_changed_by",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_audit_log_scope_org_id_organizations_id_fk": {
+          "name": "fee_config_audit_log_scope_org_id_organizations_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "scope_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_scope_creator_id_users_id_fk": {
+          "name": "fee_config_audit_log_scope_creator_id_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scope_creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_changed_by_users_id_fk": {
+          "name": "fee_config_audit_log_changed_by_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_audit_scope": {
+          "name": "check_fee_config_audit_scope",
+          "value": "\"fee_config_audit_log\".\"scope\" IN ('platform', 'org', 'override')"
+        },
+        "check_fee_config_audit_scope_org_id": {
+          "name": "check_fee_config_audit_scope_org_id",
+          "value": "(\"fee_config_audit_log\".\"scope\" = 'platform' AND \"fee_config_audit_log\".\"scope_org_id\" IS NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'org' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'override' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org": {
+      "name": "fee_config_org",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_org_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_updated_by_users_id_fk": {
+          "name": "fee_config_org_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percent_bps": {
+          "name": "check_org_platform_fee_percent_bps",
+          "value": "\"fee_config_org\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org\".\"platform_fee_percent\" >= 0 AND \"fee_config_org\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_org_org_fee_percent_bps": {
+          "name": "check_org_org_fee_percent_bps",
+          "value": "\"fee_config_org\".\"org_fee_percent\" IS NULL OR (\"fee_config_org\".\"org_fee_percent\" >= 0 AND \"fee_config_org\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_org_min_platform_fee_non_negative": {
+          "name": "check_org_min_platform_fee_non_negative",
+          "value": "\"fee_config_org\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_org_min_transfer_non_negative": {
+          "name": "check_org_min_transfer_non_negative",
+          "value": "\"fee_config_org\".\"min_transfer_cents\" IS NULL OR \"fee_config_org\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org_creator": {
+      "name": "fee_config_org_creator",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fee_config_org_creator_org": {
+          "name": "idx_fee_config_org_creator_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_org_creator_creator": {
+          "name": "idx_fee_config_org_creator_creator",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_org_creator_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_creator_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_creator_id_users_id_fk": {
+          "name": "fee_config_org_creator_creator_id_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_updated_by_users_id_fk": {
+          "name": "fee_config_org_creator_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fee_config_org_creator_pkey": {
+          "name": "fee_config_org_creator_pkey",
+          "columns": [
+            "organization_id",
+            "creator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_override_platform_fee_percent_bps": {
+          "name": "check_override_platform_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"platform_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_override_org_fee_percent_bps": {
+          "name": "check_override_org_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"org_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"org_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_override_min_platform_fee_non_negative": {
+          "name": "check_override_min_platform_fee_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org_creator\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_override_min_transfer_non_negative": {
+          "name": "check_override_min_transfer_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_transfer_cents\" IS NULL OR \"fee_config_org_creator\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_platform": {
+      "name": "fee_config_platform",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_org_fee_percent": {
+          "name": "subscription_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "one_off_org_fee_percent": {
+          "name": "one_off_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_platform_updated_by_users_id_fk": {
+          "name": "fee_config_platform_updated_by_users_id_fk",
+          "tableFrom": "fee_config_platform",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_platform_singleton": {
+          "name": "check_fee_config_platform_singleton",
+          "value": "\"fee_config_platform\".\"id\" = 'singleton'"
+        },
+        "check_platform_fee_percent_bps": {
+          "name": "check_platform_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"platform_fee_percent\" >= 0 AND \"fee_config_platform\".\"platform_fee_percent\" <= 10000"
+        },
+        "check_subscription_org_fee_percent_bps": {
+          "name": "check_subscription_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"subscription_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"subscription_org_fee_percent\" <= 10000"
+        },
+        "check_one_off_org_fee_percent_bps": {
+          "name": "check_one_off_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"one_off_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"one_off_org_fee_percent\" <= 10000"
+        },
+        "check_min_platform_fee_non_negative": {
+          "name": "check_min_platform_fee_non_negative",
+          "value": "\"fee_config_platform\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_min_transfer_non_negative": {
+          "name": "check_min_transfer_non_negative",
+          "value": "\"fee_config_platform\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_followers": {
+      "name": "organization_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_follower": {
+          "name": "idx_unique_org_follower",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_org": {
+          "name": "idx_org_followers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_user": {
+          "name": "idx_org_followers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_followers_organization_id_organizations_id_fk": {
+          "name": "organization_followers_organization_id_organizations_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_followers_user_id_users_id_fk": {
+          "name": "organization_followers_user_id_users_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_audit_logs": {
+      "name": "email_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "email_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_audit_logs_organization_id_organizations_id_fk": {
+          "name": "email_audit_logs_organization_id_organizations_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_audit_logs_creator_id_users_id_fk": {
+          "name": "email_audit_logs_creator_id_users_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "template_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_templates_org_id": {
+          "name": "idx_email_templates_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_creator_id": {
+          "name": "idx_email_templates_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_scope": {
+          "name": "idx_email_templates_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_status": {
+          "name": "idx_email_templates_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_global": {
+          "name": "idx_unique_template_global",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'global' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_org": {
+          "name": "idx_unique_template_org",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'organization' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_creator": {
+          "name": "idx_unique_template_creator",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'creator' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_org_scope": {
+          "name": "idx_templates_org_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_creator_scope": {
+          "name": "idx_templates_creator_scope",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_created_by_deleted_at": {
+          "name": "idx_templates_created_by_deleted_at",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope_deleted_at": {
+          "name": "idx_templates_status_scope_deleted_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope": {
+          "name": "idx_templates_status_scope",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_active": {
+          "name": "idx_templates_active",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_template_lookup": {
+          "name": "idx_template_lookup",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_organization_id_organizations_id_fk": {
+          "name": "email_templates_organization_id_organizations_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_creator_id_users_id_fk": {
+          "name": "email_templates_creator_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_created_by_users_id_fk": {
+          "name": "email_templates_created_by_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "global_scope_no_owners": {
+          "name": "global_scope_no_owners",
+          "value": "\"email_templates\".\"scope\" != 'global' OR (\"email_templates\".\"organization_id\" IS NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "org_scope_requires_org": {
+          "name": "org_scope_requires_org",
+          "value": "\"email_templates\".\"scope\" != 'organization' OR (\"email_templates\".\"organization_id\" IS NOT NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "creator_scope_requires_creator": {
+          "name": "creator_scope_requires_creator",
+          "value": "\"email_templates\".\"scope\" != 'creator' OR \"email_templates\".\"creator_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_marketing": {
+          "name": "email_marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_transactional": {
+          "name": "email_transactional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_digest": {
+          "name": "email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_connect_account_user_id": {
+          "name": "primary_connect_account_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_slug": {
+          "name": "idx_organizations_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_org_slug": {
+          "name": "idx_unique_org_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_primary_connect_account_user_id_users_id_fk": {
+          "name": "organizations_primary_connect_account_user_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_connect_account_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payouts": {
+      "name": "payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group": {
+          "name": "transfer_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "payout_type": {
+          "name": "payout_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payouts_stripe_transfer_id": {
+          "name": "uq_payouts_stripe_transfer_id",
+          "columns": [
+            {
+              "expression": "stripe_transfer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"stripe_transfer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_created": {
+          "name": "idx_payouts_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_status_created": {
+          "name": "idx_payouts_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_pending": {
+          "name": "idx_payouts_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payouts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_user_org_created": {
+          "name": "idx_payouts_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_subscription": {
+          "name": "idx_payouts_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_purchase": {
+          "name": "idx_payouts_purchase",
+          "columns": [
+            {
+              "expression": "purchase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_source_created": {
+          "name": "idx_payouts_org_source_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_payouts_platform_fee_per_charge": {
+          "name": "uq_payouts_platform_fee_per_charge",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"payout_type\" = 'platform_fee'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payouts_organization_id_organizations_id_fk": {
+          "name": "payouts_organization_id_organizations_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_user_id_users_id_fk": {
+          "name": "payouts_user_id_users_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_subscription_id_subscriptions_id_fk": {
+          "name": "payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payouts_purchase_id_purchases_id_fk": {
+          "name": "payouts_purchase_id_purchases_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_payouts_amount_positive": {
+          "name": "check_payouts_amount_positive",
+          "value": "\"payouts\".\"amount_cents\" > 0"
+        },
+        "check_payouts_status": {
+          "name": "check_payouts_status",
+          "value": "\"payouts\".\"status\" IN ('paid', 'pending', 'failed', 'reversed', 'cancelled_by_refund')"
+        },
+        "check_payouts_reason": {
+          "name": "check_payouts_reason",
+          "value": "\"payouts\".\"reason\" IS NULL OR \"payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        },
+        "check_payouts_type": {
+          "name": "check_payouts_type",
+          "value": "\"payouts\".\"payout_type\" IN ('platform_fee', 'organization_fee', 'creator_payout', 'creator_payout_to_owner')"
+        },
+        "check_payouts_source": {
+          "name": "check_payouts_source",
+          "value": "\"payouts\".\"source_type\" IN ('purchase', 'subscription')"
+        },
+        "check_payouts_user_required": {
+          "name": "check_payouts_user_required",
+          "value": "(\"payouts\".\"payout_type\" = 'platform_fee') OR (\"payouts\".\"user_id\" IS NOT NULL)"
+        },
+        "check_payouts_paid_invariant": {
+          "name": "check_payouts_paid_invariant",
+          "value": "(\"payouts\".\"status\" NOT IN ('paid', 'reversed')) OR ((\"payouts\".\"stripe_transfer_id\" IS NOT NULL OR \"payouts\".\"stripe_charge_id\" IS NOT NULL) AND \"payouts\".\"resolved_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.video_playback": {
+      "name": "video_playback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_video_playback_user_id": {
+          "name": "idx_video_playback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_video_playback_content_id": {
+          "name": "idx_video_playback_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_playback_user_id_users_id_fk": {
+          "name": "video_playback_user_id_users_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_playback_content_id_content_id_fk": {
+          "name": "video_playback_content_id_content_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_playback_user_id_content_id_unique": {
+          "name": "video_playback_user_id_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refund_reviews": {
+      "name": "refund_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_reversal_cents": {
+          "name": "attempted_reversal_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_refund_reviews_open_per_payout": {
+          "name": "uq_refund_reviews_open_per_payout",
+          "columns": [
+            {
+              "expression": "payout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"refund_reviews\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refund_reviews_purchase_id_purchases_id_fk": {
+          "name": "refund_reviews_purchase_id_purchases_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_payout_id_payouts_id_fk": {
+          "name": "refund_reviews_payout_id_payouts_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "payouts",
+          "columnsFrom": [
+            "payout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_creator_user_id_users_id_fk": {
+          "name": "refund_reviews_creator_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_resolved_by_user_id_users_id_fk": {
+          "name": "refund_reviews_resolved_by_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_refund_reviews_amount_positive": {
+          "name": "check_refund_reviews_amount_positive",
+          "value": "\"refund_reviews\".\"attempted_reversal_cents\" > 0"
+        },
+        "check_refund_reviews_resolution": {
+          "name": "check_refund_reviews_resolution",
+          "value": "\"refund_reviews\".\"resolution\" IS NULL OR \"refund_reviews\".\"resolution\" IN ('creator_absorbed', 'platform_absorbed', 'manually_reversed')"
+        },
+        "check_refund_reviews_resolved_pair": {
+          "name": "check_refund_reviews_resolved_pair",
+          "value": "(\"refund_reviews\".\"resolved_at\" IS NULL AND \"refund_reviews\".\"resolution\" IS NULL) OR (\"refund_reviews\".\"resolved_at\" IS NOT NULL AND \"refund_reviews\".\"resolution\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.branding_settings": {
+      "name": "branding_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_r2_path": {
+          "name": "logo_r2_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color_hex": {
+          "name": "primary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "secondary_color_hex": {
+          "name": "secondary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color_hex": {
+          "name": "accent_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_color_hex": {
+          "name": "background_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_body": {
+          "name": "font_body",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_heading": {
+          "name": "font_heading",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_value": {
+          "name": "radius_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "density_value": {
+          "name": "density_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "intro_video_media_item_id": {
+          "name": "intro_video_media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_url": {
+          "name": "intro_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_overrides": {
+          "name": "token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_mode_overrides": {
+          "name": "dark_mode_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_token_overrides": {
+          "name": "dark_token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_layout": {
+          "name": "hero_layout",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "pricing_faq": {
+          "name": "pricing_faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "branding_settings_updated_at_idx": {
+          "name": "branding_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branding_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "branding_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branding_settings_intro_video_media_item_id_media_items_id_fk": {
+          "name": "branding_settings_intro_video_media_item_id_media_items_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_settings": {
+      "name": "contact_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Codex Platform'"
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'support@example.com'"
+        },
+        "contact_url": {
+          "name": "contact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "twitter_url": {
+          "name": "twitter_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok_url": {
+          "name": "tiktok_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_settings_updated_at_idx": {
+          "name": "contact_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "contact_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "contact_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_settings": {
+      "name": "feature_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enable_signups": {
+          "name": "enable_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_purchases": {
+          "name": "enable_purchases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_subscriptions": {
+          "name": "enable_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_settings_updated_at_idx": {
+          "name": "feature_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "feature_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "feature_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_settings": {
+      "name": "platform_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_settings_updated_at_idx": {
+          "name": "platform_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_settings_organization_id_organizations_id_fk": {
+          "name": "platform_settings_organization_id_organizations_id_fk",
+          "tableFrom": "platform_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orphaned_image_files": {
+      "name": "orphaned_image_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_entity_id": {
+          "name": "original_entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_entity_type": {
+          "name": "original_entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orphaned_files_status": {
+          "name": "idx_orphaned_files_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_orphaned_at": {
+          "name": "idx_orphaned_files_orphaned_at",
+          "columns": [
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_type_status": {
+          "name": "idx_orphaned_files_type_status",
+          "columns": [
+            {
+              "expression": "image_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_pending_cleanup": {
+          "name": "idx_orphaned_files_pending_cleanup",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_image_type": {
+          "name": "check_image_type",
+          "value": "\"orphaned_image_files\".\"image_type\" IN ('avatar', 'logo', 'content_thumbnail', 'transcoding_artifact')"
+        },
+        "check_entity_type": {
+          "name": "check_entity_type",
+          "value": "\"orphaned_image_files\".\"original_entity_type\" IS NULL OR \"orphaned_image_files\".\"original_entity_type\" IN ('user', 'organization', 'content', 'media_item')"
+        },
+        "check_orphan_status": {
+          "name": "check_orphan_status",
+          "value": "\"orphaned_image_files\".\"status\" IN ('pending', 'deleted', 'failed', 'retained')"
+        },
+        "check_cleanup_attempts": {
+          "name": "check_cleanup_attempts",
+          "value": "\"orphaned_image_files\".\"cleanup_attempts\" >= 0 AND \"orphaned_image_files\".\"cleanup_attempts\" <= 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_payouts": {
+      "name": "pending_payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_payouts_user_id": {
+          "name": "idx_pending_payouts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_org_id": {
+          "name": "idx_pending_payouts_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_unresolved": {
+          "name": "idx_pending_payouts_unresolved",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_payouts_user_id_users_id_fk": {
+          "name": "pending_payouts_user_id_users_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_organization_id_organizations_id_fk": {
+          "name": "pending_payouts_organization_id_organizations_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_subscription_id_subscriptions_id_fk": {
+          "name": "pending_payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_pending_payout_positive": {
+          "name": "check_pending_payout_positive",
+          "value": "\"pending_payouts\".\"amount_cents\" > 0"
+        },
+        "check_pending_payout_reason": {
+          "name": "check_pending_payout_reason",
+          "value": "\"pending_payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stripe_connect_accounts": {
+      "name": "stripe_connect_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_connect_org_id": {
+          "name": "idx_stripe_connect_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_connect_stripe_id": {
+          "name": "idx_stripe_connect_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_connect_accounts_organization_id_organizations_id_fk": {
+          "name": "stripe_connect_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_connect_accounts_user_id_users_id_fk": {
+          "name": "stripe_connect_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_connect_accounts_stripe_account_id_unique": {
+          "name": "stripe_connect_accounts_stripe_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_account_id"
+          ]
+        },
+        "uq_stripe_connect_user": {
+          "name": "uq_stripe_connect_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_connect_status": {
+          "name": "check_connect_status",
+          "value": "\"stripe_connect_accounts\".\"status\" IN ('onboarding', 'active', 'restricted', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_org_id": {
+          "name": "idx_subscription_tiers_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_tiers_org_active": {
+          "name": "idx_subscription_tiers_org_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_org_sort": {
+          "name": "uq_subscription_tiers_org_sort",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_tiers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_tiers_organization_id_organizations_id_fk": {
+          "name": "subscription_tiers_organization_id_organizations_id_fk",
+          "tableFrom": "subscription_tiers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_tier_price_monthly_positive": {
+          "name": "check_tier_price_monthly_positive",
+          "value": "\"subscription_tiers\".\"price_monthly\" >= 0"
+        },
+        "check_tier_price_annual_positive": {
+          "name": "check_tier_price_annual_positive",
+          "value": "\"subscription_tiers\".\"price_annual\" >= 0"
+        },
+        "check_tier_sort_order_positive": {
+          "name": "check_tier_sort_order_positive",
+          "value": "\"subscription_tiers\".\"sort_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_reason": {
+          "name": "churn_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_user_id": {
+          "name": "idx_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_id": {
+          "name": "idx_subscriptions_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_tier_id": {
+          "name": "idx_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_stripe_id": {
+          "name": "idx_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_status": {
+          "name": "idx_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user_org": {
+          "name": "idx_subscriptions_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_subscription_per_user_org": {
+          "name": "uq_active_subscription_per_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_subscription_status": {
+          "name": "check_subscription_status",
+          "value": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_billing_interval": {
+          "name": "check_billing_interval",
+          "value": "\"subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        },
+        "check_churn_reason": {
+          "name": "check_churn_reason",
+          "value": "\"subscriptions\".\"churn_reason\" IS NULL OR \"subscriptions\".\"churn_reason\" IN ('too_expensive', 'not_enough_content', 'found_alternative', 'not_using_it', 'technical_issues', 'other')"
+        },
+        "check_sub_amount_positive": {
+          "name": "check_sub_amount_positive",
+          "value": "\"subscriptions\".\"amount_cents\" >= 0"
+        },
+        "check_sub_platform_fee_positive": {
+          "name": "check_sub_platform_fee_positive",
+          "value": "\"subscriptions\".\"platform_fee_cents\" >= 0"
+        },
+        "check_sub_org_fee_positive": {
+          "name": "check_sub_org_fee_positive",
+          "value": "\"subscriptions\".\"organization_fee_cents\" >= 0"
+        },
+        "check_sub_creator_payout_positive": {
+          "name": "check_sub_creator_payout_positive",
+          "value": "\"subscriptions\".\"creator_payout_cents\" >= 0"
+        },
+        "check_sub_revenue_split_equals_total": {
+          "name": "check_sub_revenue_split_equals_total",
+          "value": "\"subscriptions\".\"amount_cents\" = \"subscriptions\".\"platform_fee_cents\" + \"subscriptions\".\"organization_fee_cents\" + \"subscriptions\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_table": {
+      "name": "test_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_table_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.email_send_status": {
+      "name": "email_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.template_scope": {
+      "name": "template_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "organization",
+        "creator"
+      ]
+    },
+    "public.template_status": {
+      "name": "template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1779054739296,
       "tag": "0073_bright_kylun",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1780252145731,
+      "tag": "0074_hot_goliath",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/ecommerce.ts
+++ b/packages/database/src/schema/ecommerce.ts
@@ -418,9 +418,12 @@ export const purchases = pgTable(
     contentId: uuid('content_id')
       .notNull()
       .references(() => content.id, { onDelete: 'restrict' }),
-    organizationId: uuid('organization_id')
-      .notNull()
-      .references(() => organizations.id, { onDelete: 'restrict' }),
+    // Nullable (Codex-69t7c WP1): orgless creator-direct purchases have no
+    // organization. Org-scoped purchases still populate it; the Phase-1 gate
+    // that required it is removed in WP5.
+    organizationId: uuid('organization_id').references(() => organizations.id, {
+      onDelete: 'restrict',
+    }),
 
     // Payment (stored as integer cents to avoid rounding errors)
     amountPaidCents: integer('amount_paid_cents').notNull(),

--- a/packages/database/src/schema/organizations.ts
+++ b/packages/database/src/schema/organizations.ts
@@ -28,14 +28,14 @@ export const organizations = pgTable(
     websiteUrl: text('website_url'),
 
     /**
-     * The canonical Connect account owner for this org. Resolves "which
-     * Connect account is the org's?" — previously answered by an arbitrary
-     * .limit(1) because the unique constraint on stripe_connect_accounts
-     * is (user_id, organization_id), meaning N users per org are allowed
-     * to have their own Connect account. When the org has multiple, the
-     * one owned by this user is the canonical routing target for tier
-     * operations and revenue transfers. NULL means the org has not yet
-     * onboarded a Connect account.
+     * The user whose single Connect account settles this org's revenue slice
+     * (Codex-69t7c). This is now the SOLE org→account link: resolve it by
+     * reading this field, then looking up that user's one account
+     * (`stripe_connect_accounts.user_id` is unique). It replaced the former
+     * arbitrary `.limit(1)` over `stripe_connect_accounts.organization_id`,
+     * which is no longer part of account identity. Set when the org owner
+     * onboards Connect; NULL means the org has not onboarded an account yet,
+     * so its org-fee slice accrues to `pending_payouts` until one connects.
      */
     primaryConnectAccountUserId: text(
       'primary_connect_account_user_id'

--- a/packages/database/src/schema/subscriptions.ts
+++ b/packages/database/src/schema/subscriptions.ts
@@ -199,11 +199,16 @@ export const subscriptions = pgTable(
 );
 
 /**
- * Stripe Connect Accounts — org and creator Stripe Express accounts
+ * Stripe Connect Accounts — ONE account per user (creator or org owner).
  *
- * Both org owners and creators need Connect accounts to receive payouts.
- * One account per user (unique on userId). Orgs also have a unique constraint
- * on organizationId for the org-level account (the owner's).
+ * A user has exactly one Connect account (`unique(userId)`) which receives
+ * ALL of their earnings — from every org agreement they hold AND their own
+ * direct sales (Codex-69t7c, D2). An org resolves "its" account via
+ * `organizations.primaryConnectAccountUserId` → that user's single account.
+ * `organizationId` below is a NULLABLE, non-identity record of the org the
+ * account was first onboarded under; it is no longer used for resolution and
+ * is slated for removal in WP2 once every flow routes via
+ * `primaryConnectAccountUserId`.
  *
  * Onboarding: stripe.accounts.create() → stripe.accountLinks.create()
  * Verification: account.updated webhook updates chargesEnabled/payoutsEnabled
@@ -212,9 +217,13 @@ export const stripeConnectAccounts = pgTable(
   'stripe_connect_accounts',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    organizationId: uuid('organization_id')
-      .notNull()
-      .references(() => organizations.id, { onDelete: 'cascade' }),
+    // Nullable, non-identity (Codex-69t7c WP1): the org this account was first
+    // onboarded under. Org→account resolution lives on
+    // `organizations.primaryConnectAccountUserId`, NOT here. `set null` so
+    // deleting one org never destroys a user's shared single account.
+    organizationId: uuid('organization_id').references(() => organizations.id, {
+      onDelete: 'set null',
+    }),
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
@@ -241,13 +250,17 @@ export const stripeConnectAccounts = pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
-    // Indexes
+    // Indexes. The vestigial org index is kept until WP2 drops the column;
+    // the former idx_stripe_connect_user_id is removed because the unique
+    // constraint below already provides the user_id lookup index.
     index('idx_stripe_connect_org_id').on(table.organizationId),
-    index('idx_stripe_connect_user_id').on(table.userId),
     index('idx_stripe_connect_stripe_id').on(table.stripeAccountId),
 
-    // One Connect account per user per org
-    unique('uq_stripe_connect_user_org').on(table.userId, table.organizationId),
+    // ONE Connect account per user (Codex-69t7c WP1). Replaces the prior
+    // (user_id, organization_id) composite — a user now has a single account
+    // across all orgs; the org→account link lives on
+    // organizations.primaryConnectAccountUserId.
+    unique('uq_stripe_connect_user').on(table.userId),
 
     // CHECK constraint for status
     check(

--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -20,6 +20,7 @@ import { ContentService, MediaItemService } from '@codex/content';
 import * as schema from '@codex/database/schema';
 import { organizations } from '@codex/database/schema';
 import {
+  createTestMembershipInput,
   createUniqueSlug,
   type Database,
   seedTestUsers,
@@ -45,6 +46,7 @@ import {
   PurchaseNotFoundError,
 } from '../errors';
 import { PurchaseService } from '../services/purchase-service';
+import { resolvePrimaryConnect } from '../utils/resolve-primary-connect';
 
 describe('PurchaseService Integration', () => {
   let db: Database;
@@ -156,6 +158,16 @@ describe('PurchaseService Integration', () => {
       .update(schema.users)
       .set({ stripeCustomerId: null })
       .where(eq(schema.users.id, otherUserId));
+
+    // One Connect account per user (uq_stripe_connect_user, Codex-69t7c):
+    // clear seed users' accounts between tests so per-test seeds (which raw
+    // insert for these shared users) don't collide on the unique constraint.
+    await db
+      .delete(schema.stripeConnectAccounts)
+      .where(eq(schema.stripeConnectAccounts.userId, userId));
+    await db
+      .delete(schema.stripeConnectAccounts)
+      .where(eq(schema.stripeConnectAccounts.userId, otherUserId));
   });
 
   describe('createCheckoutSession', () => {
@@ -939,9 +951,9 @@ describe('PurchaseService Integration', () => {
       await contentService.publish(content.id, userId);
 
       // Seed org's Connect account row. The userId is the org owner.
-      // Idempotent: tests in this describe block share the same (userId, orgId)
-      // so subsequent calls reuse the existing row instead of conflicting on
-      // uq_stripe_connect_user_org.
+      // Idempotent: tests in this describe block share the same userId so
+      // subsequent calls reuse the existing row instead of conflicting on
+      // uq_stripe_connect_user (one account per user, Codex-69t7c).
       const stripeAccountId = `acct_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
       await db
         .insert(schema.stripeConnectAccounts)
@@ -954,16 +966,20 @@ describe('PurchaseService Integration', () => {
           payoutsEnabled: true,
         })
         .onConflictDoUpdate({
-          target: [
-            schema.stripeConnectAccounts.userId,
-            schema.stripeConnectAccounts.organizationId,
-          ],
+          target: [schema.stripeConnectAccounts.userId],
           set: {
             chargesEnabled: opts.chargesEnabled ?? true,
             payoutsEnabled: true,
             status: 'active',
           },
         });
+
+      // Pin the org's canonical Connect account so resolvePrimaryConnect routes
+      // the org slice (Codex-69t7c: org→account via primaryConnectAccountUserId).
+      await db
+        .update(schema.organizations)
+        .set({ primaryConnectAccountUserId: userId })
+        .where(eq(schema.organizations.id, organizationId));
 
       return {
         content,
@@ -1158,6 +1174,9 @@ describe('PurchaseService Integration', () => {
           name: 'Connect Disabled Org',
           slug: createUniqueSlug('connect-disabled'),
           ownerId: otherUserId,
+          // Pin so resolvePrimaryConnect resolves the org's (offline) account
+          // by userId (Codex-69t7c) — an onboarding org is pinned in production.
+          primaryConnectAccountUserId: otherUserId,
         })
         .returning();
 
@@ -1769,6 +1788,9 @@ describe('PurchaseService Integration', () => {
           name: 'Refund Reversal Org',
           slug: createUniqueSlug('refund-reversal'),
           ownerId: userId,
+          // Pin so resolvePrimaryConnect resolves the org's account by userId
+          // (Codex-69t7c) — onboarded orgs are pinned in production.
+          primaryConnectAccountUserId: userId,
         })
         .returning();
       await db.insert(schema.stripeConnectAccounts).values({
@@ -1993,6 +2015,9 @@ describe('PurchaseService Integration', () => {
           name: 'Partial Refund Org',
           slug: createUniqueSlug('partial-refund'),
           ownerId: userId,
+          // Pin so resolvePrimaryConnect resolves the org's account by userId
+          // (Codex-69t7c) — onboarded orgs are pinned in production.
+          primaryConnectAccountUserId: userId,
         })
         .returning();
       await db.insert(schema.stripeConnectAccounts).values({
@@ -2283,6 +2308,9 @@ describe('PurchaseService Integration', () => {
           name: 'Pending Refund Org',
           slug: createUniqueSlug('pending-refund'),
           ownerId: userId,
+          // Pin so resolvePrimaryConnect resolves the org's (not-ready) account
+          // by userId (Codex-69t7c) so the org-fee pending row is written.
+          primaryConnectAccountUserId: userId,
         })
         .returning();
       await db.insert(schema.stripeConnectAccounts).values({
@@ -4232,6 +4260,49 @@ describe('PurchaseService Integration', () => {
           verifyUserId
         )
       ).rejects.toThrow('Failed to connect to Stripe API');
+    });
+  });
+
+  // ─── resolvePrimaryConnect — org→account resolution (Codex-69t7c) ───────
+  // Production does not pin organizations.primaryConnectAccountUserId yet, so
+  // org-fee resolution relies on the deterministic org-owner fallback. These
+  // pin that contract so a regression that drops the fallback (stranding the
+  // org-fee slice) can't ship green.
+  describe('resolvePrimaryConnect — org→account resolution (Codex-69t7c)', () => {
+    it('falls back to the org owner account when no primary pin is set', async () => {
+      const [ownerUserId] = await seedTestUsers(db, 1);
+      const [org] = await db
+        .insert(organizations)
+        .values({ name: 'RPC Owner Org', slug: createUniqueSlug('rpc-owner') })
+        .returning();
+      await db
+        .insert(schema.organizationMemberships)
+        .values(
+          createTestMembershipInput(org.id, ownerUserId, { role: 'owner' })
+        );
+      const stripeAccountId = `acct_rpc_${createUniqueSlug('a')}`;
+      await db.insert(schema.stripeConnectAccounts).values({
+        userId: ownerUserId,
+        organizationId: org.id,
+        stripeAccountId,
+        status: 'active',
+        chargesEnabled: true,
+        payoutsEnabled: true,
+      });
+
+      const account = await resolvePrimaryConnect(db, org.id);
+      expect(account?.userId).toBe(ownerUserId);
+      expect(account?.stripeAccountId).toBe(stripeAccountId);
+    });
+
+    it('returns undefined when the org has neither a primary pin nor an owner', async () => {
+      const [org] = await db
+        .insert(organizations)
+        .values({ name: 'RPC Empty Org', slug: createUniqueSlug('rpc-empty') })
+        .returning();
+
+      const account = await resolvePrimaryConnect(db, org.id);
+      expect(account).toBeUndefined();
     });
   });
 });

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -839,20 +839,15 @@ export class PurchaseService extends BaseService {
       }
     }
 
-    // Look up Connect accounts up front. We need creator's (the org owner / a
-    // member, scoped by creatorId + organizationId) and org's (any active row
-    // for the org). The latter falls back to the same lookup as before.
+    // Look up Connect accounts up front: the creator's single account (by
+    // userId — one account per user, Codex-69t7c) and the org's canonical
+    // account (resolved via primaryConnectAccountUserId below).
     const [creatorConnect] =
       revenueSplit.creatorPayoutCents > 0
         ? await this.db
             .select()
             .from(stripeConnectAccounts)
-            .where(
-              and(
-                eq(stripeConnectAccounts.userId, creatorId),
-                eq(stripeConnectAccounts.organizationId, organizationId)
-              )
-            )
+            .where(eq(stripeConnectAccounts.userId, creatorId))
             .limit(1)
         : [undefined];
 
@@ -1613,7 +1608,7 @@ export class PurchaseService extends BaseService {
       stripeDisputeId?: string;
       disputeReason?: string;
     }
-  ): Promise<{ userId: string; orgId: string } | void> {
+  ): Promise<{ userId: string; orgId: string | null } | void> {
     try {
       const purchase = await this.db.query.purchases.findFirst({
         where: eq(purchases.stripePaymentIntentId, paymentIntentId),

--- a/packages/purchase/src/utils/resolve-primary-connect.ts
+++ b/packages/purchase/src/utils/resolve-primary-connect.ts
@@ -1,26 +1,31 @@
 /**
- * Resolve the org's canonical Connect settlement account (Codex-sec7i).
+ * Resolve the org's canonical Connect settlement account (Codex-69t7c).
  *
- * The org-fee slice of any payment (one-off purchase OR subscription
- * invoice) must route to a single, deterministic Connect account. That
- * account is pinned by `organizations.primary_connect_account_user_id`.
+ * The org-fee slice of any payment (one-off purchase OR subscription invoice)
+ * must route to a single, deterministic Connect account: the one owned by the
+ * org's PRIMARY settlement user. That user is the explicitly pinned
+ * `organizations.primary_connect_account_user_id` when set, otherwise the org
+ * OWNER (the `organization_memberships` row with role 'owner' — the user who
+ * onboards the org's account). Because a user has exactly ONE Connect account
+ * (`stripe_connect_accounts` is unique on `user_id`), resolution is:
+ * org → primary-or-owner user id → that user's single account.
  *
- * Multi-creator orgs commonly have multiple `stripe_connect_accounts`
- * rows scoped to the same `organizationId` — one per creator who
- * onboarded a personal Connect for their own earnings. Without the
- * primary pin, a bare `.limit(1)` lookup over `(organizationId)` was
- * picking an arbitrary member, routing org slices to random creator
- * accounts.
+ * The account's own `organization_id` is NOT consulted — it is a nullable,
+ * vestigial onboarding-origin field (WP1). The owner fallback is DETERMINISTIC
+ * (role='owner'), unlike the prior arbitrary `.limit(1)` over that org column
+ * which Codex-sec7i set out to eliminate. The pin still wins when present, so
+ * an org can route to a non-owner once onboarding/admin sets it.
  *
- * Returns null when the org has no Connect account at all. The
- * fallback `.limit(1)` only fires for legacy orgs whose
- * `primary_connect_account_user_id` has not been backfilled — fresh
- * orgs populate it at onboarding so that branch shrinks to zero over
- * time.
+ * Returns undefined when the org has no resolvable primary/owner user, or that
+ * user has not onboarded a Connect account yet.
  */
 
 import type { DatabaseClient } from '@codex/database';
-import { organizations, stripeConnectAccounts } from '@codex/database/schema';
+import {
+  organizationMemberships,
+  organizations,
+  stripeConnectAccounts,
+} from '@codex/database/schema';
 import { and, eq } from 'drizzle-orm';
 
 type StripeConnectAccount = typeof stripeConnectAccounts.$inferSelect;
@@ -37,24 +42,30 @@ export async function resolvePrimaryConnect(
     .where(eq(organizations.id, orgId))
     .limit(1);
 
-  if (org?.primaryConnectAccountUserId) {
-    const [pinned] = await db
-      .select()
-      .from(stripeConnectAccounts)
+  // Prefer the explicit pin; until onboarding sets it, fall back to the org
+  // owner (deterministic — never an arbitrary member).
+  let targetUserId = org?.primaryConnectAccountUserId ?? null;
+  if (!targetUserId) {
+    const [owner] = await db
+      .select({ userId: organizationMemberships.userId })
+      .from(organizationMemberships)
       .where(
         and(
-          eq(stripeConnectAccounts.organizationId, orgId),
-          eq(stripeConnectAccounts.userId, org.primaryConnectAccountUserId)
+          eq(organizationMemberships.organizationId, orgId),
+          eq(organizationMemberships.role, 'owner')
         )
       )
       .limit(1);
-    if (pinned) return pinned;
+    targetUserId = owner?.userId ?? null;
   }
 
-  const [fallback] = await db
+  if (!targetUserId) return undefined;
+
+  const [account] = await db
     .select()
     .from(stripeConnectAccounts)
-    .where(eq(stripeConnectAccounts.organizationId, orgId))
+    .where(eq(stripeConnectAccounts.userId, targetUserId))
     .limit(1);
-  return fallback;
+
+  return account;
 }

--- a/packages/subscription/src/services/__tests__/connect-account-service.test.ts
+++ b/packages/subscription/src/services/__tests__/connect-account-service.test.ts
@@ -33,6 +33,7 @@ import {
   teardownTestDatabase,
   validateDatabaseConnection,
 } from '@codex/test-utils';
+import { eq, inArray } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import {
   afterAll,
@@ -74,7 +75,15 @@ describe('ConnectAccountService', () => {
     orgId = org.id;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // One Connect account per user (Codex-69t7c uq_stripe_connect_user): this
+    // suite reuses the same two seed users across many tests, so clear their
+    // accounts between tests to avoid cross-test unique(userId) collisions.
+    await db
+      .delete(stripeConnectAccounts)
+      .where(
+        inArray(stripeConnectAccounts.userId, [creatorId, otherCreatorId])
+      );
     // Don't reset IDs — unique constraint on stripeAccountId means IDs must be globally unique
     stripe = createMockStripe();
     // createMockStripe() does not ship `accounts.retrieve` — install a spy
@@ -283,6 +292,10 @@ describe('ConnectAccountService', () => {
       await db
         .insert(stripeConnectAccounts)
         .values(createTestConnectAccountInput(getOrg.id, creatorId));
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, getOrg.id));
 
       const account = await service.getAccount(getOrg.id);
       expect(account).not.toBeNull();
@@ -847,6 +860,10 @@ describe('ConnectAccountService', () => {
       await db
         .insert(stripeConnectAccounts)
         .values(createTestConnectAccountInput(dashOrg.id, creatorId));
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, dashOrg.id));
 
       const result = await service.createDashboardLink(dashOrg.id);
       expect(result.url).toBeDefined();
@@ -891,6 +908,10 @@ describe('ConnectAccountService', () => {
           status: 'active',
         })
       );
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, readyOrg.id));
 
       const ready = await service.isReady(readyOrg.id);
       expect(ready).toBe(true);
@@ -983,6 +1004,10 @@ describe('ConnectAccountService', () => {
           })
         )
         .returning();
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, reqOrg.id));
 
       const deadline = 1_800_000_000;
       (stripe.accounts.retrieve as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -1039,6 +1064,10 @@ describe('ConnectAccountService', () => {
         .insert(stripeConnectAccounts)
         .values(createTestConnectAccountInput(normOrg.id, creatorId))
         .returning();
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, normOrg.id));
 
       (stripe.accounts.retrieve as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: inserted.stripeAccountId,
@@ -1088,6 +1117,10 @@ describe('ConnectAccountService', () => {
           })
         )
         .returning();
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, degOrg.id));
 
       (stripe.accounts.retrieve as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('Stripe API unreachable')
@@ -1211,6 +1244,58 @@ describe('ConnectAccountService', () => {
           requirements: { currently_due: [], disabled_reason: null },
         } as unknown as Stripe.Account)
       ).resolves.toBeUndefined();
+    });
+  });
+
+  // ─── Schema invariants (Codex-69t7c WP1) ─────────────────────────────
+  describe('schema invariants (Codex-69t7c WP1)', () => {
+    it('enforces one Connect account per user (uq_stripe_connect_user)', async () => {
+      const [orgA] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('uq-a'),
+            creatorId,
+          })
+        )
+        .returning();
+      const [orgB] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('uq-b'),
+            creatorId,
+          })
+        )
+        .returning();
+
+      await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(orgA.id, creatorId));
+
+      // A second account for the same user — even under a DIFFERENT org —
+      // must violate the single-account-per-user unique constraint.
+      await expect(
+        db
+          .insert(stripeConnectAccounts)
+          .values(createTestConnectAccountInput(orgB.id, creatorId))
+      ).rejects.toThrow();
+    });
+
+    it('allows a Connect account with a null organizationId (orgless creator)', async () => {
+      const [row] = await db
+        .insert(stripeConnectAccounts)
+        .values({
+          userId: creatorId,
+          organizationId: null,
+          stripeAccountId: `acct_orgless_${createUniqueSlug('a')}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        })
+        .returning();
+      expect(row.organizationId).toBeNull();
+      expect(row.userId).toBe(creatorId);
     });
   });
 });

--- a/packages/subscription/src/services/__tests__/subscription-service-fee-config.integration.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service-fee-config.integration.test.ts
@@ -95,7 +95,12 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
     payoutUserId = b;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // One Connect account per user (uq_stripe_connect_user, Codex-69t7c):
+    // clear seed users' accounts between tests to avoid collisions.
+    await db
+      .delete(stripeConnectAccounts)
+      .where(inArray(stripeConnectAccounts.userId, [creatorId, payoutUserId]));
     stripe = createMockStripe();
   });
 
@@ -123,6 +128,12 @@ describe('SubscriptionService × FeeConfigService — pending payouts', () => {
         stripeAccountId,
       })
     );
+    // Pin the org's canonical Connect account (Codex-69t7c): org→account
+    // resolves via primaryConnectAccountUserId to the payout user's account.
+    await db
+      .update(organizations)
+      .set({ primaryConnectAccountUserId: payoutUserId })
+      .where(eq(organizations.id, org.id));
 
     const [tier] = await db
       .insert(subscriptionTiers)

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -41,6 +41,7 @@ import {
   teardownTestDatabase,
   validateDatabaseConnection,
 } from '@codex/test-utils';
+import { eq, inArray } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import {
   afterAll,
@@ -98,7 +99,6 @@ describe('SubscriptionService', () => {
 
     // Clear any cached Customer id from previous tests so resolution is
     // deterministic per-test.
-    const { inArray } = await import('drizzle-orm');
     await db
       .update(users)
       .set({ stripeCustomerId: null })
@@ -108,31 +108,63 @@ describe('SubscriptionService', () => {
           [creatorId, otherCreatorId, thirdUserId].filter(Boolean)
         )
       );
+
+    // One Connect account per user (uq_stripe_connect_user, Codex-69t7c): clear
+    // the seed users' accounts between tests so re-seeding doesn't collide.
+    await db
+      .delete(stripeConnectAccounts)
+      .where(
+        inArray(
+          stripeConnectAccounts.userId,
+          [creatorId, otherCreatorId, thirdUserId].filter(Boolean)
+        )
+      );
   });
 
   afterAll(async () => {
     await teardownTestDatabase();
   });
 
-  /** Create org + connect + tiers for testing */
-  async function createFullOrg(slug?: string) {
+  /** Create org + connect + tiers for testing. ownerUserId owns the org's
+   * single Connect account (default creatorId); pass a distinct user when a
+   * test needs two orgs with two separate Connect accounts. */
+  async function createFullOrg(slug?: string, ownerUserId: string = creatorId) {
     const [org] = await db
       .insert(organizations)
       .values(
         createTestOrganizationInput({
           slug: createUniqueSlug(slug ?? 'sub'),
-          creatorId,
+          creatorId: ownerUserId,
         })
       )
       .returning();
 
-    await db.insert(stripeConnectAccounts).values(
-      createTestConnectAccountInput(org.id, creatorId, {
-        chargesEnabled: true,
-        payoutsEnabled: true,
-        status: 'active',
-      })
-    );
+    // Upsert on userId: a user has ONE Connect account (uq_stripe_connect_user,
+    // Codex-69t7c), so a helper invoked twice in one test (multi-org) reuses it.
+    await db
+      .insert(stripeConnectAccounts)
+      .values(
+        createTestConnectAccountInput(org.id, ownerUserId, {
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          status: 'active',
+        })
+      )
+      .onConflictDoUpdate({
+        target: stripeConnectAccounts.userId,
+        set: {
+          organizationId: org.id,
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          status: 'active',
+        },
+      });
+    // Pin the org's canonical Connect account (Codex-69t7c): org→account
+    // resolves via primaryConnectAccountUserId, not the account's org column.
+    await db
+      .update(organizations)
+      .set({ primaryConnectAccountUserId: ownerUserId })
+      .where(eq(organizations.id, org.id));
 
     const [tier1] = await db
       .insert(subscriptionTiers)
@@ -7256,18 +7288,21 @@ describe('SubscriptionService', () => {
      * row, an active subscription owned by `otherCreatorId` for FK
      * references on pendingPayouts, and the unique stripeAccountId.
      */
-    async function seedConnectAndSubscription(slug: string) {
-      const { org, tier1 } = await createFullOrg(slug);
+    async function seedConnectAndSubscription(
+      slug: string,
+      ownerUserId: string = creatorId
+    ) {
+      const { org, tier1 } = await createFullOrg(slug, ownerUserId);
       const stripeAccountId = `acct_w4jjk_${createUniqueSlug('a')}`;
 
-      const { eq } = await import('drizzle-orm');
-      // The createFullOrg helper inserted a connect account with a random
-      // stripeAccountId — overwrite it with our deterministic value so
-      // tests can assert the (orgId, stripeAccountId) lookup explicitly.
+      // createFullOrg inserted the owner's connect account with a random
+      // stripeAccountId — overwrite it (by userId, since a user has one
+      // account, Codex-69t7c) with our deterministic value so tests can
+      // assert the lookup explicitly.
       await db
         .update(stripeConnectAccounts)
         .set({ stripeAccountId })
-        .where(eq(stripeConnectAccounts.organizationId, org.id));
+        .where(eq(stripeConnectAccounts.userId, ownerUserId));
 
       const [sub] = await db
         .insert(subscriptions)
@@ -8018,15 +8053,19 @@ describe('SubscriptionService', () => {
      * Mirror seedConnectAndSubscription from the resolvePendingPayouts
      * block — deterministic stripeAccountId so we can drive the lookup.
      */
-    async function seedConnectAndSubscription(slug: string) {
-      const { org, tier1 } = await createFullOrg(slug);
+    async function seedConnectAndSubscription(
+      slug: string,
+      ownerUserId: string = creatorId
+    ) {
+      const { org, tier1 } = await createFullOrg(slug, ownerUserId);
       const stripeAccountId = `acct_vv77x_${createUniqueSlug('a')}`;
 
-      const { eq } = await import('drizzle-orm');
+      // Overwrite by userId (one account per user, Codex-69t7c) so distinct
+      // owners get distinct deterministic stripeAccountIds.
       await db
         .update(stripeConnectAccounts)
         .set({ stripeAccountId })
-        .where(eq(stripeConnectAccounts.organizationId, org.id));
+        .where(eq(stripeConnectAccounts.userId, ownerUserId));
 
       const [sub] = await db
         .insert(subscriptions)
@@ -8206,8 +8245,11 @@ describe('SubscriptionService', () => {
       const { sql: rawSql } = await import('drizzle-orm');
       await db.execute(rawSql`DELETE FROM payouts`);
 
-      const failOrg = await seedConnectAndSubscription('vv77x-fail');
-      const okOrg = await seedConnectAndSubscription('vv77x-ok');
+      // Two DISTINCT connect-account owners (Codex-69t7c: one account per
+      // user) so one account can fail retrieve while the other succeeds.
+      const [okOwnerId] = await seedTestUsers(db, 1);
+      const failOrg = await seedConnectAndSubscription('vv77x-fail', creatorId);
+      const okOrg = await seedConnectAndSubscription('vv77x-ok', okOwnerId);
 
       const longAgo = new Date(Date.now() - 60 * 60 * 1000);
       await db.insert(payoutsTable).values([
@@ -8223,7 +8265,7 @@ describe('SubscriptionService', () => {
           attemptedAt: longAgo,
         },
         {
-          userId: creatorId,
+          userId: okOwnerId,
           organizationId: okOrg.org.id,
           subscriptionId: okOrg.sub.id,
           amountCents: 700,
@@ -8692,7 +8734,12 @@ describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', ()
     [creatorId, subscriberId] = userIds;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // One Connect account per user (uq_stripe_connect_user, Codex-69t7c):
+    // clear seed users' accounts between tests to avoid collisions.
+    await db
+      .delete(stripeConnectAccounts)
+      .where(inArray(stripeConnectAccounts.userId, [creatorId, subscriberId]));
     stripe = createMockStripe();
     service = new SubscriptionService({ db, environment: 'test' }, stripe);
   });
@@ -8725,6 +8772,11 @@ describe('Payouts ledger — schema + status-column behaviour (Codex-e9v3b)', ()
         status: 'active',
       })
     );
+
+    await db
+      .update(organizations)
+      .set({ primaryConnectAccountUserId: creatorId })
+      .where(eq(organizations.id, org.id));
 
     const [tier] = await db
       .insert(subscriptionTiers)
@@ -9563,7 +9615,12 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
     [creatorId, subscriberId] = userIds;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // One Connect account per user (uq_stripe_connect_user, Codex-69t7c):
+    // clear seed users' accounts between tests to avoid collisions.
+    await db
+      .delete(stripeConnectAccounts)
+      .where(inArray(stripeConnectAccounts.userId, [creatorId, subscriberId]));
     stripe = createMockStripe();
     service = new SubscriptionService({ db, environment: 'test' }, stripe);
   });
@@ -9588,12 +9645,28 @@ describe('Currency GBP-only enforcement (Codex-yv18n)', () => {
       )
       .returning();
 
-    await db.insert(stripeConnectAccounts).values(
-      createTestConnectAccountInput(org.id, creatorId, {
-        chargesEnabled: true,
-        payoutsEnabled: true,
-      })
-    );
+    await db
+      .insert(stripeConnectAccounts)
+      .values(
+        createTestConnectAccountInput(org.id, creatorId, {
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        })
+      )
+      .onConflictDoUpdate({
+        target: stripeConnectAccounts.userId,
+        set: {
+          organizationId: org.id,
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          status: 'active',
+        },
+      });
+    // Pin the org's canonical Connect account (Codex-69t7c).
+    await db
+      .update(organizations)
+      .set({ primaryConnectAccountUserId: creatorId })
+      .where(eq(organizations.id, org.id));
 
     const [tier1] = await db
       .insert(subscriptionTiers)

--- a/packages/subscription/src/services/__tests__/tier-service.test.ts
+++ b/packages/subscription/src/services/__tests__/tier-service.test.ts
@@ -59,7 +59,12 @@ describe('TierService', () => {
     [creatorId] = userIds;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // One Connect account per user (uq_stripe_connect_user, Codex-69t7c):
+    // clear the seed user's account between tests to avoid collisions.
+    await db
+      .delete(stripeConnectAccounts)
+      .where(eq(stripeConnectAccounts.userId, creatorId));
     stripe = createMockStripe();
     // X7 (Codex-z9fzv): TierService now takes an explicit dbWs for
     // transactions instead of casting `this.db` at every call site.
@@ -83,13 +88,32 @@ describe('TierService', () => {
         })
       )
       .returning();
-    await db.insert(stripeConnectAccounts).values(
-      createTestConnectAccountInput(org.id, creatorId, {
-        chargesEnabled: true,
-        payoutsEnabled: true,
-        status: 'active',
-      })
-    );
+    // Upsert on userId (uq_stripe_connect_user, Codex-69t7c) so scoping tests
+    // that build two orgs for the same creator reuse the one account.
+    await db
+      .insert(stripeConnectAccounts)
+      .values(
+        createTestConnectAccountInput(org.id, creatorId, {
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          status: 'active',
+        })
+      )
+      .onConflictDoUpdate({
+        target: stripeConnectAccounts.userId,
+        set: {
+          organizationId: org.id,
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          status: 'active',
+        },
+      });
+    // Pin the org's canonical Connect account (Codex-69t7c): org→account now
+    // resolves via primaryConnectAccountUserId, not the account's org column.
+    await db
+      .update(organizations)
+      .set({ primaryConnectAccountUserId: creatorId })
+      .where(eq(organizations.id, org.id));
     return org;
   }
 

--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -25,8 +25,9 @@
 
 import { CacheType, type VersionedCache } from '@codex/cache';
 import { stripeConnectAccounts } from '@codex/database/schema';
+import { resolvePrimaryConnect } from '@codex/purchase';
 import { BaseService, type ServiceConfig } from '@codex/service-errors';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import { ConnectAccountNotFoundError } from '../errors';
 
@@ -220,24 +221,33 @@ export class ConnectAccountService extends BaseService {
   }
 
   /**
-   * Get Connect account for a user within an org.
+   * Get a Connect account.
+   *
+   * With `userId`, returns that user's single account (one account per user,
+   * Codex-69t7c — org-independent). With only `orgId`, resolves the org's
+   * canonical account via `organizations.primaryConnectAccountUserId`. Returns
+   * null when no matching account exists / the org has not onboarded one.
+   *
+   * NOTE: the orgId-first signature is retained for WP1 compile-compat; WP2
+   * replaces callers with explicit userId-centric methods.
    */
   async getAccount(
     orgId: string,
     userId?: string
   ): Promise<StripeConnectAccount | null> {
-    const conditions = [eq(stripeConnectAccounts.organizationId, orgId)];
+    // With userId: that user's single account (org-independent, Codex-69t7c).
     if (userId) {
-      conditions.push(eq(stripeConnectAccounts.userId, userId));
+      const [account] = await this.db
+        .select()
+        .from(stripeConnectAccounts)
+        .where(eq(stripeConnectAccounts.userId, userId))
+        .limit(1);
+      return account ?? null;
     }
 
-    const [account] = await this.db
-      .select()
-      .from(stripeConnectAccounts)
-      .where(and(...conditions))
-      .limit(1);
-
-    return account ?? null;
+    // With only orgId: resolve the org's canonical account via the shared
+    // resolver (org → primaryConnectAccountUserId → that user's account).
+    return (await resolvePrimaryConnect(this.db, orgId)) ?? null;
   }
 
   /**
@@ -372,8 +382,10 @@ export class ConnectAccountService extends BaseService {
     // Stripe's `requirements` payload changed — invalidate the cached
     // `getStatus(orgId)` response so the next read returns fresh data.
     // Idempotent: a duplicate `account.updated` delivery just bumps the
-    // version a second time, which is a no-op for correctness.
-    if (this.cache) {
+    // version a second time, which is a no-op for correctness. Skipped when
+    // organizationId is null (vestigial column, Codex-69t7c) — WP2 reworks
+    // this cache key off the org column entirely.
+    if (this.cache && updated.organizationId) {
       try {
         await this.cache.invalidate(updated.organizationId);
       } catch (error) {
@@ -414,7 +426,7 @@ export class ConnectAccountService extends BaseService {
       organizationId: updated.organizationId,
     });
 
-    if (this.cache) {
+    if (this.cache && updated.organizationId) {
       try {
         await this.cache.invalidate(updated.organizationId);
       } catch (error) {

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -3255,15 +3255,12 @@ export class SubscriptionService extends BaseService {
 
     // Query all unresolved payouts for this org that belong to the user
     // whose Connect account just became active.
+    // stripeAccountId is globally unique, so it alone identifies the account
+    // (one account per user, Codex-69t7c — the org condition is dropped).
     const [connectAccount] = await this.db
       .select({ userId: stripeConnectAccounts.userId })
       .from(stripeConnectAccounts)
-      .where(
-        and(
-          eq(stripeConnectAccounts.stripeAccountId, stripeAccountId),
-          eq(stripeConnectAccounts.organizationId, orgId)
-        )
-      )
+      .where(eq(stripeConnectAccounts.stripeAccountId, stripeAccountId))
       .limit(1);
 
     if (!connectAccount) {
@@ -4378,17 +4375,14 @@ export class SubscriptionService extends BaseService {
       return;
     }
 
-    // Batch-fetch all creator Connect accounts to avoid N+1 queries
+    // Batch-fetch all creator Connect accounts to avoid N+1 queries. Each
+    // creator has one account keyed by userId (Codex-69t7c), independent of
+    // which org this subscription belongs to.
     const creatorIds = creatorAgreements.map((a) => a.creatorId);
     const creatorConnects = await this.db
       .select()
       .from(stripeConnectAccounts)
-      .where(
-        and(
-          inArray(stripeConnectAccounts.userId, creatorIds),
-          eq(stripeConnectAccounts.organizationId, orgId)
-        )
-      );
+      .where(inArray(stripeConnectAccounts.userId, creatorIds));
     const connectByCreator = new Map(creatorConnects.map((c) => [c.userId, c]));
 
     // Codex-ez3tl (C1): per-creator amount uses the POST-PLATFORM pool
@@ -4706,20 +4700,15 @@ export class SubscriptionService extends BaseService {
         continue;
       }
       try {
-        // Find the Connect account row for this (orgId, userId) so we can
-        // look up the stripeAccountId. If the row is missing (rare — a
-        // Connect account was deleted but its payouts survived
-        // because of ON DELETE behaviour) skip this group; it will be
-        // re-attempted on the next sweep window.
+        // Find the user's single Connect account (by userId, Codex-69t7c) so
+        // we can look up the stripeAccountId. If the row is missing (rare — a
+        // Connect account was deleted but its payouts survived because of ON
+        // DELETE behaviour) skip this group; it will be re-attempted on the
+        // next sweep window.
         const [connect] = await this.db
           .select({ stripeAccountId: stripeConnectAccounts.stripeAccountId })
           .from(stripeConnectAccounts)
-          .where(
-            and(
-              eq(stripeConnectAccounts.organizationId, group.organizationId),
-              eq(stripeConnectAccounts.userId, group.userId)
-            )
-          )
+          .where(eq(stripeConnectAccounts.userId, group.userId))
           .limit(1);
 
         if (!connect) {

--- a/packages/subscription/src/services/tier-service.ts
+++ b/packages/subscription/src/services/tier-service.ts
@@ -27,11 +27,10 @@ import { CURRENCY } from '@codex/constants';
 import type { DatabaseWs } from '@codex/database';
 import {
   content,
-  organizations,
-  stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
 } from '@codex/database/schema';
+import { resolvePrimaryConnect } from '@codex/purchase';
 import {
   BaseService,
   InternalServiceError,
@@ -1011,47 +1010,13 @@ export class TierService extends BaseService {
   /**
    * Validate that the org has an active Stripe Connect account.
    *
-   * Resolves through `organizations.primary_connect_account_user_id` so
-   * orgs with multiple Connect accounts (one per user) have a single
-   * canonical source of truth. Falls back to the oldest active account
-   * only when the primary is not yet set — a safety net for orgs that
-   * onboarded before the canonical column was populated.
+   * Resolves the org's canonical account via the shared `resolvePrimaryConnect`
+   * (org → `primaryConnectAccountUserId` → that user's single account; one
+   * account per user, Codex-69t7c). No pinned account, or one missing the
+   * charges/payouts capabilities, means the org is not ready.
    */
   private async requireActiveConnect(orgId: string): Promise<void> {
-    const [org] = await this.db
-      .select({
-        primaryConnectAccountUserId: organizations.primaryConnectAccountUserId,
-      })
-      .from(organizations)
-      .where(eq(organizations.id, orgId))
-      .limit(1);
-
-    const primaryUserId = org?.primaryConnectAccountUserId ?? null;
-
-    const [account] = primaryUserId
-      ? await this.db
-          .select({
-            chargesEnabled: stripeConnectAccounts.chargesEnabled,
-            payoutsEnabled: stripeConnectAccounts.payoutsEnabled,
-          })
-          .from(stripeConnectAccounts)
-          .where(
-            and(
-              eq(stripeConnectAccounts.organizationId, orgId),
-              eq(stripeConnectAccounts.userId, primaryUserId)
-            )
-          )
-          .limit(1)
-      : await this.db
-          .select({
-            chargesEnabled: stripeConnectAccounts.chargesEnabled,
-            payoutsEnabled: stripeConnectAccounts.payoutsEnabled,
-          })
-          .from(stripeConnectAccounts)
-          .where(eq(stripeConnectAccounts.organizationId, orgId))
-          .orderBy(stripeConnectAccounts.createdAt)
-          .limit(1);
-
+    const account = await resolvePrimaryConnect(this.db, orgId);
     if (!account || !account.chargesEnabled || !account.payoutsEnabled) {
       throw new ConnectAccountNotReadyError(orgId);
     }

--- a/packages/test-utils/src/database.ts
+++ b/packages/test-utils/src/database.ts
@@ -220,6 +220,12 @@ export async function cleanupDatabase(db: Database): Promise<void> {
   await db.delete(schema.organizationPlatformAgreements);
   await db.delete(schema.content);
   await db.delete(schema.mediaItems);
+  // stripe_connect_accounts FK organizations (set null) + users (cascade);
+  // nothing references it. A user has ONE account (uq_stripe_connect_user,
+  // Codex-69t7c) and users persist across tests, so it MUST be cleared here or
+  // re-seeding the same user collides on the unique constraint
+  // (test-cleanup-fk-ordering memory). Delete before organizations.
+  await db.delete(schema.stripeConnectAccounts);
   await db.delete(schema.organizations);
   // NOTE: Users are NOT deleted - preserve them across tests
 }
@@ -250,6 +256,9 @@ export async function cleanupDatabaseComplete(db: Database): Promise<void> {
   await db.delete(schema.organizationPlatformAgreements);
   await db.delete(schema.content);
   await db.delete(schema.mediaItems);
+  // One Connect account per user (uq_stripe_connect_user, Codex-69t7c); clear
+  // before organizations/users to keep FK ordering explicit.
+  await db.delete(schema.stripeConnectAccounts);
   await db.delete(schema.organizations);
   await db.delete(schema.users);
 }

--- a/workers/ecom-api/src/handlers/payment-webhook.ts
+++ b/workers/ecom-api/src/handlers/payment-webhook.ts
@@ -217,11 +217,12 @@ async function handleChargeDisputeCreated(
     amount: dispute.amount,
   });
 
-  // Unlike one-time-purchase refunds, purchases are ALWAYS org-scoped
-  // (`purchases.organizationId` is NOT NULL), so `processDispute` always
-  // returns `orgId` when a matching purchase exists. Revocation reason
-  // reuses 'refund' because the AccessRevocation reason enum is
-  // observability-only and disputes are the same access-reducing class.
+  // Org-scoped purchases revoke access within their org; orgless
+  // creator-direct purchases (`purchases.organizationId` nullable, Codex-69t7c)
+  // have no org, so `orgId` may be null — the guard below skips org-scoped
+  // revocation in that case. Revocation reason reuses 'refund' because the
+  // AccessRevocation reason enum is observability-only and disputes are the
+  // same access-reducing class.
   invalidateLibrary(c, disputeResult?.userId);
   if (disputeResult?.userId && disputeResult.orgId) {
     revokeAccess(c, disputeResult.userId, disputeResult.orgId);


### PR DESCRIPTION
## Summary
WP1 of epic **Codex-69t7c** (Creator Studio Monetisation): redesign `stripe_connect_accounts` to **one Connect account per user**.

- **Schema (migration 0074, `db:generate`):** `unique(userId)` replaces the `(userId, organizationId)` composite; `organizationId` → nullable + `onDelete set null` (vestigial onboarding-origin, dropped in WP2); `purchases.organizationId` → nullable (orgless creator-direct purchases); dropped the redundant `idx_stripe_connect_user_id`.
- **Resolution (read-path centralised):** `resolvePrimaryConnect` resolves org → `organizations.primaryConnectAccountUserId`, else the **org owner** (`organization_memberships` role=owner — deterministic, not the arbitrary `.limit(1)` Codex-sec7i removed) → that user's single account. `connect-account-service.getAccount` + `tier-service.requireActiveConnect` delegate to it. Creator/org Connect lookups re-keyed to `userId` across purchase + subscription transfer/resolve/sweep paths. `processDispute` `orgId` → `string | null`.
- **Why the owner fallback:** codex-review found `primaryConnectAccountUserId` is **not yet written in production**, so dropping the fallback would strand org-fee payouts (CHECK `check_payouts_user_required`, 23514) and break `requireActiveConnect` org-wide. The deterministic owner fallback restores resolution until WP2 writes the pin at onboarding.

## Test Plan
- `pnpm typecheck` ✓ (57 tasks) · `pnpm check:ci` (biome) ✓ **0 errors** · `pnpm build` ✓ (32 tasks)
- Affected suites green (`--concurrency=1`): **@codex/database** 60 · **@codex/purchase** 222 (owner-fallback + tri-party/refund) · **@codex/subscription** 381 (schema-invariant `unique(userId)` + null-org) · **@codex/agreements** 104 (cleanupDatabase consumer) · **ecom-api** 370
- Migration 0074 applied to local test DB; reviewer-verified `db:generate`-clean (snapshot/journal in sync)
- codex-review (5-reviewer swarm): 1 CRITICAL fixed (org-fee strand); scoping-security + backend-conformance clean

## Follow-ups
- **Codex-ed446** — purchase org-fee pending row gets null `userId` when the org owner has no Connect account (pre-existing; purchase should mirror subscription's `resolveOrgOwnerId`).
- **WP2 (Codex-69t7c.2):** write `primaryConnectAccountUserId` at onboarding; drop the vestigial `organizationId` column; rework the connect-status cache key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
