### PR TITLE
fix(web): Codex-v2xwb allow platform worker+CDN hosts in CSP (prod playback + thumbnails blocker)

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -161,6 +161,12 @@ const config = {
           'self',
           'data:',
           'blob:',
+          // Platform CDN — thumbnails / avatars / org logos are served from
+          // cdn-assets.revelations.studio & cdn-platform.revelations.studio
+          // (worker/CDN custom domains). 'self' does not cover sibling
+          // subdomains, so the platform wildcard is required.
+          'https://*.revelations.studio',
+          'https://*.dev.revelations.studio',
           'https://*.r2.cloudflarestorage.com',
           'https://*.r2.dev',
           // Dev-only origins — dev-cdn (Miniflare R2) serves all media in
@@ -174,6 +180,13 @@ const config = {
         'font-src': ['self', 'data:', 'https://fonts.gstatic.com'],
         'connect-src': [
           'self',
+          // Platform workers/CDN — hls.js fetch()es HLS master + variant
+          // playlists from content-api.revelations.studio (WP-14 token-in-URL
+          // proxy), and the AudioPlayer fetches the waveform.json sidecar.
+          // Browser fetch/XHR is governed by connect-src; 'self' excludes
+          // sibling subdomains.
+          'https://*.revelations.studio',
+          'https://*.dev.revelations.studio',
           // Direct-to-R2 media upload: the browser PUTs the file straight to
           // the presigned R2 URL. Governed by connect-src (not media-src).
           // Mirrors the R2 origins already trusted on img-src / media-src.
@@ -187,6 +200,12 @@ const config = {
         'media-src': [
           'self',
           'blob:',
+          // Platform HLS proxy — native <video>/<audio> load master.m3u8 +
+          // variant playlists from content-api.revelations.studio (WP-14
+          // token-in-URL proxy). Segments themselves are presigned R2 URLs
+          // (the *.r2 origins below).
+          'https://*.revelations.studio',
+          'https://*.dev.revelations.studio',
           'https://*.r2.cloudflarestorage.com',
           'https://*.r2.dev',
           // Dev-only — HLS playback (master.m3u8 + segments) served from


### PR DESCRIPTION
## Summary
In production, **all HLS video/audio playback and all thumbnails are CSP-blocked**. The web-app CSP was written for an older architecture (media straight from R2) and never updated for the current worker-proxy + CDN custom-domain architecture.

Discovered while verifying **Codex-bpjg5** (single-file HLS) streaming in prod. Sibling to **Codex-xjdz7** (which fixed the R2 *upload* host in `connect-src`).

## Root cause
Media/images are served from `*.revelations.studio` sibling subdomains, which CSP `'self'` does not cover:
- **`media-src`** blocked the HLS master/variant playlist load from `https://content-api.revelations.studio/api/access/content/{id}/hls/master.m3u8?token=…` (WP-14 token-in-URL proxy) — native `<video>` playback.
- **`connect-src`** blocked hls.js `fetch()` of those playlists (+ the AudioPlayer `waveform.json` sidecar).
- **`img-src`** blocked thumbnails/avatars from `https://cdn-assets.revelations.studio/…`.

Observed live on the studio content edit media-preview: two CSP violations (`media-src` + `img-src`) for content `5be442dc` / media `17e1cad2`.

## Fix
Add `https://*.revelations.studio` (+ `https://*.dev.revelations.studio` for the deployed dev branch) to `img-src`, `media-src`, and `connect-src` — mirroring the pattern `form-action` already uses. Segments remain covered by the existing `*.r2.cloudflarestorage.com` entries.

## Testing
- `csp-svelte-hash.test.ts` — 3/3 pass (config parses; script-src hash guard unaffected).
- Biome clean.
- End-to-end prod playback verification (HLS loads with no CSP violation, seek past the 4-min CPU cliff, no 5xx) will run after this deploys — closing **Codex-v2xwb** and **Codex-bpjg5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)