### PR TITLE
fix(web): serve public cdn-assets/cdn-platform from R2 binding (WP-2)

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -36,6 +36,14 @@ declare global {
         ASSETS?: any;
         /** Versioned cache KV namespace */
         CACHE_KV?: KVNamespace;
+        /**
+         * Public R2 buckets served by the CDN asset hook (WP-2). The production
+         * `*.revelations.studio/*` route shadows the cdn-assets / cdn-platform
+         * R2 custom domains, so the worker serves these public buckets itself.
+         * Only bound in environments where the shadowing wildcard exists.
+         */
+        ASSETS_BUCKET?: R2Bucket;
+        PLATFORM_BUCKET?: R2Bucket;
       };
       context: ExecutionContext;
       caches: CacheStorage;

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -15,6 +15,24 @@ import { nanoid } from 'nanoid';
 import { dev } from '$app/environment';
 import { logger } from '$lib/observability';
 import { createServerApi } from '$lib/server/api';
+import { tryServeCdnAsset } from '$lib/server/cdn-proxy';
+
+/**
+ * Public CDN asset hook (WP-2 · Codex-fc5oh.2)
+ *
+ * The production `*.revelations.studio/*` worker route shadows the R2 custom
+ * domains cdn-assets / cdn-platform (worker routes win over R2 custom domains).
+ * This hook serves those public assets straight from the bound R2 bucket so
+ * thumbnails/logos/branding resolve instead of 500ing in SvelteKit.
+ *
+ * Runs FIRST in the sequence and short-circuits — a public asset must never
+ * trigger session validation or carry app security headers. See cdn-proxy.ts
+ * for why only the public buckets are handled here.
+ */
+const cdnAssetHook: Handle = async ({ event, resolve }) => {
+  const response = await tryServeCdnAsset(event);
+  return response ?? resolve(event);
+};
 
 /**
  * Session validation hook
@@ -138,7 +156,12 @@ const cdnRewriteHook: Handle = async ({ event, resolve }) => {
 /**
  * Combine hooks in sequence
  */
