### PR TITLE
fix(worker-utils): lazy Stripe client — fix new-creator Connect/earnings 500 (WP-12)

### DIFF
--- a/packages/worker-utils/src/procedure/__tests__/lazy-stripe-proxy.test.ts
+++ b/packages/worker-utils/src/procedure/__tests__/lazy-stripe-proxy.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression tests for `createLazyStripeProxy` (WP-12 · Codex-fc5oh.12).
+ *
+ * Bug: the service registry built the Stripe-backed services
+ * (purchase/subscription/tier/connect) by resolving the Stripe client EAGERLY.
+ * The resolver throws 'STRIPE_SECRET_KEY not configured' when the key is falsy,
+ * so merely *accessing* `ctx.services.connect` threw at construction — turning a
+ * brand-new creator's read-only Connect/earnings page (which never calls Stripe)
+ * into a 500 INTERNAL_ERROR.
+ *
+ * Fix: inject a Proxy that defers resolution until the first property access.
+ * These tests lock down that contract:
+ *   - the resolver is NOT called at proxy creation (the core regression);
+ *   - the resolver (and its throw) fires on first property access, so a genuine
+ *     misconfiguration still surfaces the moment Stripe is actually used;
+ *   - methods stay bound to the real client and nested resource namespaces pass
+ *     through, so write paths behave identically to a direct client.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createLazyStripeProxy } from '../service-registry';
+
+describe('createLazyStripeProxy', () => {
+  it('does NOT resolve the client at proxy creation (deferred)', () => {
+    const resolve = vi.fn(() => ({}) as never);
+
+    createLazyStripeProxy(resolve);
+
+    // The eager-construction bug lived here: before the fix the resolver ran
+    // synchronously while building the constructor argument.
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('resolves on first property access', () => {
+    const client = { accounts: { create: vi.fn() } };
+    const resolve = vi.fn(() => client as never);
+
+    const proxy = createLazyStripeProxy(resolve);
+    // touch a property
+    void proxy.accounts;
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the resolver throw on access, not at creation', () => {
+    const resolve = vi.fn(() => {
+      throw new Error('STRIPE_SECRET_KEY not configured.');
+    });
+
+    // Creation must succeed even when the key is missing — this is what lets a
+    // read-only zero-state endpoint render without ever touching Stripe.
+    const proxy = createLazyStripeProxy(resolve);
+    expect(resolve).not.toHaveBeenCalled();
+
+    // A real Stripe call still surfaces the misconfiguration.
+    expect(() => proxy.accounts).toThrow('STRIPE_SECRET_KEY not configured.');
+  });
+
+  it('binds methods to the real client so `this` resolves correctly', async () => {
+    const client = {
+      secret: 'sk_test',
+      async whoAmI() {
+        return this.secret;
+      },
+    };
+    const proxy = createLazyStripeProxy(() => client as never);
+
+    // If the method were returned unbound, `this` would be the proxy and the
+    // call would re-trigger resolution / lose context.
+    await expect((proxy as unknown as typeof client).whoAmI()).resolves.toBe(
+      'sk_test'
+    );
+  });
+
+  it('passes nested resource namespaces through untouched', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'acct_123' });
+    const client = { accounts: { create } };
+    const proxy = createLazyStripeProxy(() => client as never);
+
+    const result = await (proxy as unknown as typeof client).accounts.create();
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(result).toEqual({ id: 'acct_123' });
+  });
+});

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -58,6 +58,44 @@ export interface ServiceRegistryResult {
   cleanup: () => Promise<void>;
 }
 
