### PR TITLE
fix(access): deny orgless content tier-gate bypass (Codex-up7bx)

### DIFF
--- a/packages/access/src/__tests__/ContentAccessService.integration.test.ts
+++ b/packages/access/src/__tests__/ContentAccessService.integration.test.ts
@@ -2782,5 +2782,308 @@ describe('ContentAccessService Integration', () => {
         }
       });
     });
+
+    // ──────────────────────────────────────────────────────────────────
+    // Orgless tier-gate bypass (Codex-up7bx)
+    //
+    // `subscription_tiers` is org-scoped. Content with a `minimumTierId` but
+    // NO `organizationId` is a semantically invalid row: there is no org to
+    // resolve the tier against. Previously every access-decision branch
+    // conjoined the subscription check with `organizationId` being truthy, so
+    // for such a row the tier gate was SILENTLY SKIPPED and access fell
+    // through to the free/purchase arm and was GRANTED to users without a
+    // subscription. The fix fails closed: orgless + tier ⇒ DENY everywhere.
+    //
+    // These rows can't be produced via the (now-hardened) write path, so we
+    // seed the invalid state by patching the row directly with `db.update`,
+    // exactly as the subscriber/team helpers above do.
+    // ──────────────────────────────────────────────────────────────────
+    describe('Orgless tier-gated content fails closed (Codex-up7bx)', () => {
+      /** Create a real org + tier (tiers are always org-scoped). */
+      async function seedOrgAndTier(slugPrefix: string) {
+        const [tierOrg] = await db
+          .insert(organizations)
+          .values({
+            name: `Orgless Guard Org ${slugPrefix}`,
+            slug: createUniqueSlug(`orgless-guard-${slugPrefix}`),
+          })
+          .returning();
+        if (!tierOrg) throw new Error('Failed to create tier org');
+
+        const [tier] = await db
+          .insert(subscriptionTiers)
+          .values(
+            createTestTierInput(tierOrg.id, {
+              name: 'Orgless Guard Tier',
+              sortOrder: 1,
+            })
+          )
+          .returning();
+        if (!tier) throw new Error('Failed to create tier');
+
+        return { tierOrgId: tierOrg.id, tierId: tier.id };
+      }
+
+      /**
+       * Seed a PUBLISHED content row in the invalid (orgless + minimumTierId)
+       * state. Creates the row as orgless free content (passes the write
+       * path), then patches accessType/priceCents/minimumTierId directly while
+       * keeping organizationId NULL.
+       */
+      async function seedOrglessTierGatedContent(opts: {
+        slugPrefix: string;
+        creator: string;
+        accessType: 'paid' | 'subscribers' | 'free';
+        priceCents: number;
+        minimumTierId: string;
+      }) {
+        const media = await mediaService.create(
+          {
+            title: `${opts.slugPrefix} Video`,
+            mediaType: 'video',
+            mimeType: 'video/mp4',
+            r2Key: getOriginalKey(
+              opts.creator,
+              crypto.randomUUID(),
+              `${opts.slugPrefix}.mp4`
+            ),
+            fileSizeBytes: 1024,
+          },
+          opts.creator
+        );
+        await mediaService.markAsReady(
+          media.id,
+          {
+            hlsMasterPlaylistKey: `hls/${opts.slugPrefix}/master.m3u8`,
+            thumbnailKey: `thumbnails/${opts.slugPrefix}.jpg`,
+            durationSeconds: 120,
+          },
+          opts.creator
+        );
+
+        // Orgless free content — clears the create schema.
+        const item = await contentService.create(
+          {
+            title: `${opts.slugPrefix} Content`,
+            slug: createUniqueSlug(opts.slugPrefix),
+            contentType: 'video',
+            mediaItemId: media.id,
+            visibility: 'public',
+            priceCents: 0,
+            tags: [],
+          },
+          opts.creator
+        );
+        await contentService.publish(item.id, opts.creator);
+
+        // Force the invalid state: orgless (organizationId stays NULL) + a tier.
+        await db
+          .update(content)
+          .set({
+            organizationId: null,
+            accessType: opts.accessType,
+            priceCents: opts.priceCents,
+            minimumTierId: opts.minimumTierId,
+          })
+          .where(eq(content.id, item.id));
+
+        return item;
+      }
+
+      it('getStreamingUrl DENIES orgless paid content with a tier, even for a purchaser', async () => {
+        // A purchase would normally unlock paid content — but an orgless tier
+        // gate is invalid, so the fail-closed guard must deny BEFORE the
+        // purchase path is even consulted.
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(true);
+
+        const { tierId } = await seedOrgAndTier('paid-purchaser');
+        const [viewerId] = await seedTestUsers(db, 1);
+
+        const item = await seedOrglessTierGatedContent({
+          slugPrefix: 'orgless-paid-purchaser',
+          creator: userId,
+          accessType: 'paid',
+          priceCents: 1500,
+          minimumTierId: tierId,
+        });
+
+        await expect(
+          accessService.getStreamingUrl(viewerId, {
+            contentId: item.id,
+            expirySeconds: 3600,
+          })
+        ).rejects.toThrow(AccessDeniedError);
+
+        // Guard fires before the purchase check.
+        expect(mockPurchaseService.verifyPurchase).not.toHaveBeenCalled();
+      });
+
+      it('getStreamingUrl DENIES orgless subscribers content with a tier (no subscription possible)', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        const { tierId } = await seedOrgAndTier('subs');
+        const [viewerId] = await seedTestUsers(db, 1);
+
+        const item = await seedOrglessTierGatedContent({
+          slugPrefix: 'orgless-subs',
+          creator: userId,
+          accessType: 'subscribers',
+          priceCents: 0,
+          minimumTierId: tierId,
+        });
+
+        await expect(
+          accessService.getStreamingUrl(viewerId, {
+            contentId: item.id,
+            expirySeconds: 3600,
+          })
+        ).rejects.toThrow(AccessDeniedError);
+      });
+
+      it('hasContentAccess returns false for orgless tier-gated content', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(true);
+
+        const { tierId } = await seedOrgAndTier('has-access');
+        const [viewerId] = await seedTestUsers(db, 1);
+
+        const item = await seedOrglessTierGatedContent({
+          slugPrefix: 'orgless-has-access',
+          creator: userId,
+          accessType: 'paid',
+          priceCents: 1500,
+          minimumTierId: tierId,
+        });
+
+        const allowed = await accessService.hasContentAccess(viewerId, item.id);
+        expect(allowed).toBe(false);
+      });
+
+      it('POSITIVE regression: orgless paid content WITHOUT a tier still grants to a purchaser', async () => {
+        // Same shape minus the tier — the guard must NOT fire, and the normal
+        // purchase path should grant access. Proves the guard is scoped to the
+        // (orgless ∧ tier) case only.
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(true);
+
+        const [viewerId] = await seedTestUsers(db, 1);
+
+        const media = await mediaService.create(
+          {
+            title: 'Orgless No-Tier Video',
+            mediaType: 'video',
+            mimeType: 'video/mp4',
+            r2Key: getOriginalKey(
+              userId,
+              crypto.randomUUID(),
+              'orgless-no-tier.mp4'
+            ),
+            fileSizeBytes: 1024,
+          },
+          userId
+        );
+        await mediaService.markAsReady(
+          media.id,
+          {
+            hlsMasterPlaylistKey: 'hls/orgless-no-tier/master.m3u8',
+            thumbnailKey: 'thumbnails/orgless-no-tier.jpg',
+            durationSeconds: 120,
+          },
+          userId
+        );
+        const item = await contentService.create(
+          {
+            title: 'Orgless No-Tier Content',
+            slug: createUniqueSlug('orgless-no-tier'),
+            contentType: 'video',
+            mediaItemId: media.id,
+            visibility: 'public',
+            priceCents: 0,
+            tags: [],
+          },
+          userId
+        );
+        await contentService.publish(item.id, userId);
+        // Orgless PAID, NO tier.
+        await db
+          .update(content)
+          .set({ accessType: 'paid', priceCents: 1500, minimumTierId: null })
+          .where(eq(content.id, item.id));
+
+        const result = await accessService.getStreamingUrl(viewerId, {
+          contentId: item.id,
+          expirySeconds: 3600,
+        });
+        expect(result.streamingUrl).toContain('r2.cloudflarestorage.com');
+        expect(mockPurchaseService.verifyPurchase).toHaveBeenCalled();
+      });
+
+      it('POSITIVE regression: org-scoped tier-gated content still grants to an at-tier subscriber', async () => {
+        // The legitimate counterpart: org-scoped subscribers content with a
+        // tier, accessed by an active subscriber at that tier, is unaffected.
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        const { tierOrgId, tierId } = await seedOrgAndTier('org-scoped-ok');
+        const [subUserId] = await seedTestUsers(db, 1);
+
+        const media = await mediaService.create(
+          {
+            title: 'Org Scoped Tier Video',
+            mediaType: 'video',
+            mimeType: 'video/mp4',
+            r2Key: getOriginalKey(
+              userId,
+              crypto.randomUUID(),
+              'org-scoped-tier.mp4'
+            ),
+            fileSizeBytes: 1024,
+          },
+          userId
+        );
+        await mediaService.markAsReady(
+          media.id,
+          {
+            hlsMasterPlaylistKey: 'hls/org-scoped-tier/master.m3u8',
+            thumbnailKey: 'thumbnails/org-scoped-tier.jpg',
+            durationSeconds: 120,
+          },
+          userId
+        );
+        const item = await contentService.create(
+          {
+            organizationId: tierOrgId,
+            title: 'Org Scoped Tier Content',
+            slug: createUniqueSlug('org-scoped-tier'),
+            contentType: 'video',
+            mediaItemId: media.id,
+            visibility: 'public',
+            priceCents: 0,
+            tags: [],
+          },
+          userId
+        );
+        await contentService.publish(item.id, userId);
+        await db
+          .update(content)
+          .set({ accessType: 'subscribers', minimumTierId: tierId })
+          .where(eq(content.id, item.id));
+
+        // Active subscription at the required tier.
+        await db.insert(subscriptions).values(
+          createTestSubscriptionInput(subUserId, tierOrgId, tierId, {
+            status: 'active',
+          })
+        );
+
+        const result = await accessService.getStreamingUrl(subUserId, {
+          contentId: item.id,
+          expirySeconds: 3600,
+        });
+        expect(result.streamingUrl).toContain('r2.cloudflarestorage.com');
+      });
+    });
   });
 });