-export const handle = sequence(sessionHook, securityHook, cdnRewriteHook);
+export const handle = sequence(
+  cdnAssetHook,
+  sessionHook,
+  securityHook,
+  cdnRewriteHook
+);
 
 /**
  * Global error handler

--- a/apps/web/src/lib/server/cdn-proxy.test.ts
+++ b/apps/web/src/lib/server/cdn-proxy.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the public CDN asset proxy (WP-2 · Codex-fc5oh.2).
+ *
+ * Locks down the contract that fixes platform-wide image 404s and the security
+ * boundary that keeps gated buckets out:
+ *   - public hosts (cdn-assets / cdn-platform) serve straight from R2;
+ *   - the gated cdn-media / cdn-resources hosts are NEVER proxied;
+ *   - non-CDN hosts and unbound environments fall through to SvelteKit;
+ *   - conditional GETs yield 304, HEAD yields metadata, bad methods 405.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { tryServeCdnAsset } from './cdn-proxy';
+
+/** Minimal fake R2 object body. */
+function fakeObject(opts: {
+  body?: string;
+  etag?: string;
+  contentType?: string;
+  size?: number;
+}) {
+  const etag = opts.etag ?? 'v1';
+  return {
+    body: opts.body,
+    size: opts.size ?? opts.body?.length ?? 0,
+    httpEtag: `"${etag}"`,
+    writeHttpMetadata(headers: Headers) {
+      if (opts.contentType) headers.set('content-type', opts.contentType);
+    },
+  };
+}
+
+/**
+ * Fake R2 bucket. `get` honours an If-None-Match that matches the stored etag
+ * by returning a metadata-only object (no `body`) — exactly how R2's `onlyIf`
+ * precondition behaves — so the 304 path is exercised realistically.
+ */
+function fakeBucket(store: Record<string, ReturnType<typeof fakeObject>>) {
+  return {
+    get: vi.fn(async (key: string, options?: { onlyIf?: Headers }) => {
+      const object = store[key];
+      if (!object) return null;
+      const ifNoneMatch = options?.onlyIf?.get?.('if-none-match');
+      if (ifNoneMatch && ifNoneMatch === object.httpEtag) {
+        const { body: _body, ...metadataOnly } = object;
+        return metadataOnly;
+      }
+      return object;
+    }),
+    head: vi.fn(async (key: string) => store[key] ?? null),
+  } as unknown as R2Bucket;
+}
+
+function makeEvent(opts: {
+  host: string;
+  path?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  env?: Record<string, unknown>;
+}) {
+  const url = new URL(`https://${opts.host}${opts.path ?? '/'}`);
+  return {
+    url,
+    request: new Request(url, {
+      method: opts.method ?? 'GET',
+      headers: opts.headers,
+    }),
+    platform: { env: opts.env ?? {} },
+  } as unknown as Parameters<typeof tryServeCdnAsset>[0];
+}
+
+describe('tryServeCdnAsset', () => {
+  it('returns null for non-CDN hosts (normal SvelteKit handling)', async () => {
+    const res = await tryServeCdnAsset(
+      makeEvent({ host: 'revelations.studio', path: '/library' })
+    );
+    expect(res).toBeNull();
+  });
+
+  it('does NOT proxy the gated cdn-media host (security boundary)', async () => {
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-media.revelations.studio',
+        path: '/secret/video.m3u8',
+        // even if a bucket were bound under that name, the host must not resolve
+        env: { ASSETS_BUCKET: fakeBucket({}) },
+      })
+    );
+    expect(res).toBeNull();
+  });
+
+  it('does NOT proxy the gated cdn-resources host', async () => {
+    const res = await tryServeCdnAsset(
+      makeEvent({ host: 'cdn-resources.revelations.studio', path: '/x.pdf' })
+    );
+    expect(res).toBeNull();
+  });
+
+  it('falls through when the bucket binding is absent (e.g. dev)', async () => {
+    const res = await tryServeCdnAsset(
+      makeEvent({ host: 'cdn-assets.revelations.studio', path: '/logo.webp' })
+    );
+    expect(res).toBeNull();
+  });
+
+  it('serves a public asset from ASSETS_BUCKET (200 + body + headers)', async () => {
+    const bucket = fakeBucket({
+      'thumbnails/abc.webp': fakeObject({
+        body: 'IMG',
+        contentType: 'image/webp',
+      }),
+    });
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-assets.revelations.studio',
+        path: '/thumbnails/abc.webp',
+        env: { ASSETS_BUCKET: bucket },
+      })
+    );
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get('content-type')).toBe('image/webp');
+    expect(res?.headers.get('cache-control')).toContain('public');
+    expect(res?.headers.get('access-control-allow-origin')).toBe('*');
+    expect(await res?.text()).toBe('IMG');
+  });
+
+  it('serves cdn-platform from PLATFORM_BUCKET', async () => {
+    const bucket = fakeBucket({
+      'legal/terms.pdf': fakeObject({
+        body: 'PDF',
+        contentType: 'application/pdf',
+      }),
+    });
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-platform.revelations.studio',
+        path: '/legal/terms.pdf',
+        env: { PLATFORM_BUCKET: bucket },
+      })
+    );
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get('content-type')).toBe('application/pdf');
+  });
+
+  it('resolves env-suffixed host variants (cdn-assets-preview)', async () => {
+    const bucket = fakeBucket({
+      'a.png': fakeObject({ body: 'X', contentType: 'image/png' }),
+    });
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-assets-preview.revelations.studio',
+        path: '/a.png',
+        env: { ASSETS_BUCKET: bucket },
+      })
+    );
+    expect(res?.status).toBe(200);
+  });
+
+  it('returns 404 for a missing key', async () => {
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-assets.revelations.studio',
+        path: '/missing.webp',
+        env: { ASSETS_BUCKET: fakeBucket({}) },
+      })
+    );
+    expect(res?.status).toBe(404);
+  });
+
+  it('returns 304 when If-None-Match matches the stored etag', async () => {
+    const bucket = fakeBucket({
+      'logo.webp': fakeObject({
+        body: 'IMG',
+        etag: 'v1',
+        contentType: 'image/webp',
+      }),
+    });
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-assets.revelations.studio',
+        path: '/logo.webp',
+        headers: { 'if-none-match': '"v1"' },
+        env: { ASSETS_BUCKET: bucket },
+      })
+    );
+    expect(res?.status).toBe(304);
+    expect(await res?.text()).toBe('');
+  });
+
+  it('serves HEAD with metadata and no body', async () => {
+    const bucket = fakeBucket({
+      'logo.webp': fakeObject({
+        body: 'IMG',
+        size: 3,
+        contentType: 'image/webp',
+      }),
+    });
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-assets.revelations.studio',
+        path: '/logo.webp',
+        method: 'HEAD',
+        env: { ASSETS_BUCKET: bucket },
+      })
+    );
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get('content-length')).toBe('3');
+    expect(await res?.text()).toBe('');
+  });
+
+  it('rejects non-GET/HEAD methods with 405', async () => {
+    const res = await tryServeCdnAsset(
+      makeEvent({
+        host: 'cdn-assets.revelations.studio',
+        path: '/logo.webp',
+        method: 'POST',
+        env: { ASSETS_BUCKET: fakeBucket({}) },
+      })
+    );
+    expect(res?.status).toBe(405);
+  });
+});

