### PR TITLE
fix(ci): seed DB on a direct connection so the content transaction commits

### DIFF
--- a/.github/workflows/seed-dev-db.yml
+++ b/.github/workflows/seed-dev-db.yml
@@ -99,7 +99,14 @@ jobs:
         run: pnpm --filter @codex/database db:seed
         env:
           DATABASE_URL: ${{ steps.neon.outputs.DATABASE_URL }}
-          DB_METHOD: PRODUCTION
+          # NEON_BRANCH (not PRODUCTION) for the seed: the seed wraps all
+          # inserts in a single dbWs.transaction(), and PRODUCTION sets
+          # poolQueryViaFetch=true which routes Pool.query() over HTTP and
+          # breaks WS transactions (content inserts roll back → seed validator
+          # fails with 0 published rows). NEON_BRANCH keeps poolQueryViaFetch
+          # =false + secure WS. The connection_uri above is already pooled=false
+          # (direct), so this matches the proven-good config in testing.yml.
+          DB_METHOD: NEON_BRANCH
           # The seed script also touches dev CDN / KV for cache-flushing.
           # In CI we don't have those bindings, so those operations
           # will be no-ops or warn — the DB seeding still completes.

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -896,7 +896,14 @@ jobs:
       # any checkout test would fail with 422.
       - name: Seed test database
         env:
-          DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
+          # Use db_url (DIRECT), not db_url_with_pooler. The seed wraps all
+          # inserts in a single long-lived dbWs.transaction() (seed-data.ts
+          # step [3/5]); over the PgBouncer pooler that session connection is
+          # recycled mid-transaction, so the content inserts silently roll
+          # back — the validator then sees 0 published rows for every access
+          # mode and fails. Same reasoning as the "Apply migrations" step
+          # above (lines ~318-327).
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url }}
           DB_METHOD: NEON_BRANCH
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

`main` CI went red: **E2E Web Tests → "Seed test database"** fails. The seed reaches `[5/5] Validating seed invariants` and reports **0 published content rows for all six access modes** (Free, Follower, Tiered Subscriber, Purchasable, Hybrid, Member-Only all `[MISSING]`), even though `[3/5]` logs "Seeded 24 content items".

## Root cause

The seed wraps every insert in a single long-lived `dbWs.transaction()` (`seed-data.ts` step `[3/5]`). That WebSocket session transaction needs a **stable direct** Neon connection:

- **`testing.yml`** fed the seed step `db_url_with_pooler` (PgBouncer). The pooled connection is recycled mid-transaction → the content inserts silently roll back (step 3 logs the count *inside* the uncommitted tx) → the validator, reading on a fresh connection, sees an empty `content` table. The migrate step (`:865`) and unit-test step (`:327`) already use the direct `db_url` for exactly this reason (documented at `:318-327`).
- **`seed-dev-db.yml`** ran the seed under `DB_METHOD=PRODUCTION`, which sets `poolQueryViaFetch=true` and routes `Pool.query()` over HTTP — breaking WS transactions even though its `connection_uri` is already `pooled=false`.

## Fix

- `testing.yml` seed step → `db_url` (direct).
- `seed-dev-db.yml` seed step → `DB_METHOD=NEON_BRANCH` (keeps `poolQueryViaFetch=false` + secure WS; URL already direct).

No code/schema/seed-logic changes — column mapping was always correct (seed writes `accessType`/`status`/`minimumTierId`; validator reads the same).

## Not introduced by recent PRs

Latent since #265 (2026-05-26, when the seed step adopted the pooled URL). It surfaced now only because PR #311 (WP-2) touched `apps/web`, re-triggering the path-filtered E2E Web Tests job. PRs #309/#311 touched zero seed/schema/content files. `seed-dev-db.yml` has never had a successful run (both 2026-05-22 dispatches failed).

## Verification

The `workflows` path filter (`testing.yml:184-186`, E2E Web `if` at `:808-811`) forces E2E Web Tests to run on this PR even with no `apps/web` source change — so this PR re-executes the seed against the direct URL. **Green E2E Web = fix verified in the real Neon-branch environment.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)