### PR TITLE
feat(connect): creator-scoped /connect/me/* routes + schema (WP3)

### DIFF
--- a/packages/validation/src/schemas/__tests__/connect-me-onboard.test.ts
+++ b/packages/validation/src/schemas/__tests__/connect-me-onboard.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for `connectMeOnboardSchema` (Codex-69t7c.3 / WP3).
+ *
+ * The creator-scoped onboarding body carries ONLY return/refresh URLs — never a
+ * client-supplied org/user id (IDOR prevention, epic decision D8). These tests
+ * lock the security-relevant negatives: open-redirect protocols and untrusted
+ * domains are rejected, and smuggled identity fields are stripped.
+ */
+import { describe, expect, it } from 'vitest';
+import { connectMeOnboardSchema } from '../subscription';
+
+describe('connectMeOnboardSchema (WP3 / Codex-69t7c.3)', () => {
+  const returnUrl =
+    'http://localhost:3000/creators/studio/earnings?connect=success';
+  const refreshUrl =
+    'http://localhost:3000/creators/studio/earnings?connect=refresh';
+
+  it('accepts valid trusted-domain return/refresh URLs', () => {
+    const result = connectMeOnboardSchema.parse({ returnUrl, refreshUrl });
+    expect(result).toEqual({ returnUrl, refreshUrl });
+  });
+
+  it('strips any smuggled organizationId / userId (creator is session-scoped)', () => {
+    const parsed = connectMeOnboardSchema.parse({
+      returnUrl,
+      refreshUrl,
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      userId: 'attacker-supplied-id',
+    }) as Record<string, unknown>;
+
+    expect(parsed.organizationId).toBeUndefined();
+    expect(parsed.userId).toBeUndefined();
+    expect(parsed).toEqual({ returnUrl, refreshUrl });
+  });
+
+  it('rejects a missing returnUrl', () => {
+    expect(() => connectMeOnboardSchema.parse({ refreshUrl })).toThrow();
+  });
+
+  it('rejects a missing refreshUrl', () => {
+    expect(() => connectMeOnboardSchema.parse({ returnUrl })).toThrow();
+  });
+
+  it('rejects a javascript: protocol URL (XSS / open-redirect guard)', () => {
+    expect(() =>
+      connectMeOnboardSchema.parse({
+        returnUrl: 'javascript:alert(1)',
+        refreshUrl,
+      })
+    ).toThrow();
+  });
+
+  it('rejects an untrusted external domain (open-redirect guard)', () => {
+    expect(() =>
+      connectMeOnboardSchema.parse({
+        returnUrl: 'https://evil.example.com/phish',
+        refreshUrl,
+      })
+    ).toThrow();
+  });
+});

--- a/packages/validation/src/schemas/subscription.ts
+++ b/packages/validation/src/schemas/subscription.ts
@@ -268,6 +268,24 @@ export const connectDashboardSchema = z.object({
   organizationId: uuidSchema,
 });
 
+/**
+ * Creator-scoped Connect onboarding (Codex-69t7c.3 / WP3).
+ *
+ * Unlike {@link connectOnboardSchema}, this carries NO `organizationId`: the
+ * acting creator is always the authenticated user (`ctx.user.id`), never a
+ * client-supplied id (IDOR prevention — see epic design decision D8). The
+ * return/refresh URLs reuse the same host-allowlisted redirect schema as
+ * checkout, so an attacker cannot smuggle an open redirect through onboarding.
+ *
+ * The sibling `/connect/me/{status,sync,dashboard}` routes take no input — the
+ * creator is resolved entirely from the session — so this is the only new
+ * creator-scoped Connect schema.
+ */
+export const connectMeOnboardSchema = z.object({
+  returnUrl: checkoutRedirectUrlSchema,
+  refreshUrl: checkoutRedirectUrlSchema,
+});
+
 // ============================================================================
 // Type Exports
 // ============================================================================
@@ -304,3 +322,4 @@ export type ListSubscribersQueryInput = z.infer<
 >;
 
 export type ConnectOnboardInput = z.infer<typeof connectOnboardSchema>;
+export type ConnectMeOnboardInput = z.infer<typeof connectMeOnboardSchema>;

