### PR TITLE
feat(payouts): WP5 orgless purchase-gate removal + bi-party branch

### DIFF
--- a/packages/database/src/migrations/0075_content_access_org_nullable.sql
+++ b/packages/database/src/migrations/0075_content_access_org_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "content_access" ALTER COLUMN "organization_id" DROP NOT NULL;

--- a/packages/database/src/migrations/meta/0075_snapshot.json
+++ b/packages/database/src/migrations/meta/0075_snapshot.json
@@ -1,0 +1,6658 @@
+{
+  "id": "4f8ee00b-693a-4183-9064-ecf87fc49a4e",
+  "prevId": "c0e46ada-c2fb-413a-823d-9510a9dbdaca",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_username": {
+          "name": "idx_unique_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_users_stripe_customer_id": {
+          "name": "idx_unique_users_stripe_customer_id",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"stripe_customer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body": {
+          "name": "content_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body_json": {
+          "name": "content_body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "shader_preset": {
+          "name": "shader_preset",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shader_config": {
+          "name": "shader_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_tier_id": {
+          "name": "minimum_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_creator_id": {
+          "name": "idx_content_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_organization_id": {
+          "name": "idx_content_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_media_item_id": {
+          "name": "idx_content_media_item_id",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_slug_org": {
+          "name": "idx_content_slug_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_status": {
+          "name": "idx_content_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_published_at": {
+          "name": "idx_content_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_category": {
+          "name": "idx_content_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_minimum_tier": {
+          "name": "idx_content_minimum_tier",
+          "columns": [
+            {
+              "expression": "minimum_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_published": {
+          "name": "idx_content_org_published",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_creator_org_published": {
+          "name": "idx_content_creator_org_published",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_featured": {
+          "name": "idx_content_org_featured",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"featured\" = true AND \"content\".\"status\" = 'published' AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_per_org": {
+          "name": "idx_unique_content_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NOT NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_personal": {
+          "name": "idx_unique_content_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_type": {
+          "name": "idx_content_access_type",
+          "columns": [
+            {
+              "expression": "access_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_creator_id_users_id_fk": {
+          "name": "content_creator_id_users_id_fk",
+          "tableFrom": "content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_organization_id_organizations_id_fk": {
+          "name": "content_organization_id_organizations_id_fk",
+          "tableFrom": "content",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_media_item_id_media_items_id_fk": {
+          "name": "content_media_item_id_media_items_id_fk",
+          "tableFrom": "content",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_minimum_tier_id_subscription_tiers_id_fk": {
+          "name": "content_minimum_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "content",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "minimum_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_content_status": {
+          "name": "check_content_status",
+          "value": "\"content\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_content_access_type": {
+          "name": "check_content_access_type",
+          "value": "\"content\".\"access_type\" IN ('free', 'paid', 'followers', 'subscribers', 'team')"
+        },
+        "check_content_type": {
+          "name": "check_content_type",
+          "value": "\"content\".\"content_type\" IN ('video', 'audio', 'written')"
+        },
+        "check_price_non_negative": {
+          "name": "check_price_non_negative",
+          "value": "\"content\".\"price_cents\" IS NULL OR \"content\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_master_playlist_key": {
+          "name": "hls_master_playlist_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_preview_key": {
+          "name": "hls_preview_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_key": {
+          "name": "waveform_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_image_key": {
+          "name": "waveform_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runpod_job_id": {
+          "name": "runpod_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_error": {
+          "name": "transcoding_error",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_attempts": {
+          "name": "transcoding_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transcoding_priority": {
+          "name": "transcoding_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "transcoding_progress": {
+          "name": "transcoding_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_step": {
+          "name": "transcoding_step",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_key": {
+          "name": "mezzanine_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_status": {
+          "name": "mezzanine_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_variants": {
+          "name": "ready_variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_integrated": {
+          "name": "loudness_integrated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_peak": {
+          "name": "loudness_peak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_range": {
+          "name": "loudness_range",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_creator_id": {
+          "name": "idx_media_items_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_status": {
+          "name": "idx_media_items_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_type": {
+          "name": "idx_media_items_type",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_runpod_job_id": {
+          "name": "idx_media_items_runpod_job_id",
+          "columns": [
+            {
+              "expression": "runpod_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_transcoding_status": {
+          "name": "idx_media_items_transcoding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcoding_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_items_creator_id_users_id_fk": {
+          "name": "media_items_creator_id_users_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_media_status": {
+          "name": "check_media_status",
+          "value": "\"media_items\".\"status\" IN ('uploading', 'uploaded', 'transcoding', 'ready', 'failed')"
+        },
+        "check_media_type": {
+          "name": "check_media_type",
+          "value": "\"media_items\".\"media_type\" IN ('video', 'audio')"
+        },
+        "check_mezzanine_status": {
+          "name": "check_mezzanine_status",
+          "value": "\"media_items\".\"mezzanine_status\" IS NULL OR \"media_items\".\"mezzanine_status\" IN ('pending', 'processing', 'ready', 'failed')"
+        },
+        "check_transcoding_priority": {
+          "name": "check_transcoding_priority",
+          "value": "\"media_items\".\"transcoding_priority\" >= 0 AND \"media_items\".\"transcoding_priority\" <= 4"
+        },
+        "check_max_transcoding_attempts": {
+          "name": "check_max_transcoding_attempts",
+          "value": "\"media_items\".\"transcoding_attempts\" >= 0 AND \"media_items\".\"transcoding_attempts\" <= 3"
+        },
+        "check_transcoding_progress_range": {
+          "name": "check_transcoding_progress_range",
+          "value": "\"media_items\".\"transcoding_progress\" IS NULL OR (\"media_items\".\"transcoding_progress\" >= 0 AND \"media_items\".\"transcoding_progress\" <= 100)"
+        },
+        "status_ready_requires_keys": {
+          "name": "status_ready_requires_keys",
+          "value": "\"media_items\".\"status\" != 'ready' OR (\n        \"media_items\".\"hls_master_playlist_key\" IS NOT NULL\n        AND \"media_items\".\"duration_seconds\" IS NOT NULL\n        AND (\n          (\"media_items\".\"media_type\" = 'video' AND \"media_items\".\"thumbnail_key\" IS NOT NULL)\n          OR (\"media_items\".\"media_type\" = 'audio' AND \"media_items\".\"waveform_key\" IS NOT NULL)\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_membership": {
+          "name": "idx_unique_org_membership",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_id": {
+          "name": "idx_org_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_user_id": {
+          "name": "idx_org_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_role": {
+          "name": "idx_org_memberships_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_status": {
+          "name": "idx_org_memberships_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_active_role": {
+          "name": "idx_org_memberships_org_active_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organization_memberships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_membership_role": {
+          "name": "check_membership_role",
+          "value": "\"organization_memberships\".\"role\" IN ('owner', 'admin', 'creator', 'subscriber', 'member')"
+        },
+        "check_membership_status": {
+          "name": "check_membership_status",
+          "value": "\"organization_memberships\".\"status\" IN ('active', 'inactive', 'invited')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agreement_proposals": {
+      "name": "agreement_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_proposal_id": {
+          "name": "parent_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_role": {
+          "name": "proposed_by_role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_creator_share_percent": {
+          "name": "proposed_creator_share_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_term_months": {
+          "name": "proposed_term_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_effective_from": {
+          "name": "proposed_effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agreement_proposals_thread": {
+          "name": "idx_agreement_proposals_thread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_creator_status": {
+          "name": "idx_agreement_proposals_creator_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_org_status": {
+          "name": "idx_agreement_proposals_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agreement_proposals_organization_id_organizations_id_fk": {
+          "name": "agreement_proposals_organization_id_organizations_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_creator_id_users_id_fk": {
+          "name": "agreement_proposals_creator_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk": {
+          "name": "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "parent_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_proposed_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_proposed_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_responded_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_responded_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_agreement_proposals_revenue_type": {
+          "name": "check_agreement_proposals_revenue_type",
+          "value": "\"agreement_proposals\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_agreement_proposals_proposed_by_role": {
+          "name": "check_agreement_proposals_proposed_by_role",
+          "value": "\"agreement_proposals\".\"proposed_by_role\" IN ('owner', 'creator')"
+        },
+        "check_agreement_proposals_status": {
+          "name": "check_agreement_proposals_status",
+          "value": "\"agreement_proposals\".\"status\" IN ('open', 'accepted', 'declined', 'countered', 'withdrawn', 'superseded')"
+        },
+        "check_agreement_proposals_share_bps": {
+          "name": "check_agreement_proposals_share_bps",
+          "value": "\"agreement_proposals\".\"proposed_creator_share_percent\" >= 0 AND \"agreement_proposals\".\"proposed_creator_share_percent\" <= 10000"
+        },
+        "check_agreement_proposals_round_positive": {
+          "name": "check_agreement_proposals_round_positive",
+          "value": "\"agreement_proposals\".\"round_number\" >= 1"
+        },
+        "check_agreement_proposals_term_positive": {
+          "name": "check_agreement_proposals_term_positive",
+          "value": "\"agreement_proposals\".\"proposed_term_months\" IS NULL OR \"agreement_proposals\".\"proposed_term_months\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_access": {
+      "name": "content_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_access_user_id": {
+          "name": "idx_content_access_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_content_id": {
+          "name": "idx_content_access_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_organization_id": {
+          "name": "idx_content_access_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_access_user_id_users_id_fk": {
+          "name": "content_access_user_id_users_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_content_id_content_id_fk": {
+          "name": "content_access_content_id_content_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_organization_id_organizations_id_fk": {
+          "name": "content_access_organization_id_organizations_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_access_user_content_unique": {
+          "name": "content_access_user_content_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_access_type": {
+          "name": "check_access_type",
+          "value": "\"content_access\".\"access_type\" IN ('purchased', 'subscription', 'complimentary', 'preview')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_organization_agreements": {
+      "name": "creator_organization_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_fee_percentage": {
+          "name": "organization_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_by_user_id": {
+          "name": "terminated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_proposal_id": {
+          "name": "current_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiring_soon_email_sent_at": {
+          "name": "expiring_soon_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_creator_org_agreement_creator_id": {
+          "name": "idx_creator_org_agreement_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_org_id": {
+          "name": "idx_creator_org_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_effective": {
+          "name": "idx_creator_org_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_active_lookup": {
+          "name": "idx_creator_org_agreement_active_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_creator_org_agreement_active_per_type": {
+          "name": "uq_creator_org_agreement_active_per_type",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"creator_organization_agreements\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_organization_agreements_creator_id_users_id_fk": {
+          "name": "creator_organization_agreements_creator_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_organization_id_organizations_id_fk": {
+          "name": "creator_organization_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_terminated_by_user_id_users_id_fk": {
+          "name": "creator_organization_agreements_terminated_by_user_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "terminated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk": {
+          "name": "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "current_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "creator_org_agreement_unique": {
+          "name": "creator_org_agreement_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "organization_id",
+            "effective_from",
+            "revenue_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_org_fee_percentage": {
+          "name": "check_org_fee_percentage",
+          "value": "\"creator_organization_agreements\".\"organization_fee_percentage\" >= 0 AND \"creator_organization_agreements\".\"organization_fee_percentage\" <= 10000"
+        },
+        "check_creator_org_agreement_revenue_type": {
+          "name": "check_creator_org_agreement_revenue_type",
+          "value": "\"creator_organization_agreements\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_creator_org_agreement_status": {
+          "name": "check_creator_org_agreement_status",
+          "value": "\"creator_organization_agreements\".\"status\" IN ('active', 'terminated', 'expired')"
+        },
+        "check_creator_org_agreement_terminated_shape": {
+          "name": "check_creator_org_agreement_terminated_shape",
+          "value": "(\"creator_organization_agreements\".\"status\" = 'terminated') = (\"creator_organization_agreements\".\"terminated_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_platform_agreements": {
+      "name": "organization_platform_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_platform_agreement_org_id": {
+          "name": "idx_org_platform_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_platform_agreement_effective": {
+          "name": "idx_org_platform_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_platform_agreements_organization_id_organizations_id_fk": {
+          "name": "organization_platform_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "organization_platform_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percentage": {
+          "name": "check_org_platform_fee_percentage",
+          "value": "\"organization_platform_agreements\".\"platform_fee_percentage\" >= 0 AND \"organization_platform_agreements\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_fee_config": {
+      "name": "platform_fee_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_fee_config_effective": {
+          "name": "idx_platform_fee_config_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_platform_fee_percentage": {
+          "name": "check_platform_fee_percentage",
+          "value": "\"platform_fee_config\".\"platform_fee_percentage\" >= 0 AND \"platform_fee_config\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platform_agreement_id": {
+          "name": "platform_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_org_agreement_id": {
+          "name": "creator_org_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount_cents": {
+          "name": "refund_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispute_reason": {
+          "name": "dispute_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_dispute_id": {
+          "name": "stripe_dispute_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_purchases_customer_id": {
+          "name": "idx_purchases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_content_id": {
+          "name": "idx_purchases_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_organization_id": {
+          "name": "idx_purchases_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_stripe_payment_intent": {
+          "name": "idx_purchases_stripe_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_created_at": {
+          "name": "idx_purchases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_purchased_at": {
+          "name": "idx_purchases_purchased_at",
+          "columns": [
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_platform_agreement": {
+          "name": "idx_purchases_platform_agreement",
+          "columns": [
+            {
+              "expression": "platform_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_creator_org_agreement": {
+          "name": "idx_purchases_creator_org_agreement",
+          "columns": [
+            {
+              "expression": "creator_org_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_purchased": {
+          "name": "idx_purchases_customer_purchased",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_status_content": {
+          "name": "idx_purchases_customer_status_content",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_created": {
+          "name": "idx_purchases_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_purchased": {
+          "name": "idx_purchases_org_status_purchased",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "purchases_customer_id_users_id_fk": {
+          "name": "purchases_customer_id_users_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchases_content_id_content_id_fk": {
+          "name": "purchases_content_id_content_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_organization_id_organizations_id_fk": {
+          "name": "purchases_organization_id_organizations_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_platform_agreement_id_organization_platform_agreements_id_fk": {
+          "name": "purchases_platform_agreement_id_organization_platform_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organization_platform_agreements",
+          "columnsFrom": [
+            "platform_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk": {
+          "name": "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "creator_organization_agreements",
+          "columnsFrom": [
+            "creator_org_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchases_stripe_payment_intent_id_unique": {
+          "name": "purchases_stripe_payment_intent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_payment_intent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_purchase_status": {
+          "name": "check_purchase_status",
+          "value": "\"purchases\".\"status\" IN ('pending', 'completed', 'refunded', 'failed')"
+        },
+        "check_amount_positive": {
+          "name": "check_amount_positive",
+          "value": "\"purchases\".\"amount_paid_cents\" >= 0"
+        },
+        "check_platform_fee_positive": {
+          "name": "check_platform_fee_positive",
+          "value": "\"purchases\".\"platform_fee_cents\" >= 0"
+        },
+        "check_org_fee_positive": {
+          "name": "check_org_fee_positive",
+          "value": "\"purchases\".\"organization_fee_cents\" >= 0"
+        },
+        "check_creator_payout_positive": {
+          "name": "check_creator_payout_positive",
+          "value": "\"purchases\".\"creator_payout_cents\" >= 0"
+        },
+        "check_revenue_split_equals_total": {
+          "name": "check_revenue_split_equals_total",
+          "value": "\"purchases\".\"amount_paid_cents\" = \"purchases\".\"platform_fee_cents\" + \"purchases\".\"organization_fee_cents\" + \"purchases\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_audit_log": {
+      "name": "fee_config_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_creator_id": {
+          "name": "scope_creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_config_audit_scope": {
+          "name": "idx_fee_config_audit_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_org": {
+          "name": "idx_fee_config_audit_org",
+          "columns": [
+            {
+              "expression": "scope_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_creator": {
+          "name": "idx_fee_config_audit_creator",
+          "columns": [
+            {
+              "expression": "scope_creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_changed_by": {
+          "name": "idx_fee_config_audit_changed_by",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_audit_log_scope_org_id_organizations_id_fk": {
+          "name": "fee_config_audit_log_scope_org_id_organizations_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "scope_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_scope_creator_id_users_id_fk": {
+          "name": "fee_config_audit_log_scope_creator_id_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scope_creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_changed_by_users_id_fk": {
+          "name": "fee_config_audit_log_changed_by_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_audit_scope": {
+          "name": "check_fee_config_audit_scope",
+          "value": "\"fee_config_audit_log\".\"scope\" IN ('platform', 'org', 'override')"
+        },
+        "check_fee_config_audit_scope_org_id": {
+          "name": "check_fee_config_audit_scope_org_id",
+          "value": "(\"fee_config_audit_log\".\"scope\" = 'platform' AND \"fee_config_audit_log\".\"scope_org_id\" IS NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'org' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'override' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org": {
+      "name": "fee_config_org",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_org_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_updated_by_users_id_fk": {
+          "name": "fee_config_org_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percent_bps": {
+          "name": "check_org_platform_fee_percent_bps",
+          "value": "\"fee_config_org\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org\".\"platform_fee_percent\" >= 0 AND \"fee_config_org\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_org_org_fee_percent_bps": {
+          "name": "check_org_org_fee_percent_bps",
+          "value": "\"fee_config_org\".\"org_fee_percent\" IS NULL OR (\"fee_config_org\".\"org_fee_percent\" >= 0 AND \"fee_config_org\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_org_min_platform_fee_non_negative": {
+          "name": "check_org_min_platform_fee_non_negative",
+          "value": "\"fee_config_org\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_org_min_transfer_non_negative": {
+          "name": "check_org_min_transfer_non_negative",
+          "value": "\"fee_config_org\".\"min_transfer_cents\" IS NULL OR \"fee_config_org\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org_creator": {
+      "name": "fee_config_org_creator",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fee_config_org_creator_org": {
+          "name": "idx_fee_config_org_creator_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_org_creator_creator": {
+          "name": "idx_fee_config_org_creator_creator",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_org_creator_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_creator_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_creator_id_users_id_fk": {
+          "name": "fee_config_org_creator_creator_id_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_updated_by_users_id_fk": {
+          "name": "fee_config_org_creator_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fee_config_org_creator_pkey": {
+          "name": "fee_config_org_creator_pkey",
+          "columns": [
+            "organization_id",
+            "creator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_override_platform_fee_percent_bps": {
+          "name": "check_override_platform_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"platform_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_override_org_fee_percent_bps": {
+          "name": "check_override_org_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"org_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"org_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_override_min_platform_fee_non_negative": {
+          "name": "check_override_min_platform_fee_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org_creator\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_override_min_transfer_non_negative": {
+          "name": "check_override_min_transfer_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_transfer_cents\" IS NULL OR \"fee_config_org_creator\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_platform": {
+      "name": "fee_config_platform",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_org_fee_percent": {
+          "name": "subscription_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "one_off_org_fee_percent": {
+          "name": "one_off_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_platform_updated_by_users_id_fk": {
+          "name": "fee_config_platform_updated_by_users_id_fk",
+          "tableFrom": "fee_config_platform",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_platform_singleton": {
+          "name": "check_fee_config_platform_singleton",
+          "value": "\"fee_config_platform\".\"id\" = 'singleton'"
+        },
+        "check_platform_fee_percent_bps": {
+          "name": "check_platform_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"platform_fee_percent\" >= 0 AND \"fee_config_platform\".\"platform_fee_percent\" <= 10000"
+        },
+        "check_subscription_org_fee_percent_bps": {
+          "name": "check_subscription_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"subscription_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"subscription_org_fee_percent\" <= 10000"
+        },
+        "check_one_off_org_fee_percent_bps": {
+          "name": "check_one_off_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"one_off_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"one_off_org_fee_percent\" <= 10000"
+        },
+        "check_min_platform_fee_non_negative": {
+          "name": "check_min_platform_fee_non_negative",
+          "value": "\"fee_config_platform\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_min_transfer_non_negative": {
+          "name": "check_min_transfer_non_negative",
+          "value": "\"fee_config_platform\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_followers": {
+      "name": "organization_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_follower": {
+          "name": "idx_unique_org_follower",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_org": {
+          "name": "idx_org_followers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_user": {
+          "name": "idx_org_followers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_followers_organization_id_organizations_id_fk": {
+          "name": "organization_followers_organization_id_organizations_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_followers_user_id_users_id_fk": {
+          "name": "organization_followers_user_id_users_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_audit_logs": {
+      "name": "email_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "email_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_audit_logs_organization_id_organizations_id_fk": {
+          "name": "email_audit_logs_organization_id_organizations_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_audit_logs_creator_id_users_id_fk": {
+          "name": "email_audit_logs_creator_id_users_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "template_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_templates_org_id": {
+          "name": "idx_email_templates_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_creator_id": {
+          "name": "idx_email_templates_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_scope": {
+          "name": "idx_email_templates_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_status": {
+          "name": "idx_email_templates_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_global": {
+          "name": "idx_unique_template_global",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'global' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_org": {
+          "name": "idx_unique_template_org",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'organization' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_creator": {
+          "name": "idx_unique_template_creator",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'creator' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_org_scope": {
+          "name": "idx_templates_org_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_creator_scope": {
+          "name": "idx_templates_creator_scope",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_created_by_deleted_at": {
+          "name": "idx_templates_created_by_deleted_at",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope_deleted_at": {
+          "name": "idx_templates_status_scope_deleted_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope": {
+          "name": "idx_templates_status_scope",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_active": {
+          "name": "idx_templates_active",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_template_lookup": {
+          "name": "idx_template_lookup",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_organization_id_organizations_id_fk": {
+          "name": "email_templates_organization_id_organizations_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_creator_id_users_id_fk": {
+          "name": "email_templates_creator_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_created_by_users_id_fk": {
+          "name": "email_templates_created_by_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "global_scope_no_owners": {
+          "name": "global_scope_no_owners",
+          "value": "\"email_templates\".\"scope\" != 'global' OR (\"email_templates\".\"organization_id\" IS NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "org_scope_requires_org": {
+          "name": "org_scope_requires_org",
+          "value": "\"email_templates\".\"scope\" != 'organization' OR (\"email_templates\".\"organization_id\" IS NOT NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "creator_scope_requires_creator": {
+          "name": "creator_scope_requires_creator",
+          "value": "\"email_templates\".\"scope\" != 'creator' OR \"email_templates\".\"creator_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_marketing": {
+          "name": "email_marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_transactional": {
+          "name": "email_transactional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_digest": {
+          "name": "email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_connect_account_user_id": {
+          "name": "primary_connect_account_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_slug": {
+          "name": "idx_organizations_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_org_slug": {
+          "name": "idx_unique_org_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_primary_connect_account_user_id_users_id_fk": {
+          "name": "organizations_primary_connect_account_user_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_connect_account_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payouts": {
+      "name": "payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group": {
+          "name": "transfer_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "payout_type": {
+          "name": "payout_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payouts_stripe_transfer_id": {
+          "name": "uq_payouts_stripe_transfer_id",
+          "columns": [
+            {
+              "expression": "stripe_transfer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"stripe_transfer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_created": {
+          "name": "idx_payouts_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_status_created": {
+          "name": "idx_payouts_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_pending": {
+          "name": "idx_payouts_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payouts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_user_org_created": {
+          "name": "idx_payouts_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_subscription": {
+          "name": "idx_payouts_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_purchase": {
+          "name": "idx_payouts_purchase",
+          "columns": [
+            {
+              "expression": "purchase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_source_created": {
+          "name": "idx_payouts_org_source_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_payouts_platform_fee_per_charge": {
+          "name": "uq_payouts_platform_fee_per_charge",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"payout_type\" = 'platform_fee'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payouts_organization_id_organizations_id_fk": {
+          "name": "payouts_organization_id_organizations_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_user_id_users_id_fk": {
+          "name": "payouts_user_id_users_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_subscription_id_subscriptions_id_fk": {
+          "name": "payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payouts_purchase_id_purchases_id_fk": {
+          "name": "payouts_purchase_id_purchases_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_payouts_amount_positive": {
+          "name": "check_payouts_amount_positive",
+          "value": "\"payouts\".\"amount_cents\" > 0"
+        },
+        "check_payouts_status": {
+          "name": "check_payouts_status",
+          "value": "\"payouts\".\"status\" IN ('paid', 'pending', 'failed', 'reversed', 'cancelled_by_refund')"
+        },
+        "check_payouts_reason": {
+          "name": "check_payouts_reason",
+          "value": "\"payouts\".\"reason\" IS NULL OR \"payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        },
+        "check_payouts_type": {
+          "name": "check_payouts_type",
+          "value": "\"payouts\".\"payout_type\" IN ('platform_fee', 'organization_fee', 'creator_payout', 'creator_payout_to_owner')"
+        },
+        "check_payouts_source": {
+          "name": "check_payouts_source",
+          "value": "\"payouts\".\"source_type\" IN ('purchase', 'subscription')"
+        },
+        "check_payouts_user_required": {
+          "name": "check_payouts_user_required",
+          "value": "(\"payouts\".\"payout_type\" = 'platform_fee') OR (\"payouts\".\"user_id\" IS NOT NULL)"
+        },
+        "check_payouts_paid_invariant": {
+          "name": "check_payouts_paid_invariant",
+          "value": "(\"payouts\".\"status\" NOT IN ('paid', 'reversed')) OR ((\"payouts\".\"stripe_transfer_id\" IS NOT NULL OR \"payouts\".\"stripe_charge_id\" IS NOT NULL) AND \"payouts\".\"resolved_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.video_playback": {
+      "name": "video_playback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_video_playback_user_id": {
+          "name": "idx_video_playback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_video_playback_content_id": {
+          "name": "idx_video_playback_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_playback_user_id_users_id_fk": {
+          "name": "video_playback_user_id_users_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_playback_content_id_content_id_fk": {
+          "name": "video_playback_content_id_content_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_playback_user_id_content_id_unique": {
+          "name": "video_playback_user_id_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refund_reviews": {
+      "name": "refund_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_reversal_cents": {
+          "name": "attempted_reversal_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_refund_reviews_open_per_payout": {
+          "name": "uq_refund_reviews_open_per_payout",
+          "columns": [
+            {
+              "expression": "payout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"refund_reviews\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refund_reviews_purchase_id_purchases_id_fk": {
+          "name": "refund_reviews_purchase_id_purchases_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_payout_id_payouts_id_fk": {
+          "name": "refund_reviews_payout_id_payouts_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "payouts",
+          "columnsFrom": [
+            "payout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_creator_user_id_users_id_fk": {
+          "name": "refund_reviews_creator_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_resolved_by_user_id_users_id_fk": {
+          "name": "refund_reviews_resolved_by_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_refund_reviews_amount_positive": {
+          "name": "check_refund_reviews_amount_positive",
+          "value": "\"refund_reviews\".\"attempted_reversal_cents\" > 0"
+        },
+        "check_refund_reviews_resolution": {
+          "name": "check_refund_reviews_resolution",
+          "value": "\"refund_reviews\".\"resolution\" IS NULL OR \"refund_reviews\".\"resolution\" IN ('creator_absorbed', 'platform_absorbed', 'manually_reversed')"
+        },
+        "check_refund_reviews_resolved_pair": {
+          "name": "check_refund_reviews_resolved_pair",
+          "value": "(\"refund_reviews\".\"resolved_at\" IS NULL AND \"refund_reviews\".\"resolution\" IS NULL) OR (\"refund_reviews\".\"resolved_at\" IS NOT NULL AND \"refund_reviews\".\"resolution\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.branding_settings": {
+      "name": "branding_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_r2_path": {
+          "name": "logo_r2_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color_hex": {
+          "name": "primary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "secondary_color_hex": {
+          "name": "secondary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color_hex": {
+          "name": "accent_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_color_hex": {
+          "name": "background_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_body": {
+          "name": "font_body",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_heading": {
+          "name": "font_heading",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_value": {
+          "name": "radius_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "density_value": {
+          "name": "density_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "intro_video_media_item_id": {
+          "name": "intro_video_media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_url": {
+          "name": "intro_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_overrides": {
+          "name": "token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_mode_overrides": {
+          "name": "dark_mode_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_token_overrides": {
+          "name": "dark_token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_layout": {
+          "name": "hero_layout",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "pricing_faq": {
+          "name": "pricing_faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "branding_settings_updated_at_idx": {
+          "name": "branding_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branding_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "branding_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branding_settings_intro_video_media_item_id_media_items_id_fk": {
+          "name": "branding_settings_intro_video_media_item_id_media_items_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_settings": {
+      "name": "contact_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Codex Platform'"
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'support@example.com'"
+        },
+        "contact_url": {
+          "name": "contact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "twitter_url": {
+          "name": "twitter_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok_url": {
+          "name": "tiktok_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_settings_updated_at_idx": {
+          "name": "contact_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "contact_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "contact_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_settings": {
+      "name": "feature_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enable_signups": {
+          "name": "enable_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_purchases": {
+          "name": "enable_purchases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_subscriptions": {
+          "name": "enable_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_settings_updated_at_idx": {
+          "name": "feature_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "feature_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "feature_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_settings": {
+      "name": "platform_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_settings_updated_at_idx": {
+          "name": "platform_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_settings_organization_id_organizations_id_fk": {
+          "name": "platform_settings_organization_id_organizations_id_fk",
+          "tableFrom": "platform_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orphaned_image_files": {
+      "name": "orphaned_image_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_entity_id": {
+          "name": "original_entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_entity_type": {
+          "name": "original_entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orphaned_files_status": {
+          "name": "idx_orphaned_files_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_orphaned_at": {
+          "name": "idx_orphaned_files_orphaned_at",
+          "columns": [
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_type_status": {
+          "name": "idx_orphaned_files_type_status",
+          "columns": [
+            {
+              "expression": "image_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_pending_cleanup": {
+          "name": "idx_orphaned_files_pending_cleanup",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_image_type": {
+          "name": "check_image_type",
+          "value": "\"orphaned_image_files\".\"image_type\" IN ('avatar', 'logo', 'content_thumbnail', 'transcoding_artifact')"
+        },
+        "check_entity_type": {
+          "name": "check_entity_type",
+          "value": "\"orphaned_image_files\".\"original_entity_type\" IS NULL OR \"orphaned_image_files\".\"original_entity_type\" IN ('user', 'organization', 'content', 'media_item')"
+        },
+        "check_orphan_status": {
+          "name": "check_orphan_status",
+          "value": "\"orphaned_image_files\".\"status\" IN ('pending', 'deleted', 'failed', 'retained')"
+        },
+        "check_cleanup_attempts": {
+          "name": "check_cleanup_attempts",
+          "value": "\"orphaned_image_files\".\"cleanup_attempts\" >= 0 AND \"orphaned_image_files\".\"cleanup_attempts\" <= 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_payouts": {
+      "name": "pending_payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_payouts_user_id": {
+          "name": "idx_pending_payouts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_org_id": {
+          "name": "idx_pending_payouts_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_unresolved": {
+          "name": "idx_pending_payouts_unresolved",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_payouts_user_id_users_id_fk": {
+          "name": "pending_payouts_user_id_users_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_organization_id_organizations_id_fk": {
+          "name": "pending_payouts_organization_id_organizations_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_subscription_id_subscriptions_id_fk": {
+          "name": "pending_payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_pending_payout_positive": {
+          "name": "check_pending_payout_positive",
+          "value": "\"pending_payouts\".\"amount_cents\" > 0"
+        },
+        "check_pending_payout_reason": {
+          "name": "check_pending_payout_reason",
+          "value": "\"pending_payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stripe_connect_accounts": {
+      "name": "stripe_connect_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_connect_org_id": {
+          "name": "idx_stripe_connect_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_connect_stripe_id": {
+          "name": "idx_stripe_connect_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_connect_accounts_organization_id_organizations_id_fk": {
+          "name": "stripe_connect_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_connect_accounts_user_id_users_id_fk": {
+          "name": "stripe_connect_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_connect_accounts_stripe_account_id_unique": {
+          "name": "stripe_connect_accounts_stripe_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_account_id"
+          ]
+        },
+        "uq_stripe_connect_user": {
+          "name": "uq_stripe_connect_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_connect_status": {
+          "name": "check_connect_status",
+          "value": "\"stripe_connect_accounts\".\"status\" IN ('onboarding', 'active', 'restricted', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_org_id": {
+          "name": "idx_subscription_tiers_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_tiers_org_active": {
+          "name": "idx_subscription_tiers_org_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_org_sort": {
+          "name": "uq_subscription_tiers_org_sort",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_tiers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_tiers_organization_id_organizations_id_fk": {
+          "name": "subscription_tiers_organization_id_organizations_id_fk",
+          "tableFrom": "subscription_tiers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_tier_price_monthly_positive": {
+          "name": "check_tier_price_monthly_positive",
+          "value": "\"subscription_tiers\".\"price_monthly\" >= 0"
+        },
+        "check_tier_price_annual_positive": {
+          "name": "check_tier_price_annual_positive",
+          "value": "\"subscription_tiers\".\"price_annual\" >= 0"
+        },
+        "check_tier_sort_order_positive": {
+          "name": "check_tier_sort_order_positive",
+          "value": "\"subscription_tiers\".\"sort_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_reason": {
+          "name": "churn_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_user_id": {
+          "name": "idx_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_id": {
+          "name": "idx_subscriptions_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_tier_id": {
+          "name": "idx_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_stripe_id": {
+          "name": "idx_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_status": {
+          "name": "idx_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user_org": {
+          "name": "idx_subscriptions_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_subscription_per_user_org": {
+          "name": "uq_active_subscription_per_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_subscription_status": {
+          "name": "check_subscription_status",
+          "value": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_billing_interval": {
+          "name": "check_billing_interval",
+          "value": "\"subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        },
+        "check_churn_reason": {
+          "name": "check_churn_reason",
+          "value": "\"subscriptions\".\"churn_reason\" IS NULL OR \"subscriptions\".\"churn_reason\" IN ('too_expensive', 'not_enough_content', 'found_alternative', 'not_using_it', 'technical_issues', 'other')"
+        },
+        "check_sub_amount_positive": {
+          "name": "check_sub_amount_positive",
+          "value": "\"subscriptions\".\"amount_cents\" >= 0"
+        },
+        "check_sub_platform_fee_positive": {
+          "name": "check_sub_platform_fee_positive",
+          "value": "\"subscriptions\".\"platform_fee_cents\" >= 0"
+        },
+        "check_sub_org_fee_positive": {
+          "name": "check_sub_org_fee_positive",
+          "value": "\"subscriptions\".\"organization_fee_cents\" >= 0"
+        },
+        "check_sub_creator_payout_positive": {
+          "name": "check_sub_creator_payout_positive",
+          "value": "\"subscriptions\".\"creator_payout_cents\" >= 0"
+        },
+        "check_sub_revenue_split_equals_total": {
+          "name": "check_sub_revenue_split_equals_total",
+          "value": "\"subscriptions\".\"amount_cents\" = \"subscriptions\".\"platform_fee_cents\" + \"subscriptions\".\"organization_fee_cents\" + \"subscriptions\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_table": {
+      "name": "test_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_table_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.email_send_status": {
+      "name": "email_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.template_scope": {
+      "name": "template_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "organization",
+        "creator"
+      ]
+    },
+    "public.template_status": {
+      "name": "template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1780252145731,
       "tag": "0074_hot_goliath",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1781140880558,
+      "tag": "0075_content_access_org_nullable",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/ecommerce.ts
+++ b/packages/database/src/schema/ecommerce.ts
@@ -31,9 +31,14 @@ export const contentAccess = pgTable(
     contentId: uuid('content_id')
       .notNull()
       .references(() => content.id, { onDelete: 'cascade' }),
-    organizationId: uuid('organization_id')
-      .notNull()
-      .references(() => organizations.id, { onDelete: 'cascade' }),
+    // Nullable (Codex-69t7c WP5): orgless creator-direct (bi-party) purchases
+    // grant access to content with no organization. Mirrors the WP1 change to
+    // `purchases.organization_id`. Org-scoped grants still populate it. Access
+    // verification for paid content reads `purchases` (verifyPurchase), not
+    // this column, so a null org here does not weaken any access check.
+    organizationId: uuid('organization_id').references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
 
     // Access type with CHECK constraint enforcement
     accessType: varchar('access_type', { length: 50 }).notNull(),

--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -4680,6 +4680,136 @@ describe('PurchaseService Integration', () => {
       ).toBe(10000);
     });
 
+    // P1b (Codex-69t7c WP5 hardening b) — money-moved / ledger-silent guard:
+    // on the orgless path the creator transfer fires (REAL money moves to the
+    // Connect account) but the creator_payout ledger insert fails on a NON-
+    // unique DB error (e.g. a 23514 CHECK violation). That failure MUST be
+    // SURFACED via obs.error with a correlatable errorId — NOT swallowed — so
+    // the out-of-sync ledger is loud and reconcilable. (A 23505 dup is the
+    // only error that may be silently swallowed, since it means the row
+    // already exists.)
+    it('orgless path: transfer succeeds but ledger insert fails (non-unique) → error SURFACED with errorId, not swallowed', async () => {
+      const stubFeeConfig = {
+        getFeesPlatform: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 0,
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+      };
+      const creatorTransferId = `tr_orgless_ledgerfail_${Date.now()}`;
+      const createTransfer = vi
+        .fn()
+        .mockResolvedValue({ id: creatorTransferId });
+      const stubStripe = {
+        ...mockStripe,
+        transfers: { create: createTransfer },
+        paymentIntents: { retrieve: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      const { content, chargeId, paymentIntentId } =
+        await setupOrglessPaidContent({
+          title: 'Orgless Ledger Insert Fail',
+          priceCents: 10000,
+          creatorUserId: userId,
+        });
+
+      // Synthetic NON-unique Postgres error (23514 = check_violation). The
+      // hardening branch keys off `!isUniqueViolation(err)` (23505), so this
+      // exercises the surfaced-error path.
+      class FakeCheckViolation extends Error {
+        code = '23514';
+        constraint = 'check_payouts_paid_invariant';
+        constructor() {
+          super('simulated non-unique ledger insert failure');
+        }
+      }
+
+      // Intercept the service's DB so ONLY the creator_payout `paid` insert
+      // rejects. Every other insert (purchase, contentAccess, platform_fee,
+      // the pending fallbacks) delegates to the real builder unchanged.
+      // `db.insert` lives on the Drizzle client's prototype (not an own
+      // property), so vi.spyOn can't target it — wrap the whole client in a
+      // Proxy that intercepts `insert` and restores it after the test.
+      // biome-ignore lint/suspicious/noExplicitAny: test interception of Drizzle client
+      const serviceAny = service as any;
+      const realDb = serviceAny.db;
+      const dbProxy = new Proxy(realDb, {
+        get(target, prop, receiver) {
+          if (prop === 'insert') {
+            // biome-ignore lint/suspicious/noExplicitAny: Drizzle builder shape
+            return (table: any) => {
+              const builder = target.insert(table);
+              const realValues = builder.values.bind(builder);
+              // biome-ignore lint/suspicious/noExplicitAny: row payload
+              builder.values = (rows: any) => {
+                const row = Array.isArray(rows) ? rows[0] : rows;
+                if (
+                  row?.payoutType === 'creator_payout' &&
+                  row?.status === 'paid'
+                ) {
+                  return Promise.reject(new FakeCheckViolation());
+                }
+                return realValues(rows);
+              };
+              return builder;
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      serviceAny.db = dbProxy;
+
+      // biome-ignore lint/suspicious/noExplicitAny: spy protected obs.error
+      const errorSpy = vi.spyOn((service as any).obs, 'error');
+
+      // completePurchase MUST NOT throw — per-row isolation keeps the purchase
+      // itself successful; the ledger failure is logged, not propagated.
+      const purchase = await service.completePurchase(paymentIntentId, {
+        customerId: otherUserId,
+        contentId: content.id,
+        organizationId: null,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: chargeId,
+      });
+      expect(purchase.organizationId).toBeNull();
+
+      // The Stripe transfer DID fire — real money moved.
+      expect(createTransfer).toHaveBeenCalledTimes(1);
+      expect(createTransfer).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: 'gbp' }),
+        expect.objectContaining({ idempotencyKey: `${chargeId}_creator` })
+      );
+
+      // The failure was SURFACED via obs.error with the money-moved message
+      // AND a correlatable errorId + the Connect destination + idempotencyKey.
+      const surfaced = errorSpy.mock.calls.find(([msg]) =>
+        String(msg).includes(
+          'creator_payout transfer succeeded but payouts ledger insert failed'
+        )
+      );
+      expect(
+        surfaced,
+        'ledger-insert failure after a successful transfer must be logged at error level'
+      ).toBeDefined();
+      const surfacedMeta = surfaced![1] as Record<string, unknown>;
+      expect(typeof surfacedMeta.errorId).toBe('string');
+      expect((surfacedMeta.errorId as string).length).toBeGreaterThan(0);
+      expect(surfacedMeta.stripeTransferId).toBe(creatorTransferId);
+      expect(surfacedMeta.idempotencyKey).toBe(`${chargeId}_creator`);
+      expect(surfacedMeta.destination).toBeDefined();
+
+      serviceAny.db = realDb;
+      errorSpy.mockRestore();
+    });
+
     // P2 — orgless purchase BEFORE the creator finishes Connect onboarding:
     // creator_payout degrades to pending+connect_not_ready, platform_fee still
     // paid, NO transfer call. Mirrors the tri-party connect_not_ready path.
@@ -5049,13 +5179,11 @@ describe('PurchaseService Integration', () => {
           minTransferCents: 0,
         }),
       };
-      const createTransfer = vi
-        .fn()
-        .mockImplementation(() =>
-          Promise.resolve({
-            id: `tr_mixed_${Math.random().toString(36).slice(2, 10)}`,
-          })
-        );
+      const createTransfer = vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          id: `tr_mixed_${Math.random().toString(36).slice(2, 10)}`,
+        })
+      );
       const stubStripe = {
         ...mockStripe,
         transfers: { create: createTransfer },

--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -4479,4 +4479,703 @@ describe('PurchaseService Integration', () => {
       expect(account).toBeUndefined();
     });
   });
+
+  // ─── Codex-69t7c WP5: orgless (bi-party) purchase pipeline ─────────────────
+  //
+  // The Phase-1 "content must belong to an organization" gate is removed.
+  // Orgless creator-direct content (content.organizationId IS NULL) is
+  // purchasable: the buyer pays the platform, the platform retains its fee
+  // (platform_fee row) and forwards the rest to the CREATOR's single Connect
+  // account (creator_payout row) via a secondary transfer keyed by userId.
+  // NO organization_fee row is written — there is no org to pay.
+  describe('completePurchase — bi-party orgless payouts (Codex-69t7c WP5)', () => {
+    /**
+     * Seed an orgless paid content item owned by `creatorUserId` (no
+     * organizationId) plus that creator's single Connect account (keyed by
+     * userId — Codex-69t7c one-account-per-user). Returns the ids the test
+     * feeds to completePurchase.
+     */
+    async function setupOrglessPaidContent(opts: {
+      title: string;
+      priceCents: number;
+      creatorUserId: string;
+      chargesEnabled?: boolean;
+      seedConnect?: boolean;
+    }) {
+      const {
+        title,
+        priceCents,
+        creatorUserId,
+        chargesEnabled = true,
+        seedConnect = true,
+      } = opts;
+      const media = await mediaService.create(
+        {
+          title,
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          fileSizeBytes: 1024 * 1024,
+        },
+        creatorUserId
+      );
+      await mediaService.markAsReady(
+        media.id,
+        {
+          hlsMasterPlaylistKey: `hls/${title}/master.m3u8`,
+          thumbnailKey: `thumbnails/${title}.jpg`,
+          durationSeconds: 60,
+        },
+        creatorUserId
+      );
+      // No organizationId → orgless (bi-party) personal content.
+      const content = await contentService.create(
+        {
+          title,
+          slug: createUniqueSlug(title.toLowerCase().replace(/\s+/g, '-')),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'purchased_only',
+          accessType: 'paid',
+          priceCents,
+        },
+        creatorUserId
+      );
+      await contentService.publish(content.id, creatorUserId);
+
+      if (seedConnect) {
+        // The creator's SINGLE Connect account (keyed by userId). For orgless
+        // content there is no org pin — the creator slice resolves purely by
+        // `eq(stripeConnectAccounts.userId, creatorId)`. organizationId on the
+        // account row is left null (the account isn't org-scoped here).
+        await db
+          .insert(schema.stripeConnectAccounts)
+          .values({
+            userId: creatorUserId,
+            organizationId: null,
+            stripeAccountId: `acct_orgless_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+            status: chargesEnabled ? 'active' : 'onboarding',
+            chargesEnabled,
+            payoutsEnabled: chargesEnabled,
+          })
+          .onConflictDoUpdate({
+            target: [schema.stripeConnectAccounts.userId],
+            set: {
+              organizationId: null,
+              chargesEnabled,
+              payoutsEnabled: chargesEnabled,
+              status: chargesEnabled ? 'active' : 'onboarding',
+            },
+          });
+      }
+
+      return {
+        content,
+        chargeId: `ch_orgless_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        paymentIntentId: `pi_orgless_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      };
+    }
+
+    // P1 — happy path: exactly TWO rows (platform_fee + creator_payout), no
+    // organization_fee; creator transfer fires once in GBP with the verbatim
+    // `${chargeId}_creator` idempotency key; the org component is zero.
+    it('writes exactly 2 bi-party rows (platform_fee + creator_payout) and fires the creator transfer — no org_fee row', async () => {
+      // The creator is `userId`; the buyer is `otherUserId`.
+      const stubFeeConfig = {
+        // getFeesPlatform is the resolver the orgless branch calls. Return a
+        // non-zero orgFeePercent to PROVE the orgless branch forces the org
+        // leg to zero regardless (RISK B in the plan).
+        getFeesPlatform: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000, // 10%
+          orgFeePercent: 1500, // 15% — MUST be ignored for orgless
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+        getFeesForCreator: vi.fn(), // must NOT be called for orgless
+      };
+      const creatorTransferId = `tr_orgless_creator_${Date.now()}`;
+      const createTransfer = vi
+        .fn()
+        .mockResolvedValue({ id: creatorTransferId });
+      const stubStripe = {
+        ...mockStripe,
+        transfers: { create: createTransfer },
+        paymentIntents: { retrieve: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      const { content, chargeId, paymentIntentId } =
+        await setupOrglessPaidContent({
+          title: 'Orgless Bi-party Standard',
+          priceCents: 10000, // £100
+          creatorUserId: userId,
+        });
+
+      const purchase = await service.completePurchase(paymentIntentId, {
+        customerId: otherUserId,
+        contentId: content.id,
+        organizationId: null, // orgless
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: chargeId,
+      });
+
+      // Orgless purchase row carries a null org.
+      expect(purchase.organizationId).toBeNull();
+
+      const rows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+
+      // EXACTLY 2 rows — platform_fee + creator_payout. NO organization_fee.
+      expect(rows).toHaveLength(2);
+      expect(
+        rows.find((r) => r.payoutType === 'organization_fee')
+      ).toBeUndefined();
+
+      // Orgless branch uses getFeesPlatform, NOT getFeesForCreator.
+      expect(stubFeeConfig.getFeesPlatform).toHaveBeenCalledTimes(1);
+      expect(stubFeeConfig.getFeesForCreator).not.toHaveBeenCalled();
+
+      // Exactly ONE secondary transfer (the creator slice), in GBP, with the
+      // verbatim idempotency key. Org slice forced to zero → no second call.
+      expect(createTransfer).toHaveBeenCalledTimes(1);
+      expect(createTransfer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currency: 'gbp',
+          source_transaction: chargeId,
+        }),
+        expect.objectContaining({ idempotencyKey: `${chargeId}_creator` })
+      );
+
+      const platformRow = rows.find((r) => r.payoutType === 'platform_fee');
+      const creatorRow = rows.find((r) => r.payoutType === 'creator_payout');
+      expect(platformRow).toBeDefined();
+      expect(creatorRow).toBeDefined();
+
+      // Split for £100 @ platform 10%, org forced 0:
+      //   platform = ceil(10000 * 10%) = 1000
+      //   org      = 0
+      //   creator  = 10000 - 1000 - 0  = 9000
+      expect(platformRow?.amountCents).toBe(1000);
+      expect(platformRow?.status).toBe('paid');
+      expect(platformRow?.userId).toBeNull(); // platform isn't a user
+      expect(platformRow?.organizationId).toBeNull(); // orgless
+      expect(platformRow?.stripeTransferId).toBeNull();
+
+      expect(creatorRow?.amountCents).toBe(9000);
+      expect(creatorRow?.status).toBe('paid');
+      expect(creatorRow?.userId).toBe(userId); // routed to the creator
+      expect(creatorRow?.organizationId).toBeNull(); // orgless
+      expect(creatorRow?.stripeTransferId).toBe(creatorTransferId);
+      expect(creatorRow?.stripeChargeId).toBe(chargeId);
+
+      // Money conservation: platform + creator == amount (org leg is zero).
+      expect(
+        (platformRow?.amountCents ?? 0) + (creatorRow?.amountCents ?? 0)
+      ).toBe(10000);
+    });
+
+    // P2 — orgless purchase BEFORE the creator finishes Connect onboarding:
+    // creator_payout degrades to pending+connect_not_ready, platform_fee still
+    // paid, NO transfer call. Mirrors the tri-party connect_not_ready path.
+    it('degrades creator_payout to pending+connect_not_ready when the creator Connect is offline', async () => {
+      const stubFeeConfig = {
+        getFeesPlatform: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 0,
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+      };
+      const createTransfer = vi.fn();
+      const stubStripe = {
+        ...mockStripe,
+        transfers: { create: createTransfer },
+        paymentIntents: { retrieve: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      // Creator = otherUserId here so we don't collide with P1's userId account
+      // within the same test run; Connect seeded with chargesEnabled=false.
+      const { content, chargeId, paymentIntentId } =
+        await setupOrglessPaidContent({
+          title: 'Orgless Pre-Connect',
+          priceCents: 10000,
+          creatorUserId: otherUserId,
+          chargesEnabled: false,
+        });
+
+      const purchase = await service.completePurchase(paymentIntentId, {
+        customerId: userId,
+        contentId: content.id,
+        organizationId: null,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: chargeId,
+      });
+
+      const rows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+
+      // 2 rows: platform_fee (paid) + creator_payout (pending). No org row.
+      expect(rows).toHaveLength(2);
+      expect(
+        rows.find((r) => r.payoutType === 'organization_fee')
+      ).toBeUndefined();
+
+      const creatorRow = rows.find((r) => r.payoutType === 'creator_payout');
+      expect(creatorRow?.status).toBe('pending');
+      expect(creatorRow?.reason).toBe('connect_not_ready');
+      expect(creatorRow?.organizationId).toBeNull();
+      expect(creatorRow?.userId).toBe(otherUserId);
+
+      const platformRow = rows.find((r) => r.payoutType === 'platform_fee');
+      expect(platformRow?.status).toBe('paid');
+
+      // No Stripe transfer call fired — Connect not ready.
+      expect(createTransfer).not.toHaveBeenCalled();
+    });
+
+    // P3 — createCheckoutSession succeeds on orgless paid+published content and
+    // OMITS organizationId from Stripe metadata (Stripe metadata values must be
+    // strings; the webhook schema re-derives null from the absent key).
+    it('createCheckoutSession succeeds for orgless content and omits organizationId from Stripe metadata', async () => {
+      const sessionsCreate = vi
+        .fn()
+        .mockResolvedValue(
+          createMockCheckoutSession('cs_orgless_1', 'pi_orgless_co_1')
+        );
+      const stubStripe = {
+        ...mockStripe,
+        checkout: { sessions: { create: sessionsCreate, retrieve: vi.fn() } },
+        customers: {
+          list: vi.fn().mockResolvedValue({ data: [], has_more: false }),
+          create: vi.fn().mockResolvedValue({
+            id: `cus_orgless_${Date.now()}`,
+            email: 'buyer@example.com',
+          }),
+        },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        { db, environment: 'test' },
+        stubStripe
+      );
+
+      const { content } = await setupOrglessPaidContent({
+        title: 'Orgless Checkout',
+        priceCents: 4200,
+        creatorUserId: userId,
+        seedConnect: false, // checkout doesn't need the Connect account
+      });
+
+      const result = await service.createCheckoutSession(
+        {
+          contentId: content.id,
+          successUrl: 'http://localhost:3000/success',
+          cancelUrl: 'http://localhost:3000/cancel',
+        },
+        otherUserId
+      );
+
+      expect(result.sessionUrl).toBeTruthy();
+      expect(sessionsCreate).toHaveBeenCalledTimes(1);
+      const passedMetadata = sessionsCreate.mock.calls[0][0].metadata as Record<
+        string,
+        string
+      >;
+      // organizationId MUST be absent (not present, not the string "null").
+      expect(passedMetadata).not.toHaveProperty('organizationId');
+      expect(passedMetadata.contentId).toBe(content.id);
+      expect(passedMetadata.creatorId).toBe(userId);
+    });
+
+    // P4 — bi-party refund reverses the creator_payout + platform_fee rows.
+    // reversePayoutsForPurchase is data-driven (reads whatever rows exist), so
+    // with only 2 bi-party rows it reverses exactly those and never expects an
+    // org row.
+    it('refund reverses both bi-party rows (creator_payout transfer + platform_fee)', async () => {
+      const creatorTransferId = `tr_orgless_refund_${Date.now()}`;
+      const reversed: string[] = [];
+      const stubFeeConfig = {
+        getFeesPlatform: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 0,
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+      };
+      const stubStripe = {
+        ...mockStripe,
+        transfers: {
+          create: vi.fn().mockResolvedValue({ id: creatorTransferId }),
+          createReversal: vi.fn().mockImplementation((id: string) => {
+            reversed.push(id);
+            return Promise.resolve({ id: `trr_${id}` });
+          }),
+        },
+        refunds: { create: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      const { content, chargeId, paymentIntentId } =
+        await setupOrglessPaidContent({
+          title: 'Orgless Refund',
+          priceCents: 10000,
+          creatorUserId: userId,
+        });
+
+      const purchase = await service.completePurchase(paymentIntentId, {
+        customerId: otherUserId,
+        contentId: content.id,
+        organizationId: null,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: chargeId,
+      });
+
+      const before = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+      expect(before).toHaveLength(2);
+
+      await service.processRefund(paymentIntentId, {
+        stripeRefundId: 're_orgless_001',
+        refundAmountCents: 10000,
+        refundReason: 'requested_by_customer',
+      });
+
+      // Only the creator_payout had a Stripe transfer → exactly one reversal.
+      // platform_fee is marked reversed without a Stripe call.
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const reversal = (stubStripe as any).transfers.createReversal;
+      expect(reversal).toHaveBeenCalledTimes(1);
+      expect(reversed).toContain(creatorTransferId);
+
+      const after = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+      expect(after).toHaveLength(2);
+      expect(after.every((r) => r.status === 'reversed')).toBe(true);
+    });
+
+    // N1 — gate ORDER preserved: orgless but UNPUBLISHED still throws.
+    it('createCheckoutSession still throws ContentNotPurchasableError for orgless UNPUBLISHED content', async () => {
+      const media = await mediaService.create(
+        {
+          title: 'Orgless Draft',
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          fileSizeBytes: 1024 * 1024,
+        },
+        userId
+      );
+      await mediaService.markAsReady(
+        media.id,
+        {
+          hlsMasterPlaylistKey: 'hls/orgless-draft/master.m3u8',
+          thumbnailKey: 'thumbnails/orgless-draft.jpg',
+          durationSeconds: 60,
+        },
+        userId
+      );
+      // Orgless + paid + priced but NOT published.
+      const content = await contentService.create(
+        {
+          title: 'Orgless Draft',
+          slug: createUniqueSlug('orgless-draft'),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'purchased_only',
+          accessType: 'paid',
+          priceCents: 2999,
+        },
+        userId
+      );
+      // intentionally NOT published
+
+      await expect(
+        purchaseService.createCheckoutSession(
+          {
+            contentId: content.id,
+            successUrl: 'http://localhost:3000/success',
+            cancelUrl: 'http://localhost:3000/cancel',
+          },
+          otherUserId
+        )
+      ).rejects.toThrow(ContentNotPurchasableError);
+    });
+
+    // N2 — orgless but FREE (priceCents null) still throws.
+    it('createCheckoutSession still throws ContentNotPurchasableError for orgless FREE content', async () => {
+      const media = await mediaService.create(
+        {
+          title: 'Orgless Free',
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          fileSizeBytes: 1024 * 1024,
+        },
+        userId
+      );
+      await mediaService.markAsReady(
+        media.id,
+        {
+          hlsMasterPlaylistKey: 'hls/orgless-free/master.m3u8',
+          thumbnailKey: 'thumbnails/orgless-free.jpg',
+          durationSeconds: 60,
+        },
+        userId
+      );
+      const content = await contentService.create(
+        {
+          title: 'Orgless Free',
+          slug: createUniqueSlug('orgless-free'),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'public',
+          accessType: 'free',
+        },
+        userId
+      );
+      await contentService.publish(content.id, userId);
+
+      await expect(
+        purchaseService.createCheckoutSession(
+          {
+            contentId: content.id,
+            successUrl: 'http://localhost:3000/success',
+            cancelUrl: 'http://localhost:3000/cancel',
+          },
+          otherUserId
+        )
+      ).rejects.toThrow(ContentNotPurchasableError);
+    });
+
+    // N3 — even with a feeConfig that returns a non-zero orgFeePercent, the
+    // orgless branch MUST force the org leg to zero (no org_fee row, no second
+    // transfer). Guards against an org slice being stranded with no recipient.
+    it('forces the org leg to zero for orgless even when fee config returns a non-zero orgFeePercent', async () => {
+      const stubFeeConfig = {
+        getFeesPlatform: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 3000, // 30% — must be ignored
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+      };
+      const createTransfer = vi
+        .fn()
+        .mockResolvedValue({ id: `tr_orgless_n3_${Date.now()}` });
+      const stubStripe = {
+        ...mockStripe,
+        transfers: { create: createTransfer },
+        paymentIntents: { retrieve: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      const { content, chargeId, paymentIntentId } =
+        await setupOrglessPaidContent({
+          title: 'Orgless Zero Org Leg',
+          priceCents: 10000,
+          creatorUserId: userId,
+        });
+
+      const purchase = await service.completePurchase(paymentIntentId, {
+        customerId: otherUserId,
+        contentId: content.id,
+        organizationId: null,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: chargeId,
+      });
+
+      // Snapshot on the purchase row: org fee component is zero, creator gets
+      // the full post-platform remainder.
+      expect(purchase.organizationFeeCents).toBe(0);
+      expect(purchase.platformFeeCents).toBe(1000);
+      expect(purchase.creatorPayoutCents).toBe(9000);
+
+      const rows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, purchase.id));
+      expect(rows).toHaveLength(2);
+      expect(
+        rows.find((r) => r.payoutType === 'organization_fee')
+      ).toBeUndefined();
+      // Only the creator transfer fired (no org transfer).
+      expect(createTransfer).toHaveBeenCalledTimes(1);
+    });
+
+    // C1 / R2 — a creator who publishes BOTH orgless and org-scoped content:
+    // the orgless purchase writes 2 rows, the org-scoped purchase writes 3,
+    // and the two flows are independent within the same run. Doubles as the
+    // org-routed regression assertion (R1 already covered by the existing
+    // tri-party suite).
+    it('keeps orgless (2 rows) and org-scoped (3 rows) flows independent for the same creator', async () => {
+      const stubFeeConfig = {
+        // org-scoped path uses getFeesForCreator (org fee > 0);
+        // orgless path uses getFeesPlatform (org leg forced to 0).
+        getFeesForCreator: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 1000, // 10% org slice for the org-scoped purchase
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+        getFeesPlatform: vi.fn().mockResolvedValue({
+          platformFeePercent: 1000,
+          orgFeePercent: 0,
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        }),
+      };
+      const createTransfer = vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve({
+            id: `tr_mixed_${Math.random().toString(36).slice(2, 10)}`,
+          })
+        );
+      const stubStripe = {
+        ...mockStripe,
+        transfers: { create: createTransfer },
+        paymentIntents: { retrieve: vi.fn() },
+      } as unknown as Stripe;
+      const service = new PurchaseService(
+        // biome-ignore lint/suspicious/noExplicitAny: test stub
+        { db, environment: 'test', feeConfig: stubFeeConfig as any },
+        stubStripe
+      );
+
+      // Creator = userId. Seed an org owned by userId + the creator's single
+      // Connect (one account, used for BOTH the orgless creator slice AND, via
+      // the org pin, the org slice).
+      const [mixedOrg] = await db
+        .insert(organizations)
+        .values({
+          name: 'Mixed Flow Org',
+          slug: createUniqueSlug('mixed-flow'),
+          ownerId: userId,
+          primaryConnectAccountUserId: userId,
+        })
+        .returning();
+      await db
+        .insert(schema.stripeConnectAccounts)
+        .values({
+          userId,
+          organizationId: mixedOrg.id,
+          stripeAccountId: `acct_mixed_${Date.now()}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        })
+        .onConflictDoUpdate({
+          target: [schema.stripeConnectAccounts.userId],
+          set: { chargesEnabled: true, payoutsEnabled: true, status: 'active' },
+        });
+
+      // ── Orgless purchase → 2 rows ──
+      const { content: orglessContent } = await setupOrglessPaidContent({
+        title: 'Mixed Orgless Leg',
+        priceCents: 10000,
+        creatorUserId: userId,
+        seedConnect: false, // account already seeded above
+      });
+      const orglessPi = `pi_mixed_orgless_${Date.now()}`;
+      const orglessPurchase = await service.completePurchase(orglessPi, {
+        customerId: otherUserId,
+        contentId: orglessContent.id,
+        organizationId: null,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: `ch_mixed_orgless_${Date.now()}`,
+      });
+      const orglessRows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, orglessPurchase.id));
+      expect(orglessRows).toHaveLength(2);
+      expect(orglessPurchase.organizationId).toBeNull();
+      expect(
+        orglessRows.find((r) => r.payoutType === 'organization_fee')
+      ).toBeUndefined();
+
+      // ── Org-scoped purchase by the SAME creator → 3 rows (regression) ──
+      const orgMedia = await mediaService.create(
+        {
+          title: 'Mixed Org Leg',
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          fileSizeBytes: 1024 * 1024,
+        },
+        userId
+      );
+      await mediaService.markAsReady(
+        orgMedia.id,
+        {
+          hlsMasterPlaylistKey: 'hls/mixed-org/master.m3u8',
+          thumbnailKey: 'thumbnails/mixed-org.jpg',
+          durationSeconds: 60,
+        },
+        userId
+      );
+      const orgContent = await contentService.create(
+        {
+          organizationId: mixedOrg.id,
+          title: 'Mixed Org Leg',
+          slug: createUniqueSlug('mixed-org-leg'),
+          contentType: 'video',
+          mediaItemId: orgMedia.id,
+          visibility: 'purchased_only',
+          accessType: 'paid',
+          priceCents: 10000,
+        },
+        userId
+      );
+      await contentService.publish(orgContent.id, userId);
+
+      const orgPi = `pi_mixed_org_${Date.now()}`;
+      const orgPurchase = await service.completePurchase(orgPi, {
+        customerId: otherUserId,
+        contentId: orgContent.id,
+        organizationId: mixedOrg.id,
+        amountPaidCents: 10000,
+        currency: 'gbp',
+        stripeChargeId: `ch_mixed_org_${Date.now()}`,
+      });
+      const orgRows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, orgPurchase.id));
+      // 3 rows: platform_fee + organization_fee + creator_payout.
+      expect(orgRows).toHaveLength(3);
+      expect(orgPurchase.organizationId).toBe(mixedOrg.id);
+      const orgFeeRow = orgRows.find(
+        (r) => r.payoutType === 'organization_fee'
+      );
+      expect(orgFeeRow).toBeDefined();
+      expect(orgFeeRow?.amountCents).toBe(900); // 10% of post-platform 9000
+      expect(orgFeeRow?.organizationId).toBe(mixedOrg.id);
+    });
+  });
 });

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -648,6 +648,22 @@ export class PurchaseService extends BaseService {
             ? 10_000 - agreementRow.sharePercent
             : fees.orgFeePercent;
 
+        // Codex-69t7c WP5 hardening (d): record the orgless org-fee-zero
+        // override decision explicitly. For a bi-party (orgless) purchase the
+        // org fee leg is forced to 0 regardless of the platform-fee config's
+        // default `orgFeePercent`; log that override so the decision is
+        // auditable rather than silently folded into the split below.
+        if (!organizationId) {
+          this.obs.info('orgless_org_fee_override', {
+            contentId: metadata.contentId,
+            creatorId: contentRecord.creatorId,
+            stripePaymentIntentId,
+            configOrgFeePercent: fees.orgFeePercent,
+            effectiveOrgFeePercent: 0,
+            reason: 'bi_party_no_org_recipient',
+          });
+        }
+
         // Step 4: Calculate revenue split, then apply min-platform-fee floor.
         // The floor is enforced in the caller (not in calculateRevenueSplit)
         // to keep the math pure. When (amount * pct / 10000) < minFee, we
@@ -769,10 +785,20 @@ export class PurchaseService extends BaseService {
           stripeChargeId: metadata.stripeChargeId,
         });
       } else if (txResult.isNew && !metadata.stripeChargeId) {
-        this.obs.warn(
-          'Purchase completed without stripeChargeId — payouts ledger entries skipped',
+        // Codex-69t7c WP5 hardening (a): a completed purchase with no
+        // stripeChargeId means writePurchasePayouts is skipped entirely, so
+        // NO creator_payout row is ever written — the creator (org-scoped OR
+        // orgless) is never paid for this sale. That is a money-loss event,
+        // not a recoverable warning: escalate to error with a correlatable
+        // errorId so it is loud in the log aggregator / Sentry-via-logs.
+        const errorId = crypto.randomUUID();
+        this.obs.error(
+          'Purchase completed without stripeChargeId — payouts ledger entries skipped; creator will NOT be paid',
           {
+            errorId,
             purchaseId: txResult.purchase.id,
+            creatorId: txResult.creatorId,
+            organizationId: txResult.organizationId,
             stripePaymentIntentId,
           }
         );
@@ -1100,13 +1126,23 @@ export class PurchaseService extends BaseService {
         });
       } catch (insertErr) {
         if (!isUniqueViolation(insertErr)) {
+          // Codex-69t7c WP5 hardening (b): the Stripe transfer ALREADY fired
+          // (real money moved to the Connect account) but the ledger row
+          // failed on a non-dup DB error — the ledger is now silently out of
+          // sync with Stripe. Emit a correlatable errorId so this money-moved
+          // / ledger-silent state is loud and reconcilable.
+          const errorId = crypto.randomUUID();
           this.obs.error(
             `${payoutType} transfer succeeded but payouts ledger insert failed`,
             {
+              errorId,
               purchaseId: purchase.id,
               organizationId,
               stripeTransferId: transfer.id,
+              destination: connect.stripeAccountId,
+              idempotencyKey,
               amountCents,
+              constraint: getConstraintName(insertErr),
               error:
                 insertErr instanceof Error
                   ? insertErr.message
@@ -1116,10 +1152,15 @@ export class PurchaseService extends BaseService {
         }
       }
     } catch (transferErr) {
+      // Codex-69t7c WP5 hardening (c): include idempotencyKey + destination
+      // (Connect account id) so a failed transfer can be traced to the exact
+      // Stripe idempotent request and recipient during reconciliation.
       this.obs.error(`${payoutType} transfer failed`, {
         purchaseId: purchase.id,
         organizationId,
         amountCents,
+        idempotencyKey,
+        destination: connect.stripeAccountId,
         error:
           transferErr instanceof Error
             ? transferErr.message

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -250,17 +250,13 @@ export class PurchaseService extends BaseService {
         });
       }
 
-      // Phase 1: Paid content must belong to an organization
-      if (contentRecord.organizationId == null) {
-        throw new ContentNotPurchasableError(
-          validated.contentId,
-          'not_published',
-          {
-            reason:
-              'Content must belong to an organization to be purchasable (Phase 1)',
-          }
-        );
-      }
+      // Codex-69t7c WP5: the Phase-1 "must belong to an organization" gate is
+      // removed. Orgless creator-direct (bi-party) content is purchasable —
+      // `content.organizationId IS NULL` is a valid, supported state. The
+      // creator slice routes to the creator's single Connect account (by
+      // userId) and NO organization_fee leg is written. Everything downstream
+      // (purchases.organizationId, payouts.organizationId, the webhook
+      // checkoutSessionMetadataSchema) is already nullable.
 
       // Check content is published
       if (contentRecord.status !== CONTENT_STATUS.PUBLISHED) {
@@ -340,19 +336,22 @@ export class PurchaseService extends BaseService {
         });
       }
 
-      // Hoist captured non-null fields BEFORE the closure. TypeScript loses
-      // narrowing of property accesses (`contentRecord.priceCents`,
-      // `contentRecord.organizationId`) across closure boundaries — locals
-      // preserve the narrowed `number` / `string` types we already validated
-      // earlier in this function.
+      // Hoist captured non-null `priceCents` BEFORE the closure. TypeScript
+      // loses narrowing of property accesses (`contentRecord.priceCents`)
+      // across closure boundaries — the local preserves the narrowed `number`
+      // type we already validated earlier in this function.
+      //
+      // Codex-69t7c WP5: `organizationId` is intentionally NOT non-null here —
+      // orgless (bi-party) content has `organizationId === null`, which is a
+      // supported purchase. Only `priceCents` is a hard invariant at this point
+      // (the free/unpriced guard above already rejected null/<=0).
       const priceCents = contentRecord.priceCents;
       const organizationId = contentRecord.organizationId;
-      if (priceCents === null || organizationId === null) {
+      if (priceCents === null) {
         // Already validated upstream; this guards the type narrowing only.
-        throw new PaymentProcessingError(
-          'Content missing price or organization at checkout',
-          { contentId: validated.contentId }
-        );
+        throw new PaymentProcessingError('Content missing price at checkout', {
+          contentId: validated.contentId,
+        });
       }
 
       // `withStaleCustomerRecovery` resolves a customer id and self-heals
@@ -392,10 +391,16 @@ export class PurchaseService extends BaseService {
             // charge via `source_transaction`.
             success_url: validated.successUrl,
             cancel_url: validated.cancelUrl,
+            // Codex-69t7c WP5: `organizationId` is OMITTED for orgless
+            // (bi-party) content. Stripe metadata values must be strings, so
+            // we cannot pass `null`; and an empty string would fail the
+            // webhook's `uuidSchema` round-trip in checkoutSessionMetadataSchema.
+            // Omitting the key lets that schema's `.default(null)` re-derive
+            // `null` on the completePurchase side.
             metadata: {
               contentId: validated.contentId,
               customerId,
-              organizationId,
+              ...(organizationId !== null ? { organizationId } : {}),
               creatorId: contentRecord.creatorId,
               contentTitle: contentRecord.title,
             },
@@ -513,29 +518,31 @@ export class PurchaseService extends BaseService {
           );
         }
 
+        // Codex-69t7c WP5: `organizationId` is legitimately nullable now.
+        // Org-scoped purchases populate it (from metadata or the content row);
+        // orgless creator-direct (bi-party) purchases have `null`. The Phase-1
+        // "personal content cannot be purchased" throw is removed.
         const organizationId =
           metadata.organizationId ?? contentRecord.organizationId;
 
-        // Phase 1: Personal content (organizationId = null) cannot be purchased
-        if (!organizationId) {
-          throw new PaymentProcessingError(
-            'Personal content purchases not supported - content must belong to an organization',
-            {
-              contentId: metadata.contentId,
-              stripePaymentIntentId,
-            }
-          );
-        }
-
         // Step 3: Resolve fees via FeeConfigService when available (Codex-m644n).
+        //
+        // Codex-69t7c WP5: branch on org presence.
+        //   - org-scoped → getFeesForCreator(orgId, creatorId) — platform leg
+        //     PLUS the org's per-creator override (unchanged tri-party path).
+        //   - orgless (bi-party) → getFeesPlatform() — platform-only fees; there
+        //     is no organization to carve a slice for, so the org leg is forced
+        //     to ZERO below regardless of any default `orgFeePercent`.
         // Falls back to legacy constants when no resolver is injected — preserves
         // the pre-m644n behaviour covered by existing tests.
         const fees = this.feeConfig
-          ? await this.feeConfig.getFeesForCreator(
-              organizationId,
-              contentRecord.creatorId,
-              'one_off'
-            )
+          ? organizationId
+            ? await this.feeConfig.getFeesForCreator(
+                organizationId,
+                contentRecord.creatorId,
+                'one_off'
+              )
+            : await this.feeConfig.getFeesPlatform('one_off')
           : {
               platformFeePercent: DEFAULT_PLATFORM_FEE_PERCENTAGE,
               orgFeePercent: DEFAULT_ORG_FEE_PERCENTAGE,
@@ -567,55 +574,79 @@ export class PurchaseService extends BaseService {
         // makes the predicate non-deterministic — webhook replays
         // can land on the wrong side of an agreement boundary that
         // occurred mid-millisecond.
+        // Codex-69t7c WP5: the creator-org agreement lookup is org-scoped, so
+        // it only runs for org-scoped purchases. Orgless (bi-party) content has
+        // no organization and therefore no `creator_organization_agreements`
+        // row — skip the query entirely (it would also fail to typecheck
+        // against the nullable `organizationId`).
         const purchasedAt = new Date();
-        const [agreementRow] = await tx
-          .select({
-            sharePercent: agreementProposals.proposedCreatorSharePercent,
-          })
-          .from(creatorOrganizationAgreements)
-          .innerJoin(
-            agreementProposals,
-            eq(
-              agreementProposals.id,
-              creatorOrganizationAgreements.currentProposalId
-            )
-          )
-          .where(
-            and(
-              eq(creatorOrganizationAgreements.organizationId, organizationId),
-              eq(
-                creatorOrganizationAgreements.creatorId,
-                contentRecord.creatorId
-              ),
-              eq(creatorOrganizationAgreements.revenueType, 'content_purchase'),
-              // Per Decision Q3: active-as-of-purchase-date. The schema
-              // check enforces (status='terminated') = (terminatedAt IS
-              // NOT NULL) — status='active' implies terminatedAt is NULL.
-              or(
-                eq(creatorOrganizationAgreements.status, 'active'),
-                and(
-                  eq(creatorOrganizationAgreements.status, 'terminated'),
-                  gt(creatorOrganizationAgreements.terminatedAt, purchasedAt)
+        const [agreementRow] = organizationId
+          ? await tx
+              .select({
+                sharePercent: agreementProposals.proposedCreatorSharePercent,
+              })
+              .from(creatorOrganizationAgreements)
+              .innerJoin(
+                agreementProposals,
+                eq(
+                  agreementProposals.id,
+                  creatorOrganizationAgreements.currentProposalId
                 )
-              ),
-              lte(creatorOrganizationAgreements.effectiveFrom, purchasedAt),
-              or(
-                isNull(creatorOrganizationAgreements.effectiveUntil),
-                gt(creatorOrganizationAgreements.effectiveUntil, purchasedAt)
               )
-            )
-          )
-          .limit(1);
+              .where(
+                and(
+                  eq(
+                    creatorOrganizationAgreements.organizationId,
+                    organizationId
+                  ),
+                  eq(
+                    creatorOrganizationAgreements.creatorId,
+                    contentRecord.creatorId
+                  ),
+                  eq(
+                    creatorOrganizationAgreements.revenueType,
+                    'content_purchase'
+                  ),
+                  // Per Decision Q3: active-as-of-purchase-date. The schema
+                  // check enforces (status='terminated') = (terminatedAt IS
+                  // NOT NULL) — status='active' implies terminatedAt is NULL.
+                  or(
+                    eq(creatorOrganizationAgreements.status, 'active'),
+                    and(
+                      eq(creatorOrganizationAgreements.status, 'terminated'),
+                      gt(
+                        creatorOrganizationAgreements.terminatedAt,
+                        purchasedAt
+                      )
+                    )
+                  ),
+                  lte(creatorOrganizationAgreements.effectiveFrom, purchasedAt),
+                  or(
+                    isNull(creatorOrganizationAgreements.effectiveUntil),
+                    gt(
+                      creatorOrganizationAgreements.effectiveUntil,
+                      purchasedAt
+                    )
+                  )
+                )
+              )
+              .limit(1)
+          : [undefined];
 
-        // If an agreement is present, derive the org's cut from
-        // 10000 - creator_share. If not, fall through to the
-        // FeeConfigService-resolved value — that is the Q1 fallback
-        // ("org keeps 100% of post-platform" when nothing else
-        // applies; the org-fee resolution defaults to 100% post-platform
-        // unless an admin has overridden it).
-        const effectiveOrgFeePercent = agreementRow
-          ? 10_000 - agreementRow.sharePercent
-          : fees.orgFeePercent;
+        // Codex-69t7c WP5: for orgless (bi-party) purchases the org leg is
+        // ALWAYS zero — there is no organization to pay, so the creator keeps
+        // 100% of the post-platform amount. We force `0` here rather than
+        // trusting `fees.orgFeePercent`, which for the platform-fee config can
+        // carry a non-zero default that would otherwise strand a slice with no
+        // recipient. For org-scoped purchases: if an agreement is present,
+        // derive the org's cut from 10000 - creator_share; otherwise fall
+        // through to the FeeConfigService-resolved value (the Q1 fallback —
+        // "org keeps 100% of post-platform" unless an admin overrode it).
+        const effectiveOrgFeePercent = !organizationId
+          ? 0
+          : agreementRow
+            ? 10_000 - agreementRow.sharePercent
+            : fees.orgFeePercent;
 
         // Step 4: Calculate revenue split, then apply min-platform-fee floor.
         // The floor is enforced in the caller (not in calculateRevenueSplit)
@@ -793,7 +824,11 @@ export class PurchaseService extends BaseService {
       creatorPayoutCents: number;
     };
     creatorId: string;
-    organizationId: string;
+    // Codex-69t7c WP5: nullable for orgless (bi-party) purchases. When null the
+    // org-fee leg is unreachable (organizationFeeCents is forced to 0 upstream),
+    // and the payout rows carry organizationId=null (payouts.organization_id is
+    // nullable). The creator slice still routes by userId.
+    organizationId: string | null;
     stripeChargeId: string;
   }): Promise<void> {
     const {
@@ -853,8 +888,11 @@ export class PurchaseService extends BaseService {
         : [undefined];
 
     // Codex-sec7i: org slice routes to the pinned Connect account.
+    // Codex-69t7c WP5: only resolve when there IS an org — orgless purchases
+    // never carve an org slice (organizationFeeCents is forced to 0 upstream),
+    // so this stays undefined and the org-fee branch below is skipped.
     const orgConnect =
-      revenueSplit.organizationFeeCents > 0
+      organizationId !== null && revenueSplit.organizationFeeCents > 0
         ? await resolvePrimaryConnect(this.db, organizationId)
         : undefined;
 
@@ -875,7 +913,11 @@ export class PurchaseService extends BaseService {
     }
 
     // 3. Organization fee — secondary transfer with source_transaction.
-    if (revenueSplit.organizationFeeCents > 0) {
+    // Codex-69t7c WP5: `organizationId !== null` is part of the guard. Orgless
+    // (bi-party) purchases force organizationFeeCents to 0 upstream, so this
+    // branch is unreachable for them; the null-check also narrows
+    // `organizationId` to `string` for the resolvers below.
+    if (organizationId !== null && revenueSplit.organizationFeeCents > 0) {
       // Codex-ed446: the org-fee payout row's recipient userId MUST be
       // non-null (check_payouts_user_required). Prefer the resolved Connect
       // account's user; when the org owner has not onboarded a Connect
@@ -949,7 +991,10 @@ export class PurchaseService extends BaseService {
    */
   private async executePurchaseTransfer(params: {
     purchase: Purchase;
-    organizationId: string;
+    // Codex-69t7c WP5: nullable for orgless (bi-party) creator_payout rows.
+    // Written verbatim onto the payouts row (payouts.organization_id is
+    // nullable). The org-fee path always passes a non-null org.
+    organizationId: string | null;
     amountCents: number;
     payoutType: 'creator_payout' | 'organization_fee';
     rowUserId: string | null;

--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -8115,6 +8115,332 @@ describe('SubscriptionService', () => {
     });
   });
 
+  // ─── Orgless (bi-party) pending payout drain (Codex-69t7c WP5) ──────────────
+  //
+  // WP5 lets orgless (creator-direct) content be purchased. Those purchases
+  // write `creator_payout` rows with organizationId = NULL. The original drain
+  // filtered `eq(payouts.organizationId, orgId)` (resolvePendingPayouts) and
+  // skipped `!group.organizationId` groups (sweepUnresolvedPayouts) — SQL
+  // `col = value` never matches NULL, so orgless rows were INVISIBLE to BOTH
+  // drains and the creator's money was stranded forever. These tests prove the
+  // orgless leg is now drained by BOTH paths, and that the org-scoped
+  // (tri-party) drain is unaffected.
+  describe('orgless (bi-party) pending payout drain — Codex-69t7c WP5', () => {
+    /**
+     * Seed a creator's single Connect account (active) WITHOUT attaching the
+     * payout rows to any org. Returns the deterministic stripeAccountId so the
+     * lookup can be driven explicitly. We intentionally do NOT create an org
+     * for the payout rows — they carry organizationId = null.
+     */
+    async function seedOrglessConnect(slug: string, ownerUserId = creatorId) {
+      // createFullOrg gives the owner an active Connect account (one per user,
+      // Codex-69t7c) and an org we use only as the webhook's incidental orgId
+      // argument; the payout rows themselves stay orgless.
+      const { org } = await createFullOrg(slug, ownerUserId);
+      const stripeAccountId = `acct_wp5_${createUniqueSlug('a')}`;
+      await db
+        .update(stripeConnectAccounts)
+        .set({ stripeAccountId })
+        .where(eq(stripeConnectAccounts.userId, ownerUserId));
+      return { org, stripeAccountId };
+    }
+
+    function stubAccountsRetrieve(ready: boolean): ReturnType<typeof vi.fn> {
+      const fn = vi.fn().mockImplementation(async (accountId: string) => ({
+        id: accountId,
+        charges_enabled: ready,
+        payouts_enabled: ready,
+      }));
+      (stripe as unknown as { accounts: Record<string, unknown> }).accounts = {
+        ...((stripe as unknown as { accounts?: Record<string, unknown> })
+          .accounts ?? {}),
+        retrieve: fn,
+      };
+      return fn;
+    }
+
+    it('resolvePendingPayouts drains an orgless creator_payout row (organizationId = NULL)', async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      const { org, stripeAccountId } = await seedOrglessConnect('wp5-orgless');
+
+      // Orgless creator_payout: organizationId is NULL, userId is the creator,
+      // sourceType 'purchase' (orgless purchases are the WP5 source). No
+      // subscriptionId (purchase-sourced) — purchaseId/charge optional here.
+      const [orglessRow] = await db
+        .insert(payoutsTable)
+        .values({
+          userId: creatorId,
+          organizationId: null,
+          sourceType: 'purchase',
+          amountCents: 1500,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
+        })
+        .returning();
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      // The webhook caller passes the creator's incidental org id; the fix
+      // resolves BOTH org-scoped AND orgless rows for the account's userId.
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      expect(result).toEqual({ resolved: 1, failed: 0 });
+      expect(transferSpy).toHaveBeenCalledTimes(1);
+      expect(transferSpy.mock.calls[0]![0]).toMatchObject({
+        amount: 1500,
+        currency: 'gbp',
+        destination: stripeAccountId,
+      });
+
+      const [after] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, orglessRow.id));
+      expect(after.status).toBe('paid');
+      expect(after.resolvedAt).not.toBeNull();
+      expect(after.stripeTransferId).toMatch(/^tr_/);
+      expect(after.organizationId).toBeNull();
+    });
+
+    it('resolvePendingPayouts drains orgless AND org-scoped rows for the same creator in one pass', async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      const { org, tier1, stripeAccountId } =
+        await createFullOrgWithDeterministicAccount('wp5-mixed');
+
+      // Org-scoped (tri-party) subscription payout for the creator.
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+            stripeSubscriptionId: `sub_wp5_${createUniqueSlug('s')}`,
+          })
+        )
+        .returning();
+
+      const inserted = await db
+        .insert(payoutsTable)
+        .values([
+          {
+            userId: creatorId,
+            organizationId: org.id,
+            subscriptionId: sub.id,
+            sourceType: 'subscription',
+            amountCents: 800,
+            currency: 'gbp',
+            reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
+          },
+          {
+            userId: creatorId,
+            organizationId: null,
+            sourceType: 'purchase',
+            amountCents: 1200,
+            currency: 'gbp',
+            reason: 'connect_not_ready',
+            status: 'pending',
+            payoutType: 'creator_payout',
+          },
+        ])
+        .returning();
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      // BOTH rows resolved: org-scoped + orgless.
+      expect(result).toEqual({ resolved: 2, failed: 0 });
+      expect(transferSpy).toHaveBeenCalledTimes(2);
+
+      const after = await db
+        .select()
+        .from(payoutsTable)
+        .where(
+          inArray(
+            payoutsTable.id,
+            inserted.map((r) => r.id)
+          )
+        );
+      expect(after).toHaveLength(2);
+      for (const row of after) {
+        expect(row.status).toBe('paid');
+        expect(row.resolvedAt).not.toBeNull();
+        expect(row.stripeTransferId).toMatch(/^tr_/);
+      }
+    });
+
+    it('sweepUnresolvedPayouts drains an orgless creator_payout group (organizationId = NULL, userId present)', async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      const { stripeAccountId } = await seedOrglessConnect('wp5-sweep-orgless');
+
+      const longAgo = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+      const [orglessRow] = await db
+        .insert(payoutsTable)
+        .values({
+          userId: creatorId,
+          organizationId: null,
+          sourceType: 'purchase',
+          amountCents: 900,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
+          attemptedAt: longAgo,
+        })
+        .returning();
+
+      const retrieveSpy = stubAccountsRetrieve(true);
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.sweepUnresolvedPayouts(15);
+
+      // The orgless group is no longer skipped: it is scanned, the account is
+      // resolved by userId alone, and the row drains.
+      expect(result).toEqual({
+        groupsScanned: 1,
+        groupsResolved: 1,
+        groupsSkipped: 0,
+        errors: 0,
+      });
+      expect(retrieveSpy).toHaveBeenCalledTimes(1);
+      expect(retrieveSpy).toHaveBeenCalledWith(stripeAccountId);
+      expect(transferSpy).toHaveBeenCalledTimes(1);
+
+      const [after] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, orglessRow.id));
+      expect(after.status).toBe('paid');
+      expect(after.resolvedAt).not.toBeNull();
+      expect(after.stripeTransferId).toMatch(/^tr_/);
+      expect(after.organizationId).toBeNull();
+    });
+
+    it('sweepUnresolvedPayouts still skips genuinely unroutable rows (userId IS NULL)', async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      // A pending row with NO recipient userId is genuinely unroutable. (We
+      // use payoutType 'creator_payout_to_owner' only to satisfy the
+      // check_payouts_user_required carve-out is NOT hit — but that constraint
+      // forbids a null userId for non-platform_fee rows, so we model the
+      // unroutable case with a platform_fee row forced to pending instead,
+      // which is the real null-userId shape the guard defends against.)
+      const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+      await db.insert(payoutsTable).values({
+        userId: null,
+        organizationId: null,
+        sourceType: 'purchase',
+        amountCents: 100,
+        currency: 'gbp',
+        status: 'pending',
+        payoutType: 'platform_fee',
+        attemptedAt: longAgo,
+      });
+
+      const retrieveSpy = stubAccountsRetrieve(true);
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.sweepUnresolvedPayouts(15);
+
+      expect(result).toEqual({
+        groupsScanned: 1,
+        groupsResolved: 0,
+        groupsSkipped: 1,
+        errors: 0,
+      });
+      // userId-null group is skipped BEFORE any Stripe call.
+      expect(retrieveSpy).not.toHaveBeenCalled();
+      expect(transferSpy).not.toHaveBeenCalled();
+    });
+
+    it('regression: org-scoped (tri-party) drain still resolves correctly', async () => {
+      const { sql: rawSql } = await import('drizzle-orm');
+      await db.execute(rawSql`DELETE FROM payouts`);
+
+      const { org, tier1, stripeAccountId } =
+        await createFullOrgWithDeterministicAccount('wp5-triparty');
+
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+            stripeSubscriptionId: `sub_wp5tri_${createUniqueSlug('s')}`,
+          })
+        )
+        .returning();
+
+      const [orgRow] = await db
+        .insert(payoutsTable)
+        .values({
+          userId: creatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          sourceType: 'subscription',
+          amountCents: 650,
+          currency: 'gbp',
+          reason: 'connect_not_ready',
+          status: 'pending',
+          payoutType: 'creator_payout',
+        })
+        .returning();
+
+      const transferSpy = vi.mocked(stripe.transfers.create);
+      transferSpy.mockClear();
+
+      const result = await service.resolvePendingPayouts(
+        org.id,
+        stripeAccountId
+      );
+
+      expect(result).toEqual({ resolved: 1, failed: 0 });
+      expect(transferSpy).toHaveBeenCalledTimes(1);
+
+      const [after] = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.id, orgRow.id));
+      expect(after.status).toBe('paid');
+      expect(after.resolvedAt).not.toBeNull();
+      expect(after.stripeTransferId).toMatch(/^tr_/);
+      expect(after.organizationId).toBe(org.id);
+    });
+
+    /**
+     * createFullOrg with a deterministic stripeAccountId so the drain lookup
+     * (by userId → single account) can be asserted explicitly.
+     */
+    async function createFullOrgWithDeterministicAccount(slug: string) {
+      const { org, tier1 } = await createFullOrg(slug, creatorId);
+      const stripeAccountId = `acct_wp5_${createUniqueSlug('a')}`;
+      await db
+        .update(stripeConnectAccounts)
+        .set({ stripeAccountId })
+        .where(eq(stripeConnectAccounts.userId, creatorId));
+      return { org, tier1, stripeAccountId };
+    }
+  });
+
   // ─── sweepUnresolvedPayouts — hybrid event+sweep resolution (Codex-vv77x) ───
   //
   // Stripe docs (verified 2026-05-13) say account.updated webhooks retry for

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -621,20 +621,32 @@ export class SubscriptionService extends BaseService {
    *   min-transfer floor.
    */
   private async resolvePayoutFees(
-    orgId: string,
+    orgId: string | null,
     ctx: FeeContext,
     creatorId?: string
   ): Promise<FeeConfig> {
     if (!this.feeConfig) {
       return {
         platformFeePercent: FEES.PLATFORM_PERCENT,
+        // Codex-69t7c WP5: orgless (bi-party) payouts carry NO org fee leg —
+        // the creator keeps 100% of post-platform. Mirror that in the
+        // no-FeeConfigService fallback so unit tests on the orgless drain
+        // path see a zero org fee, not the org/subscription default.
         orgFeePercent:
-          ctx === 'subscription'
-            ? FEES.SUBSCRIPTION_ORG_PERCENT
-            : FEES.ORG_PERCENT,
+          orgId === null
+            ? 0
+            : ctx === 'subscription'
+              ? FEES.SUBSCRIPTION_ORG_PERCENT
+              : FEES.ORG_PERCENT,
         minPlatformFeeCents: 0,
         minTransferCents: 0,
       };
+    }
+    // Codex-69t7c WP5: orgless rows have no org to resolve per-creator or
+    // per-org overrides against — use the platform-level fee policy, which
+    // owns the same `minTransferCents` floor the org/creator configs carry.
+    if (orgId === null) {
+      return this.feeConfig.getFeesPlatform(ctx);
     }
     return creatorId
       ? this.feeConfig.getFeesForCreator(orgId, creatorId, ctx)
@@ -3472,10 +3484,17 @@ export class SubscriptionService extends BaseService {
    *   - On success: sets resolvedAt and stripeTransferId
    *   - On failure: logs and continues to the next payout (batch is best-effort)
    *
+   * Codex-69t7c WP5: `orgId` is `string | null`. Regardless of which value the
+   * caller passes, the recipient is identified by the Connect account's
+   * userId, and BOTH that user's org-scoped (organizationId = orgId) AND
+   * orgless (organizationId IS NULL) pending rows are drained in one pass —
+   * SQL `col = value` never matches NULL, so the orgless leg would otherwise
+   * be stranded. A `null` orgId resolves ONLY the orgless leg.
+   *
    * Returns the count of successfully resolved payouts.
    */
   async resolvePendingPayouts(
-    orgId: string,
+    orgId: string | null,
     stripeAccountId: string
   ): Promise<{ resolved: number; failed: number }> {
     let resolved = 0;
@@ -3499,14 +3518,31 @@ export class SubscriptionService extends BaseService {
       return { resolved: 0, failed: 0 };
     }
 
+    // Codex-69t7c WP5: a single Connect account belongs to ONE creator
+    // (routed by userId), but that creator can accrue BOTH org-scoped
+    // (tri-party) pending rows (organizationId = orgId) AND orgless
+    // (bi-party) pending rows (organizationId IS NULL). SQL `col = value`
+    // never matches NULL, so the original `eq(payouts.organizationId, orgId)`
+    // filter rendered every orgless `creator_payout` row invisible to this
+    // primary webhook drain — stranding the creator's money indefinitely.
+    // Match BOTH shapes for this user so both legs resolve in one pass.
     const unresolvedPayouts = await this.db
       .select()
       .from(payouts)
       .where(
         and(
           eq(payouts.userId, connectAccount.userId),
-          eq(payouts.organizationId, orgId),
-          eq(payouts.status, 'pending')
+          eq(payouts.status, 'pending'),
+          // A non-null orgId resolves BOTH that org's rows AND the creator's
+          // orgless rows in one pass; a null orgId (orgless-only caller, e.g.
+          // the sweep's orgless group) resolves ONLY the orgless rows. `eq`
+          // cannot take a null comparand, so branch on it.
+          orgId === null
+            ? isNull(payouts.organizationId)
+            : or(
+                eq(payouts.organizationId, orgId),
+                isNull(payouts.organizationId)
+              )
         )
       );
 
@@ -3521,30 +3557,46 @@ export class SubscriptionService extends BaseService {
       count: unresolvedPayouts.length,
     });
 
-    // Codex-iivne: group pending rows by sourceType so a creator with
-    // many sub-threshold pending rows (multi-creator split scenarios)
-    // gets resolved when the SUM clears the min-transfer floor —
-    // rather than every row failing the per-row floor check and piling
-    // up indefinitely. Fee policy depends on sourceType, so the group
-    // key reflects it. Two possible groups: 'purchase' + 'subscription'.
-    const groups: Record<
-      'purchase' | 'subscription',
-      typeof unresolvedPayouts
-    > = { purchase: [], subscription: [] };
+    // Codex-iivne + Codex-69t7c WP5: group pending rows by (orgScope,
+    // sourceType) so a creator with many sub-threshold pending rows
+    // (multi-creator split scenarios) gets resolved when the SUM clears the
+    // min-transfer floor — rather than every row failing the per-row floor
+    // check and piling up indefinitely. Fee policy depends on BOTH the
+    // org-scope (orgless → platform-only fees; org-scoped → per-creator
+    // fees) AND the sourceType, so the group key reflects both. The org
+    // attached to each group drives fee resolution in transferPendingGroup:
+    // orgless rows carry `null` and resolve fees via getFeesPlatform().
+    type PendingGroupKey =
+      `${'org' | 'orgless'}:${'purchase' | 'subscription'}`;
+    const groups = new Map<
+      PendingGroupKey,
+      { orgId: string | null; rows: typeof unresolvedPayouts }
+    >();
     for (const payout of unresolvedPayouts) {
-      const key =
+      const orgScope = payout.organizationId === null ? 'orgless' : 'org';
+      const source =
         payout.sourceType === 'purchase' ? 'purchase' : 'subscription';
-      groups[key].push(payout);
+      const key: PendingGroupKey = `${orgScope}:${source}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.rows.push(payout);
+      } else {
+        groups.set(key, {
+          orgId: payout.organizationId,
+          rows: [payout],
+        });
+      }
     }
 
-    for (const [sourceType, group] of Object.entries(groups) as Array<
-      ['purchase' | 'subscription', typeof unresolvedPayouts]
-    >) {
-      if (group.length === 0) continue;
+    for (const [key, { orgId: groupOrgId, rows }] of groups) {
+      if (rows.length === 0) continue;
+      const sourceType: 'purchase' | 'subscription' = key.endsWith('purchase')
+        ? 'purchase'
+        : 'subscription';
       const groupResult = await this.transferPendingGroup(
-        group,
+        rows,
         sourceType,
-        orgId,
+        groupOrgId,
         stripeAccountId,
         connectAccount.userId
       );
@@ -3564,11 +3616,18 @@ export class SubscriptionService extends BaseService {
   }
 
   /**
-   * Codex-iivne: resolve one (userId, sourceType) group of pending
+   * Codex-iivne: resolve one (userId, orgScope, sourceType) group of pending
    * payouts. Caller has already filtered by Connect account userId, so
    * every row in `group` shares one recipient. Fee policy is looked up
    * once per call (was: per-row); floor evaluates against the SUM
    * (was: each row individually).
+   *
+   * Codex-69t7c WP5: `orgId` is `string | null`. A null org marks an orgless
+   * (bi-party) group — fee/floor resolution routes through the platform-level
+   * policy (getFeesPlatform) rather than per-org/per-creator config. The
+   * transfer itself is identical: per-row GBP-guarded `stripe.transfers.create`
+   * to the userId→single Connect account, verbatim `payout_${id}` idempotency
+   * key, per-row error isolation.
    *
    * The schema invariant `uq_payouts_stripe_transfer_id` forbids
    * shared stripeTransferId across rows, so per-row transfers fire
@@ -3577,7 +3636,7 @@ export class SubscriptionService extends BaseService {
   private async transferPendingGroup(
     group: (typeof payouts.$inferSelect)[],
     sourceType: 'purchase' | 'subscription',
-    orgId: string,
+    orgId: string | null,
     stripeAccountId: string,
     userId: string
   ): Promise<{ resolved: number; failed: number }> {
@@ -4919,20 +4978,26 @@ export class SubscriptionService extends BaseService {
     }
 
     for (const group of groups) {
-      // Codex-h69cg: payouts.userId and .organizationId are nullable to admit
-      // platform_fee rows. Those are always status='paid' so they would never
-      // appear in this sweep, but defence-in-depth: skip any group missing
-      // either field — it can't be routed to a Connect account anyway.
-      if (!group.organizationId || !group.userId) {
+      // Codex-h69cg + Codex-69t7c WP5: payouts.userId and .organizationId are
+      // both nullable. A null `userId` is the genuinely UNROUTABLE case —
+      // platform_fee rows (always status='paid', so they shouldn't surface
+      // here) or any row with no recipient — skip those. A null
+      // `organizationId` is NOT unroutable: orgless (bi-party) creator_payout
+      // rows carry organizationId=NULL but a real userId, and MUST be drained.
+      // The original `!group.organizationId` guard skipped every orgless group,
+      // so the cron safety-net never resolved orgless rows — stranding money.
+      if (!group.userId) {
         groupsSkipped++;
         continue;
       }
       try {
         // Find the user's single Connect account (by userId, Codex-69t7c) so
-        // we can look up the stripeAccountId. If the row is missing (rare — a
-        // Connect account was deleted but its payouts survived because of ON
-        // DELETE behaviour) skip this group; it will be re-attempted on the
-        // next sweep window.
+        // we can look up the stripeAccountId. This resolves the recipient by
+        // userId ALONE — independent of org — which is exactly what lets an
+        // orgless group (organizationId=NULL) route to a Connect account. If
+        // the row is missing (rare — a Connect account was deleted but its
+        // payouts survived because of ON DELETE behaviour) skip this group; it
+        // will be re-attempted on the next sweep window.
         const [connect] = await this.db
           .select({ stripeAccountId: stripeConnectAccounts.stripeAccountId })
           .from(stripeConnectAccounts)


### PR DESCRIPTION
## Summary

WP5 of epic Codex-69t7c (Creator Studio Monetisation). Removes the Phase-1 "content must belong to an organization" purchase gate and adds the orgless creator-direct (bi-party) payout branch.

**What changed (the narrow real deliverable — most orgless infra already landed in WP1/h69cg):**
- **`PurchaseService.createCheckoutSession`** — drop the org-required throw; omit `organizationId` from Stripe metadata when null (metadata values must be strings; the webhook's `checkoutSessionMetadataSchema.default(null)` re-derives null from the absent key).
- **`PurchaseService.completePurchase`** — drop the personal-content throw; branch fee resolution (`getFeesPlatform()` for orgless vs `getFeesForCreator()` for org-scoped); skip the org-scoped agreement lookup when there is no org; **force the org fee leg to zero** for orgless so the creator keeps 100% of post-platform and no slice is stranded.
- **`writePurchasePayouts` / `executePurchaseTransfer`** — widen `organizationId` to `string | null`; guard org-fee resolution on a non-null org. The creator slice already routes by `userId` (WP4), so it works orgless unchanged.
- **Schema** — `content_access.organization_id` made nullable (migration `0075`, via `db:generate`), mirroring WP1's `purchases.organization_id`. Paid-content access is verified through `purchases` (`verifyPurchase`), not this column, so a null org does not weaken any access check.

**Pre-existing (verified, NOT rebuilt):** `purchases.organizationId` nullable, `CompletePurchaseMetadata.organizationId: string | null`, `createCheckoutSchema`/`checkoutSessionMetadataSchema` org-nullable, `payouts` nullable-org + `check_payouts_user_required`, the webhook handler passing nullable org + chargeId, and `reversePayoutsForPurchase` (data-driven — reverses whatever rows exist, so bi-party refund works with zero code change).

**Payout invariants preserved:** GBP on every `transfers.create`; verbatim idempotency keys (`${chargeId}_creator`, `${chargeId}_org_fee`); per-creator min-transfer floor; per-row error isolation; `check_payouts_user_required` (platform_fee userId null, creator_payout userId=creator).

## Test Plan

`pnpm turbo run test --filter @codex/purchase --concurrency=1` → **232/232 pass** (+8 new WP5 tests, `--force` no-cache verified).

New `completePurchase — bi-party orgless payouts` block:
- **Positive (5):** happy path writes exactly 2 rows (platform_fee + creator_payout), no org_fee, creator transfer fires once in GBP with `${chargeId}_creator`; pre-Connect → creator_payout pending+connect_not_ready (no transfer); checkout succeeds + omits `organizationId` from Stripe metadata (not the string `"null"`); bi-party refund reverses both rows; org-leg forced to zero even when fee config returns non-zero `orgFeePercent`.
- **Negative (3):** orgless-but-unpublished still throws `ContentNotPurchasableError`; orgless-but-free still throws; org-leg-zero invariant.
- **Cross/regression:** same creator's orgless purchase (2 rows) and org-scoped purchase (3 rows) stay independent; existing tri-party suite (3-row org-routed payouts) unaffected.

Gate: `typecheck` ✓, `test` ✓, `build` ✓. Whole-repo `biome (check:ci)` is red ONLY on 11 pre-existing `apps/web/**` files (Codex-zf9wf) — enumerated, **zero in this change-set** (backend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
