### PR TITLE
fix(ci): unblock E2E API suite — ecom-api /health 500 from empty Stripe vars (Codex-730tq.8)

### DIFF
--- a/.github/scripts/generate-dev-vars.sh
+++ b/.github/scripts/generate-dev-vars.sh
@@ -38,8 +38,8 @@ EOF
   case "${worker}" in
     "ecom-api")
       cat >> "${VARS_FILE}" << EOF
-STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
-STRIPE_WEBHOOK_SECRET_BOOKING=${STRIPE_WEBHOOK_SECRET_BOOKING}
+STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-sk_test_ci_placeholder_do_not_use}
+STRIPE_WEBHOOK_SECRET_BOOKING=${STRIPE_WEBHOOK_SECRET_BOOKING:-whsec_ci_booking_placeholder_32_chars}
 STRIPE_WEBHOOK_SECRET_PAYMENT=${STRIPE_WEBHOOK_SECRET_PAYMENT:-whsec_ci_payment_placeholder_32_chars__}
 STRIPE_WEBHOOK_SECRET_SUBSCRIPTION=${STRIPE_WEBHOOK_SECRET_SUBSCRIPTION:-whsec_ci_subscription_placeholder_32_}
 STRIPE_WEBHOOK_SECRET_CONNECT=${STRIPE_WEBHOOK_SECRET_CONNECT:-whsec_ci_connect_placeholder_32_chars}
@@ -49,8 +49,8 @@ EOF
       ;;
     "content-api")
       cat >> "${VARS_FILE}" << EOF
-STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
-STRIPE_WEBHOOK_SECRET_BOOKING=${STRIPE_WEBHOOK_SECRET_BOOKING}
+STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-sk_test_ci_placeholder_do_not_use}
+STRIPE_WEBHOOK_SECRET_BOOKING=${STRIPE_WEBHOOK_SECRET_BOOKING:-whsec_ci_booking_placeholder_32_chars}
 R2_ACCOUNT_ID=${R2_ACCOUNT_ID}
 R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}
 R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}
@@ -63,7 +63,7 @@ EOF
       # Without it, TierService throws "STRIPE_SECRET_KEY not configured"
       # and the agreement specs + several settings tests cascade-fail.
       cat >> "${VARS_FILE}" << EOF
-STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-sk_test_ci_placeholder_do_not_use}
 EOF
       ;;
     "media-api")

--- a/e2e/helpers/worker-manager.ts
+++ b/e2e/helpers/worker-manager.ts
@@ -288,6 +288,13 @@ async function waitForHealth(
 ): Promise<void> {
   console.log(`🔍 Waiting for ${worker.name} health check...`);
 
+  // Track the last failure detail so a timeout is diagnosable. Without this, a
+  // worker that responds-but-unhealthy (500 from a missing required env var, or
+  // 503 from a failing DB/KV sub-check) looks identical to one that never came
+  // up — which hid a chronic ecom-api /health 500 (empty STRIPE_SECRET_KEY) for
+  // days, since the suite aborts here at global setup before any test runs.
+  let lastDetail = 'no response (connection refused on every attempt)';
+
   for (let i = 0; i < maxRetries; i++) {
     try {
       const response = await fetch(worker.healthUrl);
@@ -295,6 +302,8 @@ async function waitForHealth(
         console.log(`✅ ${worker.name} health check passed`);
         return;
       }
+      const body = await response.text().catch(() => '');
+      lastDetail = `HTTP ${response.status} — ${body.slice(0, 300)}`;
     } catch (_error) {
       // Connection refused is expected while starting up
     }
@@ -303,7 +312,7 @@ async function waitForHealth(
   }
 
   throw new Error(
-    `${worker.name} health check failed after ${maxRetries} attempts`
+    `${worker.name} health check failed after ${maxRetries} attempts (last: ${lastDetail})`
   );
 }
 


### PR DESCRIPTION
## WP-A8 — E2E API gate fix (epic Codex-730tq)

`E2E API Fast Feedback` + `E2E Debug` have been **red on `dev` since ≥2026-06-12**, across unrelated commits. This unblocks them — and they gate `dev → main` go-live validation.

### Root cause (deterministic, not flake)
The suite fails at **global setup** (`worker-manager.ts waitForHealth` → ecom-api) before any test runs:
```
❌ Failed to start workers: Error: ecom-api health check failed after 20 attempts
```
`generate-dev-vars.sh` wrote `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET_BOOKING` with **no `:-` fallback** (the other 5 webhook secrets had placeholders). When those two GitHub secrets are unset in CI they're written **empty**, and **ecom-api is the only worker that lists them as `required`** in `createEnvValidationMiddleware` (`workers/ecom-api/src/index.ts:74-81`) → `/health` returns **500** on first request → 20 attempts fail → setup aborts → **zero tests run**. That's why it's deterministic and ecom-api-specific.

(Same bug class as the media-api B2 fix, mirror-imaged: there a required var should've been *removed*; here a required var's CI fallback was *forgotten*.)

### Fix
- **`generate-dev-vars.sh`**: add CI placeholder fallbacks for `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET_BOOKING` (all 5 occurrences), matching the existing pattern. **No-op when the real secret is set.**
- **`worker-manager.ts`**: `waitForHealth` now records the last HTTP status + body and includes it in the thrown error. The previous detail-free `"failed after 20 attempts"` is *why this was undiagnosable for days* — couldn't distinguish a 500 (missing env var) from a 503 (DB/KV) from no-response.

### Verification
- All 5 fallbacks confirmed present; `bash -n` clean; biome clean on the TS change.
- The added log line makes any future health failure self-explaining (status + body in the error).
- Definitive confirmation comes from this PR's own E2E run: ecom-api `/health` should now pass setup and the suite should actually execute.

### Notes
- Diagnosis: env-validation 500 was confirmed by code (required list ∩ fallback-less vars = exactly `STRIPE_SECRET_KEY` + `BOOKING`). If the suite is *still* red after this, the new `waitForHealth` detail will name the real cause (e.g. a 503 DB check on pooled Neon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)