### PR TITLE
feat(web): in-app resend verification email on /verify-email (WP-7)

### DIFF
--- a/apps/web/src/lib/remote/auth.remote.test.ts
+++ b/apps/web/src/lib/remote/auth.remote.test.ts
@@ -36,4 +36,9 @@ describe('remote/auth.remote', () => {
     const { getSession } = await import('./auth.remote');
     expect(getSession).toBeDefined();
   });
+
+  it('exports resendVerificationEmailForm', async () => {
+    const { resendVerificationEmailForm } = await import('./auth.remote');
+    expect(resendVerificationEmailForm).toBeDefined();
+  });
 });

--- a/apps/web/src/lib/remote/auth.remote.ts
+++ b/apps/web/src/lib/remote/auth.remote.ts
@@ -109,6 +109,66 @@ export const resetPasswordForm = form(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Resend Email Verification Form
+// ─────────────────────────────────────────────────────────────────────────────
+
+const resendVerificationFormSchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+});
+
+/**
+ * Resend the email-verification link.
+ *
+ * Post-registration, the user lands on /verify-email with no way to request a
+ * fresh link if the first never arrived (the old "try again" link pointed at
+ * /register, which 409s for an existing-but-unverified account). This wires the
+ * page to BetterAuth's `send-verification-email` endpoint.
+ *
+ * Always returns a neutral success message — never reveals whether the address
+ * exists or is already verified — to avoid account enumeration.
+ */
+export const resendVerificationEmailForm = form(
+  resendVerificationFormSchema,
+  async ({ email }) => {
+    const { platform, request } = getRequestEvent();
+    const authUrl = serverApiUrl(platform, 'auth');
+
+    // Forward the browser Origin so BetterAuth's trustedOrigins check accepts
+    // the server-side fetch (same reason as register/login sign-in).
+    const incomingOrigin = request.headers.get('origin');
+    const incomingHost = request.headers.get('host');
+    const forwardedOrigin =
+      incomingOrigin ??
+      (incomingHost ? `http://${incomingHost}` : 'http://lvh.me:5173');
+
+    const response = await fetch(
+      `${authUrl}/api/auth/send-verification-email`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: forwardedOrigin,
+        },
+        body: JSON.stringify({ email }),
+      }
+    );
+
+    if (!response.ok) {
+      // Log server-side for monitoring; never surface details (PII / enumeration).
+      logger.warn('Resend verification email failed', {
+        status: response.status,
+      });
+    }
+
+    return {
+      success: true as const,
+      message:
+        'If your account still needs verification, a new link is on its way. Check your inbox and spam folder.',
+    };
+  }
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Session Query
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/routes/(auth)/register/+page.server.ts
+++ b/apps/web/src/routes/(auth)/register/+page.server.ts
@@ -110,7 +110,23 @@ export const actions: Actions = {
         cookies.set(COOKIES.SESSION_NAME, sessionToken, cookieConfig);
       }
 
-      // 4. Redirect to verify email page (or library if no verification)
+      // 4. Stash the email (httpOnly, short-lived) so /verify-email can
+      // pre-fill the "resend verification" form without leaking the address
+      // into the URL/referer. Same cookie config as the session (correct
+      // cross-subdomain domain + secure flag), just a shorter lifetime.
+      cookies.set(
+        COOKIES.PENDING_VERIFICATION_EMAIL,
+        result.data.email,
+        getCookieConfig(
+          platform?.env,
+          request.headers.get('host') ?? undefined,
+          {
+            maxAge: 60 * 30,
+          }
+        )
+      );
+
+      // 5. Redirect to verify email page (or library if no verification)
       throw redirect(303, '/verify-email');
     } catch (err) {
       if (isRedirect(err)) throw err;

--- a/apps/web/src/routes/(auth)/verify-email/+page.server.ts
+++ b/apps/web/src/routes/(auth)/verify-email/+page.server.ts
@@ -10,10 +10,15 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ url, platform, cookies }) => {
   const token = url.searchParams.get('token');
 
+  // Pre-fill the "resend verification" form (set at registration). Lets a user
+  // request a fresh link without re-typing their address. Absent → empty field.
+  const pendingEmail = cookies.get(COOKIES.PENDING_VERIFICATION_EMAIL) ?? null;
+
   if (!token) {
     // Post-registration landing — user needs to check their inbox
     return {
       status: 'pending' as const,
+      email: pendingEmail,
     };
   }
 
@@ -33,6 +38,7 @@ export const load: PageServerLoad = async ({ url, platform, cookies }) => {
       return {
         status: 'error' as const,
         error: 'Invalid or expired verification link.',
+        email: pendingEmail,
       };
     }
 
@@ -62,6 +68,7 @@ export const load: PageServerLoad = async ({ url, platform, cookies }) => {
     return {
       status: 'error' as const,
       error: 'An unexpected error occurred.',
+      email: pendingEmail,
     };
   }
 };

