### PR TITLE
fix(e2e): skip hover on stable settings-tab nav (rail overlay intercepts)

### DIFF
--- a/apps/web/e2e/studio/navigation.spec.ts
+++ b/apps/web/e2e/studio/navigation.spec.ts
@@ -266,7 +266,13 @@ test.describe('Studio Navigation - Settings Tabs', () => {
     await expectClickNavigates(
       page,
       page.locator('a[href="/studio/settings/branding"]'),
-      /\/studio\/settings\/branding/
+      /\/studio\/settings\/branding/,
+      // Settings tabs are stable content-area elements, not rail items. Skip
+      // the hover: an expanded desktop rail (left over from a prior hover)
+      // overlays the tab strip and intercepts the hover, while the native JS
+      // click still bubbles to the SPA router. Per spa-nav.ts: hover:false for
+      // stable elements.
+      { hover: false }
     );
 
     const brandingTab = page.locator('.tab-trigger').filter({

--- a/apps/web/e2e/studio/settings.spec.ts
+++ b/apps/web/e2e/studio/settings.spec.ts
@@ -188,7 +188,13 @@ test.describe('Studio Settings - Tabs', () => {
     await expectClickNavigates(
       page,
       page.getByRole('tab', { name: 'Branding' }),
-      /\/studio\/settings\/branding/
+      /\/studio\/settings\/branding/,
+      // Settings tabs are stable content-area elements, not rail items. Skip
+      // the hover: an expanded desktop rail (left over from a prior hover)
+      // overlays the tab strip and intercepts the hover, while the native JS
+      // click still bubbles to the SPA router. Per spa-nav.ts: hover:false for
+      // stable elements.
+      { hover: false }
     );
 
     const brandingTab = page.getByRole('tab', { name: 'Branding' });


### PR DESCRIPTION
## Problem

After the Neon CI fix (#295) let E2E Web actually run again, 2 specs failed (205 passed, 12 skipped):
- `e2e/studio/navigation.spec.ts:259 › clicking Branding tab navigates to branding page`
- `e2e/studio/settings.spec.ts:181 › clicking Branding tab navigates to branding page`

Both fail at `spa-nav.ts:39` on `locator.hover()`:
```
<button class="studio-switcher-trigger" data-expanded="true"> from
<aside class="studio-layout__rail studio-layout__rail--desktop"> subtree intercepts pointer events
```

## Root cause — test drift, not a regression

`expectClickNavigates` hovers before a native JS click to *settle studio **rail** items that reposition on hover*. But the Branding **settings tab** is a stable content-area element. When the desktop rail is expanded (left over from a prior hover during `navigateToStudioPage`), it overlays the tab strip and intercepts the hover. The native JS click (`el.click()`) bubbles to the SPA router regardless — so the hover was the *only* failing step.

The helper's own JSDoc says `hover: false` is for stable elements; `e2e/CLAUDE.md` documents the rail-hover-interception hazard. The specs **and** the studio rail UI are byte-identical to the last green run (`bf0b8533`) — this only surfaced now because E2E Web only runs when `web`/`workflows` change, so these specs hadn't executed in CI for a while.

## Fix

Pass `{ hover: false }` to the 2 stable settings-tab `expectClickNavigates` calls (the rail-nav helper keeps `hover: true`). No locator or UI change.

## Verification

- biome clean on both files.
- Local full-stack Playwright run not possible here (stack down → health-guard skips); CI's E2E Web job (full stack + seeded Neon branch) is the authoritative verifier. The change only removes the failing hover; the JS click + `toHaveURL` assert (already green for other tests) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)