### PR TITLE
fix(content-api): record transcoding-trigger failures instead of swallowing them (WP-5)

### DIFF
--- a/packages/content/src/services/__tests__/media-service.test.ts
+++ b/packages/content/src/services/__tests__/media-service.test.ts
@@ -831,4 +831,61 @@ describe('MediaItemService', () => {
       }
     });
   });
+
+  describe('recordTranscodingTriggerFailure', () => {
+    const makeMedia = () =>
+      service.create(
+        {
+          title: 'Trigger failure media',
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          r2Key: getOriginalKey(creatorId, crypto.randomUUID(), 'tf.mp4'),
+          fileSizeBytes: 1024,
+        },
+        creatorId
+      );
+
+    it('persists the error WITHOUT changing status so re-trigger still works', async () => {
+      const created = await makeMedia();
+
+      await service.recordTranscodingTriggerFailure(
+        created.id,
+        creatorId,
+        'media-api returned 503'
+      );
+
+      const after = await service.get(created.id, creatorId);
+      expect(after?.transcodingError).toBe('media-api returned 503');
+      // Status stays 'uploaded'/'uploading' (not flipped to 'failed') so the
+      // idempotent /upload-complete re-POST remains a valid recovery path.
+      expect(after?.status).toBe('uploading');
+    });
+
+    it('truncates the error message to the 2KB column limit', async () => {
+      const created = await makeMedia();
+
+      await service.recordTranscodingTriggerFailure(
+        created.id,
+        creatorId,
+        'x'.repeat(5000)
+      );
+
+      const after = await service.get(created.id, creatorId);
+      expect(after?.transcodingError?.length).toBe(2000);
+    });
+
+    it('is creator-scoped — never touches another creator’s media', async () => {
+      const created = await makeMedia();
+
+      // Wrong creator → matches no rows → silent no-op (no throw, no write).
+      await service.recordTranscodingTriggerFailure(
+        created.id,
+        otherCreatorId,
+        'should not be written'
+      );
+
+      const after = await service.get(created.id, creatorId);
+      expect(after?.transcodingError).toBeNull();
+    });
+  });
 });

--- a/packages/content/src/services/media-service.ts
+++ b/packages/content/src/services/media-service.ts
@@ -582,4 +582,38 @@ export class MediaItemService extends BaseService {
       creatorId
     );
   }
+
+  /**
+   * Record that triggering transcoding failed.
+   *
+   * The upload-complete handler dispatches the media-api transcode call in the
+   * background (waitUntil) and returns immediately, so a dispatch failure
+   * (media-api unreachable, HMAC rejected, RunPod endpoint dead) would
+   * otherwise be invisible — the media row sits in 'uploaded' forever with no
+   * signal. Persisting the error makes it diagnosable: the transcoding-status
+   * endpoint surfaces `transcodingError`, and the row stays in 'uploaded' so
+   * re-POSTing /upload-complete re-dispatches (the existing idempotent recovery
+   * path). On a successful (re)trigger the transcoding service flips status →
+   * 'transcoding' and clears this field.
+   *
+   * Deliberately a single scoped UPDATE (no transaction) so it can run on a
+   * stateless HTTP db client created inside `waitUntil`, after the request's
+   * own db lifecycle has ended.
+   */
+  async recordTranscodingTriggerFailure(
+    id: string,
+    creatorId: string,
+    error: string
+  ): Promise<void> {
+    await this.db
+      .update(mediaItems)
+      .set({
+        // Cap at the column limit (2KB) to prevent oversized error payloads.
+        transcodingError: error.slice(0, 2000),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(mediaItems.id, id), scopedNotDeleted(mediaItems, creatorId))
+      );
+  }
 }

--- a/workers/content-api/src/routes/media.ts
+++ b/workers/content-api/src/routes/media.ts
@@ -26,10 +26,12 @@ import type {
 } from '@codex/content';
 import {
   createMediaItemSchema,
+  MediaItemService,
   MediaNotFoundError,
   mediaQuerySchema,
   updateMediaItemSchema,
 } from '@codex/content';
