### PR TITLE
fix(access): Codex-eys81 lazy Stripe so HLS streaming works without content-api Stripe key (prod 500 blocker)

### DIFF
--- a/packages/access/src/services/ContentAccessService.ts
+++ b/packages/access/src/services/ContentAccessService.ts
@@ -24,7 +24,11 @@ import {
   subscriptionTiers,
   videoPlayback,
 } from '@codex/database/schema';
-import { createStripeClient, PurchaseService } from '@codex/purchase';
+import {
+  createLazyStripeClient,
+  createStripeClient,
+  PurchaseService,
+} from '@codex/purchase';
 import {
   BaseService,
   ForbiddenError,
@@ -2358,9 +2362,18 @@ export function createContentAccessService(env: ContentAccessEnv): {
   // Create per-request database client with WebSocket support for transactions
   const { db, cleanup } = createPerRequestDbClient(env);
 
-  // Create Stripe client and PurchaseService
+  // Create Stripe client and PurchaseService.
+  //
+  // The streaming access path only calls PurchaseService.verifyPurchase (a DB
+  // read) and never touches the Stripe API. content-api is intentionally NOT
+  // provisioned with a STRIPE_SECRET_KEY (Stripe secrets are ecom-api only),
+  // so when the key is absent we build a lazy client that constructs freely
+  // but throws only if a Stripe call is ever attempted — otherwise every
+  // stream request would 500 with "Stripe API key is required" (Codex-eys81).
   const environment = env.ENVIRONMENT ?? 'development';
-  const stripe = createStripeClient(env.STRIPE_SECRET_KEY || '');
+  const stripe = env.STRIPE_SECRET_KEY
+    ? createStripeClient(env.STRIPE_SECRET_KEY)
+    : createLazyStripeClient();
   const purchaseService = new PurchaseService({ db, environment }, stripe);
   const revocation = env.CACHE_KV
     ? new AccessRevocation(env.CACHE_KV)

--- a/packages/purchase/src/__tests__/stripe-client.test.ts
+++ b/packages/purchase/src/__tests__/stripe-client.test.ts
@@ -1,0 +1,46 @@
+/**
+ * stripe-client — unit tests.
+ *
+ * Focus: createLazyStripeClient (Codex-eys81). The @codex/access streaming
+ * factory constructs a PurchaseService purely for its DB-backed verifyPurchase
+ * method and must NOT require a Stripe key (content-api is not provisioned with
+ * one). The lazy client must construct freely but fail loudly the moment a real
+ * Stripe operation is attempted.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createLazyStripeClient, createStripeClient } from '../stripe-client';
+
+describe('createStripeClient', () => {
+  it('throws immediately when the API key is empty', () => {
+    expect(() => createStripeClient('')).toThrow('Stripe API key is required');
+  });
+
+  it('constructs a real client when given a key', () => {
+    const client = createStripeClient('sk_test_dummy');
+    expect(client).toBeDefined();
+    expect(typeof client.checkout).toBe('object');
+  });
+});
+
+describe('createLazyStripeClient', () => {
+  it('constructs without throwing (no key needed)', () => {
+    expect(() => createLazyStripeClient()).not.toThrow();
+  });
+
+  it('can be stored/passed around without triggering the failure', () => {
+    const stripe = createLazyStripeClient();
+    // Mirrors PurchaseService constructor: `this.stripe = stripe` — a plain
+    // reference assignment must not trip the proxy.
+    const holder: { stripe: unknown } = { stripe };
+    expect(holder.stripe).toBe(stripe);
+  });
+
+  it('throws with a clear message the moment any Stripe API is accessed', () => {
+    const stripe = createLazyStripeClient();
+    expect(() => stripe.checkout).toThrow('Stripe API key is required');
+    // Message names the accessed path to aid debugging.
+    expect(() => stripe.checkout).toThrow(/attempted to use stripe\.checkout/);
+    expect(() => stripe.transfers).toThrow('Stripe API key is required');
+  });
+});

--- a/packages/purchase/src/index.ts
+++ b/packages/purchase/src/index.ts
@@ -106,7 +106,11 @@ export {
   type UserCustomerMatch,
 } from './services/stripe-customer-integrity';
 // Stripe client factory
-export { createStripeClient, verifyWebhookSignature } from './stripe-client';
+export {
+  createLazyStripeClient,
+  createStripeClient,
+  verifyWebhookSignature,
+} from './stripe-client';
 // Types
 export type {
   CheckoutSessionResult,

--- a/packages/purchase/src/stripe-client.ts
+++ b/packages/purchase/src/stripe-client.ts
@@ -57,6 +57,34 @@ export function createStripeClient(apiKey: string): Stripe {
 }
 
 /**
+ * Create a lazily-failing Stripe client for contexts that hold a
+ * `PurchaseService` only for its DB-backed methods (e.g. `@codex/access`
+ * `verifyPurchase`) and never call the Stripe API.
+ *
+ * content-api is intentionally NOT provisioned with a `STRIPE_SECRET_KEY`
+ * (see `.github/scripts/upload-worker-secrets.sh` — Stripe secrets are
+ * ecom-api only). Eagerly constructing a real client there throws
+ * "Stripe API key is required" and 500s every streaming request, even for
+ * free content whose access check is purely a DB read.
+ *
+ * This returns a `Stripe`-typed proxy that constructs freely (so
+ * `new PurchaseService(config, stripe)` and `verifyPurchase()` work) but
+ * throws the moment ANY Stripe operation is actually attempted — a genuine
+ * misuse still fails loudly, just at call time instead of construction time.
+ *
+ * @returns A Stripe-typed proxy that throws on any property access
+ */
+export function createLazyStripeClient(): Stripe {
+  return new Proxy(Object.create(null) as Stripe, {
+    get(_target, prop) {
+      throw new Error(
+        `Stripe API key is required (attempted to use stripe.${String(prop)})`
+      );
+    },
+  });
+}
+
+/**
  * Verify Stripe webhook signature and construct event
  *
  * Validates webhook authenticity using HMAC-SHA256 signature verification.


### PR DESCRIPTION
## Summary
Every HLS/audio stream in production 500s with `{"code":"INTERNAL_ERROR","message":"Stripe API key is required"}` — including **free** content. Discovered while verifying **Codex-bpjg5** streaming in prod (after the CSP fixes Codex-xjdz7 + Codex-v2xwb unblocked the request).

## Root cause
The HLS access proxy runs on **content-api**. Its access factory `createContentAccessService` eagerly ran `createStripeClient(env.STRIPE_SECRET_KEY || '')` to build `PurchaseService`. But content-api is **intentionally not provisioned** with `STRIPE_SECRET_KEY` (`upload-worker-secrets.sh`: Stripe secrets are ecom-api only), so `createStripeClient('')` threw at `stripe-client.ts:51` → 500 on every stream.

The streaming path only calls `PurchaseService.verifyPurchase` (a **DB read**); it never touches the Stripe API. `PurchaseService`'s constructor just stores `this.stripe`, and `verifyPurchase` never reads it.

## Fix
- Add `createLazyStripeClient()` — a `Stripe`-typed `Proxy` that constructs freely but throws `Stripe API key is required` only when a Stripe operation is **actually accessed**.
- The access factory uses it when `STRIPE_SECRET_KEY` is absent; otherwise the real client. So DB-only/free access checks succeed, and genuine misuse still fails loudly (at call time).
- `createStripeClient` keeps its strict eager-throw behaviour — **payment paths (ecom-api) unchanged**.

## Testing
- New `packages/purchase/src/__tests__/stripe-client.test.ts` — 5/5: strict client still throws on empty key; lazy client constructs, can be stored/passed, and throws with a clear message on any Stripe access.
- `@codex/purchase` + `@codex/access` typecheck clean; biome clean on changed files.
- Full prod stream verification (master + variant playlist → 200, no 500, no CPU 5xx, seek) runs after deploy — closing Codex-eys81 and Codex-bpjg5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)