### PR TITLE
fix(infra): Codex-fc5oh.16 correct R2 media-bucket CORS origins for HLS streaming

### DIFF
--- a/infrastructure/wrangler/R2/cors-config-production.json
+++ b/infrastructure/wrangler/R2/cors-config-production.json
@@ -1,11 +1,22 @@
-[
-  {
-    "AllowedOrigins": [
-      "https://codex-3x3.pages.dev// this is currently just a copy and does not update as we go. we will have to integrate this into our CI/CD TODO:: integrate cors policy push for CI CD. will have to set up a bucket for testing also... PUT https://api.cloudflare.com/client/v4/accounts/abc123/r2/buckets/my-bucket/corsAuthorization: Bearer YOUR_TOKENContent-Type: application/json so on merge to main ensure file is as such on preview build ensure we",
-      "https://revelations.studio"
-    ],
-    "AllowedMethods": ["GET", "HEAD", "PUT"],
-    "AllowedHeaders": ["*"],
-    "MaxAgeSeconds": 3600
-  }
-]
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://*.revelations.studio",
+          "https://revelations.studio"
+        ],
+        "methods": ["GET", "HEAD", "PUT"],
+        "headers": ["*"]
+      },
+      "exposeHeaders": [
+        "Content-Range",
+        "Content-Length",
+        "Accept-Ranges",
+        "ETag",
+        "Content-Type"
+      ],
+      "maxAgeSeconds": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
Prod HLS playback failed for **all** content even after the CSP + lazy-Stripe fixes landed. Root cause was **not** CPU or CSP — it was the `codex-media-production` R2 bucket's CORS policy having **stale AllowedOrigins**: the obsolete `codex-3x3.pages.dev` Pages URL + **apex-only** `revelations.studio`.

CORS origin matching is exact, so the apex never matched the `creators.revelations.studio` / `{org}.revelations.studio` subdomains where streaming happens. HLS.js byte-range segment `GET`s carry a `Range` header → CORS preflight → R2 answered `403` with no `Access-Control-*` headers → the browser blocked every segment (`net::ERR_FAILED`), even though `master.m3u8` + variant playlists returned `200` and the presigned URLs were valid server-side (`curl` → `206`). Direct-to-R2 browser **upload** (`PUT`) was blocked for the same reason.

## Fix
Rewrite `infrastructure/wrangler/R2/cors-config-production.json` into the wrangler CORS **API `rules` shape** and:
- Scope origins to the `https://*.revelations.studio` **subdomain wildcard** (empirically, R2 honors it and reflects the concrete origin) + apex.
- `GET`, `HEAD`, `PUT`.
- Add `ExposeHeaders` for byte-range media: `Content-Range, Content-Length, Accept-Ranges, ETag, Content-Type`.

## Applied + verified in prod
Pushed via `wrangler r2 bucket cors set codex-media-production --file ...` and verified against prod content `5be442dc` (single-file HLS, 10 min):
- OPTIONS preflight → `204`, `Access-Control-Allow-Origin: https://creators.revelations.studio`, methods `GET, HEAD, PUT`.
- `GET` + `Range` → `206`, `Content-Range: …/76048256`, expose headers present.
- In-browser: HLS.js segments `206`, decode `1280×720`, seek to 8:00 renders burnt-in timecode `00:08:12.750`, 0 console errors.

This unblocked the **Codex-bpjg5** streaming acceptance (now closed) and covers the direct-upload CORS gap noted on **Codex-xjdz7**.

## Remaining (tracked in Codex-fc5oh.16)
- Integrate the CORS-policy push into CI/CD (main→prod) — this apply was a manual out-of-band `wrangler` command.
- Add a `codex-media-test` preview-bucket CORS policy so prod/preview don't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)