--- a/packages/access/src/services/ContentAccessService.ts
+++ b/packages/access/src/services/ContentAccessService.ts
@@ -264,6 +264,26 @@ export class ContentAccessService extends BaseService {
 
     const orgId = contentRecord.organizationId;
 
+    // ── Fail-closed guard: orgless content can never tier-gate (Codex-up7bx) ──
+    // `subscription_tiers` is org-scoped (FK to organizations, unique per org),
+    // so a `minimumTierId` on content with NO `organizationId` is a semantically
+    // invalid row — there is no org against which a subscription/tier could be
+    // checked. Earlier this slipped through every branch that conjoined the
+    // subscription check with `orgId` being truthy, silently SKIPPING the tier
+    // gate and granting access. Deny here, before any branch, so a pre-existing
+    // bad row (regardless of how it was written) is never silently unlocked.
+    if (orgId == null && contentRecord.minimumTierId != null) {
+      this.obs.warn('Access denied - orgless content with tier gate', {
+        userId,
+        contentId,
+        minimumTierId: contentRecord.minimumTierId,
+        securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
+        severity: LOG_SEVERITY.MEDIUM,
+        eventType: LOG_EVENTS.ACCESS_CONTROL,
+      });
+      return false;
+    }
+
     // Inline reusable helpers — mirror the branches in getStreamingUrl.
     const MANAGEMENT_ROLES: string[] = [
       ORGANIZATION_ROLES.OWNER,
@@ -506,6 +526,33 @@ export class ContentAccessService extends BaseService {
               });
 
               throw new ContentNotFoundError(input.contentId);
+            }
+
+            // ── Fail-closed guard: orgless content can never tier-gate ──
+            // (Codex-up7bx) `subscription_tiers` is org-scoped, so content
+            // with a `minimumTierId` but NO `organizationId` is a semantically
+            // invalid row: there is no org against which the tier/subscription
+            // could be resolved. Every accessType branch below conjoins the
+            // subscription check with `organizationId` being present, which
+            // for such a row silently SKIPS the gate and (in the free/paid
+            // arms) grants access. Deny up front so a pre-existing bad row —
+            // however it was written — is never silently unlocked. This must
+            // precede the accessType branching.
+            if (
+              contentRecord.organizationId == null &&
+              contentRecord.minimumTierId != null
+            ) {
+              this.obs.warn('Access denied - orgless content with tier gate', {
+                userId,
+                contentId: input.contentId,
+                minimumTierId: contentRecord.minimumTierId,
+                securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
+                severity: LOG_SEVERITY.MEDIUM,
+                eventType: LOG_EVENTS.ACCESS_CONTROL,
+              });
+              throw new AccessDeniedError(userId, input.contentId, {
+                reason: 'orgless_tier_gate',
+              });
             }
 
             // NOTE: Media item existence is NOT checked here. Written content

