### PR TITLE
fix(prod): auth session not sticking + redirect to codex.revelations.studio

### DIFF
--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -129,6 +129,40 @@ export function serverApiUrl(
 }
 
 /**
+ * Build the `Cookie` header value for forwarding the session token to the
+ * AUTH worker's BetterAuth endpoints (`get-session`, `sign-out`).
+ *
+ * **The `__Secure-` prefix trap (production auth break, 2026-06-24):**
+ * BetterAuth prefixes EVERY cookie name with `__Secure-` when its `baseURL`
+ * is HTTPS — see `better-auth/dist/cookies/index.mjs`:
+ *   `secureCookiePrefix = baseURL.startsWith("https://") ? "__Secure-" : ""`
+ * The auth worker's `baseURL` is `WEB_APP_URL`, so in every deployed env
+ * (prod / staging / dev-remote) the session cookie is named
+ * `__Secure-better-auth.session_token`; only local dev (http://lvh.me) uses
+ * the unprefixed `better-auth.session_token`.
+ *
+ * BetterAuth's `get-session` reads ONLY `ctx.context.authCookies.sessionToken.name`
+ * (`api/routes/session.mjs`) with NO unprefixed fallback, so forwarding under
+ * the unprefixed name silently yields `null` → every login bounces back to
+ * /login. Forwarding BOTH names is robust across every env without env-sniffing
+ * at each call site. A `Cookie` request header carries no `__Secure-` browser
+ * restrictions (those only govern `Set-Cookie` storage), so this is safe.
+ *
+ * Non-auth workers (content/identity/...) validate via `@codex/security`,
+ * which reads `codex-session` (`COOKIES.SESSION_NAME`) — included first.
+ *
+ * IMPORTANT: the value is forwarded verbatim (no encoding) to avoid corrupting
+ * the `token.hmac` signature (URL-safe base64: A-Z a-z 0-9 - _ .).
+ */
+export function buildAuthForwardingCookie(sessionToken: string): string {
+  return (
+    `${COOKIES.SESSION_NAME}=${sessionToken}; ` +
+    `__Secure-better-auth.session_token=${sessionToken}; ` +
+    `better-auth.session_token=${sessionToken}`
+  );
+}
+
+/**
  * Create a server-side API client
  *
  * @param platform - The SvelteKit platform object with env bindings
@@ -172,16 +206,10 @@ export function createServerApi(
     };
 
     if (sessionCookie) {
-      // Send both our platform cookie name and BetterAuth's internal name.
-      // BetterAuth's get-session handler only looks for 'better-auth.session_token'
-      // regardless of cookie.name config, while other workers use COOKIES.SESSION_NAME.
-      //
-      // IMPORTANT: The cookie value from SvelteKit's cookies.get() is the raw value
-      // as stored by the browser. We pass it through without encoding to avoid
-      // corrupting JWT signatures (which use URL-safe base64: A-Z, a-z, 0-9, -, _).
-      // Calling encodeURIComponent() would corrupt tokens by encoding . - _ as %2E %2D %5F.
+      // Forward under every name the auth worker's BetterAuth might read.
+      // See buildAuthForwardingCookie for the `__Secure-` prefix rationale.
       (headers as Record<string, string>).Cookie =
-        `${COOKIES.SESSION_NAME}=${sessionCookie}; better-auth.session_token=${sessionCookie}`;
+        buildAuthForwardingCookie(sessionCookie);
     }
 
     // Abort fetch after 10 seconds to prevent indefinite hangs when a worker
@@ -302,9 +330,8 @@ export function createServerApi(
 
       const cookieToUse = customSessionCookie || sessionCookie;
       if (cookieToUse) {
-        // Pass cookie value through without encoding (see request() above for rationale)
         (headers as Record<string, string>).Cookie =
-          `${COOKIES.SESSION_NAME}=${cookieToUse}; better-auth.session_token=${cookieToUse}`;
+          buildAuthForwardingCookie(cookieToUse);
       }
 
       // AbortController timeout — matches request() to prevent indefinite hangs

--- a/apps/web/src/lib/server/auth-utils.ts
+++ b/apps/web/src/lib/server/auth-utils.ts
@@ -1,6 +1,6 @@
-import { AUTH_COOKIES, COOKIES } from '@codex/constants';
+import { COOKIES } from '@codex/constants';
 import { logger } from '$lib/observability';
-import { serverApiUrl } from './api';
+import { buildAuthForwardingCookie, serverApiUrl } from './api';
 
 /**
  * Extract session token from Set-Cookie header on an auth worker response.
@@ -52,7 +52,7 @@ export async function invalidateAuthSession(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Cookie: `${COOKIES.SESSION_NAME}=${sessionCookie}; ${AUTH_COOKIES.BETTER_AUTH}=${sessionCookie}`,
+        Cookie: buildAuthForwardingCookie(sessionCookie),
       },
       body: '{}',
     });

--- a/workers/admin-api/wrangler.jsonc
+++ b/workers/admin-api/wrangler.jsonc
@@ -91,7 +91,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "AUTH_WORKER_URL": "https://auth.revelations.studio"
       },
       "kv_namespaces": [

--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -69,7 +69,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "API_URL": "https://api.revelations.studio",
         "FROM_EMAIL": "noreply@revelations.studio",
         "FROM_NAME": "Codex"

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -99,7 +99,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "API_URL": "https://api.revelations.studio",
         "MEDIA_API_URL": "https://media-api.revelations.studio",
         "R2_PUBLIC_URL_BASE": "https://cdn.revelations.studio"

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -74,7 +74,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "AUTH_WORKER_URL": "https://auth.revelations.studio"
       },
       "kv_namespaces": [

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -95,7 +95,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "API_URL": "https://api.revelations.studio",
         "R2_PUBLIC_URL_BASE": "https://cdn.revelations.studio"
       },

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -125,7 +125,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "API_URL": "https://api.revelations.studio"
       },
       "kv_namespaces": [

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -69,7 +69,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "API_URL": "https://api.revelations.studio",
         "FROM_EMAIL": "noreply@revelations.studio",
         "FROM_NAME": "Codex"

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -96,7 +96,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
-        "WEB_APP_URL": "https://codex.revelations.studio",
+        "WEB_APP_URL": "https://revelations.studio",
         "API_URL": "https://api.revelations.studio",
         "R2_PUBLIC_URL_BASE": "https://cdn.revelations.studio"
       },


### PR DESCRIPTION
Two production auth/routing hotfixes discovered while testing email verification on prod.

## 1. Can't stay signed in — every login bounces back to /login
**Root cause:** BetterAuth prefixes every cookie name with `__Secure-` when its `baseURL` is HTTPS (`better-auth/dist/cookies/index.mjs`). The web app's server-side session forwarding sent only the **unprefixed** `better-auth.session_token`, but BetterAuth's `get-session` reads only its configured (prefixed) name with no fallback (`api/routes/session.mjs:41`) → every session lookup returned `null` → redirect to /login. **Prod-only** (dev `baseURL` is HTTP → unprefixed → works locally).

**Fix:** `buildAuthForwardingCookie()` forwards `codex-session` + both prefixed and unprefixed `better-auth.session_token` names. Wired into `createServerApi` (`getSession` path run by `hooks.server.ts` on every request) and `invalidateAuthSession` (sign-out). Non-auth workers unaffected — `@codex/security` already probes all four name variants.

## 2. Redirected to codex.revelations.studio (should be bare apex)
**Root cause:** `WEB_APP_URL` was `https://codex.revelations.studio` across all workers, but the routing model (`ENV_HOSTS`/`buildPlatformUrl`/`parseHost`) treats **bare `revelations.studio`** as the platform apex. So verification email links + BetterAuth baseURL pointed at `codex.*` while logout/platform nav pointed at the bare apex → cross-host bouncing.

**Fix:** Align all 8 workers' production `WEB_APP_URL` → `https://revelations.studio`. The app is already served at the bare apex (`apps/web/wrangler.jsonc` routes `revelations.studio/*`). Cookie domain unaffected (both hosts → `.revelations.studio`).

## Deploy (both are deploy-time)
- Redeploy **web app** (api.ts/auth-utils.ts) and **all 8 workers** (WEB_APP_URL is a wrangler var).
- Cannot reproduce locally (dev uses HTTP/unprefixed). Verify on prod: `/api/auth/get-session` returns `{user, session}` (not null); verify email link is `revelations.studio/verify-email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)