--- a/workers/ecom-api/src/routes/__tests__/connect-me-routes.test.ts
+++ b/workers/ecom-api/src/routes/__tests__/connect-me-routes.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Integration tests for creator-scoped /connect/me/* routes (Codex-69t7c.3 / WP3).
+ *
+ * These run against the REAL `procedure()` resolver (NOT mocked). The routes are
+ * mounted on a Hono app and driven via `app.fetch()` with a real
+ * `ExecutionContext` (so `procedure`'s `waitUntil` cleanup works). Only two
+ * seams are stubbed:
+ *
+ *  1. The session: a test middleware sets `c.set('user', …)` BEFORE the route, so
+ *     the real `authenticateSession()` early-returns (`if (c.get('user')) return`,
+ *     helpers.ts) and the rest of `enforcePolicyInline` runs for real —
+ *     rate-limit → `enforceRole([])` → `needsOrg === false` → handler. The
+ *     unauthenticated path injects no user, so the real session middleware runs
+ *     and returns 401.
+ *  2. `@codex/subscription`'s `ConnectAccountService` is replaced with spies so no
+ *     real Stripe/DB call fires (the established ecom-api mocking pattern).
+ *
+ * This deliberately AVOIDS mocking `procedure()` (memory:
+ * procedure_mock_hides_resolver_bugs) — doing so would skip the very resolver
+ * branch that decides whether an org-less `auth:'required'` route is reachable.
+ * Here we prove, through the real resolver, that a plain member (no org role)
+ * reaches the route and that an unauthenticated request is rejected.
+ */
+import {
+  createExecutionContext,
+  env,
+  waitOnExecutionContext,
+} from 'cloudflare:test';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Spies for the userId-centric ConnectAccountService methods (WP2) --------
+const connectSpies = {
+  createAccountForUser: vi.fn(),
+  getStatusForUser: vi.fn(),
+  syncAccountStatusForUser: vi.fn(),
+  createDashboardLinkForUser: vi.fn(),
+  // The registry calls setCache() when CACHE_KV is bound (it is, in env=test).
+  setCache: vi.fn(),
+};
+
+vi.mock('@codex/subscription', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@codex/subscription')>();
+  return {
+    ...actual,
+    ConnectAccountService: vi.fn(() => connectSpies),
+  };
+});
+
+// Import AFTER the mock so the real service registry resolves the mocked class.
+import connect from '../connect';
+
+const CREATOR_USER = {
+  id: '7a1d0f2e-3b4c-4d5e-8f60-112233445566',
+  email: 'creator@test.com',
+  role: 'creator',
+};
+
+// A "plain member": a role with NO org-management capability. Reaching the
+// route proves it is gated by `auth:'required'` alone, not requireOrgManagement.
+const PLAIN_MEMBER = {
+  id: '9c2e1a3f-4d5b-4e6a-9071-223344556677',
+  email: 'member@test.com',
+  role: 'member',
+};
+
+const STATUS_PAYLOAD = {
+  isConnected: true,
+  accountId: 'acct_test_123',
+  chargesEnabled: true,
+  payoutsEnabled: true,
+  status: 'active' as const,
+  requirements: null,
+};
+
+const VALID_ONBOARD = {
+  returnUrl: 'http://localhost:3000/creators/studio/earnings?connect=success',
+  refreshUrl: 'http://localhost:3000/creators/studio/earnings?connect=refresh',
+};
+
+/**
+ * Mount the real /connect routes behind a middleware that injects `user`
+ * (or none, to exercise the real session middleware's 401 path).
+ */
+function buildApp(user: Record<string, unknown> | null) {
+  const app = new Hono<{ Variables: Record<string, unknown> }>();
+  app.use('*', async (c, next) => {
+    if (user) {
+      c.set('user', user);
+      c.set('session', { id: 'sess_test', userId: user.id });
+    }
+    await next();
+  });
+  app.route('/connect', connect);
+  return app;
+}
+
+/**
+ * Drive a request through the real worker pipeline with a genuine
+ * ExecutionContext (procedure() needs `ctx.executionCtx.waitUntil` for cleanup).
+ */
+async function dispatch(
+  app: ReturnType<typeof buildApp>,
+  req: Request
+): Promise<Response> {
+  const ec = createExecutionContext();
+  const res = await app.fetch(req, env, ec);
+  await waitOnExecutionContext(ec);
+  return res;
+}
+
+function postReq(path: string, body?: unknown) {
+  return new Request(`http://ecom-api.test${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function getReq(path: string) {
+  return new Request(`http://ecom-api.test${path}`, { method: 'GET' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  connectSpies.createAccountForUser.mockResolvedValue({
+    accountId: 'acct_test_123',
+    onboardingUrl: 'https://connect.stripe.com/setup/acct_test_123',
+  });
+  connectSpies.getStatusForUser.mockResolvedValue(STATUS_PAYLOAD);
+  connectSpies.syncAccountStatusForUser.mockResolvedValue({
+    stripeAccountId: 'acct_test_123',
+    chargesEnabled: true,
+    payoutsEnabled: true,
+    status: 'active',
+  });
+  connectSpies.createDashboardLinkForUser.mockResolvedValue({
+    url: 'https://connect.stripe.com/express/acct_test_123',
+  });
+});
+
+describe('POST /connect/me/onboard — real resolver', () => {
+  it('authenticated creator → 201, service called with the SESSION user id', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/onboard', VALID_ONBOARD)
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      data: {
+        accountId: 'acct_test_123',
+        onboardingUrl: 'https://connect.stripe.com/setup/acct_test_123',
+      },
+    });
+    expect(connectSpies.createAccountForUser).toHaveBeenCalledWith(
+      CREATOR_USER.id,
+      VALID_ONBOARD.returnUrl,
+      VALID_ONBOARD.refreshUrl
+    );
+  });
+
+  it('unauthenticated → 401, service NOT called', async () => {
+    const res = await dispatch(
+      buildApp(null),
+      postReq('/connect/me/onboard', VALID_ONBOARD)
+    );
+
+    expect(res.status).toBe(401);
+    expect(connectSpies.createAccountForUser).not.toHaveBeenCalled();
+  });
+
+  it('IDOR: a body-smuggled userId/organizationId is ignored — the session id wins', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/onboard', {
+        ...VALID_ONBOARD,
+        userId: PLAIN_MEMBER.id,
+        organizationId: '11111111-1111-4111-8111-111111111111',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(connectSpies.createAccountForUser).toHaveBeenCalledWith(
+      CREATOR_USER.id,
+      VALID_ONBOARD.returnUrl,
+      VALID_ONBOARD.refreshUrl
+    );
+    // The forged id never reaches the service.
+    expect(connectSpies.createAccountForUser).not.toHaveBeenCalledWith(
+      PLAIN_MEMBER.id,
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('invalid returnUrl (javascript:) → 400 via the real validation step, service NOT called', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/onboard', {
+        returnUrl: 'javascript:alert(1)',
+        refreshUrl: VALID_ONBOARD.refreshUrl,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(connectSpies.createAccountForUser).not.toHaveBeenCalled();
+  });
+
+  it('a service failure propagates as an error, not a masked success', async () => {
+    connectSpies.createAccountForUser.mockRejectedValue(
+      new Error('stripe down')
+    );
+
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/onboard', VALID_ONBOARD)
+    );
+
+    // The rejection surfaces via mapErrorToResponse (500) — never a 201.
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('GET /connect/me/status — real resolver', () => {
+  it('plain member (no org-management role) reaches the route → 200', async () => {
+    const res = await dispatch(
+      buildApp(PLAIN_MEMBER),
+      getReq('/connect/me/status')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: STATUS_PAYLOAD });
+    expect(connectSpies.getStatusForUser).toHaveBeenCalledWith(PLAIN_MEMBER.id);
+  });
+
+  it('unauthenticated → 401, service NOT called', async () => {
+    const res = await dispatch(buildApp(null), getReq('/connect/me/status'));
+
+    expect(res.status).toBe(401);
+    expect(connectSpies.getStatusForUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /connect/me/sync — real resolver', () => {
+  it('syncs THEN returns the refreshed status payload (shape parity with /status)', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/sync')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: STATUS_PAYLOAD });
+    expect(connectSpies.syncAccountStatusForUser).toHaveBeenCalledWith(
+      CREATOR_USER.id
+    );
+    expect(connectSpies.getStatusForUser).toHaveBeenCalledWith(CREATOR_USER.id);
+    // sync must run before the status read. invocationCallOrder is 1-based,
+    // so `?? 0` keeps the "never called" case below any real order (caught by
+    // the toBeGreaterThan guards) while satisfying the number-only matcher.
+    const syncOrder =
+      connectSpies.syncAccountStatusForUser.mock.invocationCallOrder[0] ?? 0;
+    const statusOrder =
+      connectSpies.getStatusForUser.mock.invocationCallOrder[0] ?? 0;
+    expect(syncOrder).toBeGreaterThan(0);
+    expect(statusOrder).toBeGreaterThan(0);
+    expect(syncOrder).toBeLessThan(statusOrder);
+  });
+
+  it('a sync failure propagates as an error and SKIPS the status read (no masking)', async () => {
+    connectSpies.syncAccountStatusForUser.mockRejectedValue(
+      new Error('stripe unreachable')
+    );
+
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/sync')
+    );
+
+    // The rejection must surface (mapErrorToResponse → 500), NOT be masked by a
+    // subsequent getStatus read returning a stale-but-200 payload. This pins the
+    // sync-then-status sequence against a future "resilience" refactor.
+    expect(res.status).toBe(500);
+    expect(connectSpies.getStatusForUser).not.toHaveBeenCalled();
+  });
+
+  it('unauthenticated → 401, neither sync nor status called', async () => {
+    const res = await dispatch(buildApp(null), postReq('/connect/me/sync'));
+
+    expect(res.status).toBe(401);
+    expect(connectSpies.syncAccountStatusForUser).not.toHaveBeenCalled();
+    expect(connectSpies.getStatusForUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /connect/me/dashboard — real resolver', () => {
+  it('authenticated creator → 200 with dashboard url, service called with session id', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR_USER),
+      postReq('/connect/me/dashboard')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      data: { url: 'https://connect.stripe.com/express/acct_test_123' },
+    });
+    expect(connectSpies.createDashboardLinkForUser).toHaveBeenCalledWith(
+      CREATOR_USER.id
+    );
+  });
+
+  it('unauthenticated → 401, service NOT called', async () => {
+    const res = await dispatch(
+      buildApp(null),
+      postReq('/connect/me/dashboard')
+    );
+
+    expect(res.status).toBe(401);
+    expect(connectSpies.createDashboardLinkForUser).not.toHaveBeenCalled();
+  });
+});

--- a/workers/ecom-api/src/routes/connect.ts
+++ b/workers/ecom-api/src/routes/connect.ts
@@ -1,17 +1,26 @@
 /**
  * Stripe Connect Endpoints
  *
- * Manages Connect account onboarding and status for org owners and creators.
+ * Manages Connect account onboarding and status. Two route families:
  *
- * Endpoints:
- * - POST /connect/onboard   - Create Connect account + return onboarding URL
- * - GET  /connect/status    - Get Connect account status
- * - POST /connect/dashboard - Get Stripe Express dashboard link
+ * Org-scoped (owner/admin, `requireOrgManagement`) — the org's primary account:
+ * - POST /connect/onboard    - Create Connect account + return onboarding URL
+ * - GET  /connect/status     - Get Connect account status
+ * - POST /connect/sync       - Force a Stripe status sync
+ * - POST /connect/dashboard  - Get Stripe Express dashboard link
+ *
+ * Creator-scoped (`/connect/me/*`, `auth: 'required'`, self-scoped to
+ * `ctx.user.id`) — one Connect account per user, no org context (Codex-69t7c.3):
+ * - POST /connect/me/onboard   - Create/reuse the creator's account + onboarding URL
+ * - GET  /connect/me/status    - Get the creator's account status
+ * - POST /connect/me/sync      - Force sync, return refreshed status payload
+ * - POST /connect/me/dashboard - Get the creator's Express dashboard link
  */
 
 import type { HonoEnv } from '@codex/shared-types';
 import {
   connectDashboardSchema,
+  connectMeOnboardSchema,
   connectOnboardSchema,
   connectStatusQuerySchema,
 } from '@codex/validation';
@@ -126,6 +135,98 @@ app.post(
       return await ctx.services.connect.createDashboardLink(
         ctx.input.body.organizationId
       );
+    },
+  })
+);
+
+// ─────────────────────────────────────────────────────────────────────────
+// Creator-scoped routes (/connect/me/*) — Codex-69t7c.3 / WP3
+//
+// One Stripe Connect account per USER. These routes are self-scoped to
+// `ctx.user.id` (never a client-supplied id — IDOR prevention, epic decision
+// D8) and carry NO org context, so the policy is `auth: 'required'` only: any
+// authenticated creator reaches them, regardless of org membership/management
+// role. They consume the userId-centric `*ForUser` service methods (WP2).
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * POST /connect/me/onboard
+ * Create (or reuse) the current creator's Connect account and return the
+ * Stripe onboarding URL.
+ */
+app.post(
+  '/me/onboard',
+  procedure({
+    policy: {
+      auth: 'required',
+      rateLimit: 'strict',
+    },
+    input: { body: connectMeOnboardSchema },
+    successStatus: 201,
+    handler: async (ctx) => {
+      return await ctx.services.connect.createAccountForUser(
+        ctx.user.id,
+        ctx.input.body.returnUrl,
+        ctx.input.body.refreshUrl
+      );
+    },
+  })
+);
+
+/**
+ * GET /connect/me/status
+ * Get the current creator's Connect account status (cached 10 min,
+ * invalidated by the `account.updated` webhook).
+ */
+app.get(
+  '/me/status',
+  procedure({
+    policy: {
+      auth: 'required',
+    },
+    handler: async (ctx) => {
+      return await ctx.services.connect.getStatusForUser(ctx.user.id);
+    },
+  })
+);
+
+/**
+ * POST /connect/me/sync
+ * Force a Stripe status sync for the current creator, then return the
+ * refreshed status payload (shape parity with GET /connect/me/status). Used by
+ * the earnings hub on `?connect=success` return from Stripe onboarding, where
+ * the `account.updated` webhook may not yet have landed (e.g. local dev).
+ *
+ * Note: the returned status is best-effort — a `requirements: null` can mean
+ * "no outstanding requirements" OR "the live Stripe read degraded"; surfacing
+ * that distinction is tracked in Codex-y2htq.
+ */
+app.post(
+  '/me/sync',
+  procedure({
+    policy: {
+      auth: 'required',
+      rateLimit: 'strict',
+    },
+    handler: async (ctx) => {
+      await ctx.services.connect.syncAccountStatusForUser(ctx.user.id);
+      return await ctx.services.connect.getStatusForUser(ctx.user.id);
+    },
+  })
+);
+
+/**
+ * POST /connect/me/dashboard
+ * Get a Stripe Express dashboard login link for the current creator.
+ */
+app.post(
+  '/me/dashboard',
+  procedure({
+    policy: {
+      auth: 'required',
+    },
+    handler: async (ctx) => {
+      return await ctx.services.connect.createDashboardLinkForUser(ctx.user.id);
     },
   })
 );