--- a/apps/web/src/lib/server/cdn-proxy.ts
+++ b/apps/web/src/lib/server/cdn-proxy.ts
@@ -1,0 +1,130 @@
+/**
+ * Public CDN asset proxy (WP-2 · Codex-fc5oh.2).
+ *
+ * Cloudflare Worker routes take precedence over R2 custom domains on the same
+ * hostname (documented behaviour). The web app's `*.revelations.studio/*`
+ * production route therefore shadows the R2 custom domains
+ * `cdn-assets.revelations.studio` and `cdn-platform.revelations.studio` — every
+ * request for a thumbnail/logo/branding asset hits this worker and 500s in
+ * SvelteKit instead of being served by R2. (Local dev has no wildcard route, so
+ * the R2 custom domain serves directly — which is why it "worked locally".)
+ *
+ * Fix (approach B): when a request arrives for one of the PUBLIC CDN hosts,
+ * serve the object straight from the bound R2 bucket — the worker acts as the
+ * R2 origin. The wildcard route stays intact for org subdomains.
+ *
+ * SECURITY: only the PUBLIC buckets are proxied here. `cdn-media` and
+ * `cdn-resources` are `publicAccess: false` in r2-infrastructure.json — they are
+ * gated behind presigned-URL signatures. Serving those through a raw
+ * `bucket.get(key)` binding would bypass signature verification and expose gated
+ * content to anyone who guesses a key, so they are deliberately NOT handled here
+ * and fall through to normal request handling.
+ */
+import type { RequestEvent } from '@sveltejs/kit';
+
+/**
+ * Public R2-backed CDN host prefix → the `platform.env` binding that serves it.
+ * Matched against the first DNS label, so it covers the production host
+ * (`cdn-assets`) and any env-suffixed variant (`cdn-assets-preview`, …).
+ */
+const PUBLIC_CDN_BINDINGS = {
+  'cdn-assets': 'ASSETS_BUCKET',
+  'cdn-platform': 'PLATFORM_BUCKET',
+} as const satisfies Record<string, 'ASSETS_BUCKET' | 'PLATFORM_BUCKET'>;
+
+type CdnBinding =
+  (typeof PUBLIC_CDN_BINDINGS)[keyof typeof PUBLIC_CDN_BINDINGS];
+
+const CORS_HEADERS: Record<string, string> = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, HEAD, OPTIONS',
+};
+
+/**
+ * Resolve a hostname to a public-CDN bucket binding, or null when the host is
+ * not a public CDN host (including the gated `cdn-media`/`cdn-resources`).
+ */
+function resolveCdnBinding(hostname: string): CdnBinding | null {
+  const firstLabel = hostname.split('.')[0];
+  for (const [prefix, binding] of Object.entries(PUBLIC_CDN_BINDINGS)) {
+    if (firstLabel === prefix || firstLabel.startsWith(`${prefix}-`)) {
+      return binding;
+    }
+  }
+  return null;
+}
+
+/** Build response headers from an R2 object (metadata + CORS + cache). */
+function buildAssetHeaders(object: R2Object): Headers {
+  const headers = new Headers(CORS_HEADERS);
+  object.writeHttpMetadata(headers);
+  headers.set('etag', object.httpEtag);
+  // Worker-served path bypasses the R2 custom-domain cache rule, so set a sane
+  // public cache policy here (browser 1h, edge 1d). Public assets only.
+  if (!headers.has('cache-control')) {
+    headers.set('cache-control', 'public, max-age=3600, s-maxage=86400');
+  }
+  return headers;
+}
+
+/**
+ * If this request targets a public CDN host whose bucket is bound, serve the
+ * object from R2 and return a Response. Otherwise return null so the caller
+ * proceeds with normal SvelteKit handling.
+ */
+export async function tryServeCdnAsset(
+  event: Pick<RequestEvent, 'url' | 'request' | 'platform'>
+): Promise<Response | null> {
+  const binding = resolveCdnBinding(event.url.hostname);
+  if (!binding) return null;
+
+  // Binding absent in this environment (e.g. dev, which has no shadowing
+  // wildcard) → let the real R2 custom domain handle it.
+  const bucket = event.platform?.env?.[binding] as R2Bucket | undefined;
+  if (!bucket) return null;
+
+  const { method } = event.request;
+
+  if (method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (method !== 'GET' && method !== 'HEAD') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: CORS_HEADERS,
+    });
+  }
+
+  // R2 keys are the pathname without the leading slash, URL-decoded.
+  const key = decodeURIComponent(event.url.pathname.slice(1));
+  if (!key) {
+    return new Response('Not Found', { status: 404, headers: CORS_HEADERS });
+  }
+
+  if (method === 'HEAD') {
+    const object = await bucket.head(key);
+    if (!object) {
+      return new Response(null, { status: 404, headers: CORS_HEADERS });
+    }
+    const headers = buildAssetHeaders(object);
+    headers.set('content-length', String(object.size));
+    return new Response(null, { status: 200, headers });
+  }
+
+  // GET — forward conditional headers (If-None-Match / If-Modified-Since) to R2
+  // via `onlyIf` so a matching client cache yields a metadata-only 304.
+  const object = await bucket.get(key, { onlyIf: event.request.headers });
+  if (!object) {
+    return new Response('Not Found', { status: 404, headers: CORS_HEADERS });
+  }
+
+  const headers = buildAssetHeaders(object);
+
+  // Precondition failed (etag matched): R2 returns metadata only, no body.
+  if (!('body' in object)) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  headers.set('content-length', String(object.size));
+  return new Response(object.body, { status: 200, headers });
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -63,6 +63,22 @@
           "id": "499d67770dc2405ab80cba5629b16511"
         }
       ],