--- a/apps/web/src/routes/(auth)/verify-email/+page.svelte
+++ b/apps/web/src/routes/(auth)/verify-email/+page.svelte
@@ -2,6 +2,10 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import AuthLayout from '$lib/components/auth/AuthLayout.svelte';
+  import Button from '$lib/components/ui/Button/Button.svelte';
+  import Input from '$lib/components/ui/Input/Input.svelte';
+  import Label from '$lib/components/ui/Label/Label.svelte';
+  import { resendVerificationEmailForm } from '$lib/remote/auth.remote';
 
   const { data } = $props();
 
@@ -23,17 +27,47 @@
     <div class="auth-success">
       <p>Your email has been verified. Redirecting to your library...</p>
     </div>
-  {:else if data.status === 'pending'}
-    <p class="auth-footer" style="margin-bottom: var(--space-4);">
-      We've sent a verification link to your email address. Click the link to verify your account.
-    </p>
-    <p class="auth-footer">Didn't receive the email? Check your spam folder or <a href="/register" class="auth-link">try again</a>.</p>
   {:else}
-    <div class="auth-error" role="alert">
-      <p>{data.error ?? 'Invalid or expired verification link.'}</p>
-    </div>
+    {#if data.status === 'pending'}
+      <p class="auth-footer" style="margin-bottom: var(--space-4);">
+        We've sent a verification link to your email address. Click the link to verify your account.
+      </p>
+    {:else}
+      <div class="auth-error" role="alert">
+        <p>{data.error ?? 'Invalid or expired verification link.'}</p>
+      </div>
+    {/if}
+
+    {#if resendVerificationEmailForm.result?.success && !resendVerificationEmailForm.pending}
+      <div class="auth-success" role="alert">
+        <p>{resendVerificationEmailForm.result.message}</p>
+      </div>
+    {:else}
+      <p class="auth-footer" style="margin-bottom: var(--space-4);">
+        Didn't receive it? Check your spam folder, or request a new link below.
+      </p>
+      <form {...resendVerificationEmailForm} class="auth-form">
+        <div class="auth-field">
+          <Label for="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            value={data.email ?? ''}
+            placeholder="you@example.com"
+            autocomplete="email"
+            required
+          />
+        </div>
+
+        <Button type="submit" loading={resendVerificationEmailForm.pending > 0} class="auth-submit">
+          Resend verification email
+        </Button>
+      </form>
+    {/if}
+
     <p class="auth-footer">
-      <a href="/register" class="auth-link">Register again</a> or <a href="/login" class="auth-link">sign in</a>.
+      Already verified? <a href="/login" class="auth-link">Sign in</a>.
     </p>
   {/if}
 </AuthLayout>

--- a/packages/constants/src/cookies.ts
+++ b/packages/constants/src/cookies.ts
@@ -2,6 +2,9 @@ export const COOKIES = {
   SESSION_NAME: 'codex-session',
   SESSION_MAX_AGE: 60 * 60 * 24 * 7, // 7 days
   TOKEN_MAX_AGE: 300, // 5 minutes
+  // Short-lived hint set at registration so /verify-email can pre-fill the
+  // "resend verification" form without putting the email in the URL.
+  PENDING_VERIFICATION_EMAIL: 'codex-pending-verification-email',
 } as const;
 
 export interface CookieConfig {


### PR DESCRIPTION
## WP-7 (Codex-fc5oh.3) — email-verification resend flow

### The gap
After registration the user lands on `/verify-email` with **no way to request a fresh link** if the first never arrived — the old "try again" link pointed at `/register`, which 409s for an existing-but-unverified account. Emails *do* arrive in prod; the missing piece was self-service resend.

### Changes
- **`auth.remote`**: `resendVerificationEmailForm` → `POST /api/auth/send-verification-email`. Endpoint + body (`{ email, callbackURL? }`) verified against the installed `better-auth@1.4.11` rather than memory (a wrong path would 404 silently). Origin forwarded for BetterAuth's `trustedOrigins` check (same as register/login). Returns a **neutral success message** regardless of outcome — no account enumeration.
- **`/verify-email`**: a prefilled, editable resend form on **both** the `pending` (post-registration) and `error` (expired/invalid link) states; the dead `/register` link is replaced with a Sign-in link.
- **`register`**: stashes the email in a short-lived **httpOnly** cookie (`COOKIES.PENDING_VERIFICATION_EMAIL`, same cross-subdomain config as the session, 30 min) so the resend form prefills **without leaking the address into the URL/referer**.
- **Login-403 path needs no change** — `auth-config` already sets `emailVerification.sendOnSignIn: true`, so BetterAuth auto-resends when an unverified user signs in; the existing "we've sent a new link" message is accurate.

### Verification
- `tsc --noEmit` clean; biome clean; Svelte autofixer clean; web unit suite **861** green (+1 export test).
- Post-merge/deploy (live): register → `/verify-email` shows the resend form prefilled; clicking "Resend" sends a new email and shows the neutral confirmation; the expired-link state also offers resend.

### Out of scope (ops)
The bead's "provision a pre-verified prod test creator" half is a manual ops step (so Connect/transcoding can be live-tested) — left tracked on `Codex-fc5oh.3`, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)