### PR TITLE
fix(runpod): unblock transcoder CI/CD — flake8 dead-code in resilient-decode test

### DIFF
--- a/infrastructure/runpod/tests/integration/test_resilient_decode.py
+++ b/infrastructure/runpod/tests/integration/test_resilient_decode.py
@@ -17,11 +17,8 @@ Fixtures are checked in at tests/fixtures/ — see tests/fixtures/README.md.
 
 from __future__ import annotations
 
-import os
 import shutil
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -245,8 +242,6 @@ class TestPermanentFailures:
 
         # Override create_mezzanine to produce an empty file — simulates
         # the "ffmpeg exited 0 but something went wrong" scenario.
-        original_create = handler_module.create_mezzanine
-
         def broken_create_mezzanine(
             input_path: str, output_path: str, use_gpu: bool
         ) -> None:


### PR DESCRIPTION
## What
Removes 4 flake8 violations in `infrastructure/runpod/tests/integration/test_resilient_decode.py` (unused `os`/`subprocess`/`tempfile` imports + unused `original_create` var).

## Why this matters (prod-readiness WP-13)
The **RunPod Transcoder CI/CD** (`runpod-ci.yml`) quality gate has failed on these violations **since March**, so its `deploy` job (which `needs` the gate) never ran — freezing the prod transcoder image at `sha-8b51b8b8` (2026-03-27).

That stale image emits audio `readyVariants: ["128k","64k"]`, but the current `hlsVariantSchema` only accepts `"audio"` → media-api rejects the completion webhook payload (ValidationError) and returns 200-to-stop-retries → **media never reaches `ready`** even though the RunPod job succeeds. The current handler already emits `["audio"]` (`main.py:783`).

Clearing this gate lets CI build + deploy the current handler image (via `update_runpod_endpoint.py`, which preserves the env mappings). Combined with the live RunPod secret/template fixes (Codex-fc5oh.13/.15) and the now-corrected production GitHub secrets, this is the last blocker to end-to-end transcoding in prod.

Note: `runpod-ci.yml` only triggers on `main`, so the deploy fires after this reaches main via the normal dev→main promotion (production environment approval still gates the deploy job).

Refs Codex-fc5oh.13, Codex-fc5oh.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)