### PR TITLE
fix(web): redirect become-creator to personal creator studio (WP-8)

### DIFF
--- a/apps/web/src/lib/remote/account.remote.ts
+++ b/apps/web/src/lib/remote/account.remote.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import { command, form, getRequestEvent, query } from '$app/server';
 import { createServerApi } from '$lib/server/api';
 import { ApiError } from '$lib/server/errors';
+import { buildCreatorsUrl } from '$lib/utils/subdomain';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas for forms
@@ -204,7 +205,7 @@ const becomeCreatorFormSchema = z.object({
 export const becomeCreatorForm = form(
   becomeCreatorFormSchema,
   async ({ username, bio, website, twitter, youtube, instagram }, issue) => {
-    const { platform, cookies } = getRequestEvent();
+    const { platform, cookies, url } = getRequestEvent();
     const api = createServerApi(platform, cookies);
 
     const emptyToUndef = (v: string | undefined) => (v === '' ? undefined : v);
@@ -221,7 +222,12 @@ export const becomeCreatorForm = form(
         },
       });
 
-      redirect(303, '/studio');
+      // New creators have no org yet — send them to their personal creator
+      // studio on the `creators` subdomain. `/studio` on the platform apex
+      // has no route and 404s; studio surfaces only exist on the `creators`
+      // and `<org-slug>` subdomains. Org creation is a separate, optional
+      // step via the studio switcher's "Add Organisation" flow.
+      redirect(303, buildCreatorsUrl(url, '/studio'));
     } catch (error) {
       if (isRedirect(error)) throw error;
 

--- a/apps/web/src/routes/(platform)/become-creator/+page.server.ts
+++ b/apps/web/src/routes/(platform)/become-creator/+page.server.ts
@@ -7,15 +7,18 @@
 
 import { redirect } from '@sveltejs/kit';
 
+import { buildCreatorsUrl } from '$lib/utils/subdomain';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
   if (!locals.user) {
     redirect(303, '/login?redirect=/become-creator');
   }
 
   if (locals.user.role !== 'customer') {
-    redirect(303, '/studio');
+    // Already a creator — their studio lives on the `creators` subdomain,
+    // not the platform apex (`/studio` here 404s).
+    redirect(303, buildCreatorsUrl(url, '/studio'));
   }
 
   return {


### PR DESCRIPTION
## Problem (Codex-fc5oh.8 / WP-8)

`becomeCreatorForm` and the become-creator page's load guard redirected to `/studio` on the **platform apex** (`revelations.studio/studio`), which has no route → **404**. A brand-new creator has no org yet, so there's no org subdomain to land on.

## Corrected model (after orientation fleet)

- **Creator** = a user-level role; **studio** = a UI surface; **organization** = a separate, optional 1:N entity. A creator with zero orgs already has a home: the **personal creator studio** at `creators.revelations.studio/studio` (`_creators/studio/`), gated only on the `creator` role — no org required.
- `/studio` exists only on the `creators.` and `<org-slug>.` subdomains, never the apex.

## Fix

Both redirect paths now use `buildCreatorsUrl(url, '/studio')` → `creators.revelations.studio/studio` (dev: `creators.lvh.me:3000/studio`):
- `apps/web/src/lib/remote/account.remote.ts` — `becomeCreatorForm` success redirect
- `apps/web/src/routes/(platform)/become-creator/+page.server.ts` — already-creator load guard

Org creation remains a separate, optional step via the existing `CreateOrganizationDialog` (StudioSwitcher → "Add Organisation"). Cross-origin redirect from a `form()` handler is an existing pattern in this file (`portalSessionForm` → stripe.com).

## Verification

biome clean; svelte-check clean on touched files; 31 `subdomain` util tests pass (covers `buildCreatorsUrl`). Live verification of the redirect to follow post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)