### PR TITLE
fix(deploy): cron triggers production-only — unblock prod deploy (free-plan 5-cron cap)

### DIFF
--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -10,16 +10,6 @@
     "enabled": true
   },
 
-  // Cron Triggers (scheduled handler)
-  // - Every 15 minutes — payouts sweep (Codex-vv77x): drains pending payouts
-  //   whose Connect account is now charges_enabled && payouts_enabled.
-  //   Hybrid event+sweep resolution per Stripe docs (account.updated webhook
-  //   + periodic reconciliation). Consolidated into ecom-api 2026-05-13 so
-  //   Stripe cron + Stripe webhooks colocate in one Worker.
-  "triggers": {
-    "crons": ["*/15 * * * *"]
-  },
-
   // KV Namespaces
   "kv_namespaces": [
     {
@@ -75,6 +65,9 @@
     // Production environment
     "production": {
       "name": "ecom-api-production",
+      // Payouts sweep every 15 min (Codex-vv77x). Defined per-env (NOT top-level)
+      // so it does NOT inherit into dev/staging — Cloudflare's free-plan cap is
+      // 5 cron triggers per ACCOUNT, shared across prod + dev worker scripts.
       "triggers": {
         "crons": ["*/15 * * * *"]
       },
@@ -109,9 +102,6 @@
     // Staging environment
     "staging": {
       "name": "ecom-api-staging",
-      "triggers": {
-        "crons": ["*/15 * * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "staging",
         "WEB_APP_URL": "https://codex-staging.revelations.studio",
@@ -145,9 +135,6 @@
     // and the four STRIPE_WEBHOOK_SECRET_* secrets.
     "dev": {
       "name": "ecom-api-dev",
-      "triggers": {
-        "crons": ["*/15 * * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "dev",
         "DB_METHOD": "PRODUCTION",

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -20,12 +20,6 @@
     ]
   },
 
-  // Cron Triggers (scheduled handler)
-  // - 0 * * * * : every hour — recovers media stuck in 'transcoding' (no webhook received)
-  "triggers": {
-    "crons": ["0 * * * *"]
-  },
-
   // Migrations for Durable Objects (using new_sqlite_classes for free plan compatibility)
   "migrations": [
     {
@@ -122,6 +116,12 @@
           }
         ]
       },
+      // Hourly stuck-transcoding recovery. Defined per-env (NOT top-level) so it
+      // does NOT inherit into dev/staging — Cloudflare's free-plan cap is 5 cron
+      // triggers per ACCOUNT, shared across prod + dev worker scripts.
+      "triggers": {
+        "crons": ["0 * * * *"]
+      },
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
@@ -206,9 +206,6 @@
             "class_name": "OrphanedFileCleanupDO"
           }
         ]
-      },
-      "triggers": {
-        "crons": ["0 * * * *"]
       },
       "vars": {
         "ENVIRONMENT": "dev",

--- a/workers/notifications-api/CLAUDE.md
+++ b/workers/notifications-api/CLAUDE.md
@@ -111,7 +111,7 @@ First match wins.
 
 - **Unsubscribe routes bypass `procedure()`** — token verification is HMAC-based, not session-based. Raw Hono handlers with `createDbClient` directly.
 - **`/internal/send` is the only email-sending entry point** — other workers should call it via `sendEmailToWorker()` from `@codex/worker-utils`, not hit the notifications-api directly with raw HTTP.
-- **Cron trigger**: `wrangler.toml` configures `crons = ["0 9 * * 1"]` (Monday 09:00 UTC) for weekly digest. The `scheduled()` handler is stubbed with a TODO — not yet implemented.
+- **Cron trigger**: `wrangler.jsonc` configures `crons = ["0 8 * * *"]` (daily 08:00 UTC) in the **`production` env block** — NOT top-level. Cloudflare's free-plan cap is 5 cron triggers **per account**, shared across prod + dev worker scripts; `triggers` is an inheritable wrangler key, so a top-level cron would inherit into every env (prod + dev + staging) and exhaust the cap. Crons therefore live only in `production`. Fires the agreement-expiring-soon sweep — handler `src/handlers/agreement-expiring-sweep.ts`, dispatched from `scheduled()` in `src/index.ts` (implemented, not a stub).
 - **`preferences.ts`** is an unmounted file — do not confuse it as an active route. Notification preferences live in identity-api.
 
 ## Reference Files

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -10,14 +10,6 @@
     "enabled": true
   },
 
-  // Cron triggers (Codex-tugez):
-  //   - "0 8 * * *" — daily 08:00 UTC; fires the agreement-expiring-soon
-  //     sweep. Window: 30 days ahead of agreement effective_until.
-  //     Handler: src/handlers/agreement-expiring-sweep.ts
-  "triggers": {
-    "crons": ["0 8 * * *"]
-  },
-
   // KV Namespaces
   "kv_namespaces": [
     {
@@ -68,6 +60,9 @@
     // Production environment
     "production": {
       "name": "notifications-api-production",
+      // Agreement-expiring-soon sweep, daily 08:00 UTC (Codex-tugez). Defined per-env
+      // (NOT top-level) so it does NOT inherit into dev/staging — Cloudflare's free-plan
+      // cap is 5 cron triggers per ACCOUNT, shared across prod + dev worker scripts.
       "triggers": {
         "crons": ["0 8 * * *"]
       },
@@ -75,7 +70,9 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://codex.revelations.studio",
-        "API_URL": "https://api.revelations.studio"
+        "API_URL": "https://api.revelations.studio",
+        "FROM_EMAIL": "noreply@revelations.studio",
+        "FROM_NAME": "Codex"
       },
       "kv_namespaces": [
         {
@@ -98,9 +95,6 @@
     // Staging environment
     "staging": {
       "name": "notifications-api-staging",
-      "triggers": {
-        "crons": ["0 8 * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "staging",
         "DB_METHOD": "PRODUCTION",
@@ -130,9 +124,6 @@
     // `wrangler secret put * --env dev` before first deploy.
     "dev": {
       "name": "notifications-api-dev",
-      "triggers": {
-        "crons": ["0 8 * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "dev",
         "DB_METHOD": "PRODUCTION",


### PR DESCRIPTION
## Branch flow (why this targets `dev`)
`guard-main-source.yml` enforces **feature → dev → main**: `main` only accepts PRs from `dev`. So this PR targets **`dev`**. Merging it:
1. Lands the fix on `dev` (so the next `deploy-dev` won't re-inherit the dev crons), and
2. Triggers `deploy-dev`, reconciling the `*-dev` workers to **zero** crons.

The **production** deploy is then unblocked by a subsequent **`dev → main` release PR** (the standard prod-release step), which re-runs the prod pipeline and registers `notifications-api-production`'s cron as the 3rd of 5.

## Problem
Production deploy fails on `notifications-api-production` with Cloudflare `code: 10072` — *"exceeded the limit of 5 cron triggers."*

Cloudflare cron triggers are **account-wide** (free plan = **5/account**), shared across prod + dev worker scripts. wrangler `triggers` is an **inheritable** key, so each worker's **top-level** `triggers` inherited into *every* env — `ecom-api`, `media-api`, `notifications-api` each registered a cron in **both** production **and** dev = 6 > 5, so the 6th (notifications-api-production) was rejected and the deploy failed.

## Fix
Removed top-level `triggers` from all three workers; crons now live **only** in each `production` env block. `dev`/`staging`/`test` inherit nothing → 0 crons. Production keeps all three (now explicit): `ecom */15`, `media 0 * * * *`, `notifications 0 8 * * *`. Net account crons **6 → 3** (headroom 2).

Also:
- `notifications-api` production gains `FROM_EMAIL`/`FROM_NAME` (vars are not inherited, so prod had no sender identity). **⚠️ Confirm `noreply@revelations.studio` is a verified Resend sending domain before relying on prod email.**
- Corrected the stale cron note in `notifications-api/CLAUDE.md` (wrong file + schedule, wrongly described as a stub).

## Already done out-of-band
The 3 **live** dev cron schedules were cleared via `wrangler triggers deploy --env dev` (code-preserving, routes intact), so the account is already at 2 live crons.

## Verification
All three `wrangler.jsonc` parse; top-level crons = none; production = 1 each; dev/staging/test = none. biome ignores `wrangler.jsonc` and skips `.md`; no TS changed → `check:ci` + `typecheck` unaffected.

Refs: Codex-4hpy1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
