### PR TITLE
promote: dev → main — Neon CI fix + cron-cap fix + e2e drift fix + CI consolidation

### DIFF
--- a/.github/workflows/e2e-api-fast.yml
+++ b/.github/workflows/e2e-api-fast.yml
@@ -54,10 +54,13 @@ jobs:
 
       - name: Generate Neon branch name
         id: branch-name
-        # Unique per run to avoid races with the omnibus workflow which also
-        # creates ephemeral branches. cleanup-stale-branches in the omnibus
-        # only deletes non-default branches once at start of its own run, so
-        # our branch is safe as long as our cleanup step fires reliably.
+        # Unique per run so this branch never collides with the omnibus
+        # (testing.yml) or e2e-debug branches. Safety against the omnibus's
+        # cleanup-stale-branches job relies on that job being AGE-BASED: it
+        # only deletes branches older than the longest run, so this freshly
+        # created branch is never deleted mid-run. (A previous blanket "delete
+        # everything except production/dev" cleanup deleted this branch
+        # mid-migration and took CI red on 2026-06-18 — do not reintroduce it.)
         run: echo "name=ci-e2e-api-fast-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
 
       - name: Create Neon branch

--- a/.github/workflows/e2e-api-fast.yml
+++ b/.github/workflows/e2e-api-fast.yml
@@ -11,28 +11,14 @@ name: E2E API Fast Feedback
 # Identical Neon branch + dev-vars setup as the omnibus to avoid drift.
 # Runs on the same `test` environment so the same secrets resolve.
 #
-# Path filters: only triggers when something that could affect e2e:api
-# actually changes (workers/, packages/, e2e/, the dev-vars script, or this
-# workflow itself).
-
+# Manual-only: this isolated fast-feedback variant no longer triggers on
+# push/PR. The omnibus `testing.yml` (PR and Push CI) is the single automatic
+# pipeline and already runs the e2e:api suite (its e2e-api-tests job). Run this
+# on demand for debugging: Actions → E2E API Fast Feedback → Run workflow.
+# Dropping the automatic triggers also removes the cross-workflow Neon-branch
+# deletion race — it forked its own ephemeral branch concurrently with the
+# omnibus cleanup-stale-branches job, which took CI red on 2026-06-18.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'e2e/**'
-      - 'workers/**'
-      - 'packages/**'
-      - '.github/scripts/generate-dev-vars.sh'
-      - '.github/workflows/e2e-api-fast.yml'
-  push:
-    branches-ignore:
-      - main
-    paths:
-      - 'e2e/**'
-      - 'workers/**'
-      - 'packages/**'
-      - '.github/scripts/generate-dev-vars.sh'
-      - '.github/workflows/e2e-api-fast.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-debug.yml
+++ b/.github/workflows/e2e-debug.yml
@@ -6,13 +6,13 @@
 # - Better artifacts (screenshots, traces, logs)
 # - Can be triggered manually or on specific branches
 #
-# Usage:
-# 1. Manual trigger: Go to Actions → E2E Debug → Run workflow
-# 2. Push to branch with [debug-e2e] in commit message
-# 3. Comment '/debug-e2e' on a PR
+# Usage (manual-only — not part of automatic CI):
+# - Actions → E2E Debug → Run workflow (optionally scope to a file/pattern)
 
 name: E2E Debug
 
+# Manual-only (+ workflow_call). Automatic push/PR triggers removed so the
+# omnibus `testing.yml` is the only pipeline that runs on push/PR.
 on:
   workflow_dispatch:
     inputs:
@@ -24,15 +24,6 @@ on:
         description: 'Grep filter (e.g., "account|profile"). Leave empty for full suite.'
         required: false
         type: string
-  push:
-    branches:
-      - '**'
-    paths:
-      - 'apps/web/**'
-      - 'apps/web/e2e/**'
-      - '.github/workflows/e2e-debug.yml'
-  pull_request:
-    types: [labeled, synchronize, reopened]
   workflow_call:
 
 # Skip if this is a documentation-only change

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,44 +19,80 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Clean up ALL non-production Neon branches before creating new ones
-  # This prevents hitting the 9-branch limit on Neon free tier
+  # Reclaim ONLY stale (leaked) Neon branches before creating new ones, so we
+  # stay under the 9-branch free-tier limit WITHOUT deleting a branch that a
+  # concurrently-running workflow is still using.
+  #
+  # Why age-based and NOT "delete everything except production/dev":
+  # testing.yml, e2e-api-fast.yml and e2e-debug.yml are independent workflows
+  # that trigger on the SAME push and each fork their own ephemeral branch off
+  # `production`. They have no ordering relative to this job. A blanket delete
+  # therefore removed a sibling workflow's in-flight branch mid-migration —
+  # tearing down its Neon compute endpoint and surfacing as "terminating
+  # connection due to administrator command" / "password authentication failed
+  # for user 'neondb_owner'" / "endpoint could not be found". That race took
+  # the entire CI suite red on 2026-06-18: go-live churn meant every push fired
+  # several cleanup-bearing runs at once, so the race lost every time (the
+  # workflow files were byte-identical to the last green run — it was purely a
+  # timing regression). Deleting only branches OLDER than the longest possible
+  # run can never touch an in-flight branch. Each test job already deletes its
+  # own branch inline at completion (if: always()), so this job is purely a
+  # leaked-branch safety net for hard-cancelled runs.
   cleanup-stale-branches:
     runs-on: ubuntu-latest
     steps:
       - name: Install neonctl
         run: npm i -g neonctl@2
 
