### PR TITLE
fix(ci): unblock E2E suites — test.skip bail + sidebar hover (Codex-730tq.9)

### DIFF
--- a/apps/web/e2e/nav-redesign/desktop-sidebar.spec.ts
+++ b/apps/web/e2e/nav-redesign/desktop-sidebar.spec.ts
@@ -28,45 +28,62 @@ test.describe('Desktop sidebar rail (platform)', () => {
     expect(collapsedWidth).toBe(64);
   });
 
-  test('rail expand state can be toggled programmatically (jsdriven)', async ({
+  test('rail expands on hover and collapses on mouse-leave', async ({
     page,
   }) => {
-    // The hover-driven 200ms delay is verified manually (T-01) — Svelte 5's
-    // onmouseenter binding does not reliably react to Playwright-synthesised
-    // pointer events in headless Chromium even though the OS-level event
-    // fires. Instead, verify the contract: when expanded is true, width
-    // matches the expanded token; when false, width matches the collapsed
-    // token. This protects the token wiring (Codex-onjxy) without depending
-    // on the hover trigger.
+    // Drive the REAL component state via trusted CDP pointer movements.
+    // SidebarRail.svelte owns `data-expanded` through a Svelte 5 $state
+    // rune (flipped by onmouseenter → 200ms timer → expanded=true), so we
+    // must NOT setAttribute on the bound node — under the production build
+    // Svelte reconciles the attribute back to its $state value and the
+    // .sidebar-rail[data-expanded='true'] width rule never sticks (it
+    // measures the collapsed 64px). Real `page.mouse.move` events fire the
+    // genuine onmouseenter/onmouseleave handlers, exercising the
+    // expand→width token contract (Codex-onjxy) end-to-end.
     await page.goto('/');
 
     const rail = page.getByRole('navigation', { name: 'Main navigation' });
+    await expect(rail).toBeVisible();
 
-    // Force-expand by setting the data-expanded attribute directly. The
-    // CSS selector .sidebar-rail[data-expanded='true'] drives the width
-    // change — this exercises the styling contract end-to-end. Poll until
-    // the spring-easing width transition (var(--duration-slow)) settles.
-    await rail.evaluate((el) => el.setAttribute('data-expanded', 'true'));
-    await expect
-      .poll(
-        async () =>
-          await rail.evaluate((el) =>
-            Math.round((el as HTMLElement).getBoundingClientRect().width)
-          ),
-        { timeout: 3000 }
-      )
-      .toBeGreaterThanOrEqual(230);
+    const railWidth = async () =>
+      await rail.evaluate((el) =>
+        Math.round((el as HTMLElement).getBoundingClientRect().width)
+      );
 
-    await rail.evaluate((el) => el.setAttribute('data-expanded', 'false'));
-    await expect
-      .poll(
-        async () =>
-          await rail.evaluate((el) =>
-            Math.round((el as HTMLElement).getBoundingClientRect().width)
-          ),
-        { timeout: 3000 }
-      )
-      .toBe(64);
+    // Explicit off-rail → onto-rail moves (NOT `locator.hover()`) drive the
+    // real onmouseenter. Two reasons hover() / a single move are unreliable:
+    //   1. Playwright's default cursor is (0,0), which already sits inside
+    //      the collapsed rail's box (the rail is fixed at x:0, width 64,
+    //      full height). Moving deeper into an element the cursor is already
+    //      inside fires no `mouseenter`, so the 200ms expand timer never
+    //      starts and the width stays 64. Parking off-rail first guarantees
+    //      the enter is genuine.
+    //   2. Under load the page may not have finished hydrating when the
+    //      first enter fires, so the Svelte handler isn't attached yet. We
+    //      therefore RETRY the whole off→on enter, waiting past the 200ms
+    //      expand timer + width transition between attempts. Crucially we do
+    //      NOT poll-retry faster than the timer — re-entering before it fires
+    //      cancels it (onmouseleave clears the pending timeout), which would
+    //      wedge the rail collapsed forever.
+    await page.mouse.move(1300, 450); // park clear of the rail
+    expect(await railWidth()).toBe(64);
+
+    let expandedWidth = 64;
+    for (let attempt = 0; attempt < 8 && expandedWidth < 230; attempt++) {
+      await page.mouse.move(1300, 450); // ensure a clean mouseleave…
+      await page.mouse.move(32, 450); // …then a genuine mouseenter (x=32 ∈ 0..64)
+      // Wait longer than the 200ms expand delay + transition before checking.
+      await page.waitForTimeout(350);
+      expandedWidth = await railWidth();
+    }
+    // expanded=true → width animates to --app-sidebar-width-expanded
+    // (15rem = 240px). The collapsed token is 64px, so >=230 proves expansion.
+    expect(expandedWidth).toBeGreaterThanOrEqual(230);
+
+    // Move the pointer well clear of the rail → onmouseleave → expanded=false
+    // → width returns to the collapsed token (--app-sidebar-width = 64px).
+    await page.mouse.move(1300, 450);
+    await expect.poll(railWidth, { timeout: 3000 }).toBe(64);
   });
 
   test('clicking a nav item navigates and aria-current marks active page', async ({

--- a/e2e/helpers/test-isolation.ts
+++ b/e2e/helpers/test-isolation.ts
@@ -33,9 +33,9 @@ export interface ScopedTestContext {
   email: (base: string) => string;
 
   /**
-   * Generate a unique slug
+   * Generate a unique, slug-safe value (lowercase, hyphen-separated).
    * @param base - Base identifier (e.g., "org", "content")
-   * @returns Slug like "t_a1b2c3d4_org"
+   * @returns Slug like "t-a1b2c3d4-org"
    */
   slug: (base: string) => string;
 
@@ -61,7 +61,7 @@ export interface ScopedTestContext {
  * ```typescript
  * const ctx = createScopedTestContext();
  * const email = ctx.email('buyer'); // "t_a1b2c3d4_buyer@example.com"
- * const slug = ctx.slug('org');     // "t_a1b2c3d4_org"
+ * const slug = ctx.slug('org');     // "t-a1b2c3d4-org"
  * ```
  *
  * All data created with the same context instance shares the same prefix,
@@ -73,7 +73,16 @@ export function createScopedTestContext(): ScopedTestContext {
   return {
     prefix,
     email: (base: string) => `${prefix}${base}@example.com`,
-    slug: (base: string) => `${prefix}${base}`,
+    // Slug-safe: org/content slug schemas allow only lowercase letters,
+    // digits, and single hyphens (no underscores, no leading/trailing
+    // hyphens). The shared prefix uses underscores (fine for emails/ids),
+    // so slugify the combined value here — otherwise org creation 400s with
+    // VALIDATION_ERROR on body.slug.
+    slug: (base: string) =>
+      `${prefix}${base}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, ''),
     id: (base: string) => `${prefix}${base}`,
     name: (base: string) => `${prefix.slice(0, -1)} ${base}`,
   };

--- a/e2e/tests/11-payout-flows-biparty.test.ts
+++ b/e2e/tests/11-payout-flows-biparty.test.ts
@@ -123,14 +123,20 @@ describe('Bi-party (orgless) payout flows', () => {
     await closeDbPool();
   });
 
-  test('should write platform_fee + creator_payout rows on orgless purchase, surface on /me/payouts, then reverse on refund', async () => {
+  test('should write platform_fee + creator_payout rows on orgless purchase, surface on /me/payouts, then reverse on refund', async ({
+    skip,
+  }) => {
     // ── Env skip-gate ────────────────────────────────────────────────────────
     // Both webhook secrets are required. Without them the worker rejects the
     // HMAC signature before any payout logic runs.
+    // Runtime skip via the test context (`ctx.skip()`). `test.skip()` is the
+    // collection-time chained modifier; calling it inside a running test body
+    // throws "Calling the test function inside another test function" and, with
+    // CI bail:1, aborts the entire e2e:api suite (Codex-730tq.9).
     const bookingSecret = process.env.STRIPE_WEBHOOK_SECRET_BOOKING;
     const paymentSecret = process.env.STRIPE_WEBHOOK_SECRET_PAYMENT;
     if (!bookingSecret || !paymentSecret) {
-      test.skip();
+      skip();
       return;
     }
 

--- a/e2e/tests/11-payout-flows-triparty.test.ts
+++ b/e2e/tests/11-payout-flows-triparty.test.ts
@@ -124,12 +124,18 @@ describe('Tri-party (in-org agreement) payout flows', () => {
     await closeDbPool();
   });
 
-  test('should write platform_fee + creator_payout + organization_fee rows for in-org purchase, then release creator_payout on Connect activation', async () => {
+  test('should write platform_fee + creator_payout + organization_fee rows for in-org purchase, then release creator_payout on Connect activation', async ({
+    skip,
+  }) => {
     // ── Env skip-gate ────────────────────────────────────────────────────────
+    // Runtime skip via the test context (`ctx.skip()`). `test.skip()` is the
+    // collection-time chained modifier; calling it inside a running test body
+    // throws "Calling the test function inside another test function" and, with
+    // CI bail:1, aborts the entire e2e:api suite (Codex-730tq.9).
     const bookingSecret = process.env.STRIPE_WEBHOOK_SECRET_BOOKING;
     const connectSecret = process.env.STRIPE_WEBHOOK_SECRET_CONNECT;
     if (!bookingSecret || !connectSecret) {
-      test.skip();
+      skip();
       return;
     }
 

--- a/e2e/tests/11-payout-flows-triparty.test.ts
+++ b/e2e/tests/11-payout-flows-triparty.test.ts
@@ -265,9 +265,10 @@ describe('Tri-party (in-org agreement) payout flows', () => {
         data: {
           creatorId: creator.id,
           revenueType: 'content_purchase',
-          // 70% to creator (post-platform basis points: 7000 / 10000)
-          creatorShareBps: 7000,
-          notes: 'E2E test agreement',
+          // 70% to creator. sharePercent is in basis points (7000 / 10000).
+          sharePercent: 7000,
+          termMonths: 12,
+          note: 'E2E test agreement',
         },
       }
     );
@@ -646,8 +647,9 @@ describe('Tri-party (in-org agreement) payout flows', () => {
         data: {
           creatorId: creator.id,
           revenueType: 'content_purchase',
-          creatorShareBps: 6000,
-          notes: 'E2E /me test',
+          sharePercent: 6000,
+          termMonths: 12,
+          note: 'E2E /me test',
         },
       }
     );


### PR DESCRIPTION
## Summary

Gets dev CI green by fixing the **two E2E root causes** that red `PR and Push CI (Neon ephemeral DB)` (the production-deploy gate) and `E2E API Fast Feedback`. Every other job (static-analysis, packages, all 7 worker suites) is already green — the entire red surface was E2E.

Part of epic **Codex-730tq** (Production Go-Live Prep), task **Codex-730tq.9**. Unblocks the dev→main promote + first production deploy.

## Root cause 1 — E2E API suite aborts (reds `E2E API Fast Feedback` + the `E2E API Tests` job)

`e2e/tests/11-payout-flows-{tri,bi}party.test.ts` called `test.skip()` — the **collection-time** chained modifier — *inside a running test body*. That throws `Calling the test function inside another test function is not allowed`, and with `e2e/vitest.config.ts` `bail: 1` in CI, the single collection error **aborts the entire e2e:api suite** (the CI artifact showed 0/21 tests ran).

Introduced in #282 (`a582022c`, 2026-06-12) and immediately masked: first by the ecom-api `/health` 500 (fixed in #289), so it only surfaced as the residual cause once health was unblocked. Git history confirms the suite was **green through `f5591068` (2026-06-12 07:27)** and broke at exactly `a582022c`.

**Fix:** both specs now use the vitest **runtime** skip via the test context (`async ({ skip }) => { … skip(); }`). They skip cleanly when the optional Stripe webhook secrets (`_CONNECT`/`_PAYMENT`) are absent — which is the case in CI (the "Run E2E API tests" step passes only `_BOOKING`).

## Root cause 2 — E2E Web sidebar spec (reds the `E2E Web Tests` job)

`apps/web/e2e/nav-redesign/desktop-sidebar.spec.ts` force-set `data-expanded='true'` via `setAttribute` on the `SidebarRail` `<nav>`. That attribute is bound to a Svelte 5 `$state` rune; under the **production build** (what CI serves via `wrangler dev`), Svelte reconciles the externally-set attribute back to its state value, so the `.sidebar-rail[data-expanded='true']` width rule never sticks → the rail measures the collapsed 64px (`Expected >= 230, Received 64`). Reproduces only against the prod build, not Vite dev — which is why it slipped through locally.

**Fix:** drive the **real** component state with trusted CDP pointer moves (park off-rail → genuine off→on `mouseenter` past the 200ms expand timer, with a self-healing retry for the pre-hydration race → assert ≥230 → move away → poll back to 64). Renamed to `rail expands on hover and collapses on mouse-leave`.

## Verification (local)

- **R1:** isolated vitest repro — `test.skip()` inside body → exact CI error; `({ skip }) => skip()` → clean skip.
- **R1:** full `pnpm test:e2e:api` locally on a fresh build → **96 passed**. The 7 local-only failures are all environment artifacts that do **not** occur in CI:
  - 4 payout specs *ran* (instead of skipping) only because the local `.env.test` *has* `_CONNECT`/`_PAYMENT`; CI doesn't pass them to the test-runner step → they skip.
  - 3 `09-media-workflow` failures: 2 were stale local `dist/` (B2 required-env removed in #287 but not rebuilt — `wrangler` serves `dist`); fixed by a fresh build. The 1 remaining (`should allow retrying failed transcoding`) is the macOS **workerd localhost self-fetch** block hitting the inline-awaited RunPod mock dispatch — proven a local-only artifact by the green CI history (this unchanged test passed in CI through 2026-06-12 07:27).
- **R2:** sidebar spec verified against the **production build** (`CI=true`, `workers=2`): target spec `--repeat-each=3` → 9 passed / 0 flaky; whole `e2e/nav-redesign/` → 18 passed.
- Both edited files pass `biome check`.

## Follow-up (not blocking — tracked separately)

The WP11 payout E2E specs **always skip in CI** (their `_CONNECT`/`_PAYMENT` secrets aren't passed to the test-runner step) and **fail when actually run** (locally). That's a real coverage gap in the payout pipeline E2E, but it's faithful to the specs' documented "skip cleanly without secrets" design and is out of scope for getting CI green. Will file a follow-up to either wire the secrets + fix the bodies or convert to a proper integration test.

Refs Codex-730tq.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
