### PR TITLE
feat(connect): userId-centric Connect service + pin-write (WP2)

### DIFF
--- a/packages/subscription/src/services/__tests__/connect-account-service.test.ts
+++ b/packages/subscription/src/services/__tests__/connect-account-service.test.ts
@@ -16,6 +16,7 @@
 
 import type { KVNamespace } from '@cloudflare/workers-types';
 import {
+  organizationMemberships,
   organizations,
   stripeConnectAccounts,
   subscriptions,
@@ -134,8 +135,9 @@ describe('ConnectAccountService', () => {
             card_payments: { requested: true },
             transfers: { requested: true },
           },
+          // Onboarding is userId-centric (Codex-69t7c.2) — no org metadata;
+          // the org→account link is materialised at activation via the pin.
           metadata: {
-            codex_organization_id: freshOrg.id,
             codex_user_id: creatorId,
           },
         })
@@ -237,8 +239,9 @@ describe('ConnectAccountService', () => {
 
       expect(stripe.accounts.create).toHaveBeenCalledWith(
         expect.objectContaining({
+          // userId-centric onboarding (Codex-69t7c.2): metadata carries only
+          // the user; there is no single owning org for a user account.
           metadata: {
-            codex_organization_id: metaOrg.id,
             codex_user_id: creatorId,
           },
         })
@@ -1182,7 +1185,9 @@ describe('ConnectAccountService', () => {
         requirements: { currently_due: [], disabled_reason: null },
       } as unknown as Stripe.Account);
 
-      expect(invalidateSpy).toHaveBeenCalledWith(invOrg.id);
+      // Keyed on the account's userId now, not the vestigial organizationId
+      // (Codex-69t7c.2). creatorId is the account's user.
+      expect(invalidateSpy).toHaveBeenCalledWith(creatorId);
       expect(invalidateSpy).toHaveBeenCalledTimes(1);
 
       // Duplicate Stripe webhook delivery — second invalidation must be a
@@ -1245,6 +1250,55 @@ describe('ConnectAccountService', () => {
         } as unknown as Stripe.Account)
       ).resolves.toBeUndefined();
     });