+      // Public R2 buckets served directly by the CDN asset hook (WP-2).
+      // The `*.revelations.studio/*` route below shadows the cdn-assets /
+      // cdn-platform R2 custom domains (worker routes win over R2 custom
+      // domains), so the worker serves these PUBLIC buckets itself. The gated
+      // media/resources buckets are intentionally NOT bound — they require
+      // presigned-URL access and must not be served via a raw binding.
+      "r2_buckets": [
+        {
+          "binding": "ASSETS_BUCKET",
+          "bucket_name": "codex-assets-production"
+        },
+        {
+          "binding": "PLATFORM_BUCKET",
+          "bucket_name": "codex-platform-production"
+        }
+      ],
       "routes": [
         // Specific routes first (for priority)
         {


### PR DESCRIPTION
## WP-2 · Codex-fc5oh.2 (P0) — Production Readiness epic

### Problem
All platform images 404/500 in prod (thumbnails, logos, branding). The web app's production `*.revelations.studio/*` worker route **shadows** the R2 custom domains `cdn-assets` / `cdn-platform` — Cloudflare worker routes take precedence over R2 custom domains on the same hostname, so every CDN request 500s in SvelteKit. Worked locally because dev has no wildcard route.

### Fix (Approach B — worker-as-origin)
A `cdnAssetHook` runs **first** in the hooks sequence; for the two **public** CDN hosts it serves the object straight from the bound R2 bucket (CORS, public cache headers, ETag/304, HEAD). The wildcard route stays intact for org subdomains.

- `apps/web/src/lib/server/cdn-proxy.ts` — `tryServeCdnAsset()` + 11 unit tests
- `apps/web/src/hooks.server.ts` — `cdnAssetHook` first in sequence (short-circuits before session validation)
- `apps/web/wrangler.jsonc` — bind `ASSETS_BUCKET`→`codex-assets-production`, `PLATFORM_BUCKET`→`codex-platform-production` (production env)
- `apps/web/src/app.d.ts` — type the R2 bindings on `Platform.env`

### Security boundary
Only the **public** buckets (assets, platform) are proxied. `cdn-media` / `cdn-resources` are presigned-gated (`publicAccess: false`) — `resolveCdnBinding` returns `null` for them so they fall through to normal handling, never to a raw `bucket.get()`. Two tests assert this.

### Notes
- Runs on **Workers Free** — one hook, no paid features, self-disables where the binding is absent (dev/staging).
- 11 proof tests green, existing `hooks.test.ts` green, `tsc --noEmit` + biome clean, bucket names verified against `r2-infrastructure.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)