### PR TITLE
fix(deploy): isolate production KV namespaces from live dev (Codex-730tq.1)

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -57,6 +57,12 @@
       "vars": {
         "ENVIRONMENT": "production"
       },
+      "kv_namespaces": [
+        {
+          "binding": "CACHE_KV",
+          "id": "499d67770dc2405ab80cba5629b16511"
+        }
+      ],
       "routes": [
         // Specific routes first (for priority)
         {

--- a/workers/admin-api/wrangler.jsonc
+++ b/workers/admin-api/wrangler.jsonc
@@ -97,15 +97,15 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         },
         {
           "binding": "CACHE_KV",
-          "id": "c5e85d4c8ecb46f9a3e5d4d96a14e9f1"
+          "id": "499d67770dc2405ab80cba5629b16511"
         }
       ],
       "r2_buckets": [

--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -77,11 +77,11 @@
       "kv_namespaces": [
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         },
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         }
       ],
       "routes": [

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -107,15 +107,15 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         },
         {
           "binding": "CACHE_KV",
-          "id": "c5e85d4c8ecb46f9a3e5d4d96a14e9f1"
+          "id": "499d67770dc2405ab80cba5629b16511"
         }
       ],
       "r2_buckets": [

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -87,15 +87,15 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         },
         {
           "binding": "CACHE_KV",
-          "id": "c5e85d4c8ecb46f9a3e5d4d96a14e9f1"
+          "id": "499d67770dc2405ab80cba5629b16511"
         }
       ],
       "routes": [

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -102,15 +102,15 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         },
         {
           "binding": "CACHE_KV",
-          "id": "c5e85d4c8ecb46f9a3e5d4d96a14e9f1"
+          "id": "499d67770dc2405ab80cba5629b16511"
         }
       ],
       "r2_buckets": [

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -131,11 +131,11 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         }
       ],
       "r2_buckets": [

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -80,11 +80,11 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         }
       ],
       "routes": [

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -103,15 +103,15 @@
       "kv_namespaces": [
         {
           "binding": "RATE_LIMIT_KV",
-          "id": "cea7153364974737b16870df08f31083"
+          "id": "06b7205ce78042ca9cad7b7e582ddf21"
         },
         {
           "binding": "AUTH_SESSION_KV",
-          "id": "82d04a4236df4aac8e9d87793344f0ed"
+          "id": "aab4025dcb5c44ad8d1156bcfda055d2"
         },
         {
           "binding": "CACHE_KV",
-          "id": "c5e85d4c8ecb46f9a3e5d4d96a14e9f1"
+          "id": "499d67770dc2405ab80cba5629b16511"
         }
       ],
       "r2_buckets": [


### PR DESCRIPTION
## WP-A1 — Production KV namespace isolation (epic Codex-730tq)

Completes the **last in-repo production blocker**. Unblocked by creating 3 prod-only KV namespaces.

### Problem
`env.production` for `RATE_LIMIT_KV` + `AUTH_SESSION_KV` reused the **same physical KV namespace IDs as the live dev environment** (`cea71…`, `82d04…`). Going live would share **session storage** and **rate-limit counters** with `dev.revelations.studio` — a dev login/logout would churn prod sessions. `CACHE_KV` prod reused the shared `c5e85…` ID too.

### Fix
Created 3 prod-only namespaces and pointed every `env.production` at them:

| Binding | New prod ID | Workers |
|---|---|---|
| `RATE_LIMIT_KV` | `06b7205ce78042ca9cad7b7e582ddf21` | all 8 |
| `AUTH_SESSION_KV` | `aab4025dcb5c44ad8d1156bcfda055d2` | all 8 |
| `CACHE_KV` | `499d67770dc2405ab80cba5629b16511` | content/ecom/org/admin/identity + web |

**Only `env.production` blocks changed** — `test`/`staging`/`dev` keep their existing IDs.

### Bonus bug fixed
`apps/web` `env.production` had **no `kv_namespaces` block at all**. Wrangler named environments don't inherit top-level bindings, so `codex-web-production` would have deployed with **no `CACHE_KV`** → broken SSR cache reads. Added it with the new prod ID.

### Verification
- All 9 `wrangler.jsonc` parse as JSONC (inline comment-stripping parser).
- Every `env.production` KV resolves to the new IDs; **zero stale shared IDs** remain in production.
- Diff is exactly 21 prod-block ID swaps + the 6-line web KV addition — no test/staging/dev lines touched.

### Follow-ups (NOT this PR)
- `web-staging` + `auth-staging` still lack KV bindings → WP-A4 (staging-only, not a prod blocker).

> Merges to `dev` (deploys to dev.revelations.studio). Production happens later via `promote dev → main` + dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)