### PR TITLE
fix(ci): stop cleanup-stale-branches deleting in-flight Neon branches

### DIFF
--- a/.github/workflows/e2e-api-fast.yml
+++ b/.github/workflows/e2e-api-fast.yml
@@ -54,10 +54,13 @@ jobs:
 
       - name: Generate Neon branch name
         id: branch-name
-        # Unique per run to avoid races with the omnibus workflow which also
-        # creates ephemeral branches. cleanup-stale-branches in the omnibus
-        # only deletes non-default branches once at start of its own run, so
-        # our branch is safe as long as our cleanup step fires reliably.
+        # Unique per run so this branch never collides with the omnibus
+        # (testing.yml) or e2e-debug branches. Safety against the omnibus's
+        # cleanup-stale-branches job relies on that job being AGE-BASED: it
+        # only deletes branches older than the longest run, so this freshly
+        # created branch is never deleted mid-run. (A previous blanket "delete
+        # everything except production/dev" cleanup deleted this branch
+        # mid-migration and took CI red on 2026-06-18 — do not reintroduce it.)
         run: echo "name=ci-e2e-api-fast-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
 
       - name: Create Neon branch

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,44 +19,80 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Clean up ALL non-production Neon branches before creating new ones
-  # This prevents hitting the 9-branch limit on Neon free tier
+  # Reclaim ONLY stale (leaked) Neon branches before creating new ones, so we
+  # stay under the 9-branch free-tier limit WITHOUT deleting a branch that a
+  # concurrently-running workflow is still using.
+  #
+  # Why age-based and NOT "delete everything except production/dev":
+  # testing.yml, e2e-api-fast.yml and e2e-debug.yml are independent workflows
+  # that trigger on the SAME push and each fork their own ephemeral branch off
+  # `production`. They have no ordering relative to this job. A blanket delete
+  # therefore removed a sibling workflow's in-flight branch mid-migration —
+  # tearing down its Neon compute endpoint and surfacing as "terminating
+  # connection due to administrator command" / "password authentication failed
+  # for user 'neondb_owner'" / "endpoint could not be found". That race took
+  # the entire CI suite red on 2026-06-18: go-live churn meant every push fired
+  # several cleanup-bearing runs at once, so the race lost every time (the
+  # workflow files were byte-identical to the last green run — it was purely a
+  # timing regression). Deleting only branches OLDER than the longest possible
+  # run can never touch an in-flight branch. Each test job already deletes its
+  # own branch inline at completion (if: always()), so this job is purely a
+  # leaked-branch safety net for hard-cancelled runs.
   cleanup-stale-branches:
     runs-on: ubuntu-latest
     steps:
       - name: Install neonctl
         run: npm i -g neonctl@2
 
-      - name: Delete all CI branches (keep only production)
+      - name: Delete stale CI branches (preserve in-flight)
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
         run: |
           echo "::add-mask::$NEON_API_KEY"
+
+          # A branch counts as "stale" only if it is older than the longest
+          # single-branch lifetime in CI. No one ephemeral branch outlives its
+          # own job (each job creates + deletes its branch); the omnibus run as
+          # a whole is ~1h. 2h gives comfortable margin, so any branch this old
+          # cannot belong to a still-running workflow — it leaked from a
+          # hard-cancelled run. Keep this ABOVE the max run duration: lowering
+          # it below an in-flight branch's lifetime reintroduces the
+          # cross-workflow deletion race documented on the job above.
+          STALE_THRESHOLD_SECONDS=7200
+
           echo "Listing all branches..."
           BRANCHES=$(neonctl branches list --project-id ${{ vars.NEON_PROJECT_ID }} --output json 2>/dev/null || echo "[]")
+          echo "Found $(echo "$BRANCHES" | jq 'length') branches total"
 