### PR DESCRIPTION
## Summary

WP3 of epic **Codex-69t7c** (Creator Studio Monetisation). Adds four **creator-self-scoped** Stripe Connect routes in `ecom-api`, scoped to `ctx.user.id` via `policy: { auth: 'required' }` (no org context — one Connect account per user):

| Method | Path | Service call | Response |
|---|---|---|---|
| POST | `/connect/me/onboard` | `createAccountForUser` | `{ accountId, onboardingUrl }` (201) |
| GET | `/connect/me/status` | `getStatusForUser` | `ConnectStatusPayload` |
| POST | `/connect/me/sync` | sync → `getStatusForUser` | `ConnectStatusPayload` (refreshed) |
| POST | `/connect/me/dashboard` | `createDashboardLinkForUser` | `{ url }` |

- Consumes WP2's userId-centric `ConnectAccountService.*ForUser` methods.
- Adds `connectMeOnboardSchema` — return/refresh URLs reuse the host-allowlisted `checkoutRedirectUrlSchema`; **no client-supplied identity** (IDOR prevention, epic decision D8).
- Verified the procedure resolver's `needsOrg` branch short-circuits for org-less `auth:'required'`, so these routes never 400 `ORG_CONTEXT_REQUIRED`.

## Test plan

- **Unit** (`@codex/validation`): `connectMeOnboardSchema` — valid URLs, smuggled-id stripping, missing fields, `javascript:` + untrusted-domain rejection.
- **Integration** (`ecom-api`, against the **real** `procedure()` resolver — not mocked, avoiding the procedure-mock-hides-resolver-bugs trap): auth pos/neg (401), structural IDOR (body `userId` ignored → session id wins), plain-member reachability (no org-management role), invalid-URL 400 via the real validation step, and failure propagation (service rejection → 500, status read skipped — not masked).
- `pnpm turbo run test --filter ecom-api --filter @codex/validation` → **ecom-api 382 pass, validation 410 pass**. Typecheck green.

## Review

`codex-review` swarm (scoping-security · backend-conformance · commerce-stripe · silent-failure-hunter): **0 critical / 0 high / 0 medium / 2 low**. One LOW fixed (added negative-path propagation tests); one LOW — an inherited WP2 `requirements:null` degradation surfaced via `/me/sync` — tracked as **Codex-y2htq**.

## Notes

- No DB migration (Zod schema only).
- `gate.sh` whole-repo `biome` flags 20 **pre-existing** violations across 11 `apps/web/` files (none in this PR's scope; tracked in **Codex-zf9wf**). WP3's own files are biome-clean; typecheck/test/build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
