### PR TITLE
chore(epic-loop): resilient audit tally + SHIP emission (Codex-3l73h)

### DIFF
--- a/.claude/skills/codex-epic-implement/SKILL.md
+++ b/.claude/skills/codex-epic-implement/SKILL.md
@@ -42,7 +42,7 @@ The cycle IS the architecture. **Never skip a stage. Never batch closures.**
 | # | Rule | Why |
 |---|---|---|
 | R1 | One WP at a time through all 10 stages. Never batch. | Each gate catches a different defect class. |
-| R2 | Write a `bd audit record` entry on every stage EXIT. | This is the trail `codex-epic-retro` measures; a missing entry is a drift signal. |
+| R2 | Write a `bd audit record` entry on every stage EXIT (the §2 table's last column IS the command — run it before advancing). SHIP auto-emits stage-9 via `gate.sh --wp <id>`; stages 0–8 are manual. | This is the trail `codex-epic-retro` measures; a missing entry is a drift signal. Codex-69t7c shipped 11/11 WPs with ZERO audit rows — emission was skipped, the retro went blind (Codex-3l73h). |
 | R3 | VERIFY (stage 2) surfaces the plan and asks "what's wrong with this plan?" — not "looks good?". Redirect → back to ORIENT. | Per nmemo; catches scope drift before code. `--autonomous` skips with an `autonomous` label. |
 | R4 | `codex-review` CRITICAL/HIGH must be fixed before SHIP. `silent-failure-hunter` CRITICAL = must-fix, no litigation. | 100% real-bug rate. |
 | R5 | Branch `feat/<wp-id>-<slug>`. NEVER push to main/dev directly. Re-check `git branch --show-current` before every git op. | `feedback_agent_branch_not_main`, `feedback_main_worktree_head_shift`. |
@@ -55,20 +55,29 @@ The cycle IS the architecture. **Never skip a stage. Never batch closures.**
 
 ## §2 — The 10-stage cycle
 
-| # | Stage | Gate to advance | bd-audit on exit |
-|---|---|---|---|
-| 0 | PREFLIGHT | on `feat/<wp>` branch off a clean tree; WP is `bd ready` | `stage-0 PREFLIGHT complete` |
-| 1 | ORIENT | plan written to the WP as a bd comment; stale pointers verified; retro-scan run | `stage-1 ORIENT complete` |
-| 2 | VERIFY | user confirms the plan (or `--autonomous`) | `stage-2 VERIFY complete` |
-| 3 | IMPLEMENT | code compiles; Codex patterns followed | `stage-3 IMPLEMENT complete` |
-| 4 | TEST | `pnpm test --filter` + `typecheck` green; pos+neg for money/auth | `stage-4 TEST complete` |
-| 5 | SIMPLIFY | `/simplify` findings applied or rejected-with-reason | `stage-5 SIMPLIFY complete` |
-| 6 | REVIEW | `codex-review` no CRITICAL/HIGH left; (UI) VISUAL-VERIFY MCP gate passed | `stage-6 REVIEW complete` |
-| 7 | FALLOW | no new dead code / unused exports (verified vs `src/`) | `stage-7 FALLOW complete` |
-| 8 | REGRESSION | full affected suite green; migration applied to fresh DB if touched | `stage-8 REGRESSION complete` |
-| 9 | SHIP | `gate.sh` → `✓ ALL GATES PASSED`; worktrees clean; pushed; PR open | `stage-9 SHIP complete` |
+The **bd-audit on exit** column is a literal checklist: before you advance past a stage, run that exact
+`bd audit record` (R2). This is the only trail `codex-epic-retro` reads — a skipped row blinds the retro.
+Set `WP=<wp-id>` once at PREFLIGHT and reuse it. **Stage 9 is auto-emitted by `gate.sh --wp "$WP"`; stages 0–8 are manual.**
 
-Audit entry shape (see conventions §3):
+```bash
+WP=Codex-xxxx.N   # set once; every audit row below uses it
+audit() { bd audit record --kind=tool_call --issue-id="$WP" --tool-name=codex-epic-implement --prompt="$1"; }
+```
+
+| # | Stage | Gate to advance | bd-audit on exit — RUN before advancing |
+|---|---|---|---|
+| 0 | PREFLIGHT | on `feat/<wp>` branch off a clean tree; WP is `bd ready` | `audit "stage-0 PREFLIGHT complete"` |
+| 1 | ORIENT | plan written to the WP as a bd comment; stale pointers verified; retro-scan run | `audit "stage-1 ORIENT complete"` |
+| 2 | VERIFY | user confirms the plan (or `--autonomous`) | `audit "stage-2 VERIFY complete"` |
+| 3 | IMPLEMENT | code compiles; Codex patterns followed | `audit "stage-3 IMPLEMENT complete"` |
+| 4 | TEST | `pnpm test --filter` + `typecheck` green; pos+neg for money/auth | `audit "stage-4 TEST complete"` |
+| 5 | SIMPLIFY | `/simplify` findings applied or rejected-with-reason | `audit "stage-5 SIMPLIFY complete"` |
+| 6 | REVIEW | `codex-review` no CRITICAL/HIGH left; (UI) VISUAL-VERIFY MCP gate passed | (codex-review writes `swarm-start`/`swarm-end`) → `audit "stage-6 REVIEW complete"` |
+| 7 | FALLOW | no new dead code / unused exports (verified vs `src/`) | `audit "stage-7 FALLOW complete"` |
+| 8 | REGRESSION | full affected suite green; migration applied to fresh DB if touched | `audit "stage-8 REGRESSION complete"` |
+| 9 | SHIP | `gate.sh --wp "$WP"` → `✓ ALL GATES PASSED`; worktrees clean; pushed; PR open | **auto-emitted by `gate.sh`** (`stage-9 SHIP complete`) |
+
+Audit entry shape (see conventions §3): the `audit` helper above expands to
 ```bash
 bd audit record --kind=tool_call --issue-id=<wp> --tool-name=codex-epic-implement --prompt="stage-<N> <NAME> complete"
 ```
@@ -133,7 +142,9 @@ bd ready                      # the WP must appear with no open blockers
 
 ### Stage 9 — SHIP (gate + push)
 ```bash
-.claude/skills/codex-epic-implement/scripts/gate.sh --pkg <filter>   # trust ONLY "✓ ALL GATES PASSED"
+.claude/skills/codex-epic-implement/scripts/gate.sh --pkg <filter> --wp "$WP"   # trust ONLY "✓ ALL GATES PASSED"
+#   --wp "$WP" auto-emits the stage-9 SHIP bd-audit record on PASS (Codex-3l73h). Best-effort: a bd
+#   failure can NEVER flip the gate's PASS/FAIL or its terminal marker. Omit only if not on a tracked WP.
 git worktree list                                                    # remove any agent-* worktrees: git worktree remove --force --force <path>
 git commit -m "feat(<scope>): WP-N <subject>"                        # conventional; co-author trailer
 git push -u origin feat/<wp-id>-<slug>

--- a/.claude/skills/codex-epic-implement/scripts/gate.sh
+++ b/.claude/skills/codex-epic-implement/scripts/gate.sh
@@ -10,20 +10,52 @@
 #   gate.sh --pkg @codex/foo      # scope test/build/typecheck to one turbo package
 #   gate.sh --skip-build          # skip the build gate
 #   gate.sh --skip-tests          # skip the test gate (build/typecheck only — NOT a real gate)
+#   gate.sh --wp <wp-id>          # emit the SHIP (stage-9) bd-audit record for this WP on PASS
+#                                 #   (also reads $WP_ID, then the feat/<wp-id>-… branch name)
+#
+# bd-audit emission (Codex-3l73h): on a PASS we write the stage-9 SHIP audit record so the trail the
+# retro reads is never empty (codex-epic-implement R2 / conventions §3). It is best-effort — wrapped
+# in `|| true` and emitted BEFORE the terminal marker — and can NEVER change the gate's pass/fail
+# result or the `✓ ALL GATES PASSED` / `✗ FAILED GATES` markers the cycle trusts.
 set -uo pipefail
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
 
-PKG=""; SKIP_TESTS=0; SKIP_BUILD=0
+PKG=""; SKIP_TESTS=0; SKIP_BUILD=0; WP="${WP_ID:-}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pkg) PKG="${2:?--pkg needs a turbo filter}"; shift 2 ;;
+    --wp)  WP="${2:?--wp needs a wp id}"; shift 2 ;;
     --skip-tests) SKIP_TESTS=1; shift ;;
     --skip-build) SKIP_BUILD=1; shift ;;
     *) echo "gate: unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+# Last resort: derive the WP id from a feat/<wp-id>-<slug> branch name (e.g. feat/Codex-69t7c.9-hub).
+# WP ids look like Codex-<base>[.<n>]; the slug follows the next hyphen. (POSIX ERE — no `+?`, which
+# bash 3.2 / macOS rejects: feedback_ci bootstrap-dev-env bash-3.2-compat.)
+if [[ -z "$WP" ]]; then
+  branch="$(git branch --show-current 2>/dev/null || true)"
+  [[ "$branch" =~ ^feat/([A-Za-z]+-[A-Za-z0-9]+(\.[0-9]+)?)- ]] && WP="${BASH_REMATCH[1]}"
+fi
+
+# emit_ship_audit — write the stage-9 SHIP bd-audit record. Best-effort ONLY: never affects the gate.
+emit_ship_audit() {
+  if [[ -z "$WP" ]]; then
+    echo "note: no WP id (pass --wp <id>, set \$WP_ID, or run on a feat/<wp>-… branch) — skipping SHIP bd-audit emission" >&2
+    return 0
+  fi
+  if ! command -v bd >/dev/null 2>&1; then
+    echo "note: bd not on PATH — skipping SHIP bd-audit emission for $WP" >&2
+    return 0
+  fi
+  bd audit record --kind=tool_call --issue-id="$WP" --tool-name=codex-epic-implement \
+    --prompt="stage-9 SHIP complete" >/dev/null 2>&1 \
+    || echo "note: bd audit record failed (non-fatal) — emit stage-9 SHIP for $WP manually" >&2
+  return 0
+}
 
 failed=()
 run() { local label="$1"; shift; echo ""; echo "=== $label ==="; if ! "$@"; then failed+=("$label"); echo "FAIL: $label" >&2; fi; }
@@ -47,6 +79,7 @@ fi
 
 echo ""
 if [[ ${#failed[@]} -eq 0 ]]; then
+  emit_ship_audit || true   # best-effort, BEFORE the marker — must never flip a PASS to a fail
   echo "✓ ALL GATES PASSED"; exit 0
 else
   echo "✗ FAILED GATES (${#failed[@]}):" >&2

--- a/.claude/skills/codex-epic-retro/SKILL.md
+++ b/.claude/skills/codex-epic-retro/SKILL.md
@@ -47,7 +47,7 @@ Defer when:
 
 ### Stage 1 — Load the epic's history
 - `bd show <epic-id>` + `bd list --parent <epic-id> --json` (or by label) — the WPs + their close reasons.
-- **Audit tally:** `.claude/skills/codex-epic-retro/scripts/audit-tally.sh <epic-id>` — per-WP stage completeness + swarm counts. Flag any `partial`/`missing` WP (a skipped gate is itself a finding). (Path is skill-relative; from repo root use the full `.claude/skills/...` path or it silently misfires with "no such file".)
+- **Audit tally:** `.claude/skills/codex-epic-retro/scripts/audit-tally.sh <epic-id>` — per-WP stage completeness + swarm counts, plus an appended `git-trail:<c>c/<f>fix[/PRs]` cross-check column. Flag any `partial`/`missing` WP (a skipped gate is itself a finding). If the bd-audit trail is empty the script reconstructs the WP list FROM the git topology (so it is never blind — Codex-3l73h); the git-trail proves *shipped/reviewed/merged*, NOT that the 10 gates ran — treat an all-`missing`/git-only result as the emission-discipline finding it is. For an OLDER epic whose WP commits aren't the most-recent block, scope with `GIT_TRAIL_RANGE=<git-range>`. (Path is skill-relative; from repo root use the full `.claude/skills/...` path or it silently misfires with "no such file".)
 - Read the merged PRs (`gh pr view`) and the `codex-review` findings recorded in each WP's audit (`swarm-end` tallies).
 - If a prior retro exists for a related area, read `docs/epics/retros/*.md` for patterns to re-check.
 

--- a/.claude/skills/codex-epic-retro/scripts/audit-tally.sh
+++ b/.claude/skills/codex-epic-retro/scripts/audit-tally.sh
@@ -4,9 +4,23 @@
 #
 # A WP showing < 10/10 stages or no swarm-start/end is a DRIFT signal the retro must explain.
 #
+# PRIMARY source = the bd-audit trail (.beads/interactions.jsonl). When that trail is empty or partial
+# for the epic, this script FALLS BACK to the git commit trail as a cross-check, so a future retro is
+# NEVER blind even if per-stage emission was skipped (the Codex-69t7c lesson — bead Codex-3l73h).
+# The git-trail is a CROSS-CHECK, not a substitute: it cannot prove the 10 gates ran, only that a WP
+# shipped (a `feat/test/...: WP-N` commit), was review-fixed (a trailing `fix(...): WP-N … review`
+# commit), and merged (a trailing `(#PR)` ref). The bd-audit columns stay authoritative.
+#
 # Usage:   audit-tally.sh <epic-id>          # all WPs (epic-id and epic-id.*)
 #          audit-tally.sh --task <wp-id>      # a single WP
-# Output:  TSV  <wp-id>\t<n>/10 stages\tstart:<k>\tend:<k>\t<complete|partial|missing>
+# Env:     GIT_TRAIL_RANGE=<git-range>        # scope the git-trail fallback explicitly
+#                                             #   (e.g. origin/dev~13..origin/dev) — use for OLDER epics.
+#                                             #   Default: the most recent contiguous run of WP commits.
+#          GIT_TRAIL_GAP=<n>                  # non-WP commits that break the contiguous run (default 3)
+#          GIT_TRAIL_SCAN=<n>                 # commits to scan when no range is given (default 400)
+#          GIT_TRAIL=0                         # disable the git-trail fallback entirely
+# Output:  TSV  <wp-id>\t<n>/10 stages\tstart:<k>\tend:<k>\t<complete|partial|missing>\tgit-trail:<c>c/<f>fix[/PRs]
+#          The git-trail column is APPENDED; the first five fields are unchanged from before.
 set -uo pipefail
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -20,7 +34,71 @@ case "${1:-}" in
   *)      target="$1" ;;
 esac
 
-EPIC="$target" MODE="$mode" python3 -c '
+# --- git-trail fallback: extract the WP commit topology -----------------------------------------
+# Emits TSV  wp-num<TAB>commits<TAB>fixes<TAB>review-fixes<TAB>pr-refs  (one row per WP number).
+# Commit subjects carry `WP-N`, not the bd epic id, so by default we take the most recent CONTIGUOUS
+# block of WP-tagged commits (the epic that just shipped). Override precisely with GIT_TRAIL_RANGE.
+GIT_TRAIL="${GIT_TRAIL:-1}"
+git_trail() {
+  [[ "$GIT_TRAIL" != "0" ]] || return 0
+  command -v git >/dev/null 2>&1 || return 0
+  local range="${GIT_TRAIL_RANGE:-}" log
+  if [[ -n "$range" ]]; then
+    log="$(git log --no-merges --format='%H%x09%s' "$range" 2>/dev/null)" || return 0
+  else
+    log="$(git log --no-merges --format='%H%x09%s' -"${GIT_TRAIL_SCAN:-400}" 2>/dev/null)" || return 0
+  fi
+  [[ -n "$log" ]] || return 0
+  GIT_TRAIL_GAP="${GIT_TRAIL_GAP:-3}" GTR="$range" python3 -c '
+import os, re, sys
+gap_limit = int(os.environ.get("GIT_TRAIL_GAP", "3"))
+explicit  = bool(os.environ.get("GTR", ""))
+wp_re  = re.compile(r"\bWP[ ._-]?(\d+)", re.I)
+pr_re  = re.compile(r"#(\d+)")
+fix_re = re.compile(r"^fix\b", re.I)        # fix(...): … → a follow-up commit
+rev_re = re.compile(r"review", re.I)        # … review … → driven by codex-review findings
+rows = [l.split("\t", 1) for l in sys.stdin.read().splitlines() if "\t" in l]
+# rows are newest-first (git log default). Skip leading non-WP commits (e.g. the retro/docs commit),
+# then collect the first contiguous WP run; a gap of > gap_limit non-WP commits ends the block.
+# With an explicit range, keep every WP commit in range (no contiguity trimming).
+block, seen_wp, gap = [], False, 0
+for _h, subj in rows:
+    if wp_re.search(subj):
+        seen_wp, gap = True, 0
+        block.append(subj)
+    else:
+        if not seen_wp:
+            continue
+        if explicit:
+            continue
+        gap += 1
+        if gap > gap_limit:
+            break
+agg = {}   # wp-num -> [commits, fixes, review_fixes, set(prs)]
+for subj in block:
+    m = wp_re.search(subj)
+    if not m:
+        continue
+    n = m.group(1)
+    a = agg.setdefault(n, [0, 0, 0, set()])
+    a[0] += 1
+    if fix_re.search(subj):
+        a[1] += 1
+        if rev_re.search(subj):
+            a[2] += 1
+    prs = pr_re.findall(subj)
+    if prs:
+        a[3].add(prs[-1])     # the TRAILING #NNN is the squash-merge ref
+for n in sorted(agg, key=lambda x: int(x)):
+    c, f, rf, prs = agg[n]
+    pr = ",".join("#" + p for p in sorted(prs, key=int))
+    sys.stdout.write("\t".join([n, str(c), str(f), str(rf), pr]) + "\n")
+' <<<"$log"
+}
+
+GIT_TRAIL_TSV="$(git_trail)"
+
+EPIC="$target" MODE="$mode" GIT_TRAIL_TSV="$GIT_TRAIL_TSV" python3 -c '
 import os, json, re, collections
 epic=os.environ["EPIC"]; mode=os.environ["MODE"]
 def inscope(iid):
@@ -38,11 +116,41 @@ for line in open(".beads/interactions.jsonl"):
     if t=="codex-epic-implement" and m: stages[iid].add(int(m.group(1)))
     if t=="codex-review" and p.startswith("swarm-start"): ss[iid]+=1
     if t=="codex-review" and p.startswith("swarm-end"):   se[iid]+=1
+
+# --- git-trail cross-check, keyed by WP number ---
+git_rows={}
+for line in (os.environ.get("GIT_TRAIL_TSV") or "").splitlines():
+    parts=line.split("\t")
+    if len(parts)<5: continue
+    git_rows[parts[0]]={"c":parts[1],"f":parts[2],"rf":parts[3],"prs":parts[4]}
+def git_col(num):
+    g=git_rows.get(str(num))
+    if not g: return "git-trail:-"
+    s="git-trail:"+g["c"]+"c/"+g["rf"]+"fix"
+    if g["prs"]: s+="/"+g["prs"]
+    return s
+def wp_num(iid):
+    m=re.search(r"\.(\d+)$", iid or "")   # Codex-69t7c.9 -> "9"; bare epic id -> ""
+    return m.group(1) if m else ""
+
 ids=sorted(set(list(stages)+list(ss)+list(se)))
 if not ids:
-    print("(no codex audit entries for %s — cycle not run, or audit discipline skipped)"%epic)
-for iid in ids:
-    n=len(stages[iid])
-    marker = "complete" if (n>=10 and ss[iid]>=1 and se[iid]>=1) else ("missing" if n==0 else "partial")
-    print(f"{iid}\t{n}/10 stages\tstart:{ss[iid]}\tend:{se[iid]}\t{marker}")
+    if git_rows:
+        # bd-audit empty → reconstruct the WP list FROM the git trail so the retro is not blind.
+        print("(no bd-audit entries for %s — falling back to the git commit trail; "
+              "columns are a CROSS-CHECK, NOT proof the 10 gates ran)" % epic)
+        for num in sorted(git_rows, key=lambda x:int(x)):
+            print("%s.%s\t0/10 stages\tstart:0\tend:0\tmissing\t%s" % (epic, num, git_col(num)))
+    else:
+        print("(no codex audit entries for %s — cycle not run, or audit discipline skipped; "
+              "no WP commit trail found either)" % epic)
+else:
+    for iid in ids:
+        n=len(stages[iid])
+        marker = "complete" if (n>=10 and ss[iid]>=1 and se[iid]>=1) else ("missing" if n==0 else "partial")
+        print("%s\t%d/10 stages\tstart:%d\tend:%d\t%s\t%s" % (iid, n, ss[iid], se[iid], marker, git_col(wp_num(iid))))
+    # surface git-trail WPs that the bd-audit trail missed entirely (so they are never invisible).
+    seen={wp_num(i) for i in ids}
+    for num in sorted([n for n in git_rows if n not in seen], key=lambda x:int(x)):
+        print("%s.%s\t0/10 stages\tstart:0\tend:0\tmissing\t%s" % (epic, num, git_col(num)))
 '

--- a/docs/epics/conventions.md
+++ b/docs/epics/conventions.md
@@ -82,6 +82,15 @@ Rules:
   left no audit entry is itself a drift signal the retro flags.
 - Standalone `/codex-review` (no WP context) skips audit entries but still prints the tally header.
 - Stage names (canonical): `0 PREFLIGHT, 1 ORIENT, 2 VERIFY, 3 IMPLEMENT, 4 TEST, 5 SIMPLIFY, 6 REVIEW, 7 FALLOW, 8 REGRESSION, 9 SHIP`.
+- The SHIP gate auto-emits stage-9 (`gate.sh --wp <id>`); stages 0–8 are emitted manually (Codex-3l73h).
+
+**Git-trail cross-check (fallback, NOT a substitute substrate).** This bd-audit trail stays the
+PRIMARY data source. But Codex-69t7c shipped 11/11 WPs with zero rows (emission was skipped), so
+`audit-tally.sh` now *falls back* to the git commit topology when the trail is empty/partial: it scans
+`feat/test/…: WP-N` commits, trailing `fix(…): WP-N … review` follow-ups, and `(#PR)` merge refs, and
+appends a `git-trail:<c>c/<f>fix[/PRs]` column so a future retro is never blind. The git-trail only
+proves a WP *shipped / was reviewed / merged* — it canNOT prove the 10 gates ran. Fix the emission gap
+(above); the git-trail is a safety net, not a licence to skip `bd audit record`.
 
 ---
 


### PR DESCRIPTION
## Summary

Bead **Codex-3l73h** (P1). The codex-* epic loop's first real run (epic **Codex-69t7c**) shipped 11/11 WPs with **zero** bd-audit rows — per-stage emission was skipped, so the retro went blind and `audit-tally.sh Codex-69t7c` printed *"no codex audit entries"*. The git **commit trail** carried the signal reliably, though. This resolves the bead's **A-vs-B** framing pragmatically by shipping the safe parts of **both**, plus a surgical directive tighten. Markdown + bash/python only — no application code.

**1. Strengthen emission (A).** `gate.sh` now auto-emits the stage-9 SHIP audit record on PASS via `--wp <id>` (also reads `$WP_ID`, then the `feat/<wp>-…` branch name). It is **best-effort and cannot affect the gate**: wrapped in `|| true`, emitted *before* the terminal marker, guarded on `command -v bd`. A `bd` failure can never flip PASS/FAIL or the `✓ ALL GATES PASSED` marker the cycle trusts; absent a WP id it no-ops with a notice. Branch-name extraction uses POSIX ERE (verified on the bash 3.2 macOS default — no `+?`).

**2. Resilient tally (B — the key fix).** `audit-tally.sh` keeps the bd-audit trail **PRIMARY** but **falls back to the git topology** when it's empty/partial: it scans `feat/test/…: WP-N` commits, trailing `fix(…): WP-N … review` follow-ups, and `(#PR)` merge refs, appending a `git-trail:<c>c/<f>fix[/PRs]` column. Default scope = the most-recent contiguous WP block; `GIT_TRAIL_RANGE=<git-range>` scopes an older epic precisely. **The first five TSV fields are unchanged** (`<wp-id>\t<n>/10 stages\tstart:<k>\tend:<k>\t<complete|partial|missing>`) — the column is appended, contract preserved.

**3. Tighten the directive.** `codex-epic-implement` SKILL.md folds the exact `bd audit record` per stage into the §2 table's exit-marker column (R2 — hard to skip), and notes SHIP is auto-emitted. Minimal `conventions §3` + `codex-epic-retro` SKILL.md edits document the git-trail as a **cross-check, not a substitute substrate**.

### Files changed
- `.claude/skills/codex-epic-retro/scripts/audit-tally.sh` — git-trail fallback + appended column (PRIMARY path untouched)
- `.claude/skills/codex-epic-implement/scripts/gate.sh` — `--wp`/`$WP_ID`/branch-derived SHIP emission, fail-safe
- `.claude/skills/codex-epic-implement/SKILL.md` — per-stage `audit` command folded into §2 table; R2 + SHIP `--wp`
- `.claude/skills/codex-epic-retro/SKILL.md` — Stage 1 documents the git-trail cross-check
- `docs/epics/conventions.md` — minimal §3 note (git-trail = safety net, not licence to skip)

## Test Plan

**`audit-tally.sh Codex-69t7c` — before vs after** (the bead's headline check):

Before (committed `origin/dev`):
```
(no codex audit entries for Codex-69t7c — cycle not run, or audit discipline skipped)
```
After (this branch):
```
(no bd-audit entries for Codex-69t7c — falling back to the git commit trail; columns are a CROSS-CHECK, NOT proof the 10 gates ran)
Codex-69t7c.1   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#272
Codex-69t7c.2   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#273
Codex-69t7c.3   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#275
Codex-69t7c.4   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#277
Codex-69t7c.5   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#278
Codex-69t7c.6   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#274
Codex-69t7c.7   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#276
Codex-69t7c.8   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#279
Codex-69t7c.9   0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#283
Codex-69t7c.10  0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#281
Codex-69t7c.11  0/10 stages  start:0  end:0  missing  git-trail:1c/0fix/#282
```
All 11 WPs surfaced; PR refs correct; WP9 → **#283** (the re-land merge ref, not the stranded #280).

- **Review-fix column populates** — against an epic with *unsquashed* `fix(…): WP-N review findings` commits (`GIT_TRAIL_RANGE=8c3033f7~1..516406d6`), WP1/2/3/8 report `git-trail:2c/1fix`, the rest `1c/0fix`.
- **bd-audit PRIMARY path** — a synthetic WP with 2 stages + swarm-start + swarm-end prints `…\t2/10 stages\tstart:1\tend:1\tpartial\tgit-trail:-` — first five fields match the documented contract.
- **gate.sh fail-safety** — with a `bd` stub forced to exit 7, the PASS branch still prints `✓ ALL GATES PASSED` and exits 0.
- **Branch → WP id** (bash 3.2): `feat/Codex-69t7c.9-earnings-hub`→`Codex-69t7c.9`, `feat/Codex-3l73h-audit-tally`→`Codex-3l73h`, `feat/Codex-9wkbs.10-foo`→`Codex-9wkbs.10`; `fix/…`/`main`/empty → no-op.
- `bash -n` clean on both scripts.

## A-vs-B recommendation

**Adopt the hybrid; do not pick one.** **A (automate emission)** is the right *primary* fix — the bd-audit trail is the only source that can record *which gates actually ran* (stages 0–9 + swarm-start/end), which git cannot. But A alone is fragile: it depends on every stage in every cycle remembering to emit, and the Codex-69t7c evidence is that this discipline silently lapsed for an entire epic. **B (git-trail)** can never replace A — a commit proves a WP *shipped/was-reviewed/merged*, not that TEST/REVIEW/FALLOW fired — but as a **fallback cross-check** it guarantees a future retro is never blind even when emission lapses again. So: A is the substrate, B is the safety net. This PR strengthens A only where it's risk-free (the SHIP gate already runs at stage 9, so auto-emitting there adds a guaranteed row with no new failure surface) and makes B a non-authoritative backstop. Conventions §3's substrate definition is deliberately left intact — only annotated.

**Follow-up (NOT built here):** the fully-robust version of A is a harness `PostToolUse`/stage hook that emits each stage automatically, removing the manual step entirely. That's a larger change to the loop's execution model and should be a separate, user-approved bead. An **ADR 0002** recording this audit-substrate decision is also still open (the retro deferred it pending this bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