+
+    it('invalidates by userId even when organizationId is NULL (Codex-69t7c.2 regression)', async () => {
+      // The WP1 cache key was gated on the vestigial `organizationId`, so an
+      // orgless account (organizationId IS NULL) silently SKIPPED invalidation
+      // and served stale status until the 10-min TTL. Keying on userId fixes it.
+      const { VersionedCache } = await import('@codex/cache');
+      const { createMockKVNamespace, createMockObservability } = await import(
+        '@codex/test-utils'
+      );
+
+      const kv = createMockKVNamespace();
+      const { obs } = createMockObservability();
+      const cache = new VersionedCache({
+        kv: kv as unknown as KVNamespace,
+        prefix: 'cache',
+        obs,
+      });
+
+      const cachedService = new ConnectAccountService(
+        { db, environment: 'test', cache },
+        stripe
+      );
+
+      // Orgless account — organizationId deliberately NULL.
+      const [inserted] = await db
+        .insert(stripeConnectAccounts)
+        .values({
+          userId: creatorId,
+          organizationId: null,
+          stripeAccountId: `acct_orgless_inv_${createUniqueSlug('a')}`,
+          status: 'onboarding',
+          chargesEnabled: false,
+          payoutsEnabled: false,
+        })
+        .returning();
+
+      const invalidateSpy = vi.spyOn(cache, 'invalidate');
+
+      await cachedService.handleAccountUpdated({
+        id: inserted.stripeAccountId,
+        charges_enabled: true,
+        payouts_enabled: true,
+        requirements: { currently_due: [], disabled_reason: null },
+      } as unknown as Stripe.Account);
+
+      // Pre-WP2 this was NOT called (organizationId null → invalidation skipped).
+      expect(invalidateSpy).toHaveBeenCalledWith(creatorId);
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ─── Schema invariants (Codex-69t7c WP1) ─────────────────────────────
@@ -1296,6 +1350,358 @@ describe('ConnectAccountService', () => {
         .returning();
       expect(row.organizationId).toBeNull();
       expect(row.userId).toBe(creatorId);
+    });
+  });
+
+  // ─── getAccountForUser (Codex-69t7c.2) ───────────────────────────────
+
+  describe('getAccountForUser', () => {
+    it('resolves the account for a userId (self-account resolution)', async () => {
+      const [selfOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('self-acct'),
+            creatorId,
+          })
+        )
+        .returning();
+      const [inserted] = await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(selfOrg.id, creatorId))
+        .returning();
+
+      const account = await service.getAccountForUser(creatorId);
+      expect(account).not.toBeNull();
+      expect(account?.userId).toBe(creatorId);
+      expect(account?.stripeAccountId).toBe(inserted.stripeAccountId);
+    });
+
+    it('returns null when the user has no account', async () => {
+      const account = await service.getAccountForUser(otherCreatorId);
+      expect(account).toBeNull();
+    });
+  });
+
+  // ─── getAccount org → primary-user resolution (Codex-69t7c.2) ─────────
+
+  describe('getAccount org resolution', () => {
+    it('resolves org → owner account via fallback when the pin is unset', async () => {
+      const [fbOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('owner-fallback'),
+            creatorId,
+          })
+        )
+        .returning();
+      // Owner membership but NO pin — resolvePrimaryConnect falls back to owner.
+      await db.insert(organizationMemberships).values({
+        organizationId: fbOrg.id,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(fbOrg.id, creatorId));
+
+      const account = await service.getAccount(fbOrg.id);
+      expect(account).not.toBeNull();
+      expect(account?.userId).toBe(creatorId);
+    });
+
+    it('returns null when the org has neither a pin nor an owner account', async () => {
+      const [noneOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('no-resolution'),
+            creatorId,
+          })
+        )
+        .returning();
+      const account = await service.getAccount(noneOrg.id);
+      expect(account).toBeNull();
+    });
+  });
+
+  // ─── getStatusForUser (Codex-69t7c.2) ────────────────────────────────
+
+  describe('getStatusForUser', () => {
+    it('returns the disconnected sentinel when the user has no account', async () => {
+      const result = await service.getStatusForUser(otherCreatorId);
+      expect(result).toEqual({
+        isConnected: false,
+        accountId: null,
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        status: null,
+        requirements: null,
+      });
+      expect(stripe.accounts.retrieve).not.toHaveBeenCalled();
+    });
+
+    it('returns the status payload for a connected user', async () => {
+      const [inserted] = await db
+        .insert(stripeConnectAccounts)
+        .values(
+          createTestConnectAccountInput(orgId, creatorId, {
+            status: 'active',
+            chargesEnabled: true,
+            payoutsEnabled: true,
+          })
+        )
+        .returning();
+      (stripe.accounts.retrieve as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: inserted.stripeAccountId,
+        charges_enabled: true,
+        payouts_enabled: true,
+        requirements: {
+          currently_due: [],
+          eventually_due: [],
+          past_due: [],
+          pending_verification: [],
+          current_deadline: null,
+          disabled_reason: null,
+          errors: [],
+        },
+      } as unknown as Stripe.Account);
+
+      const result = await service.getStatusForUser(creatorId);
+      expect(result.isConnected).toBe(true);
+      expect(result.accountId).toBe(inserted.stripeAccountId);
+      expect(result.status).toBe('active');
+    });
+  });
+
+  // ─── pin-write: organizations.primaryConnectAccountUserId (Codex-69t7c.2) ─
+  //
+  // The load-bearing WP1 finding: the pin is NEVER written in production, so
+  // resolvePrimaryConnect relies entirely on the owner fallback. WP2 materialises
+  // it at account activation — scoped to orgs the user OWNS, only when unset.
+  // These guard that materialisation (the SOLE production write of the pin).
+
+  describe('pin-write on account activation', () => {
+    const readPin = async (id: string) => {
+      const [row] = await db
+        .select({ pin: organizations.primaryConnectAccountUserId })
+        .from(organizations)
+        .where(eq(organizations.id, id));
+      return row?.pin ?? null;
+    };
+
+    const activate = (stripeAccountId: string) =>
+      service.handleAccountUpdated({
+        id: stripeAccountId,
+        charges_enabled: true,
+        payouts_enabled: true,
+        requirements: { currently_due: [], disabled_reason: null },
+      } as unknown as Stripe.Account);
+
+    it('pins owned orgs whose pin is unset to the activating user', async () => {
+      const [ownedOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('pin-owned'),
+            creatorId,
+          })
+        )
+        .returning();
+      await db.insert(organizationMemberships).values({
+        organizationId: ownedOrg.id,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      const [acct] = await db
+        .insert(stripeConnectAccounts)
+        .values(
+          createTestConnectAccountInput(ownedOrg.id, creatorId, {
+            status: 'onboarding',
+            chargesEnabled: false,
+            payoutsEnabled: false,
+          })
+        )
+        .returning();
+
+      expect(await readPin(ownedOrg.id)).toBeNull();
+      await activate(acct.stripeAccountId);
+      expect(await readPin(ownedOrg.id)).toBe(creatorId);
+    });
+
+    it('does NOT overwrite an existing (non-null) pin', async () => {
+      const [pinnedOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('pin-existing'),
+            creatorId,
+          })
+        )
+        .returning();
+      // creatorId is the owner, but the org is already pinned to a DIFFERENT
+      // user (e.g. a future "designate payout account" feature).
+      await db.insert(organizationMemberships).values({
+        organizationId: pinnedOrg.id,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: otherCreatorId })
+        .where(eq(organizations.id, pinnedOrg.id));
+      const [acct] = await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(pinnedOrg.id, creatorId))
+        .returning();
+
+      await activate(acct.stripeAccountId);
+
+      // Pin untouched — an explicit assignment is never stolen.
+      expect(await readPin(pinnedOrg.id)).toBe(otherCreatorId);
+    });
+
+    it('pins nothing when the activating user owns no orgs', async () => {
+      // Org owned by otherCreatorId; the account belongs to creatorId, who is
+      // NOT an owner — a creator-slice account, not the org's payout owner.
+      const [foreignOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('pin-nonowner'),
+            creatorId: otherCreatorId,
+          })
+        )
+        .returning();
+      await db.insert(organizationMemberships).values({
+        organizationId: foreignOrg.id,
+        userId: otherCreatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      const [acct] = await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(foreignOrg.id, creatorId))
+        .returning();
+
+      await activate(acct.stripeAccountId);
+
+      expect(await readPin(foreignOrg.id)).toBeNull();
+    });
+
+    it('is idempotent across duplicate webhook deliveries', async () => {
+      const [idemOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('pin-idem'),
+            creatorId,
+          })
+        )
+        .returning();
+      await db.insert(organizationMemberships).values({
+        organizationId: idemOrg.id,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      const [acct] = await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(idemOrg.id, creatorId))
+        .returning();
+
+      await activate(acct.stripeAccountId);
+      await activate(acct.stripeAccountId);
+
+      expect(await readPin(idemOrg.id)).toBe(creatorId);
+    });
+
+    it('pins the org even on a non-active (onboarding) account.updated', async () => {
+      // The pin records the owner regardless of payability — payability is
+      // gated at transfer time, not by pin existence (Codex-69t7c.2).
+      const [obPinOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('pin-onboarding'),
+            creatorId,
+          })
+        )
+        .returning();
+      await db.insert(organizationMemberships).values({
+        organizationId: obPinOrg.id,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      const [acct] = await db
+        .insert(stripeConnectAccounts)
+        .values(
+          createTestConnectAccountInput(obPinOrg.id, creatorId, {
+            status: 'onboarding',
+            chargesEnabled: false,
+            payoutsEnabled: false,
+          })
+        )
+        .returning();
+
+      // account.updated arrives still in onboarding (NOT active).
+      await service.handleAccountUpdated({
+        id: acct.stripeAccountId,
+        charges_enabled: false,
+        payouts_enabled: false,
+        requirements: {
+          currently_due: ['external_account'],
+          disabled_reason: null,
+        },
+      } as unknown as Stripe.Account);
+
+      expect(await readPin(obPinOrg.id)).toBe(creatorId);
+    });
+
+    it('retains the pin on deauthorization (account surfaces as disabled)', async () => {
+      // Deliberate: the pin stays so resolvePrimaryConnect surfaces the
+      // now-disabled account, which transfer-time active-checks block — rather
+      // than silently rerouting the org slice to a different owner.
+      const [deauthOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('pin-deauth'),
+            creatorId,
+          })
+        )
+        .returning();
+      await db.insert(organizationMemberships).values({
+        organizationId: deauthOrg.id,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      });
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, deauthOrg.id));
+      const [acct] = await db
+        .insert(stripeConnectAccounts)
+        .values(
+          createTestConnectAccountInput(deauthOrg.id, creatorId, {
+            status: 'active',
+            chargesEnabled: true,
+            payoutsEnabled: true,
+          })
+        )
+        .returning();
+
+      await service.handleAccountDeauthorized(acct.stripeAccountId);
+
+      expect(await readPin(deauthOrg.id)).toBe(creatorId);
+      const after = await service.getAccountForUser(creatorId);
+      expect(after?.status).toBe('disabled');
     });
   });
 });

