### PR TITLE
chore(ci): make e2e-api-fast + e2e-debug manual-only (single automatic pipeline)

### DIFF
--- a/.github/workflows/e2e-api-fast.yml
+++ b/.github/workflows/e2e-api-fast.yml
@@ -11,28 +11,14 @@ name: E2E API Fast Feedback
 # Identical Neon branch + dev-vars setup as the omnibus to avoid drift.
 # Runs on the same `test` environment so the same secrets resolve.
 #
-# Path filters: only triggers when something that could affect e2e:api
-# actually changes (workers/, packages/, e2e/, the dev-vars script, or this
-# workflow itself).
-
+# Manual-only: this isolated fast-feedback variant no longer triggers on
+# push/PR. The omnibus `testing.yml` (PR and Push CI) is the single automatic
+# pipeline and already runs the e2e:api suite (its e2e-api-tests job). Run this
+# on demand for debugging: Actions → E2E API Fast Feedback → Run workflow.
+# Dropping the automatic triggers also removes the cross-workflow Neon-branch
+# deletion race — it forked its own ephemeral branch concurrently with the
+# omnibus cleanup-stale-branches job, which took CI red on 2026-06-18.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'e2e/**'
-      - 'workers/**'
-      - 'packages/**'
-      - '.github/scripts/generate-dev-vars.sh'
-      - '.github/workflows/e2e-api-fast.yml'
-  push:
-    branches-ignore:
-      - main
-    paths:
-      - 'e2e/**'
-      - 'workers/**'
-      - 'packages/**'
-      - '.github/scripts/generate-dev-vars.sh'
-      - '.github/workflows/e2e-api-fast.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-debug.yml
+++ b/.github/workflows/e2e-debug.yml
@@ -6,13 +6,13 @@
 # - Better artifacts (screenshots, traces, logs)
 # - Can be triggered manually or on specific branches
 #
-# Usage:
-# 1. Manual trigger: Go to Actions → E2E Debug → Run workflow
-# 2. Push to branch with [debug-e2e] in commit message
-# 3. Comment '/debug-e2e' on a PR
+# Usage (manual-only — not part of automatic CI):
+# - Actions → E2E Debug → Run workflow (optionally scope to a file/pattern)
 
 name: E2E Debug
 
+# Manual-only (+ workflow_call). Automatic push/PR triggers removed so the
+# omnibus `testing.yml` is the only pipeline that runs on push/PR.
 on:
   workflow_dispatch:
     inputs:
@@ -24,15 +24,6 @@ on:
         description: 'Grep filter (e.g., "account|profile"). Leave empty for full suite.'
         required: false
         type: string
-  push:
-    branches:
-      - '**'
-    paths:
-      - 'apps/web/**'
-      - 'apps/web/e2e/**'
-      - '.github/workflows/e2e-debug.yml'
-  pull_request:
-    types: [labeled, synchronize, reopened]
   workflow_call:
 
 # Skip if this is a documentation-only change


### PR DESCRIPTION
Consolidates CI to a single automatic pipeline (`testing.yml`, "PR and Push CI").

**What changes:** `e2e-api-fast.yml` (fast feedback) and `e2e-debug.yml` (debug) are converted to `workflow_dispatch`-only. They no longer trigger on push/PR — `testing.yml` already runs both the e2e:api suite and the web e2e suite. Both remain available for on-demand debugging from the Actions tab (e2e-debug keeps its `test_file`/`test_pattern` inputs + `workflow_call`).

**Why:** these sibling workflows were the *source* of the cross-workflow Neon-branch deletion race (#295) — they forked their own ephemeral branches concurrently with the omnibus `cleanup-stale-branches` job. Making `testing.yml` the sole automatic pipeline eliminates that race at the root; the age-based cleanup from #295 stays as defense-in-depth. Also drops the redundant triple-run of the e2e:api suite per push.

**Safety:** `main` and `dev` are unprotected — no required status check references "E2E API Fast" or "E2E Debug", so this doesn't block the dev→main promotion. Nothing calls e2e-debug via `workflow_call`. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)