### PR TITLE
fix(web): Codex-xjdz7 allow R2 host in CSP connect-src (prod upload blocker)

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -40,10 +40,15 @@ const config = {
     // already covered by `font-src 'https://fonts.gstatic.com'`. Other
     // external stylesheet origins remain disallowed.
     //
-    // `connect-src` is `self` in production because all worker traffic is
-    // server-to-server (apps/web -> workers via createServerApi). The
-    // browser only ever fetches from its own origin (SvelteKit endpoints,
-    // remote functions, /__data.json).
+    // `connect-src`: worker API traffic is server-to-server (apps/web ->
+    // workers via createServerApi), so those calls never reach the browser's
+    // connect-src at all. The browser DOES make one cross-origin fetch
+    // directly, though: media upload PUTs the file straight to the presigned
+    // R2 URL (https://<account>.r2.cloudflarestorage.com). Browser fetch/XHR
+    // is governed by connect-src, so the R2 host MUST be allow-listed here —
+    // mirroring the R2 origins already trusted on img-src / media-src. It was
+    // previously omitted, which silently blocked all direct-to-R2 uploads in
+    // production (Codex-xjdz7).
     //
     // The dev-only `localhost:4100` / `*.nip.io:4100` entries on
     // `connect-src` cover the AudioPlayer's `fetch(waveform.json)` sidecar.
@@ -169,6 +174,11 @@ const config = {
         'font-src': ['self', 'data:', 'https://fonts.gstatic.com'],
         'connect-src': [
           'self',
+          // Direct-to-R2 media upload: the browser PUTs the file straight to
+          // the presigned R2 URL. Governed by connect-src (not media-src).
+          // Mirrors the R2 origins already trusted on img-src / media-src.
+          'https://*.r2.cloudflarestorage.com',
+          'https://*.r2.dev',
           // Dev-only — AudioPlayer fetches waveform.json from dev-cdn.
           // See header comment above on `connect-src`. Inert in production.
           'http://localhost:4100',


### PR DESCRIPTION
## Summary
Production media upload is broken for **all creators**: the web-app CSP `connect-src` omits the R2 host, so the browser's direct `PUT` to the presigned R2 URL is blocked.

Discovered while verifying **Codex-bpjg5** (single-file HLS) in prod — the CSP block prevented uploading a test asset.

## Root cause
`apps/web/svelte.config.js` → `kit.csp.directives['connect-src']` was `['self', http://localhost:4100, http://*.nip.io:4100]` (dev hosts inert in prod). Media upload PUTs the file straight to `https://<account>.r2.cloudflarestorage.com`; browser `fetch`/XHR is governed by `connect-src`, which lacked the R2 host.

- Console: `Refused to connect … violates … "connect-src 'self' http://localhost:4100 http://*.nip.io:4100"`
- Network: two `PUT …r2.cloudflarestorage.com` → `[FAILED] csp`
- `img-src` and `media-src` **already** trust `https://*.r2.cloudflarestorage.com` — `connect-src` was simply missed.

### Secondary (follow-up, not in this PR)
After the PUT is CSP-blocked, the client still POSTs `/api/media/{id}/upload` → 200, so the row is marked `UPLOADED` with **no object in R2** and never transcodes. The upload-complete callback should gate on the PUT succeeding. Tracked in Codex-xjdz7 notes.

## Fix
Add `https://*.r2.cloudflarestorage.com` (+ `https://*.r2.dev` for parity) to `connect-src`, mirroring `img-src`/`media-src`, and correct the rationale comment that wrongly claimed the browser never makes a cross-origin fetch.

## Testing
- `csp-svelte-hash.test.ts` — 3/3 pass (config parses; script-src hash guard unaffected).
- Full acceptance (real prod upload → single-file transcode → stream/seek past the 4-min CPU cliff) will run after this deploys, closing both Codex-xjdz7 and Codex-bpjg5.

## Deploy note
Targeted at `main` (clean off main; prod deploy is manual `workflow_dispatch`). Bypasses the usual dev→main route intentionally for a launch-blocker hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)