--- a/packages/content/src/services/__tests__/content-service.test.ts
+++ b/packages/content/src/services/__tests__/content-service.test.ts
@@ -19,10 +19,16 @@
  * - No cleanup needed - fresh database for this file
  */
 
-import { mediaItems, organizations } from '@codex/database/schema';
+import {
+  content,
+  mediaItems,
+  organizations,
+  subscriptionTiers,
+} from '@codex/database/schema';
 import {
   createTestMediaItemInput,
   createTestOrganizationInput,
+  createTestTierInput,
   createUniqueSlug,
   type Database,
   seedTestUsers,
@@ -223,6 +229,90 @@ describe('ContentService', () => {
 
         // Assert
         expect(result.organizationId).toBeNull();
+      });
+
+      it('rejects orgless content with a minimumTierId set (Codex-up7bx)', async () => {
+        // subscription_tiers is org-scoped, so a tier on orgless content is
+        // a semantically invalid row. The write schema rejects it at create().
+        const [media] = await db
+          .insert(mediaItems)
+          .values(
+            createTestMediaItemInput(creatorId, {
+              mediaType: 'video',
+              status: 'ready',
+            })
+          )
+          .returning();
+
+        const input = {
+          title: 'Orgless Tier Content',
+          slug: createUniqueSlug('orgless-tier'),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'public',
+          accessType: 'paid',
+          priceCents: 1000,
+          // no organizationId
+          minimumTierId: '123e4567-e89b-12d3-a456-426614174000',
+          tags: [],
+        } as unknown as CreateContentInput;
+
+        await expect(service.create(input, creatorId)).rejects.toThrow(
+          /orgless content cannot be tier-gated/i
+        );
+      });
+
+      it('clears a lingering tier when content is updated to be orgless (Codex-up7bx)', async () => {
+        // Seed org-scoped subscriber content WITH a real tier, then move it
+        // out of the org via update. The service must clamp the now-dangling
+        // tier to null so the access layer never has to fail closed on it.
+        const [org] = await db
+          .insert(organizations)
+          .values(createTestOrganizationInput())
+          .returning();
+
+        const [tier] = await db
+          .insert(subscriptionTiers)
+          .values(createTestTierInput(org.id, { sortOrder: 1 }))
+          .returning();
+
+        const [media] = await db
+          .insert(mediaItems)
+          .values(
+            createTestMediaItemInput(creatorId, {
+              mediaType: 'video',
+              status: 'ready',
+            })
+          )
+          .returning();
+
+        // Insert a valid org-scoped tier-gated row directly (bypasses the
+        // create schema, mirroring how legitimate subscriber content lands).
+        const [seeded] = await db
+          .insert(content)
+          .values({
+            creatorId,
+            organizationId: org.id,
+            mediaItemId: media.id,
+            title: 'Org Tier Content',
+            slug: createUniqueSlug('org-tier'),
+            contentType: 'video',
+            accessType: 'subscribers',
+            minimumTierId: tier.id,
+            status: 'draft',
+          })
+          .returning();
+
+        // Update to orgless WITHOUT touching minimumTierId in the payload —
+        // the schema can't reason here; the service clamp must clear the tier.
+        const updated = await service.update(
+          seeded.id,
+          { organizationId: null },
+          creatorId
+        );
+
+        expect(updated.organizationId).toBeNull();
+        expect(updated.minimumTierId).toBeNull();
       });
 
       it('should create content with tags and category', async () => {

--- a/packages/content/src/services/content-service.ts
+++ b/packages/content/src/services/content-service.ts
@@ -154,10 +154,17 @@ export class ContentService extends BaseService {
             // Tier is only meaningful for 'subscribers' (required) and 'paid'
             // (optional, hybrid). Clamp to null for the other access modes so
             // we never persist a nonsensical (accessType, minimumTierId) pair.
+            // Also clamp for ORGLESS content (Codex-up7bx): subscription_tiers
+            // is org-scoped, so a tier on content with no organizationId is
+            // invalid (no org to resolve it against). The Zod schema rejects
+            // this combination outright; this clamp is the defensive backstop
+            // for any direct service caller that bypasses validation — never
+            // persist a row the access layer must then fail closed on.
             minimumTierId:
               (validated.accessType === CONTENT_ACCESS_TYPE.SUBSCRIBERS ||
                 validated.accessType === CONTENT_ACCESS_TYPE.PAID) &&
-              validated.minimumTierId
+              validated.minimumTierId &&
+              validated.organizationId
                 ? validated.minimumTierId
                 : null,
             status: CONTENT_STATUS.DRAFT, // Always start as draft
@@ -280,10 +287,24 @@ export class ContentService extends BaseService {
         // the DB and the access service continues to honour it (e.g. paid
         // content still granting subscribers access via the hybrid branch).
         const accessTypeUpdating = restValidated.accessType;
-        const clearTier =
+        const accessTypeIncompatible =
           accessTypeUpdating !== undefined &&
           accessTypeUpdating !== CONTENT_ACCESS_TYPE.SUBSCRIBERS &&
           accessTypeUpdating !== CONTENT_ACCESS_TYPE.PAID;
+
+        // Codex-up7bx: a tier is only valid on org-scoped content. Determine
+        // the org the row will have AFTER this update (the incoming value when
+        // the payload touches organizationId, otherwise the existing value).
+        // If that resolves to orgless, the tier must be cleared — moving
+        // content out of an org (or setting it on already-orgless content)
+        // can never leave a dangling minimumTierId for the access layer to
+        // honour. Mirrors the create-path clamp + the read-path fail-closed
+        // guard in ContentAccessService.
+        const resultingOrgId =
+          'organizationId' in restValidated
+            ? restValidated.organizationId
+            : existing.organizationId;
+        const clearTier = accessTypeIncompatible || resultingOrgId == null;
 
         // Update content
         const [updated] = await tx

--- a/packages/validation/src/__tests__/content-schemas.test.ts
+++ b/packages/validation/src/__tests__/content-schemas.test.ts
@@ -576,6 +576,90 @@ describe('Content Schemas', () => {
       ).not.toThrow();
     });
   });
+
+  describe('orgless content cannot be tier-gated (Codex-up7bx)', () => {
+    // subscription_tiers is org-scoped; a tier on content with no
+    // organizationId is a semantically invalid row the access layer must
+    // fail closed on. The write schema rejects it outright.
+    const tierUuid = '123e4567-e89b-12d3-a456-426614174000';
+    const orgUuid = '223e4567-e89b-12d3-a456-426614174000';
+    const mediaUuid = '323e4567-e89b-12d3-a456-426614174000';
+
+    const orglessBase = {
+      title: 'T',
+      slug: 'orgless-test',
+      contentType: 'video' as const,
+      mediaItemId: mediaUuid,
+    };
+
+    it('rejects orgless paid content with a tier (hybrid mode needs an org)', () => {
+      expect(() =>
+        createContentSchema.parse({
+          ...orglessBase,
+          accessType: 'paid',
+          priceCents: 1000,
+          minimumTierId: tierUuid,
+          // organizationId intentionally absent
+        })
+      ).toThrow(/orgless content cannot be tier-gated/i);
+    });
+
+    it('rejects orgless paid content with an explicitly-null org and a tier', () => {
+      expect(() =>
+        createContentSchema.parse({
+          ...orglessBase,
+          accessType: 'paid',
+          priceCents: 1000,
+          minimumTierId: tierUuid,
+          organizationId: null,
+        })
+      ).toThrow(/orgless content cannot be tier-gated/i);
+    });
+
+    it('accepts org-scoped paid content with a tier (the legitimate counterpart)', () => {
+      expect(() =>
+        createContentSchema.parse({
+          ...orglessBase,
+          accessType: 'paid',
+          priceCents: 1000,
+          minimumTierId: tierUuid,
+          organizationId: orgUuid,
+        })
+      ).not.toThrow();
+    });
+
+    it('accepts orgless content with NO tier (unchanged)', () => {
+      expect(() =>
+        createContentSchema.parse({
+          ...orglessBase,
+          accessType: 'free',
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects a partial update that sets a tier while clearing the org', () => {
+      expect(() =>
+        updateContentSchema.parse({
+          accessType: 'paid',
+          priceCents: 1000,
+          minimumTierId: tierUuid,
+          organizationId: null,
+        })
+      ).toThrow(/orgless content cannot be tier-gated/i);
+    });
+
+    it('defers the tier-without-org case to the service when org is omitted from the update', () => {
+      // organizationId absent → schema can't reason about the existing row;
+      // ContentService.update() applies the defensive clamp.
+      expect(() =>
+        updateContentSchema.parse({
+          accessType: 'paid',
+          priceCents: 1000,
+          minimumTierId: tierUuid,
+        })
+      ).not.toThrow();
+    });
+  });
 });
 
 describe('Query Schemas', () => {

--- a/packages/validation/src/content/content-schemas.ts
+++ b/packages/validation/src/content/content-schemas.ts
@@ -439,6 +439,23 @@ export const createContentSchema = baseContentSchema
         'Subscription tier is only valid for subscriber-gated or paid-hybrid content',
       path: ['minimumTierId'],
     }
+  )
+  .refine(
+    (data) => {
+      // Codex-up7bx: `subscription_tiers` is org-scoped (FK to organizations,
+      // unique per org), so a `minimumTierId` is only meaningful on content
+      // that belongs to an organization. Orgless (creator-direct) content with
+      // a tier set is a semantically invalid row — there is no org against
+      // which a subscription/tier could be resolved — and the access layer
+      // must fail closed on it. Reject the combination here at the write
+      // boundary so such a row is never created in the first place.
+      return !data.minimumTierId || !!data.organizationId;
+    },
+    {
+      message:
+        'Subscription tier requires an organisation — orgless content cannot be tier-gated',
+      path: ['minimumTierId'],
+    }
   );
 
 export type CreateContentInput = z.infer<typeof createContentSchema>;
@@ -450,22 +467,43 @@ export type CreateContentInput = z.infer<typeof createContentSchema>;
  * "did the admin leave a tier set when switching to an incompatible mode?"
  * case is handled defensively in ContentService.update() (see content-service.ts).
  */
-export const updateContentSchema = baseContentSchema.partial().refine(
-  (data) => {
-    // Only evaluate when the caller sent both fields. If accessType is absent,
-    // the DB value stands and we can't reason about the combination here.
-    if (data.accessType === undefined || !data.minimumTierId) return true;
-    return (
-      data.accessType === CONTENT_ACCESS_TYPE.SUBSCRIBERS ||
-      data.accessType === CONTENT_ACCESS_TYPE.PAID
-    );
-  },
-  {
-    message:
-      'Subscription tier is only valid for subscriber-gated or paid-hybrid content',
-    path: ['minimumTierId'],
-  }
-);
+export const updateContentSchema = baseContentSchema
+  .partial()
+  .refine(
+    (data) => {
+      // Only evaluate when the caller sent both fields. If accessType is absent,
+      // the DB value stands and we can't reason about the combination here.
+      if (data.accessType === undefined || !data.minimumTierId) return true;
+      return (
+        data.accessType === CONTENT_ACCESS_TYPE.SUBSCRIBERS ||
+        data.accessType === CONTENT_ACCESS_TYPE.PAID
+      );
+    },
+    {
+      message:
+        'Subscription tier is only valid for subscriber-gated or paid-hybrid content',
+      path: ['minimumTierId'],
+    }
+  )
+  .refine(
+    (data) => {
+      // Codex-up7bx: reject an update that sets a tier while simultaneously
+      // clearing the organisation (organizationId explicitly null in the same
+      // payload). Tiers are org-scoped, so orgless content can never be
+      // tier-gated. When organizationId is ABSENT from the payload the existing
+      // org value stands and we can't reason here — ContentService.update()
+      // applies the defensive clamp for the "tier left set on an already-orgless
+      // row" case.
+      if (!data.minimumTierId) return true;
+      if (!('organizationId' in data)) return true;
+      return data.organizationId != null;
+    },
+    {
+      message:
+        'Subscription tier requires an organisation — orgless content cannot be tier-gated',
+      path: ['minimumTierId'],
+    }
+  );
 
 export type UpdateContentInput = z.infer<typeof updateContentSchema>;
 


### PR DESCRIPTION
## Summary

`subscription_tiers` is **org-scoped** (FK to `organizations`, unique per org), so content carrying a `minimumTierId` but **no** `organizationId` is a semantically invalid row — there is no org against which a subscription/tier can be resolved. Every access-decision path in `ContentAccessService` conjoined the subscription check with `organizationId` being truthy, so for **orgless creator-direct content** (introduced by epic Codex-69t7c) the tier/subscription gate was **silently skipped** and the free/paid arms **granted access to users without an active subscription**.

Fix = **fail closed at every layer** (defense in depth):

- **Read path (the security fix)** — `ContentAccessService.hasContentAccess` and `getStreamingUrl` now DENY up front when `organizationId == null && minimumTierId != null`, *before* any `accessType` branching. This protects pre-existing bad rows regardless of how they were written (`getStreamingUrl` throws `AccessDeniedError`; `hasContentAccess` returns `false`).
- **Write path** — `createContentSchema` / `updateContentSchema` reject the (orgless ∧ tier) combination; `ContentService.create` clamps `minimumTierId` to null for orgless content, and `ContentService.update` clears a lingering tier when content is moved out of (or already lacks) an org.

Why fail-closed rather than tier-gate-anyway: a tier belongs to an organization, so orgless content referencing a tier is invalid by construction. Such a row must never be silently granted.

### Files changed
- `packages/access/src/services/ContentAccessService.ts` — read-path guards in both decision methods
- `packages/content/src/services/content-service.ts` — create clamp + update clamp
- `packages/validation/src/content/content-schemas.ts` — create + update refines
- `packages/access/src/__tests__/ContentAccessService.integration.test.ts` — read-path tests
- `packages/content/src/services/__tests__/content-service.test.ts` — write-path tests
- `packages/validation/src/__tests__/content-schemas.test.ts` — schema tests

## Test Plan

Run per-package (shared Neon branch — concurrency unchanged):

- `pnpm --filter @codex/access test` → **164 passed, 4 skipped** (+5 new orgless tests)
- `pnpm --filter @codex/content test` → **151 passed, 3 skipped** (+2 new Codex-up7bx tests)
- `pnpm --filter @codex/validation test` → **416 passed** (+6 new orgless-tier tests)

**Negative tests proven to fail without the fix:** with both read-path guards temporarily neutralized, `getStreamingUrl DENIES orgless paid content (purchaser)` failed with *"promise resolved instead of rejecting"* and `hasContentAccess returns false` failed with *"expected true to be false"* — i.e. access was wrongly granted (the bug). Both positive regressions continued to pass (guard scope correct). Guards restored after the proof.

`pnpm typecheck` (access, content, validation) and `pnpm exec biome check` pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)