-      - name: Delete all CI branches (keep only production)
+      - name: Delete stale CI branches (preserve in-flight)
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
         run: |
           echo "::add-mask::$NEON_API_KEY"
+
+          # A branch counts as "stale" only if it is older than the longest
+          # single-branch lifetime in CI. No one ephemeral branch outlives its
+          # own job (each job creates + deletes its branch); the omnibus run as
+          # a whole is ~1h. 2h gives comfortable margin, so any branch this old
+          # cannot belong to a still-running workflow — it leaked from a
+          # hard-cancelled run. Keep this ABOVE the max run duration: lowering
+          # it below an in-flight branch's lifetime reintroduces the
+          # cross-workflow deletion race documented on the job above.
+          STALE_THRESHOLD_SECONDS=7200
+
           echo "Listing all branches..."
           BRANCHES=$(neonctl branches list --project-id ${{ vars.NEON_PROJECT_ID }} --output json 2>/dev/null || echo "[]")
+          echo "Found $(echo "$BRANCHES" | jq 'length') branches total"
 
-          # Count branches before cleanup
-          BRANCH_COUNT=$(echo "$BRANCHES" | jq 'length')
-          echo "Found $BRANCH_COUNT branches total"
+          # Select ONLY stale ephemeral branches:
+          #   - not the default (production) branch
+          #   - not the long-lived "dev" branch (carries seeded org data +
+          #     webhook secrets; deleting it forces a full re-bootstrap — see
+          #     PR #243 Phase 7)
+          #   - created more than STALE_THRESHOLD_SECONDS ago
+          # try/catch on the timestamp parse fails safe: an unparseable
+          # created_at yields null and the branch is PRESERVED, never deleted.
+          STALE_IDS=$(echo "$BRANCHES" | jq -r --argjson maxage "$STALE_THRESHOLD_SECONDS" '
+            .[]
+            | select(.default != true and .name != "dev")
+            | select(
+                (try (.created_at | sub("\\.[0-9]+";"") | fromdateiso8601) catch null) as $c
+                | $c != null and ((now - $c) > $maxage)
+              )
+            | .id
+          ')
 
-          # Get the default/main branch name to protect it
-          DEFAULT_BRANCH=$(echo "$BRANCHES" | jq -r '.[] | select(.default == true) | .name' | head -1)
-          echo "Default branch: $DEFAULT_BRANCH"
-
-          # Delete ephemeral CI branches only — preserve the long-lived "dev"
-          # branch alongside the default (production) branch. The dev branch
-          # carries seeded org data and configured webhook secrets; deleting
-          # it forces a full re-bootstrap + re-seed for every CI cycle, which
-          # broke the dev environment after PR #243 merged (Phase 7 verify).
-          # Includes: ci-test-branch, ci-e2e-branch, pr-*, push-*, neon-testing.
-          # Excludes: default branch + "dev".
-          echo "$BRANCHES" | jq -r '.[] | select(.default != true and .name != "dev") | .id' | while read branch_id; do
-            if [ -n "$branch_id" ] && [ "$branch_id" != "null" ]; then
-              BRANCH_NAME=$(echo "$BRANCHES" | jq -r ".[] | select(.id == \"$branch_id\") | .name")
-              echo "Deleting branch: $BRANCH_NAME ($branch_id)"
-              neonctl branches delete "$branch_id" --project-id ${{ vars.NEON_PROJECT_ID }} --force || true
-            fi
-          done
+          if [ -z "$STALE_IDS" ]; then
+            echo "No stale branches to delete — all ephemeral branches are recent (likely in-flight)."
+          else
+            echo "$STALE_IDS" | while read branch_id; do
+              if [ -n "$branch_id" ] && [ "$branch_id" != "null" ]; then
+                BRANCH_NAME=$(echo "$BRANCHES" | jq -r ".[] | select(.id == \"$branch_id\") | .name")
+                echo "Deleting stale branch: $BRANCH_NAME ($branch_id)"
+                neonctl branches delete "$branch_id" --project-id ${{ vars.NEON_PROJECT_ID }} --force || true
+              fi
+            done
+          fi
 
           echo "Cleanup complete"
 

--- a/apps/web/e2e/studio/navigation.spec.ts
+++ b/apps/web/e2e/studio/navigation.spec.ts
@@ -266,7 +266,13 @@ test.describe('Studio Navigation - Settings Tabs', () => {
     await expectClickNavigates(
       page,
       page.locator('a[href="/studio/settings/branding"]'),
-      /\/studio\/settings\/branding/
+      /\/studio\/settings\/branding/,
+      // Settings tabs are stable content-area elements, not rail items. Skip
+      // the hover: an expanded desktop rail (left over from a prior hover)
+      // overlays the tab strip and intercepts the hover, while the native JS
+      // click still bubbles to the SPA router. Per spa-nav.ts: hover:false for
+      // stable elements.
+      { hover: false }
     );
 
     const brandingTab = page.locator('.tab-trigger').filter({

--- a/apps/web/e2e/studio/settings.spec.ts
+++ b/apps/web/e2e/studio/settings.spec.ts
@@ -188,7 +188,13 @@ test.describe('Studio Settings - Tabs', () => {
     await expectClickNavigates(
       page,
       page.getByRole('tab', { name: 'Branding' }),
-      /\/studio\/settings\/branding/
+      /\/studio\/settings\/branding/,
+      // Settings tabs are stable content-area elements, not rail items. Skip
+      // the hover: an expanded desktop rail (left over from a prior hover)
+      // overlays the tab strip and intercepts the hover, while the native JS
+      // click still bubbles to the SPA router. Per spa-nav.ts: hover:false for
+      // stable elements.
+      { hover: false }
     );
 
     const brandingTab = page.getByRole('tab', { name: 'Branding' });

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -10,16 +10,6 @@
     "enabled": true
   },
 
-  // Cron Triggers (scheduled handler)
-  // - Every 15 minutes — payouts sweep (Codex-vv77x): drains pending payouts
-  //   whose Connect account is now charges_enabled && payouts_enabled.
-  //   Hybrid event+sweep resolution per Stripe docs (account.updated webhook
-  //   + periodic reconciliation). Consolidated into ecom-api 2026-05-13 so
-  //   Stripe cron + Stripe webhooks colocate in one Worker.
-  "triggers": {
-    "crons": ["*/15 * * * *"]
-  },
-
   // KV Namespaces
   "kv_namespaces": [
     {
@@ -75,6 +65,9 @@
     // Production environment
     "production": {
       "name": "ecom-api-production",
+      // Payouts sweep every 15 min (Codex-vv77x). Defined per-env (NOT top-level)
+      // so it does NOT inherit into dev/staging — Cloudflare's free-plan cap is
+      // 5 cron triggers per ACCOUNT, shared across prod + dev worker scripts.
       "triggers": {
         "crons": ["*/15 * * * *"]
       },
@@ -109,9 +102,6 @@
     // Staging environment
     "staging": {
       "name": "ecom-api-staging",
-      "triggers": {
-        "crons": ["*/15 * * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "staging",
         "WEB_APP_URL": "https://codex-staging.revelations.studio",
@@ -145,9 +135,6 @@
     // and the four STRIPE_WEBHOOK_SECRET_* secrets.
     "dev": {
       "name": "ecom-api-dev",
-      "triggers": {
-        "crons": ["*/15 * * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "dev",
         "DB_METHOD": "PRODUCTION",

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -20,12 +20,6 @@
     ]
   },
 
-  // Cron Triggers (scheduled handler)
-  // - 0 * * * * : every hour — recovers media stuck in 'transcoding' (no webhook received)
-  "triggers": {
-    "crons": ["0 * * * *"]
-  },
-
   // Migrations for Durable Objects (using new_sqlite_classes for free plan compatibility)
   "migrations": [
     {
@@ -122,6 +116,12 @@
           }
         ]
       },
+      // Hourly stuck-transcoding recovery. Defined per-env (NOT top-level) so it
+      // does NOT inherit into dev/staging — Cloudflare's free-plan cap is 5 cron
+      // triggers per ACCOUNT, shared across prod + dev worker scripts.
+      "triggers": {
+        "crons": ["0 * * * *"]
+      },
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
@@ -206,9 +206,6 @@
             "class_name": "OrphanedFileCleanupDO"
           }
         ]
-      },
-      "triggers": {
-        "crons": ["0 * * * *"]
       },
       "vars": {
         "ENVIRONMENT": "dev",

--- a/workers/notifications-api/CLAUDE.md
+++ b/workers/notifications-api/CLAUDE.md
@@ -111,7 +111,7 @@ First match wins.
 
 - **Unsubscribe routes bypass `procedure()`** — token verification is HMAC-based, not session-based. Raw Hono handlers with `createDbClient` directly.
 - **`/internal/send` is the only email-sending entry point** — other workers should call it via `sendEmailToWorker()` from `@codex/worker-utils`, not hit the notifications-api directly with raw HTTP.
-- **Cron trigger**: `wrangler.toml` configures `crons = ["0 9 * * 1"]` (Monday 09:00 UTC) for weekly digest. The `scheduled()` handler is stubbed with a TODO — not yet implemented.
+- **Cron trigger**: `wrangler.jsonc` configures `crons = ["0 8 * * *"]` (daily 08:00 UTC) in the **`production` env block** — NOT top-level. Cloudflare's free-plan cap is 5 cron triggers **per account**, shared across prod + dev worker scripts; `triggers` is an inheritable wrangler key, so a top-level cron would inherit into every env (prod + dev + staging) and exhaust the cap. Crons therefore live only in `production`. Fires the agreement-expiring-soon sweep — handler `src/handlers/agreement-expiring-sweep.ts`, dispatched from `scheduled()` in `src/index.ts` (implemented, not a stub).
 - **`preferences.ts`** is an unmounted file — do not confuse it as an active route. Notification preferences live in identity-api.
 
 ## Reference Files

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -10,14 +10,6 @@
     "enabled": true
   },
 
-  // Cron triggers (Codex-tugez):
-  //   - "0 8 * * *" — daily 08:00 UTC; fires the agreement-expiring-soon
-  //     sweep. Window: 30 days ahead of agreement effective_until.
-  //     Handler: src/handlers/agreement-expiring-sweep.ts
-  "triggers": {
-    "crons": ["0 8 * * *"]
-  },
-
   // KV Namespaces
   "kv_namespaces": [
     {
@@ -68,6 +60,9 @@
     // Production environment
     "production": {
       "name": "notifications-api-production",
+      // Agreement-expiring-soon sweep, daily 08:00 UTC (Codex-tugez). Defined per-env
+      // (NOT top-level) so it does NOT inherit into dev/staging — Cloudflare's free-plan
+      // cap is 5 cron triggers per ACCOUNT, shared across prod + dev worker scripts.
       "triggers": {
         "crons": ["0 8 * * *"]
       },
@@ -75,7 +70,9 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://codex.revelations.studio",
-        "API_URL": "https://api.revelations.studio"
+        "API_URL": "https://api.revelations.studio",
+        "FROM_EMAIL": "noreply@revelations.studio",
+        "FROM_NAME": "Codex"
       },
       "kv_namespaces": [
         {
@@ -98,9 +95,6 @@
     // Staging environment
     "staging": {
       "name": "notifications-api-staging",
-      "triggers": {
-        "crons": ["0 8 * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "staging",
         "DB_METHOD": "PRODUCTION",
@@ -130,9 +124,6 @@
     // `wrangler secret put * --env dev` before first deploy.
     "dev": {
       "name": "notifications-api-dev",
-      "triggers": {
-        "crons": ["0 8 * * *"]
-      },
       "vars": {
         "ENVIRONMENT": "dev",
         "DB_METHOD": "PRODUCTION",


### PR DESCRIPTION
Production go-live promotion. Promotes `dev` → `main` (per guard-main-source, main only accepts PRs from dev). Merging this triggers the Production Deployment.

## What's being promoted (8 commits)

| Area | Change | PR |
|---|---|---|
| **CI infra** | Neon `cleanup-stale-branches` made age-based — stop deleting in-flight ephemeral branches of concurrent workflows (the cross-workflow race that took CI red on 2026-06-18) | #295 |
| **Prod deploy** | Cron triggers defined per-env (production only) for the free-plan 5-cron/account cap | #294 |
| **E2E** | `{ hover: false }` on 2 stable Studio settings-tab nav specs (test drift unmasked once e2e-web ran again) | #297 |
| **CI hygiene** | `e2e-api-fast` + `e2e-debug` → manual-only (`workflow_dispatch`); `testing.yml` is now the single automatic pipeline (also removes the race at its source) | #298 |

## Verification

- **Neon provisioning:** E2E API Fast (full pass), omnibus E2E API Tests (pass), post-merge dev migration — all green.
- **E2E Web:** 207 passed / 0 failed (was 205/2 before the hover fix).
- All gating omnibus jobs verified green on the component PRs (static-analysis, unit, 7 workers, E2E API, E2E Web).
- Non-gating a11y/visual steps run with `|| true` and do not gate.

## Notes
- `main`/`dev` are unprotected; the `cancelled`→"fail" checks that appear are superseded push+PR dual-trigger runs, not real failures.
- Merging deploys to production — includes the cron fix (#294) that was the original go-live blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)