-          # Count branches before cleanup
-          BRANCH_COUNT=$(echo "$BRANCHES" | jq 'length')
-          echo "Found $BRANCH_COUNT branches total"
+          # Select ONLY stale ephemeral branches:
+          #   - not the default (production) branch
+          #   - not the long-lived "dev" branch (carries seeded org data +
+          #     webhook secrets; deleting it forces a full re-bootstrap — see
+          #     PR #243 Phase 7)
+          #   - created more than STALE_THRESHOLD_SECONDS ago
+          # try/catch on the timestamp parse fails safe: an unparseable
+          # created_at yields null and the branch is PRESERVED, never deleted.
+          STALE_IDS=$(echo "$BRANCHES" | jq -r --argjson maxage "$STALE_THRESHOLD_SECONDS" '
+            .[]
+            | select(.default != true and .name != "dev")
+            | select(
+                (try (.created_at | sub("\\.[0-9]+";"") | fromdateiso8601) catch null) as $c
+                | $c != null and ((now - $c) > $maxage)
+              )
+            | .id
+          ')
 
-          # Get the default/main branch name to protect it
-          DEFAULT_BRANCH=$(echo "$BRANCHES" | jq -r '.[] | select(.default == true) | .name' | head -1)
-          echo "Default branch: $DEFAULT_BRANCH"
-
-          # Delete ephemeral CI branches only — preserve the long-lived "dev"
-          # branch alongside the default (production) branch. The dev branch
-          # carries seeded org data and configured webhook secrets; deleting
-          # it forces a full re-bootstrap + re-seed for every CI cycle, which
-          # broke the dev environment after PR #243 merged (Phase 7 verify).
-          # Includes: ci-test-branch, ci-e2e-branch, pr-*, push-*, neon-testing.
-          # Excludes: default branch + "dev".
-          echo "$BRANCHES" | jq -r '.[] | select(.default != true and .name != "dev") | .id' | while read branch_id; do
-            if [ -n "$branch_id" ] && [ "$branch_id" != "null" ]; then
-              BRANCH_NAME=$(echo "$BRANCHES" | jq -r ".[] | select(.id == \"$branch_id\") | .name")
-              echo "Deleting branch: $BRANCH_NAME ($branch_id)"
-              neonctl branches delete "$branch_id" --project-id ${{ vars.NEON_PROJECT_ID }} --force || true
-            fi
-          done
+          if [ -z "$STALE_IDS" ]; then
+            echo "No stale branches to delete — all ephemeral branches are recent (likely in-flight)."
+          else
+            echo "$STALE_IDS" | while read branch_id; do
+              if [ -n "$branch_id" ] && [ "$branch_id" != "null" ]; then
+                BRANCH_NAME=$(echo "$BRANCHES" | jq -r ".[] | select(.id == \"$branch_id\") | .name")
+                echo "Deleting stale branch: $BRANCH_NAME ($branch_id)"
+                neonctl branches delete "$branch_id" --project-id ${{ vars.NEON_PROJECT_ID }} --force || true
+              fi
+            done
+          fi
 
           echo "Cleanup complete"
 


### PR DESCRIPTION
## Problem

The **"PR and Push CI (Neon ephemeral DB)"**, **E2E API Fast**, and **E2E Debug** suites have been red on `dev` and `main` since **2026-06-18**, blocking the `dev → main` release path (incl. the finished cron fix in #294). The failure is at DB setup, not test logic:

```
attempt 1: Connecting… → Skipped 0027 (already applied) → ❌ terminating connection due to administrator command
attempt 2: Connecting… → ❌ password authentication failed for user 'neondb_owner'
attempt 3: Connecting… → ❌ The requested endpoint could not be found
```

## Root cause (proven, not theorized)

`testing.yml`'s `cleanup-stale-branches` deleted **every** Neon branch except `production`+`dev` at the start of each run. But `e2e-api-fast.yml` and `e2e-debug.yml` are **independent workflows that trigger on the same push** and fork their own ephemeral branches off `production`, with no ordering against that cleanup. The cleanup deleted a sibling workflow's **in-flight branch mid-migration** (~60s before its migration even ran — the slow `pnpm install` sits between branch-create and migrate), tearing down the Neon compute endpoint. The three "different" errors are one event: the endpoint being torn down across the 3 retries.

Evidence:
- **Attempt 1 connected successfully and read `__drizzle_migrations`** (saw 0027 "already applied") → NEON_API_KEY valid, branch created fine, `neondb_owner` role works, `production` parent healthy. Falsifies the broken-parent / rotated-secret theories.
- The CI workflow files are **byte-identical** between the last green run (`bf0b8533`, 06-17) and now → a pure timing regression, tipped by go-live churn (every push fired several cleanup-bearing runs at once, so the race lost every time).
- Live Neon state = **2/9 branches** → the blanket delete was solving a free-tier-limit problem that doesn't currently exist.

## Fix

Make `cleanup-stale-branches` **age-based**: delete only branches older than **2h** (well above the ~1h max run and the longest single-branch lifetime), so it can never touch an in-flight branch. Each test job already deletes its own branch inline (`if: always()`); this job is now purely a leaked-branch safety net. Also corrected a now-false comment in `e2e-api-fast.yml` that asserted the old (buggy) safety assumption.

## Verification

Reproduced the deployed `run:` script **locally** (extracted from the edited YAML, stubbed `neonctl`):
- ✅ deletes a 3h-old leaked branch
- ✅ preserves a just-created branch, a 50-min mid-omnibus branch, `production`, and `dev`
- ✅ jq escaping survives the YAML round-trip; exit 0

This PR touches `testing.yml` + `e2e-api-fast.yml`, so CI on this PR exercises the exact cross-workflow scenario that was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)