### PR TITLE
fix(payouts): exclude org_fee from per-creator total (WP6)

### DIFF
--- a/apps/web/src/lib/components/studio/payouts/CreatorBreakdownCard.svelte
+++ b/apps/web/src/lib/components/studio/payouts/CreatorBreakdownCard.svelte
@@ -51,12 +51,13 @@
     breakdown.transactionCount === 1 ? 'transaction' : 'transactions'
   );
 
-  // Owner-card composition disclosure (Codex-6nt4l). The owner's
-  // `totalPaidCents` mixes `organization_fee` rows with any
-  // `creator_payout_to_owner` slice — non-owner creators see only their
-  // own `creator_payout` rows. Surfacing the org-fee subset keeps the
-  // owner card visually comparable with the rest of the rail rather
-  // than always headlining "biggest number" for accounting reasons.
+  // Owner-card composition disclosure (Codex-6nt4l, Codex-h3864). The owner's
+  // `totalPaidCents` is personal creator earnings only (`creator_payout` +
+  // `creator_payout_to_owner`); the `organization_fee` slice is NOT folded in —
+  // it is surfaced separately as `orgFeePaidCents` ("of which £X org fee").
+  // Non-owner creators see only their own `creator_payout` rows. The separate
+  // org-fee disclosure keeps the owner card comparable with the rest of the
+  // rail rather than headlining a total inflated by the org slice.
   const showOrgFeeBreakdown = $derived(
     breakdown.isOrgOwner && breakdown.orgFeePaidCents > 0
   );

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -6810,7 +6810,9 @@ describe('SubscriptionService', () => {
       const result = await service.getPayoutsByCreatorBreakdown(org.id);
       expect(result).toHaveLength(1);
       expect(result[0].transactionCount).toBe(2);
-      expect(result[0].totalPaidCents).toBe(700); // 100 + 200 + 150 + 250
+      // creator_payout 200 + 250 = 450; the two organization_fee rows
+      // (100 + 150) are excluded from personal totalPaidCents (Codex-h3864).
+      expect(result[0].totalPaidCents).toBe(450);
     });
 
     it('isOrgOwner is true for the user whose membership.role = "owner"', async () => {
@@ -7077,7 +7079,7 @@ describe('SubscriptionService', () => {
       const owner = result.find((r) => r.userId === otherCreatorId);
       const creator = result.find((r) => r.userId === thirdUserId);
       expect(owner?.isOrgOwner).toBe(true);
-      expect(owner?.totalPaidCents).toBe(1000); // 150 + 850
+      expect(owner?.totalPaidCents).toBe(850); // personal earnings; org_fee 150 excluded (Codex-h3864)
       expect(owner?.orgFeePaidCents).toBe(150); // organization_fee only
       expect(creator?.isOrgOwner).toBe(false);
       expect(creator?.totalPaidCents).toBe(400);
@@ -7183,20 +7185,12 @@ describe('SubscriptionService', () => {
     });
 
     // REGRESSION (PR #204 deep-review F-3, DQ-8) — multi-creator orgs.
-    // ea08ca29 ships the orgFeePaidCents TRANSPARENCY field on the owner
-    // card, but leaves organization_fee inside totalPaidCents. DQ-8
-    // resolution (option a) requires excluding org_fee from totalPaidCents
-    // entirely — surface the org slice as a separate panel, not as
-    // personal earnings. See docs/pr-203-review/design-questions.md.
-    //
-    // Currently fails because production reports totalPaidCents=270 for the
-    // owner (the org slice). When the fix lands:
-    //   1. this assertion (owner totalPaidCents === 0) passes, vitest
-    //      flips this it.fails red, fixer removes .fails.
-    //   2. The 'orgFeePaidCents tracks ...' test above also needs its
-    //      `owner.totalPaidCents` assertion updated from 1000 → 850
-    //      (excluding org_fee from the total).
-    it.fails('F-3/DQ-8: excludes organization_fee from per-creator totalPaidCents (multi-creator regression)', async () => {
+    // ea08ca29 shipped the orgFeePaidCents transparency field but left
+    // organization_fee inside totalPaidCents. DQ-8 (option a), now resolved in
+    // Codex-69t7c.6: org_fee is excluded from totalPaidCents entirely — the org
+    // slice is a separate disclosure (orgFeePaidCents), not personal earnings
+    // (Codex-h3864). See docs/pr-203-review/design-questions.md.
+    it('F-3/DQ-8: excludes organization_fee from per-creator totalPaidCents (multi-creator regression)', async () => {
       const { org, tier1 } = await createFullOrg('h3864-exclude-orgfee');
       const sub = await seedSubscriptionForOrg(
         org.id,

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -3154,17 +3154,21 @@ export class SubscriptionService extends BaseService {
       }
 
       if (row.status === 'paid') {
-        acc.totalPaidCents += row.amountCents;
-        if (row.sourceType === 'purchase') {
-          acc.purchasePaidCents += row.amountCents;
-        } else if (row.sourceType === 'subscription') {
-          acc.subscriptionPaidCents += row.amountCents;
-        }
-        // Track the `organization_fee` slice separately so the owner
-        // card can disclose "of which £X org fee" — keeps the owner's
-        // headline comparable to non-owner creator cards.
+        // `organization_fee` is the org-admin slice, NOT the user's personal
+        // creator earnings — it is disclosed ONLY via `orgFeePaidCents` and must
+        // never be folded into the per-creator `totalPaidCents` headline
+        // (Codex-h3864). This keeps `totalPaidCents == purchasePaidCents +
+        // subscriptionPaidCents` a clean "personal earnings" invariant; the
+        // owner card surfaces the org slice separately as "of which £X org fee".
         if (row.payoutType === 'organization_fee') {
           acc.orgFeePaidCents += row.amountCents;
+        } else {
+          acc.totalPaidCents += row.amountCents;
+          if (row.sourceType === 'purchase') {
+            acc.purchasePaidCents += row.amountCents;
+          } else if (row.sourceType === 'subscription') {
+            acc.subscriptionPaidCents += row.amountCents;
+          }
         }
         if (row.resolvedAt) {
           // Drizzle hands back `Date` for timestamp columns; defensive cast


### PR DESCRIPTION
## Summary

WP6 of epic **Codex-69t7c**. Fixes **Codex-h3864**: `SubscriptionService.getPayoutsByCreatorBreakdown` conflated the org-admin slice into the owner's per-creator *personal-earnings* headline.

A paid `organization_fee` row was added to **both** `totalPaidCents` (personal earnings) **and** `orgFeePaidCents` (the separate disclosure). The owner card therefore reported the org fee as personal creator earnings.

**Fix** — an if/else split in the `status === 'paid'` branch:
- `organization_fee` → `orgFeePaidCents` **only** (the org slice).
- everything else (`creator_payout`, `creator_payout_to_owner`) → `totalPaidCents` + the purchase/subscription source split.

This restores the invariant `totalPaidCents == purchasePaidCents + subscriptionPaidCents` as clean *personal earnings*; `orgFeePaidCents` is the separate "of which £X org fee" disclosure. `lastPaidAt` and `transactionCount` are **unchanged** — they still count `organization_fee` rows, because the owner did receive that transfer (per the WP's "totalPaidCents only" scope).

Also corrects a now-stale comment in `CreatorBreakdownCard.svelte` that described the old conflated behaviour (the card's render logic was already correct).

No schema change, no migration. Read/reporting method only — no queries, scoping, error handling, or transfers touched.

## Test Plan

- Flipped the landed `it.fails('F-3/DQ-8 …')` regression → `it` (now green): owner `organization_fee` 270 → `totalPaidCents` **0**; co-creator `creator_payout` 1530 → **1530**.
- Corrected 2 sibling assertions that baked in the buggy total, both verified arithmetically:
  - `orgFeePaidCents tracks …`: owner `1000 → 850` (org_fee 150 excluded; `orgFeePaidCents` 150 unchanged).
  - `transactionCount dedupes …`: `700 → 450` (creator 200+250; org_fee 100+150 excluded; `transactionCount` 2 unchanged).
- Full `@codex/subscription` suite: **394 passed**, 1 skipped (16 turbo tasks). `gate.sh` → `✓ ALL GATES PASSED`.

## Review

`codex-review` swarm (silent-failure-hunter, scoping-security, backend-conformance, commerce-stripe): **0 findings, all clean**. commerce-stripe verified the sum-invariant, no double-count/lost-pence, integer pence, and that `creator_payout_to_owner` is correctly **retained** in the personal total (only `organization_fee` excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
