### PR TITLE
fix(web): drop duplicate Cache-Control setHeaders on creator earnings (WP-12)

### DIFF
--- a/apps/web/src/routes/_creators/studio/earnings/+page.server.ts
+++ b/apps/web/src/routes/_creators/studio/earnings/+page.server.ts
@@ -13,7 +13,6 @@
 import { redirect } from '@sveltejs/kit';
 import { logger } from '$lib/observability';
 import { createServerApi } from '$lib/server/api';
-import { CACHE_HEADERS } from '$lib/server/cache';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({
@@ -21,17 +20,18 @@ export const load: PageServerLoad = async ({
   url,
   platform,
   cookies,
-  setHeaders,
 }) => {
   // Auth guard (layout.server.ts already handles this, but belt-and-suspenders)
   if (!locals.user) {
     redirect(302, `/login?redirect=${encodeURIComponent(url.pathname)}`);
   }
 
-  // CACHE_HEADERS.PRIVATE is safe to set early — no cache-poisoning risk
-  // (private, no-cache is exactly what we want for error responses too).
-  setHeaders(CACHE_HEADERS.PRIVATE);
-
+  // NOTE: do NOT call setHeaders('Cache-Control') here. The studio
+  // +layout.server.ts already sets CACHE_HEADERS.PRIVATE for the whole studio
+  // subtree. SvelteKit forbids setting the same response header twice across
+  // the load chain — on an invalidated __data.json re-run (where both the
+  // layout node and this page node re-run), a duplicate setHeaders throws
+  // '"Cache-Control" header is already set', surfacing as a studio INTERNAL_ERROR.
   const api = createServerApi(platform, cookies);
 
   // ── Connect-return handling ────────────────────────────────────────────────


### PR DESCRIPTION
## WP-12 (Codex-fc5oh.12) — true root cause of the creator earnings "Studio Error"

**Captured live from prod** via `wrangler tail codex-web-production` while reloading the failing account's earnings page. The error fires on the exact request the bead flagged — `GET /studio/earnings/__data.json?x-sveltekit-invalidated=11101`:

```
"Cache-Control" header is already set
  at setHeaders (_worker.js)
  at load (_worker.js:93503)   ← _creators/studio/earnings/+page.server.ts
```

### Mechanism
- `_creators/studio/+layout.server.ts` sets `CACHE_HEADERS.PRIVATE` for the entire studio subtree.
- `_creators/studio/earnings/+page.server.ts` **also** set `CACHE_HEADERS.PRIVATE`.
- SvelteKit forbids setting the same response header twice across the load chain. A full SSR navigation tolerates it (returns 200), but an **invalidated `__data.json` re-run** whose bitmask re-runs *both* the studio layout node and the earnings page node makes the second `setHeaders` throw → `handleError` → `{ code: INTERNAL_ERROR }`.
- The throw is at the `setHeaders` line, **before any Connect/subscription API call**, so the lazy-Stripe fix (#309) — valid hardening — never touched this path.

### Why it looked "account-specific"
It's **route-specific**, gated by org ownership:
- A creator with **no org** lands on the personal `_creators/studio/earnings` — the only studio child that re-set Cache-Control → collision.
- A creator **with an org** views earnings via the org studio (`_org/[slug]/studio`, a different route whose pages rely on the layout header) → no collision.

So this is a genuine remaining bug, not corrupt test data.

### Fix
Remove the redundant `setHeaders(CACHE_HEADERS.PRIVATE)` from the earnings page; the studio layout remains the single Cache-Control owner. Added a regression-guard comment. Aligns with `docs`/CLAUDE.md "SvelteKit headers once" guidance.

### Verification
- `tsc --noEmit` clean; biome clean (lint-staged ran on commit).
- Post-merge/deploy: re-tail `codex-web-production` while reloading the org-less creator's earnings page — expect no `"Cache-Control" header is already set` and a rendered earnings page (no Studio Error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)