--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -14,7 +14,8 @@
  * - Express-equivalent via controller properties (new Stripe API)
  * - Platform controls fees (controller.fees.payer = 'application')
  * - Stripe handles identity verification and compliance
- * - One account per user per org (unique constraint)
+ * - One account per user (unique constraint, Codex-69t7c) — org-independent;
+ *   the org→account link lives on `organizations.primaryConnectAccountUserId`
  *
  * Onboarding Flow:
  * 1. createAccount() → Stripe account + Account Link
@@ -24,10 +25,14 @@
  */
 
 import { CacheType, type VersionedCache } from '@codex/cache';
-import { stripeConnectAccounts } from '@codex/database/schema';
+import {
+  organizationMemberships,
+  organizations,
+  stripeConnectAccounts,
+} from '@codex/database/schema';
 import { resolvePrimaryConnect } from '@codex/purchase';
 import { BaseService, type ServiceConfig } from '@codex/service-errors';
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import { ConnectAccountNotFoundError } from '../errors';
 
@@ -79,6 +84,21 @@ export interface ConnectStatusPayload {
  * is the safety net for when the webhook silently misses a delivery.
  */
 const CONNECT_STATUS_TTL_SECONDS = 600;
+
+/**
+ * Status payload for a user/org that has never onboarded a Connect account.
+ *
+ * Shared by the user- and org-keyed status paths so the "no account" branch is
+ * identical regardless of how the lookup was keyed.
+ */
+const DISCONNECTED_STATUS: ConnectStatusPayload = {
+  isConnected: false,
+  accountId: null,
+  chargesEnabled: false,
+  payoutsEnabled: false,
+  status: null,
+  requirements: null,
+};
 
 /**
  * Normalise Stripe's `Account.Requirements` payload for the UI.
@@ -144,18 +164,22 @@ export class ConnectAccountService extends BaseService {
   }
 
   /**
-   * Create a Stripe Express Connect account and return the onboarding URL.
-   * Stores the account record in our database.
+   * Create a Stripe Express Connect account for a user and return the
+   * onboarding URL. One account per user (Codex-69t7c) — org-independent.
+   *
+   * The org→account link is materialised separately by `handleAccountUpdated`
+   * (on the user's `account.updated` events), which pins
+   * `primaryConnectAccountUserId` for the orgs this user owns. Onboarding
+   * therefore carries NO org context.
    */
-  async createAccount(
-    orgId: string,
+  async createAccountForUser(
     userId: string,
     returnUrl: string,
     refreshUrl: string
   ): Promise<{ accountId: string; onboardingUrl: string }> {
     try {
-      // Check if account already exists for this user + org
-      const existing = await this.getAccount(orgId, userId);
+      // One account per user — resume any existing one rather than duplicating.
+      const existing = await this.getAccountForUser(userId);
       if (existing) {
         // Resume onboarding if not complete
         if (!existing.chargesEnabled || !existing.payoutsEnabled) {
@@ -187,7 +211,6 @@ export class ConnectAccountService extends BaseService {
         },
         country: 'GB',
         metadata: {
-          codex_organization_id: orgId,
           codex_user_id: userId,
         },
       });
@@ -199,9 +222,10 @@ export class ConnectAccountService extends BaseService {
         refreshUrl
       );
 
-      // Store in database
+      // Store in database. `organizationId` is the vestigial WP1 column — the
+      // org→account link now lives on `organizations.primaryConnectAccountUserId`
+      // — so we leave it null; a user account has no single owning org.
       await this.db.insert(stripeConnectAccounts).values({
-        organizationId: orgId,
         userId,
         stripeAccountId: account.id,
         status: 'onboarding',
@@ -210,43 +234,62 @@ export class ConnectAccountService extends BaseService {
       });
 
       this.obs.info('Connect account created', {
-        organizationId: orgId,
+        userId,
         stripeAccountId: account.id,
       });
 
       return { accountId: account.id, onboardingUrl };
     } catch (error) {
-      this.handleError(error, 'createAccount');
+      this.handleError(error, 'createAccountForUser');
     }
+  }
+
+  /**
+   * @deprecated Org-context shim retained for the current studio onboarding
+   * route until WP3 migrates it to the creator-scoped `/connect/me` flow. The
+   * account is keyed on the user (org-independent); `orgId` is ignored.
+   */
+  async createAccount(
+    _orgId: string,
+    userId: string,
+    returnUrl: string,
+    refreshUrl: string
+  ): Promise<{ accountId: string; onboardingUrl: string }> {
+    return this.createAccountForUser(userId, returnUrl, refreshUrl);
+  }
+
+  /**
+   * Get a user's single Connect account (one account per user, Codex-69t7c —
+   * org-independent). Returns null when the user has not onboarded.
+   */
+  async getAccountForUser(
+    userId: string
+  ): Promise<StripeConnectAccount | null> {
+    const [account] = await this.db
+      .select()
+      .from(stripeConnectAccounts)
+      .where(eq(stripeConnectAccounts.userId, userId))
+      .limit(1);
+    return account ?? null;
   }
 
   /**
    * Get a Connect account.
    *
-   * With `userId`, returns that user's single account (one account per user,
-   * Codex-69t7c — org-independent). With only `orgId`, resolves the org's
-   * canonical account via `organizations.primaryConnectAccountUserId`. Returns
-   * null when no matching account exists / the org has not onboarded one.
+   * With `userId`, delegates to `getAccountForUser`. With only `orgId`, resolves
+   * the org's canonical account via `organizations.primaryConnectAccountUserId`
+   * (with owner fallback). Returns null when no matching account exists.
    *
-   * NOTE: the orgId-first signature is retained for WP1 compile-compat; WP2
-   * replaces callers with explicit userId-centric methods.
+   * @deprecated orgId-first shim retained for compile-compat; prefer
+   * `getAccountForUser(userId)` or `resolvePrimaryConnect(db, orgId)`.
    */
   async getAccount(
     orgId: string,
     userId?: string
   ): Promise<StripeConnectAccount | null> {
-    // With userId: that user's single account (org-independent, Codex-69t7c).
     if (userId) {
-      const [account] = await this.db
-        .select()
-        .from(stripeConnectAccounts)
-        .where(eq(stripeConnectAccounts.userId, userId))
-        .limit(1);
-      return account ?? null;
+      return this.getAccountForUser(userId);
     }
-
-    // With only orgId: resolve the org's canonical account via the shared
-    // resolver (org → primaryConnectAccountUserId → that user's account).
     return (await resolvePrimaryConnect(this.db, orgId)) ?? null;
   }
 
@@ -287,34 +330,53 @@ export class ConnectAccountService extends BaseService {
    * @param orgId - Organization ID (cache key namespace)
    * @returns Connect status payload with requirements
    */
-  async getStatus(orgId: string): Promise<ConnectStatusPayload> {
+  /**
+   * Get the full Connect status for a user — cache-aside, keyed by `userId`.
+   *
+   * Keying on the user (not the org) means `account.updated` can invalidate the
+   * cache reliably: the webhook always has the account's `userId`, whereas the
+   * vestigial `organizationId` is frequently null (Codex-69t7c.2 — closes the
+   * WP1 TTL-stale-skip review finding).
+   */
+  async getStatusForUser(userId: string): Promise<ConnectStatusPayload> {
     if (this.cache) {
       const result = await this.cache.getWithResult(
-        orgId,
+        userId,
         CacheType.CONNECT_STATUS,
-        () => this.fetchStatusFromStripe(orgId),
+        () => this.fetchStatusFromStripeForUser(userId),
         { ttl: CONNECT_STATUS_TTL_SECONDS }
       );
-      this.obs.debug('getStatus', { orgId, cacheHit: result.hit });
+      this.obs.debug('getStatusForUser', { userId, cacheHit: result.hit });
       return result.data;
     }
 
-    return this.fetchStatusFromStripe(orgId);
+    return this.fetchStatusFromStripeForUser(userId);
   }
 
   /**
-   * Generate a new onboarding link for an existing account.
+   * Get the full Connect status for an org.
+   *
+   * @deprecated orgId-first shim — resolves org → primary user, then delegates
+   * to `getStatusForUser`. Prefer `getStatusForUser(userId)`.
+   */
+  async getStatus(orgId: string): Promise<ConnectStatusPayload> {
+    const userId = await this.resolveUserIdForOrg(orgId);
+    if (!userId) return DISCONNECTED_STATUS;
+    return this.getStatusForUser(userId);
+  }
+
+  /**
+   * Generate a new onboarding link for a user's existing account.
    * Used to resume abandoned onboarding — Stripe remembers prior progress.
    */
-  async refreshOnboardingLink(
-    orgId: string,
+  async refreshOnboardingLinkForUser(
     userId: string,
     returnUrl: string,
     refreshUrl: string
   ): Promise<{ onboardingUrl: string }> {
-    const account = await this.getAccount(orgId, userId);
+    const account = await this.getAccountForUser(userId);
     if (!account) {
-      throw new ConnectAccountNotFoundError(orgId);
+      throw new ConnectAccountNotFoundError(userId);
     }
 
     const onboardingUrl = await this.createOnboardingLink(
@@ -324,6 +386,18 @@ export class ConnectAccountService extends BaseService {
     );
 
     return { onboardingUrl };
+  }
+
+  /**
+   * @deprecated orgId-first shim — delegates to `refreshOnboardingLinkForUser`.
+   */
+  async refreshOnboardingLink(
+    _orgId: string,
+    userId: string,
+    returnUrl: string,
+    refreshUrl: string
+  ): Promise<{ onboardingUrl: string }> {
+    return this.refreshOnboardingLinkForUser(userId, returnUrl, refreshUrl);
   }
 
   /**
@@ -373,28 +447,24 @@ export class ConnectAccountService extends BaseService {
 
     this.obs.info('Connect account updated', {
       stripeAccountId,
-      organizationId: updated.organizationId,
+      userId: updated.userId,
       status,
       chargesEnabled,
       payoutsEnabled,
     });
 
-    // Stripe's `requirements` payload changed — invalidate the cached
-    // `getStatus(orgId)` response so the next read returns fresh data.
-    // Idempotent: a duplicate `account.updated` delivery just bumps the
-    // version a second time, which is a no-op for correctness. Skipped when
-    // organizationId is null (vestigial column, Codex-69t7c) — WP2 reworks
-    // this cache key off the org column entirely.
-    if (this.cache && updated.organizationId) {
-      try {
-        await this.cache.invalidate(updated.organizationId);
-      } catch (error) {
-        this.obs.warn('Connect status cache invalidation failed', {
-          organizationId: updated.organizationId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
+    // Materialise the org→account pin for every org this user OWNS that has no
+    // pin yet (Codex-69t7c.2). This is the SOLE production write of
+    // `organizations.primaryConnectAccountUserId`; until it fires,
+    // `resolvePrimaryConnect` falls back to the org owner — so a failure here
+    // degrades to that fallback, never a broken payout (see pinOwnedOrgsToUser).
+    await this.pinOwnedOrgsToUser(updated.userId);
+
+    // Connect status changed — invalidate the cached `getStatusForUser`
+    // response so the next read is fresh. Keyed on `userId` (always present on
+    // the row), NOT the vestigial `organizationId` which was frequently null and
+    // silently skipped invalidation pre-WP2 (Codex-69t7c.2).
+    await this.invalidateStatusCache(updated.userId);
   }
 
   /**
@@ -423,28 +493,22 @@ export class ConnectAccountService extends BaseService {
 
     this.obs.info('Connect account deauthorized', {
       stripeAccountId,
-      organizationId: updated.organizationId,
+      userId: updated.userId,
     });
 
-    if (this.cache && updated.organizationId) {
-      try {
-        await this.cache.invalidate(updated.organizationId);
-      } catch (error) {
-        this.obs.warn('Connect status cache invalidation failed', {
-          organizationId: updated.organizationId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
+    // The pin is intentionally left in place — resolvePrimaryConnect surfaces
+    // the now-`disabled` account, which correctly blocks payouts until the user
+    // reconnects (Codex-69t7c.2).
+    await this.invalidateStatusCache(updated.userId);
   }
 
   /**
-   * Generate an Express Dashboard login link for the org owner.
+   * Generate an Express Dashboard login link for a user's account.
    */
-  async createDashboardLink(orgId: string): Promise<{ url: string }> {
-    const account = await this.getAccount(orgId);
+  async createDashboardLinkForUser(userId: string): Promise<{ url: string }> {
+    const account = await this.getAccountForUser(userId);
     if (!account) {
-      throw new ConnectAccountNotFoundError(orgId);
+      throw new ConnectAccountNotFoundError(userId);
     }
 
     const loginLink = await this.stripe.accounts.createLoginLink(
@@ -455,26 +519,47 @@ export class ConnectAccountService extends BaseService {
   }
 
   /**
-   * Check if the org's Connect account is fully ready for transactions.
+   * @deprecated orgId-first shim — resolves org → primary user, then delegates
+   * to `createDashboardLinkForUser`.
    */
-  async isReady(orgId: string): Promise<boolean> {
-    const account = await this.getAccount(orgId);
+  async createDashboardLink(orgId: string): Promise<{ url: string }> {
+    const userId = await this.resolveUserIdForOrg(orgId);
+    if (!userId) {
+      throw new ConnectAccountNotFoundError(orgId);
+    }
+    return this.createDashboardLinkForUser(userId);
+  }
+
+  /**
+   * Check if a user's Connect account is fully ready for transactions.
+   */
+  async isReadyForUser(userId: string): Promise<boolean> {
+    const account = await this.getAccountForUser(userId);
     if (!account) return false;
     return account.chargesEnabled && account.payoutsEnabled;
   }
 
   /**
-   * Sync local account status with Stripe's current state.
-   * Calls stripe.accounts.retrieve() and updates the local record.
-   * Useful as a fallback when webhooks can't reach the server (local dev, missed events).
+   * @deprecated orgId-first shim — resolves org → primary user, then delegates
+   * to `isReadyForUser`.
    */
-  async syncAccountStatus(
-    orgId: string,
-    userId?: string
+  async isReady(orgId: string): Promise<boolean> {
+    const userId = await this.resolveUserIdForOrg(orgId);
+    if (!userId) return false;
+    return this.isReadyForUser(userId);
+  }
+
+  /**
+   * Sync a user's local account status with Stripe's current state.
+   * Calls stripe.accounts.retrieve() and updates the local record. Useful as a
+   * fallback when webhooks can't reach the server (local dev, missed events).
+   */
+  async syncAccountStatusForUser(
+    userId: string
   ): Promise<StripeConnectAccount | null> {
-    const account = await this.getAccount(orgId, userId);
+    const account = await this.getAccountForUser(userId);
     if (!account) {
-      throw new ConnectAccountNotFoundError(orgId);
+      throw new ConnectAccountNotFoundError(userId);
     }
 
     const stripeAccount = await this.stripe.accounts.retrieve(
@@ -485,13 +570,128 @@ export class ConnectAccountService extends BaseService {
     await this.handleAccountUpdated(stripeAccount);
 
     // Return the updated record
-    return this.getAccount(orgId, userId);
+    return this.getAccountForUser(userId);
+  }
+
+  /**
+   * @deprecated orgId-first shim. With `userId`, delegates directly; with only
+   * `orgId`, resolves org → primary user then delegates to
+   * `syncAccountStatusForUser`.
+   */
+  async syncAccountStatus(
+    orgId: string,
+    userId?: string
+  ): Promise<StripeConnectAccount | null> {
+    if (userId) {
+      return this.syncAccountStatusForUser(userId);
+    }
+    const resolvedUserId = await this.resolveUserIdForOrg(orgId);
+    if (!resolvedUserId) {
+      throw new ConnectAccountNotFoundError(orgId);
+    }
+    return this.syncAccountStatusForUser(resolvedUserId);
   }
 
   // ─── Private Helpers ─────────────────────────────────────────────────────
 
   /**
-   * Fetch live Connect status from DB + Stripe (cache miss path).
+   * Resolve an org to its primary Connect user id (pin → owner fallback).
+   *
+   * Shared by the `@deprecated` orgId-first shims so they all funnel through
+   * the same `resolvePrimaryConnect` semantics. Returns null when neither an
+   * explicit pin nor an owner account exists.
+   */
+  private async resolveUserIdForOrg(orgId: string): Promise<string | null> {
+    return (await resolvePrimaryConnect(this.db, orgId))?.userId ?? null;
+  }
+
+  /**
+   * Invalidate the cached Connect status for a user (best-effort).
+   *
+   * Keyed on `userId` so invalidation fires regardless of the vestigial
+   * `organizationId` (Codex-69t7c.2). Idempotent — a duplicate webhook delivery
+   * just bumps the cache version again, a no-op for correctness. Failures are
+   * logged at WARN and swallowed: a stale-cache risk must never fail a webhook
+   * whose DB write already committed.
+   */
+  private async invalidateStatusCache(userId: string): Promise<void> {
+    if (!this.cache) return;
+    try {
+      await this.cache.invalidate(userId);
+    } catch (error) {
+      this.obs.warn('Connect status cache invalidation failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Materialise `organizations.primaryConnectAccountUserId` for every org this
+   * user OWNS that has no pin yet, settling the org's revenue slice on the
+   * user's single Connect account (Codex-69t7c.2).
+   *
+   * Runs on EVERY `account.updated` (not only activation): pinning early is
+   * harmless because payability is gated separately at transfer time
+   * (`chargesEnabled`/`payoutsEnabled`), never by the pin's existence.
+   *
+   * Idempotent + safe:
+   * - `role = 'owner'` only, and `WHERE primaryConnectAccountUserId IS NULL` →
+   *   the FIRST owner to onboard wins the pin; it is never overwritten, never
+   *   stolen, and a re-delivered event is a no-op.
+   * - Until the pin is set, `resolvePrimaryConnect` falls back to an org owner;
+   *   the pin (first owner to onboard) then makes the settlement target explicit
+   *   and stable. NB the unpinned fallback's owner selection across multi-owner
+   *   orgs is not yet deterministic — tracked in Codex-rjwdm.
+   *
+   * Best-effort: a failure is logged at WARN and swallowed — resolution still
+   * works via the deterministic owner fallback until a later event sets the
+   * pin, so we never fail the webhook over this materialisation.
+   */
+  private async pinOwnedOrgsToUser(userId: string): Promise<void> {
+    try {
+      const ownedOrgs = await this.db
+        .select({ organizationId: organizationMemberships.organizationId })
+        .from(organizationMemberships)
+        .where(
+          and(
+            eq(organizationMemberships.userId, userId),
+            eq(organizationMemberships.role, 'owner')
+          )
+        );
+
+      if (ownedOrgs.length === 0) return;
+
+      const orgIds = ownedOrgs.map((o) => o.organizationId);
+      // Bare `.returning()` (no projection) — the `Database | DatabaseWs` union
+      // collapses the projected overload; we only need the affected-row count.
+      const pinned = await this.db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: userId })
+        .where(
+          and(
+            inArray(organizations.id, orgIds),
+            isNull(organizations.primaryConnectAccountUserId)
+          )
+        )
+        .returning();
+
+      if (pinned.length > 0) {
+        this.obs.info('Connect primary pin materialised', {
+          userId,
+          pinnedOrgCount: pinned.length,
+        });
+      }
+    } catch (error) {
+      this.obs.warn('Connect primary pin materialisation failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Fetch live Connect status for a user from DB + Stripe (cache-miss path).
    *
    * Combines the local DB row (source of truth for charges/payouts toggles
    * and derived status) with Stripe's live `requirements` payload so the UI
@@ -499,22 +699,15 @@ export class ConnectAccountService extends BaseService {
    *
    * Returns the disconnected sentinel when no DB row exists — this matches
    * the route handler's existing "no account" branch and avoids a Stripe
-   * call for orgs that never started onboarding.
+   * call for users who never started onboarding.
    */
-  private async fetchStatusFromStripe(
-    orgId: string
+  private async fetchStatusFromStripeForUser(
+    userId: string
   ): Promise<ConnectStatusPayload> {
-    const account = await this.getAccount(orgId);
+    const account = await this.getAccountForUser(userId);
 
     if (!account) {
-      return {
-        isConnected: false,
-        accountId: null,
-        chargesEnabled: false,
-        payoutsEnabled: false,
-        status: null,
-        requirements: null,
-      };
+      return DISCONNECTED_STATUS;
     }
 
     // Read live requirements from Stripe. Stripe's `account.updated` webhook
@@ -530,7 +723,7 @@ export class ConnectAccountService extends BaseService {
       // Stripe is unreachable. The UI degrades to "status only" rather than
       // failing the page load.
       this.obs.warn('Failed to fetch Stripe Connect requirements', {
-        organizationId: orgId,
+        userId,
         stripeAccountId: account.stripeAccountId,
         error: error instanceof Error ? error.message : String(error),
       });


### PR DESCRIPTION
## Summary

WP2 of epic **Codex-69t7c** (single-account Connect). Builds on WP1's schema redesign (PR #272).

Makes `ConnectAccountService` **userId-centric** (one Connect account per user) and writes the org→account pin that WP1 left unwritten.

- **userId-centric API**: `createAccountForUser`, `getAccountForUser`, `getStatusForUser`, `createDashboardLinkForUser`, `isReadyForUser`, `syncAccountStatusForUser`, `refreshOnboardingLinkForUser`. The org-named methods become `@deprecated` shims that resolve org→primary-user via `resolvePrimaryConnect` and delegate — so the existing `/connect` route keeps compiling until **WP3** migrates it to `/connect/me`. (Additive, not rename — the build stays green across the WP2→WP3 gap.)
- **Pin-write (the load-bearing WP1 finding)**: `handleAccountUpdated` now materialises `organizations.primaryConnectAccountUserId` for every org the activating user **owns** where the pin is `NULL` (`pinOwnedOrgsToUser`). This is the **sole production write** of the pin — idempotent (NULL-only, never steals), owner-scoped, best-effort (a failure degrades to `resolvePrimaryConnect`'s owner fallback, never a broken payout).
- **Cache rework (closes WP1's deferred MEDIUM)**: Connect status is cached and invalidated by `userId` instead of the vestigial `organizationId` (which was frequently null → invalidation silently skipped → TTL-stale). Extracted `invalidateStatusCache`.

No schema change (WP1 owns it). No migration.

## Test Plan

- `connect-account-service.test.ts` — **47 tests**, incl. new: pin-write (pins-when-null / never-steal / non-owner-noop / idempotent / non-active-transition / deauth-retention), `getAccountForUser` resolution, owner-fallback resolution, NULL-org cache-invalidation regression.
- Full affected suites green @ `--concurrency=1`: **@codex/subscription 394** (1 skip) · **@codex/purchase 222** · **ecom-api 370** (7 skip).
- `typecheck` 17/17 · `biome check:ci` clean · `gate.sh` → `✓ ALL GATES PASSED`.

## Review

`codex-review` swarm (silent-failure-hunter, scoping-security, backend-conformance, commerce-stripe): **0 CRITICAL/HIGH**. scoping-security + backend-conformance clean. One MEDIUM (multi-owner fallback nondeterminism) — the in-scope part (an overclaiming comment) is fixed here; the root resolver fix is tracked in **Codex-rjwdm** (reverted from this WP: the one-line `.orderBy` broke a hand-rolled db-chain mock in `subscription-service-orchestrator.test.ts`, so it needs its own pass with a mock audit).

## Follow-ups
- **Codex-rjwdm** (P2) — `resolvePrimaryConnect` owner-fallback determinism across multi-owner orgs (+ db-mock update).
- **Codex-ed446** (P2) — purchase org-fee pending row gets null userId when the org owner has no Connect account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
