### PR TITLE
feat(payouts): creator earnings/payouts query + /me routes (WP7)

### DIFF
--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -76,7 +76,9 @@ export {
   type WaitUntilFn,
 } from './services/subscription-invalidation';
 export type {
+  CreatorEarningsSummary,
   CreatorPayoutBreakdown,
+  CreatorPayoutRow,
   PayoutDisplayStatus,
   PayoutSummary,
   PayoutWithCreator,

--- a/packages/subscription/src/services/__tests__/creator-earnings.test.ts
+++ b/packages/subscription/src/services/__tests__/creator-earnings.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Creator earnings query tests (Codex-69t7c.7 / WP7).
+ *
+ * Integration tests with a real DB for `listPayoutsForCreator` +
+ * `getEarningsSummaryForCreator`. The load-bearing assertions are SECURITY:
+ *  - cross-creator isolation: a caller sees ONLY their own payout rows, never
+ *    another user's (the `eq(userId)` predicate is the tenant boundary).
+ *  - payout-type exclusion: `organization_fee` rows (which carry the owner's
+ *    userId) are NOT a creator's personal earnings (consistent with WP6).
+ *
+ * Seeds use `crypto.randomUUID()` for `stripeTransferId` to avoid the
+ * `uq_payouts_stripe_transfer_id` dup-key on the shared Neon branch
+ * (memory: payout-tests-hardcoded-transfer-ids), and clean up in afterEach.
+ */
+import { randomUUID } from 'node:crypto';
+import { organizations, payouts as payoutsTable } from '@codex/database/schema';
+import {
+  createMockStripe,
+  createTestOrganizationInput,
+  createUniqueSlug,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+  validateDatabaseConnection,
+} from '@codex/test-utils';
+import { inArray } from 'drizzle-orm';
+import type Stripe from 'stripe';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { SubscriptionService } from '../subscription-service';
+
+describe('SubscriptionService — creator earnings (WP7)', () => {
+  let db: ReturnType<typeof setupTestDatabase>;
+  let service: SubscriptionService;
+  let creatorId: string;
+  let otherCreatorId: string;
+  let orgAId: string;
+  let orgBId: string;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    await validateDatabaseConnection(db);
+    [creatorId, otherCreatorId] = await seedTestUsers(db, 2);
+
+    const stripe = createMockStripe() as unknown as Stripe;
+    service = new SubscriptionService({ db, environment: 'test' }, stripe);
+
+    const [orgA] = await db
+      .insert(organizations)
+      .values(createTestOrganizationInput({ slug: createUniqueSlug('wp7a') }))
+      .returning();
+    const [orgB] = await db
+      .insert(organizations)
+      .values(createTestOrganizationInput({ slug: createUniqueSlug('wp7b') }))
+      .returning();
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+  });
+
+  afterEach(async () => {
+    // Clean only the rows this suite seeded (keyed by its two users), so the
+    // shared Neon branch stays clean for sibling test files.
+    await db
+      .delete(payoutsTable)
+      .where(inArray(payoutsTable.userId, [creatorId, otherCreatorId]));
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  function seedPayout(o: {
+    userId: string | null;
+    organizationId: string | null;
+    payoutType:
+      | 'creator_payout'
+      | 'creator_payout_to_owner'
+      | 'organization_fee'
+      | 'platform_fee';
+    status: 'paid' | 'pending' | 'failed';
+    amountCents: number;
+    sourceType?: 'purchase' | 'subscription';
+  }) {
+    return db.insert(payoutsTable).values({
+      id: randomUUID(),
+      organizationId: o.organizationId,
+      userId: o.userId,
+      payoutType: o.payoutType,
+      status: o.status,
+      amountCents: o.amountCents,
+      currency: 'gbp',
+      sourceType: o.sourceType ?? 'subscription',
+      // Unique → never collides with the uq_payouts_stripe_transfer_id index.
+      stripeTransferId: randomUUID(),
+      stripeChargeId: `ch_${randomUUID()}`,
+      resolvedAt: o.status === 'paid' ? new Date() : null,
+    });
+  }
+
+  /** The caller's mixed ledger + a foreign creator's row that must never leak. */
+  async function seedScenario() {
+    await seedPayout({
+      userId: creatorId,
+      organizationId: orgAId,
+      payoutType: 'creator_payout',
+      status: 'paid',
+      amountCents: 1000,
+    });
+    await seedPayout({
+      userId: creatorId,
+      organizationId: orgBId,
+      payoutType: 'creator_payout_to_owner',
+      status: 'paid',
+      amountCents: 500,
+    });
+    // org_fee carries the caller's userId but is NOT personal earnings (WP6).
+    await seedPayout({
+      userId: creatorId,
+      organizationId: orgAId,
+      payoutType: 'organization_fee',
+      status: 'paid',
+      amountCents: 300,
+    });
+    // pending creator slice → counts toward in-transit + needs-attention.
+    await seedPayout({
+      userId: creatorId,
+      organizationId: orgAId,
+      payoutType: 'creator_payout',
+      status: 'pending',
+      amountCents: 200,
+    });
+    // foreign creator — must be invisible to `creatorId`.
+    await seedPayout({
+      userId: otherCreatorId,
+      organizationId: orgAId,
+      payoutType: 'creator_payout',
+      status: 'paid',
+      amountCents: 99999,
+    });
+  }
+
+  describe('listPayoutsForCreator', () => {
+    it('returns ONLY the caller’s creator slices — excludes org_fee and other users', async () => {
+      await seedScenario();
+
+      const result = await service.listPayoutsForCreator(creatorId, {
+        page: 1,
+        limit: 50,
+      });
+
+      // 2 paid creator-type + 1 pending creator-type = 3. NOT the org_fee, NOT the foreign row.
+      expect(result.pagination.total).toBe(3);
+      expect(result.items).toHaveLength(3);
+      for (const row of result.items) {
+        expect(['creator_payout', 'creator_payout_to_owner']).toContain(
+          row.payoutType
+        );
+      }
+      // The £999.99 foreign payout never appears.
+      expect(result.items.some((r) => r.amountCents === 99999)).toBe(false);
+      // The org_fee (£3) never appears.
+      expect(result.items.some((r) => r.amountCents === 300)).toBe(false);
+      // org grouping signal is present on rows.
+      expect(result.items.map((r) => r.organizationId).sort()).toEqual(
+        [orgAId, orgAId, orgBId].sort()
+      );
+    });
+
+    it('applies the status filter (pending only)', async () => {
+      await seedScenario();
+
+      const result = await service.listPayoutsForCreator(creatorId, {
+        page: 1,
+        limit: 50,
+        status: 'pending',
+      });
+
+      expect(result.pagination.total).toBe(1);
+      expect(result.items[0]?.amountCents).toBe(200);
+      expect(result.items[0]?.status).toBe('pending');
+    });
+
+    it('returns an empty page for a creator with no payouts', async () => {
+      const result = await service.listPayoutsForCreator(otherCreatorId, {
+        page: 1,
+        limit: 50,
+      });
+      expect(result.pagination.total).toBe(0);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  describe('getEarningsSummaryForCreator', () => {
+    it('sums ONLY the caller’s creator slices (excludes org_fee + other users)', async () => {
+      await seedScenario();
+
+      const summary = await service.getEarningsSummaryForCreator(creatorId);
+
+      // paid creator slices: 1000 + 500 = 1500 (org_fee 300 + foreign 99999 excluded).
+      expect(summary.totalEarnedCents).toBe(1500);
+      expect(summary.earnedInPeriodCents).toBe(1500);
+      // pending creator slice: 200.
+      expect(summary.inTransitCents).toBe(200);
+      // needs-attention = pending|failed count = 1.
+      expect(summary.needsAttentionCount).toBe(1);
+    });
+
+    it('returns zeros for a creator with no payouts', async () => {
+      const summary =
+        await service.getEarningsSummaryForCreator(otherCreatorId);
+      expect(summary).toEqual({
+        earnedInPeriodCents: 0,
+        totalEarnedCents: 0,
+        inTransitCents: 0,
+        needsAttentionCount: 0,
+      });
+    });
+  });
+});

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -295,6 +295,59 @@ export interface PayoutSummary {
 }
 
 /**
+ * A single creator-owned payout row for the creator earnings hub
+ * (Codex-69t7c.7 / WP7). Unlike {@link PayoutWithCreator} (the org-table view)
+ * this omits creator identity (it IS the caller) and subscriber denorm (a
+ * creator must not see who paid inside another org — cross-org privacy). It
+ * keeps `organizationId` so the hub can group "earned from each org".
+ */
+export interface CreatorPayoutRow {
+  id: string;
+  organizationId: string | null;
+  amountCents: number;
+  currency: string;
+  reason: string;
+  status: PayoutDisplayStatus;
+  payoutType: PayoutType;
+  sourceType: 'purchase' | 'subscription';
+  resolvedAt: string | null;
+  stripeTransferId: string | null;
+  transferGroup: string | null;
+  createdAt: string;
+  purchaseId: string | null;
+  subscriptionId: string | null;
+  stripeChargeId: string | null;
+}
+
+/**
+ * Creator earnings KPIs (Codex-69t7c.7 / WP7) — the userId-scoped counterpart
+ * of {@link PayoutSummary}. Same four numbers, INVERSE scoping invariant:
+ * where `PayoutSummary` must NEVER relax to user-only scope (an org's KPIs
+ * can't leak other orgs), this one is DELIBERATELY user-scoped ACROSS every
+ * org that paid the creator. Only `creator_payout` + `creator_payout_to_owner`
+ * count — `organization_fee`/`platform_fee` are never a creator's personal
+ * earnings (consistent with the WP6 / Codex-h3864 fix).
+ */
+export interface CreatorEarningsSummary {
+  earnedInPeriodCents: number;
+  totalEarnedCents: number;
+  inTransitCents: number;
+  needsAttentionCount: number;
+}
+
+/**
+ * Payout types that count as a creator's PERSONAL earnings (Codex-69t7c.7).
+ * Excludes `organization_fee` (the platform's per-charge org cut — attributed
+ * to the owner's userId but NOT personal earnings, see WP6) and `platform_fee`
+ * (no creator recipient). The single source of truth for the creator-scope
+ * payout filter, shared by the list query and the earnings-summary aggregates.
+ */
+const CREATOR_EARNING_PAYOUT_TYPES = [
+  'creator_payout',
+  'creator_payout_to_owner',
+] as const satisfies readonly PayoutType[];
+
+/**
  * Map the persisted `payouts.status` column to the UI display vocabulary.
  *
  * Storage column: `'paid' | 'pending' | 'failed'` (CHECK-enforced).
@@ -2844,9 +2897,18 @@ export class SubscriptionService extends BaseService {
    * Date conditions use the helper `dateWindow(createdAt, from, to)` so empty
    * args produce no SQL clauses (rather than `WHERE TRUE`).
    */
-  private buildPayoutConditions(orgId: string, options: PayoutFilterOptions) {
+  /**
+   * Status/source/date predicates shared by EVERY payout surface — the org
+   * table/rail (`buildPayoutConditions`) AND the creator earnings hub
+   * (`buildCreatorPayoutConditions`). Carries NO scope predicate, so chip
+   * semantics (a `needs_attention` chip means pending|failed everywhere) stay
+   * single-sourced regardless of whether the caller scopes by org or by user.
+   */
+  private buildPayoutFilterConditions(options: PayoutFilterOptions) {
     const { status = 'all', sourceType = 'all', fromDate, toDate } = options;
-    const conditions = [eq(payouts.organizationId, orgId)];
+    // Seed from dateWindow (SQL[], empty when no dates) into a fresh mutable
+    // array so the element type is inferred without importing the SQL type.
+    const conditions = [...dateWindow(payouts.createdAt, fromDate, toDate)];
 
     if (status === 'pending') {
       conditions.push(eq(payouts.status, 'pending'));
@@ -2866,9 +2928,36 @@ export class SubscriptionService extends BaseService {
       conditions.push(eq(payouts.sourceType, sourceType));
     }
 
-    conditions.push(...dateWindow(payouts.createdAt, fromDate, toDate));
-
     return conditions;
+  }
+
+  /**
+   * Org-scoped payout predicate set (the `/studio/payouts` table + rail).
+   * Scope predicate first, shared chip filters appended.
+   */
+  private buildPayoutConditions(orgId: string, options: PayoutFilterOptions) {
+    return [
+      eq(payouts.organizationId, orgId),
+      ...this.buildPayoutFilterConditions(options),
+    ];
+  }
+
+  /**
+   * Creator-scoped payout predicate set (Codex-69t7c.7 / WP7). Scopes by the
+   * acting user across ALL orgs and to their PERSONAL earning payout types
+   * only ({@link CREATOR_EARNING_PAYOUT_TYPES}) — the `eq(userId)` predicate is
+   * the security boundary that keeps one creator from reading another's
+   * payouts. Shares the chip filters with the org surfaces.
+   */
+  private buildCreatorPayoutConditions(
+    userId: string,
+    options: PayoutFilterOptions
+  ) {
+    return [
+      eq(payouts.userId, userId),
+      inArray(payouts.payoutType, [...CREATOR_EARNING_PAYOUT_TYPES]),
+      ...this.buildPayoutFilterConditions(options),
+    ];
   }
 
   async listPayoutsByOrg(
@@ -3045,6 +3134,141 @@ export class SubscriptionService extends BaseService {
             eq(payouts.organizationId, orgId),
             inArray(payouts.status, ['pending', 'failed'])
           )
+        ),
+    ]);
+
+    return {
+      earnedInPeriodCents: paid[0]?.inPeriod ?? 0,
+      totalEarnedCents: paid[0]?.total ?? 0,
+      inTransitCents: inTransit[0]?.sum ?? 0,
+      needsAttentionCount: needsAttention[0]?.count ?? 0,
+    };
+  }
+
+  /**
+   * Creator earnings hub (Codex-69t7c.7 / WP7): the acting creator's OWN
+   * payout rows across every org that paid them, newest first. Scoped by
+   * `buildCreatorPayoutConditions` (userId + personal payout types) — the
+   * `eq(userId)` predicate is the cross-creator isolation boundary. Unlike
+   * `listPayoutsByOrg` this paginates per-row (not per-transferGroup): a
+   * creator sees their individual slices, not an org operator's charge groups.
+   */
+  async listPayoutsForCreator(
+    userId: string,
+    options: {
+      page: number;
+      limit: number;
+    } & PayoutFilterOptions
+  ): Promise<PaginatedListResponse<CreatorPayoutRow>> {
+    const { page, limit } = options;
+    const offset = (page - 1) * limit;
+
+    const conditions = this.buildCreatorPayoutConditions(userId, options);
+
+    const [rows, [totalResult]] = await Promise.all([
+      this.db
+        .select({
+          id: payouts.id,
+          organizationId: payouts.organizationId,
+          amountCents: payouts.amountCents,
+          currency: payouts.currency,
+          reason: payouts.reason,
+          status: payouts.status,
+          payoutType: payouts.payoutType,
+          sourceType: payouts.sourceType,
+          resolvedAt: payouts.resolvedAt,
+          stripeTransferId: payouts.stripeTransferId,
+          transferGroup: payouts.transferGroup,
+          createdAt: payouts.createdAt,
+          purchaseId: payouts.purchaseId,
+          subscriptionId: payouts.subscriptionId,
+          stripeChargeId: payouts.stripeChargeId,
+        })
+        .from(payouts)
+        .where(and(...conditions))
+        .orderBy(desc(payouts.createdAt), payouts.id)
+        .limit(limit)
+        .offset(offset),
+      this.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(payouts)
+        .where(and(...conditions)),
+    ]);
+
+    const total = totalResult?.count ?? 0;
+
+    return {
+      items: rows.map((row) => ({
+        id: row.id,
+        organizationId: row.organizationId ?? null,
+        amountCents: row.amountCents,
+        currency: row.currency,
+        reason: row.reason ?? '',
+        status: derivePayoutStatus(row.status),
+        payoutType: row.payoutType as PayoutType,
+        sourceType: row.sourceType as 'purchase' | 'subscription',
+        resolvedAt: row.resolvedAt ? row.resolvedAt.toISOString() : null,
+        stripeTransferId: row.stripeTransferId,
+        transferGroup: row.transferGroup ?? null,
+        createdAt: row.createdAt.toISOString(),
+        purchaseId: row.purchaseId ?? null,
+        subscriptionId: row.subscriptionId ?? null,
+        stripeChargeId: row.stripeChargeId ?? null,
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * Creator earnings KPIs (Codex-69t7c.7 / WP7) — the userId-scoped inverse of
+   * {@link getPayoutSummary}. Three parallel aggregates over the creator's
+   * personal payout rows (userId + `CREATOR_EARNING_PAYOUT_TYPES`) across all
+   * orgs. `earnedInPeriodCents` honours the date window; the rest are lifetime.
+   */
+  async getEarningsSummaryForCreator(
+    userId: string,
+    options: { fromDate?: string; toDate?: string } = {}
+  ): Promise<CreatorEarningsSummary> {
+    const { fromDate, toDate } = options;
+
+    // Reusable scope predicate (userId + personal payout types) shared by all
+    // three aggregates, so an org-fee or another user's row can never inflate
+    // a KPI.
+    const creatorScope = [
+      eq(payouts.userId, userId),
+      inArray(payouts.payoutType, [...CREATOR_EARNING_PAYOUT_TYPES]),
+    ];
+
+    const dateConditions = dateWindow(payouts.createdAt, fromDate, toDate);
+    const inPeriodSum =
+      dateConditions.length === 0
+        ? sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`
+        : sql<number>`COALESCE(SUM(CASE WHEN ${and(...dateConditions)} THEN ${payouts.amountCents} ELSE 0 END),0)::int`;
+
+    const [paid, inTransit, needsAttention] = await Promise.all([
+      this.db
+        .select({
+          inPeriod: inPeriodSum,
+          total: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
+        })
+        .from(payouts)
+        .where(and(...creatorScope, eq(payouts.status, 'paid'))),
+      this.db
+        .select({
+          sum: sql<number>`COALESCE(SUM(${payouts.amountCents}),0)::int`,
+        })
+        .from(payouts)
+        .where(and(...creatorScope, eq(payouts.status, 'pending'))),
+      this.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(payouts)
+        .where(
+          and(...creatorScope, inArray(payouts.status, ['pending', 'failed']))
         ),
     ]);
 

--- a/packages/validation/src/schemas/subscription.ts
+++ b/packages/validation/src/schemas/subscription.ts
@@ -242,6 +242,36 @@ export const getPayoutsByCreatorBreakdownQuerySchema = z.object({
   toDate: z.string().datetime().optional(),
 });
 
+/**
+ * Creator-self-scoped payouts list (Codex-69t7c.7 / WP7).
+ *
+ * The creator-earnings counterpart of {@link listPayoutsQuerySchema}: carries
+ * NO `organizationId`. The caller is resolved from the session (`ctx.user.id`),
+ * never client-supplied (IDOR prevention, epic decision D8). A creator's
+ * payouts span every org that paid them, so org-scope is intentionally absent.
+ * Status/source/date chips share the enums with the org table for parity.
+ */
+export const listMyPayoutsQuerySchema = paginationSchema.extend({
+  status: payoutStatusFilterEnum.default('all'),
+  source: payoutSourceFilterEnum.default('all'),
+  fromDate: z.string().datetime().optional(),
+  toDate: z.string().datetime().optional(),
+});
+
+/**
+ * Creator-self-scoped earnings summary (Codex-69t7c.7 / WP7). Dates only — no
+ * `organizationId` (session-scoped, spans all orgs).
+ */
+export const getMyEarningsSummaryQuerySchema = z.object({
+  fromDate: z.string().datetime().optional(),
+  toDate: z.string().datetime().optional(),
+});
+
+export type ListMyPayoutsQueryInput = z.infer<typeof listMyPayoutsQuerySchema>;
+export type GetMyEarningsSummaryQueryInput = z.infer<
+  typeof getMyEarningsSummaryQuerySchema
+>;
+
 export const getCurrentSubscriptionQuerySchema = z.object({
   organizationId: uuidSchema,
 });

--- a/workers/ecom-api/src/routes/__tests__/subscriptions-me-payouts-routes.test.ts
+++ b/workers/ecom-api/src/routes/__tests__/subscriptions-me-payouts-routes.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Integration tests for creator-self-scoped /subscriptions/me/* routes
+ * (Codex-69t7c.7 / WP7) — GET /me/payouts + GET /me/earnings-summary.
+ *
+ * Runs against the REAL `procedure()` resolver (memory:
+ * implement/real-resolver-route-test-ecom): a test middleware injects `user`
+ * BEFORE the route so the real `authenticateSession` early-returns and the
+ * rest of the resolver runs (rate-limit → role([]) → needsOrg=false). Only
+ * `@codex/subscription`'s service is mocked (spies), so no DB/Stripe fires.
+ * Dispatched via `app.fetch(req, env, createExecutionContext())` (procedure
+ * needs `ctx.executionCtx.waitUntil`).
+ *
+ * Proves, through the real resolver: a plain member reaches the routes (no org
+ * gate), unauthenticated is rejected, and a query-smuggled userId/organizationId
+ * is ignored in favour of the session id.
+ */
+import {
+  createExecutionContext,
+  env,
+  waitOnExecutionContext,
+} from 'cloudflare:test';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const subscriptionSpies = {
+  listPayoutsForCreator: vi.fn(),
+  getEarningsSummaryForCreator: vi.fn(),
+};
+
+vi.mock('@codex/subscription', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@codex/subscription')>();
+  return {
+    ...actual,
+    SubscriptionService: vi.fn(() => subscriptionSpies),
+  };
+});
+
+// Import AFTER the mock so the real service registry resolves the mocked class.
+import subscriptions from '../subscriptions';
+
+const CREATOR = {
+  id: '7a1d0f2e-3b4c-4d5e-8f60-112233445566',
+  email: 'creator@test.com',
+  role: 'creator',
+};
+
+// A "plain member": no org-management capability. Reaching the routes proves
+// they are gated by `auth:'required'` alone, not requireOrgManagement.
+const PLAIN_MEMBER = {
+  id: '9c2e1a3f-4d5b-4e6a-9071-223344556677',
+  email: 'member@test.com',
+  role: 'member',
+};
+
+const PAYOUTS_PAGE = {
+  items: [
+    {
+      id: 'p1',
+      organizationId: 'org-1',
+      amountCents: 1000,
+      currency: 'gbp',
+      reason: '',
+      status: 'resolved',
+      payoutType: 'creator_payout',
+      sourceType: 'subscription',
+      resolvedAt: null,
+      stripeTransferId: 'tr_1',
+      transferGroup: null,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      purchaseId: null,
+      subscriptionId: null,
+      stripeChargeId: null,
+    },
+  ],
+  pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+};
+
+const SUMMARY = {
+  earnedInPeriodCents: 1000,
+  totalEarnedCents: 1500,
+  inTransitCents: 200,
+  needsAttentionCount: 1,
+};
+
+function buildApp(user: Record<string, unknown> | null) {
+  const app = new Hono<{ Variables: Record<string, unknown> }>();
+  app.use('*', async (c, next) => {
+    if (user) {
+      c.set('user', user);
+      c.set('session', { id: 'sess_test', userId: user.id });
+    }
+    await next();
+  });
+  app.route('/subscriptions', subscriptions);
+  return app;
+}
+
+async function dispatch(
+  app: ReturnType<typeof buildApp>,
+  req: Request
+): Promise<Response> {
+  const ec = createExecutionContext();
+  const res = await app.fetch(req, env, ec);
+  await waitOnExecutionContext(ec);
+  return res;
+}
+
+function getReq(path: string) {
+  return new Request(`http://ecom-api.test${path}`, { method: 'GET' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  subscriptionSpies.listPayoutsForCreator.mockResolvedValue(PAYOUTS_PAGE);
+  subscriptionSpies.getEarningsSummaryForCreator.mockResolvedValue(SUMMARY);
+});
+
+describe('GET /subscriptions/me/payouts — real resolver', () => {
+  it('authenticated creator → 200 with {items,pagination}, service called with SESSION user id', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR),
+      getReq('/subscriptions/me/payouts')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      items: PAYOUTS_PAGE.items,
+      pagination: PAYOUTS_PAGE.pagination,
+    });
+    expect(subscriptionSpies.listPayoutsForCreator).toHaveBeenCalledWith(
+      CREATOR.id,
+      expect.objectContaining({ status: 'all', sourceType: 'all' })
+    );
+  });
+
+  it('plain member (no org-management role) reaches the route → 200', async () => {
+    const res = await dispatch(
+      buildApp(PLAIN_MEMBER),
+      getReq('/subscriptions/me/payouts')
+    );
+
+    expect(res.status).toBe(200);
+    expect(subscriptionSpies.listPayoutsForCreator).toHaveBeenCalledWith(
+      PLAIN_MEMBER.id,
+      expect.anything()
+    );
+  });
+
+  it('unauthenticated → 401, service NOT called', async () => {
+    const res = await dispatch(
+      buildApp(null),
+      getReq('/subscriptions/me/payouts')
+    );
+
+    expect(res.status).toBe(401);
+    expect(subscriptionSpies.listPayoutsForCreator).not.toHaveBeenCalled();
+  });
+
+  it('IDOR: query-smuggled userId/organizationId is ignored — session id wins', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR),
+      getReq(
+        `/subscriptions/me/payouts?userId=${PLAIN_MEMBER.id}&organizationId=11111111-1111-4111-8111-111111111111`
+      )
+    );
+
+    expect(res.status).toBe(200);
+    expect(subscriptionSpies.listPayoutsForCreator).toHaveBeenCalledWith(
+      CREATOR.id,
+      expect.anything()
+    );
+    // The forged id never reaches the service.
+    expect(subscriptionSpies.listPayoutsForCreator).not.toHaveBeenCalledWith(
+      PLAIN_MEMBER.id,
+      expect.anything()
+    );
+  });
+
+  it('passes the status filter through to the service', async () => {
+    await dispatch(
+      buildApp(CREATOR),
+      getReq('/subscriptions/me/payouts?status=pending')
+    );
+
+    expect(subscriptionSpies.listPayoutsForCreator).toHaveBeenCalledWith(
+      CREATOR.id,
+      expect.objectContaining({ status: 'pending' })
+    );
+  });
+});
+
+describe('GET /subscriptions/me/earnings-summary — real resolver', () => {
+  it('authenticated creator → 200 with {data: summary}, service called with session id', async () => {
+    const res = await dispatch(
+      buildApp(CREATOR),
+      getReq('/subscriptions/me/earnings-summary')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: SUMMARY });
+    expect(subscriptionSpies.getEarningsSummaryForCreator).toHaveBeenCalledWith(
+      CREATOR.id,
+      expect.any(Object)
+    );
+  });
+
+  it('unauthenticated → 401, service NOT called', async () => {
+    const res = await dispatch(
+      buildApp(null),
+      getReq('/subscriptions/me/earnings-summary')
+    );
+
+    expect(res.status).toBe(401);
+    expect(
+      subscriptionSpies.getEarningsSummaryForCreator
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/workers/ecom-api/src/routes/subscriptions.ts
+++ b/workers/ecom-api/src/routes/subscriptions.ts
@@ -21,9 +21,11 @@ import {
   changeTierSchema,
   createSubscriptionCheckoutSchema,
   getCurrentSubscriptionQuerySchema,
+  getMyEarningsSummaryQuerySchema,
   getPayoutSummaryQuerySchema,
   getPayoutsByCreatorBreakdownQuerySchema,
   getSubscriptionStatsQuerySchema,
+  listMyPayoutsQuerySchema,
   listPayoutsQuerySchema,
   listSubscribersQuerySchema,
   reactivateSubscriptionSchema,
@@ -447,6 +449,61 @@ subscriptions.get(
         {
           status: ctx.input.query.status,
           sourceType: ctx.input.query.source,
+          fromDate: ctx.input.query.fromDate,
+          toDate: ctx.input.query.toDate,
+        }
+      );
+    },
+  })
+);
+
+/**
+ * GET /subscriptions/me/payouts
+ *
+ * Codex-69t7c.7 (WP7): the acting creator's OWN payouts across every org that
+ * paid them. Creator-self-scoped — `policy:{auth:'required'}` only (NO
+ * `requireOrgManagement`); the service filters by `ctx.user.id` + personal
+ * payout types, so the route cannot read another creator's payouts and accepts
+ * NO client-supplied userId/organizationId (IDOR prevention, epic decision D8).
+ */
+subscriptions.get(
+  '/me/payouts',
+  procedure({
+    policy: { auth: 'required' },
+    input: { query: listMyPayoutsQuerySchema },
+    handler: async (ctx) => {
+      const result = await ctx.services.subscription.listPayoutsForCreator(
+        ctx.user.id,
+        {
+          page: ctx.input.query.page,
+          limit: ctx.input.query.limit,
+          status: ctx.input.query.status,
+          sourceType: ctx.input.query.source,
+          fromDate: ctx.input.query.fromDate,
+          toDate: ctx.input.query.toDate,
+        }
+      );
+      return new PaginatedResult(result.items, result.pagination);
+    },
+  })
+);
+
+/**
+ * GET /subscriptions/me/earnings-summary
+ *
+ * Codex-69t7c.7 (WP7): KPI numbers for the creator earnings hub (earned in
+ * period, total earned, in transit, needs-attention), userId-scoped across ALL
+ * orgs. Same self-scoping invariant as /me/payouts — never client-supplied id.
+ */
+subscriptions.get(
+  '/me/earnings-summary',
+  procedure({
+    policy: { auth: 'required' },
+    input: { query: getMyEarningsSummaryQuerySchema },
+    handler: async (ctx) => {
+      return ctx.services.subscription.getEarningsSummaryForCreator(
+        ctx.user.id,
+        {
           fromDate: ctx.input.query.fromDate,
           toDate: ctx.input.query.toDate,
         }


### PR DESCRIPTION
## Summary

WP7 of epic **Codex-69t7c** (Creator Studio Monetisation) — D7: this PR **owns** the creator earnings query (the Analytics epic will consume it). Adds the creator-self-scoped counterpart of the org `/studio/payouts` surface.

**Service (`@codex/subscription`)** — two new `SubscriptionService` methods:
| Method | Returns | Scope |
|---|---|---|
| `listPayoutsForCreator(userId, filters)` | `PaginatedListResponse<CreatorPayoutRow>` | `userId` + `payoutType IN (creator_payout, creator_payout_to_owner)`, per-row paginated |
| `getEarningsSummaryForCreator(userId, {dates})` | `CreatorEarningsSummary` (earned-in-period / total / in-transit / needs-attention) | same scope, 3 parallel aggregates |

**Routes (`ecom-api`)** — `GET /subscriptions/me/payouts` + `GET /subscriptions/me/earnings-summary`, `policy: { auth: 'required' }` (no `requireOrgManagement`), scoped to `ctx.user.id` — never a client-supplied id (IDOR prevention, epic decision D8).

- The `payoutType` filter **excludes `organization_fee`/`platform_fee`** — the same per-creator boundary WP6 (Codex-h3864) fixed, so an owner's org-fee cut is never double-counted as personal creator earnings.
- Refactor: extracted `buildPayoutFilterConditions` (scope-free status/source/date chips), shared by the org `buildPayoutConditions` and the new `buildCreatorPayoutConditions` — chip semantics single-sourced, org behaviour unchanged.

## Test plan

- **Service** (`creator-earnings.test.ts`, real DB): cross-creator isolation (a foreign creator's row never returned), `organization_fee` exclusion, and KPIs **to the penny** (`totalEarnedCents === 1500`, excluding a seeded £3 org-fee + a £999.99 foreign row); status filter; empty/zero states. Seeds use `crypto.randomUUID()` transfer IDs (dup-key-safe).
- **Route** (`subscriptions-me-payouts-routes.test.ts`, real `procedure()` resolver — not mocked): auth pos/neg (401), plain-member reachability (no org gate), structural IDOR (query-smuggled `userId`/`organizationId` ignored → session id wins), filter pass-through, envelope shapes.
- `pnpm turbo run test --filter @codex/subscription --filter ecom-api --filter @codex/validation` → **subscription 399 pass** (org payout tests green ⇒ the builder refactor is regression-clean), **ecom-api 377 pass**, validation green. Typecheck 26/26.

## Review

`codex-review` swarm (scoping-security · backend-conformance · commerce-stripe · silent-failure-hunter): **0 critical / 0 high / 0 medium / 0 low**. scoping-security verified `eq(userId)` on every query path; commerce-stripe verified the org-fee exclusion is consistent with — and stronger than — WP6, proven to the penny.

## Notes

- No DB migration (Zod schema + read-only query only).
- `getEarningsSummaryForCreator` is the **intentional inverse** of `getPayoutSummary`'s org-scoping invariant (a creator's earnings span every org that paid them) — documented on the new type.
- `gate.sh` whole-repo `biome` flags the same **pre-existing** apps/web violations as PR #275 (tracked in **Codex-zf9wf**); WP7's own files are biome-clean (typecheck/test/build pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