+import { createDbClient } from '@codex/database';
 import { workerFetch } from '@codex/security';
 import { ConflictError, InternalServiceError } from '@codex/service-errors';
 import type { HonoEnv } from '@codex/shared-types';
@@ -42,6 +44,35 @@ import {
 import { Hono } from 'hono';
 
 const app = new Hono<HonoEnv>();
+
+/**
+ * Persist a transcoding-dispatch failure so it's diagnosable + recoverable.
+ *
+ * Runs inside `waitUntil`, after the request's own db lifecycle has ended, so
+ * it builds a fresh stateless HTTP db client (same pattern as the cache-bump
+ * helpers in content.ts). Never throws — failing to record a failure must not
+ * crash the background task; it's logged instead.
+ */
+async function recordTranscodingTriggerFailure(
+  env: HonoEnv['Bindings'],
+  mediaId: string,
+  creatorId: string,
+  reason: string,
+  obs?: { error: (message: string, metadata?: Record<string, unknown>) => void }
+): Promise<void> {
+  try {
+    const media = new MediaItemService({
+      db: createDbClient(env),
+      environment: env.ENVIRONMENT,
+    });
+    await media.recordTranscodingTriggerFailure(mediaId, creatorId, reason);
+  } catch (error) {
+    obs?.error('Failed to persist transcoding-trigger failure', {
+      mediaId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 /**
  * POST /api/media
@@ -282,13 +313,29 @@ app.post(
               statusCode: response.status,
               error: errorText,
             });
+            await recordTranscodingTriggerFailure(
+              ctx.env,
+              mediaId,
+              creatorId,
+              `Transcoding dispatch returned ${response.status}: ${errorText}`,
+              ctx.obs
+            );
           }
         })
-        .catch((error) => {
+        .catch(async (error) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
           ctx.obs?.error('Transcoding trigger failed', {
             mediaId,
-            error: error instanceof Error ? error.message : String(error),
+            error: message,
           });
+          await recordTranscodingTriggerFailure(
+            ctx.env,
+            mediaId,
+            creatorId,
+            `Transcoding dispatch failed: ${message}`,
+            ctx.obs
+          );
         });
 
       ctx.executionCtx.waitUntil(triggerPromise);


### PR DESCRIPTION
## WP-5 (Codex-fc5oh.7) — un-silence transcoding-trigger failures

### The silent failure
`POST /api/media/:id/upload-complete` dispatches the media-api transcode call via `waitUntil` and returned `transcodingTriggered: true` **unconditionally** — both the `!response.ok` and `.catch` branches only logged. So a dispatch failure (media-api unreachable, HMAC rejected, RunPod endpoint dead — cf. WP-13) left the media row stuck in `uploaded` forever with **no end-to-end signal**: invisible in prod, unrecoverable except by chance.

### Fix (no migration — `transcoding_error` already exists)
- **`MediaItemService.recordTranscodingTriggerFailure(id, creatorId, error)`**: a single creator-scoped `UPDATE` (deliberately *not* a transaction, so it runs on a fresh stateless HTTP db client created inside `waitUntil`, after the request's own db lifecycle has ended). Persists `transcodingError` (capped at the 2KB column limit).
- **Status intentionally stays `uploaded`** rather than flipping to `failed`:
  - **Diagnosable** — the transcoding-status endpoint already returns `transcodingError`.
  - **Distinguishable** — success transitions `uploaded → transcoding`; a dispatch failure is `uploaded` + non-null `transcodingError`.
  - **Recoverable** — the existing idempotent `upload-complete` re-POST (allowed from `uploaded`) re-dispatches; a successful (re)trigger flips → `transcoding` and clears the field.
- **`media.ts`**: both dispatch-failure branches now persist the error via a fresh `MediaItemService` (`createDbClient`), mirroring the cache-bump `waitUntil` pattern in `content.ts`. Recording never throws (logs on its own failure).

### Verification
- 3 proof tests: persist-without-status-change, 2KB truncation, creator-scoping no-op.
- Ran locally against the real Neon proxy: full `@codex/content` suite **154 green**; `tsc --noEmit` + biome clean on content-api and the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)