+/** The concrete Stripe client type, derived from the factory return. */
+type StripeClient = ReturnType<typeof createStripeClient>;
+
+/**
+ * Wrap a Stripe-client resolver in a Proxy that defers resolution until the
+ * first property access.
+ *
+ * WP-12 (Codex-fc5oh.12): the Stripe-backed service getters built their
+ * constructor argument by calling the resolver EAGERLY. The resolver throws
+ * 'STRIPE_SECRET_KEY not configured' when the key is falsy, so merely accessing
+ * `ctx.services.connect` (or subscription/tier/purchase) threw at construction —
+ * BEFORE the handler ran. That turned read-only zero-state endpoints (a brand
+ * new creator's empty Connect status returns DISCONNECTED without ever calling
+ * Stripe; earnings-summary and payouts are pure DB reads) into 500
+ * INTERNAL_ERROR responses whenever the key was missing or late-bound.
+ *
+ * The returned Proxy holds the constructor arg without resolving it. `resolve()`
+ * (and its missing-key throw) runs lazily on the FIRST property access — i.e.
+ * the first real Stripe API call. Services store the proxy as `this.stripe` and
+ * only touch it inside async methods, so read paths never trip the guard, while
+ * a genuine misconfiguration still surfaces (as the same thrown error) the
+ * moment a Stripe call is actually attempted.
+ */
+export function createLazyStripeProxy(
+  resolve: () => StripeClient
+): StripeClient {
+  return new Proxy({} as StripeClient, {
+    get(_target, prop) {
+      const client = resolve();
+      const value = Reflect.get(client as object, prop);
+      // Bind methods to the real client so `this` resolves correctly; Stripe
+      // resource namespaces (accounts, checkout, …) are objects and pass
+      // through untouched.
+      return typeof value === 'function' ? value.bind(client) : value;
+    },
+  });
+}
+
 /**
  * Creates lazy-loaded service registry
  *
@@ -148,6 +186,19 @@ export function createServiceRegistry(
       _stripeClient = createStripeClient(stripeKey);
     }
     return _stripeClient;
+  }
+
+  // WP-12 (Codex-fc5oh.12): inject a lazy Stripe proxy instead of resolving the
+  // client eagerly, so read-only zero-state endpoints never trip the missing-key
+  // guard. See createLazyStripeProxy() above for the full rationale. Memoised so
+  // all Stripe-backed services share one proxy (and one underlying client).
+  let _lazyStripeClient: StripeClient | undefined;
+
+  function getLazyStripeClient(): StripeClient {
+    if (!_lazyStripeClient) {
+      _lazyStripeClient = createLazyStripeProxy(getStripeClient);
+    }
+    return _lazyStripeClient;
   }
 
   const registry: ServiceRegistry = {
@@ -458,7 +509,7 @@ export function createServiceRegistry(
             mailer: purchaseMailer,
             webAppUrl: env.WEB_APP_URL,
           },
-          getStripeClient()
+          getLazyStripeClient()
         );
       }
       return _purchase;
@@ -634,7 +685,7 @@ export function createServiceRegistry(
             // receive different splits.
             feeConfig: registry.feeConfig,
           },
-          getStripeClient()
+          getLazyStripeClient()
         );
       }
       return _subscription;
@@ -694,7 +745,7 @@ export function createServiceRegistry(
             environment: getEnvironment(),
             propagator,
           },
-          getStripeClient()
+          getLazyStripeClient()
         );
       }
       return _tier;
@@ -707,7 +758,7 @@ export function createServiceRegistry(
             db: getSharedDb(),
             environment: getEnvironment(),
           },
-          getStripeClient()
+          getLazyStripeClient()
         );
 
         // Wire VersionedCache for `getStatus(orgId)` cache-aside. Mirrors the


### PR DESCRIPTION
## WP-12 · Codex-fc5oh.12 (P0) — Production Readiness epic

### Problem
Live prod (2026-06-25): a brand-new creator (verified, no org, no Connect, zero earnings) visiting `creators.revelations.studio/studio/earnings` got **`Studio Error`** — `__data.json` returned `{type:error, code:INTERNAL_ERROR}`.

### Root cause (confirmed against live code)
The service registry built the Stripe-backed services — `purchase`, `subscription`, `tier`, `connect` — by calling `getStripeClient()` **eagerly** while constructing the service argument. `getStripeClient()` throws `STRIPE_SECRET_KEY not configured` when the key is falsy, so merely *accessing* `ctx.services.connect` threw **at construction, before the handler ran**.

The earnings/Connect read path is otherwise Stripe-free: `getStatusForUser` returns `DISCONNECTED_STATUS` without calling Stripe, and earnings-summary/payouts are pure DB reads. The eager throw is what turned that zero-state page into a 500 — matching the live error node exactly.

### Fix
Inject a lazy **Proxy** (`createLazyStripeProxy`) that defers `getStripeClient()` — and its missing-key throw — until the **first property access**, i.e. the first real Stripe API call. All four getters now share one memoized proxy.

- Read-only zero-state endpoints never trip the missing-key guard → page renders.
- A genuine misconfiguration still surfaces (same error) the moment a Stripe call is actually attempted.
- Fix lives at the **injection boundary** — the services already only touch `this.stripe` inside async methods, so **no service-class changes** were needed.

### Tests
`createLazyStripeProxy` is exported and unit-tested (5 cases): resolver not called at creation (the regression), throw fires on access not creation, methods stay bound to the real client, nested resource namespaces pass through. Full `@codex/worker-utils` suite green; typecheck + biome clean.

### Scope note
This fixes the **construction-time crash**. If `STRIPE_SECRET_KEY` genuinely isn't bound to `ecom-api-production`, the Connect *onboarding action* (a real Stripe call) will still fail — that binding-verification is the ops half of the bead, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)