### PR TITLE
fix(prod): transcoding webhook + R2 CDN host + dead-host API_URL (WP-1/2/3)

### DIFF
--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -70,7 +70,8 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://revelations.studio",
-        "API_URL": "https://api.revelations.studio",
+        // No API_URL: it was only a CORS trusted-origin entry for the dead host
+        // api.revelations.studio (no worker owns it), so it added nothing.
         "FROM_EMAIL": "noreply@revelations.studio",
         "FROM_NAME": "Codex"
       },

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -100,9 +100,16 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://revelations.studio",
-        "API_URL": "https://api.revelations.studio",
+        // No API_URL override here: buildServiceUrl uses API_URL as the
+        // override key for the content/access services, and a stale
+        // api.revelations.studio (dead host) would beat the correct
+        // ENV_HOSTS default (content-api.revelations.studio).
         "MEDIA_API_URL": "https://media-api.revelations.studio",
-        "R2_PUBLIC_URL_BASE": "https://cdn.revelations.studio"
+        // Public R2 asset host (thumbnails, logos). MUST match the provisioned
+        // R2 custom domain in .github/config/r2-infrastructure.json (assets bucket
+        // → cdn-assets.revelations.studio). `cdn.revelations.studio` is unprovisioned,
+        // so every thumbnail/logo/public image 404'd.
+        "R2_PUBLIC_URL_BASE": "https://cdn-assets.revelations.studio"
       },
       "kv_namespaces": [
         {

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -96,8 +96,13 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://revelations.studio",
-        "API_URL": "https://api.revelations.studio",
-        "R2_PUBLIC_URL_BASE": "https://cdn.revelations.studio"
+        // No API_URL override: api.revelations.studio is a dead host and the
+        // ENV_HOSTS defaults resolve content/access correctly without it.
+        // Public R2 asset host (avatars, logos). MUST match the provisioned R2
+        // custom domain (assets bucket → cdn-assets.revelations.studio in
+        // .github/config/r2-infrastructure.json). `cdn.revelations.studio` is
+        // unprovisioned, so avatars/logos 404'd.
+        "R2_PUBLIC_URL_BASE": "https://cdn-assets.revelations.studio"
       },
       "kv_namespaces": [
         {

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -126,7 +126,12 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://revelations.studio",
-        "API_URL": "https://api.revelations.studio"
+        // RunPod transcoding completion callbacks POST to `${API_URL}/api/transcoding/webhook`
+        // (service-registry.ts: webhookBaseUrl = env.API_URL). `api.revelations.studio` is
+        // owned by NO worker, so callbacks were black-holed and media never reached `ready`.
+        // media-api.revelations.studio has a custom_domain route + DNS (below) and owns the
+        // /api/transcoding/webhook handler.
+        "API_URL": "https://media-api.revelations.studio"
       },
       "kv_namespaces": [
         {

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -70,7 +70,8 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://revelations.studio",
-        "API_URL": "https://api.revelations.studio",
+        // No API_URL: only ever a CORS/trusted-origin entry for the dead host
+        // api.revelations.studio (no worker owns it).
         "FROM_EMAIL": "noreply@revelations.studio",
         "FROM_NAME": "Codex"
       },

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -97,8 +97,13 @@
         "ENVIRONMENT": "production",
         "DB_METHOD": "PRODUCTION",
         "WEB_APP_URL": "https://revelations.studio",
-        "API_URL": "https://api.revelations.studio",
-        "R2_PUBLIC_URL_BASE": "https://cdn.revelations.studio"
+        // No API_URL override: api.revelations.studio is a dead host and the
+        // ENV_HOSTS defaults resolve content/access correctly without it.
+        // Public R2 asset host (org logos, branding). MUST match the provisioned
+        // R2 custom domain (assets bucket → cdn-assets.revelations.studio in
+        // .github/config/r2-infrastructure.json). `cdn.revelations.studio` is
+        // unprovisioned, so logos/branding images 404'd.
+        "R2_PUBLIC_URL_BASE": "https://cdn-assets.revelations.studio"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
First wave of the **Production Readiness** epic (`Codex-fc5oh`) — three pure wrangler-config P0/P1 fixes for dead-host misconfigurations found by the prod-readiness audit. Plan + evidence: `docs/prod-readiness/README.md`.

## WP-1 (P0) — RunPod transcoding never completes `Codex-fc5oh.1`
RunPod posts completion callbacks to `${API_URL}/api/transcoding/webhook`, but media-api prod `API_URL = https://api.revelations.studio` — **a host no worker owns**. Callbacks were black-holed → uploaded media never reached `ready` (matches the reported "upload never transcodes"). Fix: point media-api `API_URL` at its own custom-domain host `media-api.revelations.studio`, which owns the webhook route. RunPod secrets confirmed present in the prod GitHub environment, so this is the high-confidence fix.

## WP-2 (P0) — all images 404 platform-wide `Codex-fc5oh.2`
content/identity/organization-api set `R2_PUBLIC_URL_BASE = https://cdn.revelations.studio`, but the provisioned R2 custom domain (assets bucket) is `cdn-assets.revelations.studio` (`.github/config/r2-infrastructure.json`). Thumbnails, org logos, public catalogue images all 404. Fix: point at the provisioned host.
⚠️ **Verify before closing:** confirm `cdn-assets.revelations.studio` is actually applied and serves a 200 image — the var fix is necessary but may be insufficient if the custom domain was never provisioned (tracked in WP-4).

## WP-3 (P1) — dead-host `API_URL` overrides `Codex-fc5oh.5`
`buildServiceUrl` reads `API_URL` as the override key for the content/access services, so a stale `api.revelations.studio` would beat the correct `ENV_HOSTS` default for any worker→worker content/access call. On auth/notifications it was only a useless CORS entry. Removed from all 5 non-media prod blocks.

## Validation
- All 6 `wrangler.jsonc` files parse as valid JSONC (comments + no trailing commas).
- No remaining `cdn.revelations.studio` / `api.revelations.studio` config values (only explanatory comments).
- Config-only change — no app/source code touched.

## Deploy
Deploy-time (wrangler vars): merge → `dev` → `main` → approve the `production` GitHub Environment. Affected workers: media-api, content-api, identity-api, organization-api, auth, notifications-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)