### PR TITLE
feat(payouts): WP4 creator-slice userId routing lock + ed446 fix

### DIFF
--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -1291,6 +1291,180 @@ describe('PurchaseService Integration', () => {
       expect((stubStripe as any).transfers.create).not.toHaveBeenCalled();
     });
 
+    // ─── Codex-69t7c WP4 (D2/D4): single-account routing invariant ───
+    // The creator slice is resolved by `eq(stripeConnectAccounts.userId,
+    // creatorId)` — userId-only. The creator's single account carries a
+    // vestigial organizationId (nullable; the org it was first onboarded
+    // under). Here we null it out to prove routing ignores it; a regression
+    // that re-adds an organizationId predicate would miss the account and
+    // strand the slice in pending instead of firing the transfer.
+    it('routes the creator slice by userId regardless of the Connect account vestigial organizationId (Codex-69t7c D4)', async () => {
+      const { content, chargeId, paymentIntentId, stripeAccountId } =
+        await setupPaidContentWithConnect({
+          title: 'Creator userId routing',
+          priceCents: 10000,
+        });
+
+      // Sever the account's vestigial org link — userId routing must hold.
+      await db
+        .update(schema.stripeConnectAccounts)
+        .set({ organizationId: null })
+        .where(eq(schema.stripeConnectAccounts.userId, userId));
+
+      const creatorTransferId = `tr_creator_${Date.now()}`;
+      const orgTransferId = `tr_org_${Date.now()}`;
+      const createTransfer = vi
+        .fn()
+        .mockImplementation((args: { metadata?: { type?: string } }) =>
+          Promise.resolve({
+            id:
+              args?.metadata?.type === 'creator_payout'
+                ? creatorTransferId
+                : orgTransferId,
+          })
+        );
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      (mockStripe as any).transfers = { create: createTransfer };
+
+      const purchase = await purchaseService.completePurchase(paymentIntentId, {
+        customerId: otherUserId,
+        contentId: content.id,
+        organizationId,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: chargeId,
+      });
+
+      // Creator transfer fired to the userId-resolved account despite the
+      // null vestigial org column.
+      expect(createTransfer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination: stripeAccountId,
+          metadata: expect.objectContaining({ type: 'creator_payout' }),
+        }),
+        expect.objectContaining({ idempotencyKey: `${chargeId}_creator` })
+      );
+
+      const rows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+      const creatorRow = rows.find((r) => r.payoutType === 'creator_payout');
+      expect(creatorRow?.status).toBe('paid');
+      expect(creatorRow?.userId).toBe(userId);
+    });
+
+    // ─── Codex-ed446: org-fee pending row must carry a non-null userId ───
+    // When the org owner has NO Connect account at all (distinct from the
+    // offline-account case above), resolvePrimaryConnect returns undefined.
+    // The org-fee slice MUST still be recorded as a pending row attributed to
+    // the org owner (resolveOrgOwnerId fallback, mirroring the subscription
+    // path) so it persists and is swept — instead of a null-userId insert
+    // that violates check_payouts_user_required (23514) and strands the slice
+    // in the platform balance with no ledger row (the bug this locks).
+    it('Codex-ed446: org owner with no Connect account still gets a non-null-userId pending org_fee row (no 23514 strand)', async () => {
+      const [ownerUserId] = await seedTestUsers(db, 1);
+      const [org2] = await db
+        .insert(organizations)
+        .values({
+          name: 'No-Connect Owner Org',
+          slug: createUniqueSlug('no-connect-owner'),
+          ownerId: ownerUserId,
+        })
+        .returning();
+      // resolveOrgOwnerId reads organizationMemberships(role='owner'), NOT
+      // organizations.ownerId — seed the membership explicitly.
+      await db
+        .insert(schema.organizationMemberships)
+        .values(
+          createTestMembershipInput(org2.id, ownerUserId, { role: 'owner' })
+        );
+      // Deliberately seed NO stripe_connect_accounts row for ownerUserId.
+
+      const stubFeeConfig = {
+        getFeesForCreator: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 1500,
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+      };
+      const stubStripe = {
+        ...mockStripe,
+        transfers: { create: vi.fn() },
+        paymentIntents: { retrieve: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      const media = await mediaService.create(
+        {
+          title: 'No Connect Owner',
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          fileSizeBytes: 1024 * 1024,
+        },
+        ownerUserId
+      );
+      await mediaService.markAsReady(
+        media.id,
+        {
+          hlsMasterPlaylistKey: 'hls/no-connect/master.m3u8',
+          thumbnailKey: 'thumbnails/no-connect.jpg',
+          durationSeconds: 60,
+        },
+        ownerUserId
+      );
+      const content = await contentService.create(
+        {
+          organizationId: org2.id,
+          title: 'No Connect Owner',
+          slug: createUniqueSlug('no-connect-owner-content'),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'purchased_only',
+          accessType: 'paid',
+          priceCents: 10000,
+        },
+        ownerUserId
+      );
+      await contentService.publish(content.id, ownerUserId);
+
+      const chargeId = `ch_no_connect_${Date.now()}`;
+      const purchase = await service.completePurchase(
+        `pi_no_connect_${Date.now()}`,
+        {
+          customerId: userId,
+          contentId: content.id,
+          organizationId: org2.id,
+          amountPaidCents: 10000,
+          currency: 'gbp',
+          stripeChargeId: chargeId,
+        }
+      );
+
+      const rows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+
+      const orgFeeRow = rows.find((r) => r.payoutType === 'organization_fee');
+      // The crux: the org-fee row EXISTS (pre-fix it was dropped by the 23514
+      // catch) and carries a non-null userId = the org owner.
+      expect(orgFeeRow).toBeDefined();
+      expect(orgFeeRow?.userId).toBe(ownerUserId);
+      expect(orgFeeRow?.status).toBe('pending');
+      expect(orgFeeRow?.reason).toBe('connect_not_ready');
+      expect(orgFeeRow?.sourceType).toBe('purchase');
+
+      // No transfer fired — there is no Connect account to receive it.
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      expect((stubStripe as any).transfers.create).not.toHaveBeenCalled();
+    });
+
     it('schema rejects paid rows with neither stripe_transfer_id nor stripe_charge_id', async () => {
       // Try to insert a paid row that satisfies neither side of the
       // check_payouts_paid_invariant OR clause. The DB MUST reject it.

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -27,12 +27,13 @@ import {
   CURRENCY,
   PURCHASE_STATUS,
 } from '@codex/constants';
-import { isUniqueViolation, toIso } from '@codex/database';
+import { getConstraintName, isUniqueViolation, toIso } from '@codex/database';
 import {
   agreementProposals,
   content,
   contentAccess,
   creatorOrganizationAgreements,
+  organizationMemberships,
   payouts,
   purchases,
   refundReviews,
@@ -875,19 +876,67 @@ export class PurchaseService extends BaseService {
 
     // 3. Organization fee — secondary transfer with source_transaction.
     if (revenueSplit.organizationFeeCents > 0) {
-      await this.executePurchaseTransfer({
-        purchase,
-        organizationId,
-        amountCents: revenueSplit.organizationFeeCents,
-        payoutType: 'organization_fee',
-        rowUserId: orgConnect?.userId ?? null,
-        connect: orgConnect,
-        stripeChargeId,
-        transferGroup,
-        idempotencyKey: `${stripeChargeId}_org_fee`,
-        now,
-      });
+      // Codex-ed446: the org-fee payout row's recipient userId MUST be
+      // non-null (check_payouts_user_required). Prefer the resolved Connect
+      // account's user; when the org owner has not onboarded a Connect
+      // account, orgConnect is undefined — fall back to the org owner so a
+      // pending organization_fee row still persists and is swept (mirrors the
+      // subscription path) instead of stranding the slice via a 23514
+      // violation that the per-row catch would silently swallow.
+      const orgRowUserId =
+        orgConnect?.userId ?? (await this.resolveOrgOwnerId(organizationId));
+      if (orgRowUserId) {
+        await this.executePurchaseTransfer({
+          purchase,
+          organizationId,
+          amountCents: revenueSplit.organizationFeeCents,
+          payoutType: 'organization_fee',
+          rowUserId: orgRowUserId,
+          connect: orgConnect,
+          stripeChargeId,
+          transferGroup,
+          idempotencyKey: `${stripeChargeId}_org_fee`,
+          now,
+        });
+      } else {
+        // No Connect account AND no resolvable org owner — cannot attribute
+        // the slice to any user, so a ledger row is impossible. Surface loudly
+        // (data-integrity event) rather than emit a 23514-bound insert.
+        this.obs.error(
+          'Cannot record organization_fee payout: no Connect account and no org owner found',
+          {
+            purchaseId: purchase.id,
+            organizationId,
+            amountCents: revenueSplit.organizationFeeCents,
+          }
+        );
+      }
     }
+  }
+
+  /**
+   * Resolve an org's owner userId (Codex-ed446). The org-fee payout row MUST
+   * carry a non-null userId (check_payouts_user_required); when the org owner
+   * has not onboarded a Connect account, `resolvePrimaryConnect` returns
+   * undefined, so we fall back to the owner here rather than writing a
+   * null-userId row that violates 23514 and strands the org slice in the
+   * platform balance. Mirrors `SubscriptionService.resolveOrgOwnerId`. No
+   * ORDER BY — matches that resolver's shape; deterministic-owner ordering
+   * across multi-owner orgs is tracked separately in Codex-rjwdm.
+   */
+  private async resolveOrgOwnerId(orgId: string): Promise<string | null> {
+    const [owner] = await this.db
+      .select({ userId: organizationMemberships.userId })
+      .from(organizationMemberships)
+      .where(
+        and(
+          eq(organizationMemberships.organizationId, orgId),
+          eq(organizationMemberships.role, 'owner')
+        )
+      )
+      .limit(1);
+
+    return owner?.userId ?? null;
   }
 
   /**
@@ -951,6 +1000,10 @@ export class PurchaseService extends BaseService {
               purchaseId: purchase.id,
               organizationId,
               amountCents,
+              // Codex-ed446: surface the constraint so a CHECK violation
+              // (e.g. check_payouts_user_required, 23514) on this money-ledger
+              // insert is logged distinctly from the suppressed 23505 dup.
+              constraint: getConstraintName(err),
               error: err instanceof Error ? err.message : String(err),
             }
           );

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -3387,6 +3387,109 @@ describe('SubscriptionService', () => {
         }));
     }
 
+    // ─── Codex-69t7c WP4 (D2/D4): single-account routing invariant ───
+    // A creator has exactly ONE Connect account (uq_stripe_connect_user) that
+    // receives their slice from EVERY org they hold an agreement with. The
+    // per-creator lookup is `inArray(stripeConnectAccounts.userId, creatorIds)`
+    // — userId-only, never (userId, organizationId). This test pays from org A
+    // while the creator's single account was onboarded under a DIFFERENT org
+    // (its vestigial organizationId points at org B). The slice MUST still
+    // route to that account by userId. A regression that re-introduces an
+    // organizationId predicate would fail to match → route the slice to a
+    // pending row instead of firing the transfer → this test goes red.
+    it('routes a creator slice to the creator single account even when that account was onboarded under a different org (multi-org creator → one account, D4)', async () => {
+      const { org, tier1 } = await createFullOrg('multiorg-creator');
+
+      // A second org; the creator's ONE Connect account records orgB as its
+      // vestigial onboarding origin — it must NOT influence routing.
+      const [orgB] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('creator-home-org'),
+            creatorId: thirdUserId,
+          })
+        )
+        .returning();
+
+      const [xorgCreatorId] = await seedTestUsers(db, 1);
+      const creatorConnect = createTestConnectAccountInput(
+        orgB.id,
+        xorgCreatorId,
+        {
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          status: 'active',
+        }
+      );
+      await db.insert(stripeConnectAccounts).values(creatorConnect);
+
+      // Active subscription agreement lives in the PAYING org (org), not orgB.
+      await seedAgreement(org.id, xorgCreatorId, 5000);
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+
+      // Distinct transfer ids per call so the two ledger rows (creator + org)
+      // don't collide on uq_payouts_stripe_transfer_id.
+      const createTransfer = vi
+        .fn()
+        .mockImplementation(
+          (args: { metadata?: { type?: string; creator_id?: string } }) =>
+            Promise.resolve({
+              id: `tr_${args?.metadata?.type ?? 'x'}_${args?.metadata?.creator_id ?? 'org'}_${Math.random().toString(36).slice(2, 8)}`,
+            })
+        );
+      (stripe as unknown as { transfers: unknown }).transfers = {
+        create: createTransfer,
+      };
+
+      const chargeId = 'ch_multiorg_creator';
+      const mockInvoice = createMockStripeInvoice({
+        amount_paid: 1000,
+        parent: {
+          subscription_details: { subscription: sub.stripeSubscriptionId },
+        },
+        payments: {
+          data: [
+            { payment: { charge: chargeId, payment_intent: 'pi_multiorg' } },
+          ],
+        },
+      }) as unknown as Stripe.Invoice;
+
+      await service.handleInvoicePaymentSucceeded(mockInvoice);
+
+      const creatorCalls = perCreatorTransferCalls(createTransfer);
+      const call = creatorCalls.find(
+        (c) => c.idempotencyKey === `${chargeId}_creator_${xorgCreatorId}`
+      );
+      expect(call).toBeDefined();
+      // THE PROOF: destination is the creator's single account (resolved by
+      // userId), independent of that account's vestigial organizationId (orgB).
+      expect(call?.destination).toBe(creatorConnect.stripeAccountId);
+
+      // Ledger row lands on the creator userId, status paid.
+      const rows = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.organizationId, org.id));
+      const creatorRow = rows.find(
+        (r) =>
+          r.userId === xorgCreatorId &&
+          r.payoutType === 'creator_payout' &&
+          r.stripeChargeId === chargeId
+      );
+      expect(creatorRow).toBeDefined();
+      expect(creatorRow?.status).toBe('paid');
+      expect(creatorRow?.stripeTransferId).toBeTruthy();
+    });
+
     it('share-sum exactly 10000 bps (2 creators, 50/50): each receives floor(payout/2)', async () => {
       const { org, tier1 } = await createFullOrg('split-5050');
       const c1 = await seedCreatorWithConnect(org.id);


### PR DESCRIPTION
## Summary
WP4 (`Codex-69t7c.4`) of the Creator Studio Monetisation epic.

**Finding:** the creator-slice → single-Connect-account-by-`userId` routing that decision D4 describes **already landed pre-epic** (subscription `inArray(stripeConnectAccounts.userId, …)`, purchase `eq(userId, creatorId)`); WP1's `unique(userId)` schema change is what made those lookups resolve to a single *deterministic* account. So WP4's real deliverable is **locking that invariant with regression tests** + closing the one money-correctness gap in the touched purchase path.

**ed446 fix** (`packages/purchase/src/services/purchase-service.ts`): the org-fee pending payout row now carries a non-null `userId` via a new private `resolveOrgOwnerId(orgId)` fallback (mirrors `SubscriptionService.resolveOrgOwnerId`). Previously, when the org owner had no Connect account, `resolvePrimaryConnect` returned `undefined` → the row was inserted with `userId=null` → violated `check_payouts_user_required` (Postgres 23514); the catch only suppressed 23505, so the slice stranded in the platform balance with no recoverable ledger row. The no-owner case now logs + skips (a non-null-userId row is structurally impossible there). Adds `getConstraintName(err)` to the pending-insert catch so a CHECK violation is logged distinctly from a 23505 dup.

Subscription transfer logic is **unchanged** (already userId-correct) — only a regression test was added there.

Deliberately **out of scope** (own beads): `Codex-rjwdm` (resolvePrimaryConnect owner-fallback `ORDER BY` determinism — adding `.orderBy` carries a db-mock blast radius); purchase-path `assertGbpOnly` (hardening, not a routing bug).

## Test Plan
All real-DB integration tests (mocked Stripe), run `--concurrency=1`:
- **subscription** `multi-org creator → one account`: creator's single account onboarded under org B, paid from org A → transfer `destination` resolves by `userId` regardless of the account's vestigial `organizationId`.
- **purchase** `creator routing ignores vestigial organizationId`: account's org column nulled → creator slice still routes by `userId`.
- **purchase** `ed446 negative`: org owner with **no** Connect account + org-fee > 0 → a pending `organization_fee` row exists with a **non-null** userId (the owner), `reason=connect_not_ready`; no transfer fired.
- Full suites green: `@codex/purchase` 224 passed; `@codex/subscription` 400 passed.
- typecheck clean (both packages); `gate.sh` typecheck + test + build all pass.

## codex-review
4 reviewers (commerce-stripe, silent-failure-hunter, backend-conformance, scoping-security): **0 critical / 0 high / 0 medium**. Two LOW, both no-action (the `resolveOrgOwnerId` `ORDER BY` → `Codex-rjwdm`; the no-owner log+skip → correct-by-constraint). The adversarial silent-failure-hunter independently traced the new guard and confirmed it is not a silent failure.

## Note on CI biome
`gate.sh` reports `✗ biome (check:ci)` — **all 20+ diagnostics are pre-existing `apps/web/**` violations** (tracked in `Codex-zf9wf`); **zero** are in this PR's 3 files (verified by enumerating every diagnostic location). Shipped scoped per precedent (#275, #276). typecheck/test/build gates all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
