### PR TITLE
Promote dev → main: Codex-fc5oh.16 R2 media-bucket CORS origins fix

### DIFF
--- a/infrastructure/wrangler/R2/cors-config-production.json
+++ b/infrastructure/wrangler/R2/cors-config-production.json
@@ -1,11 +1,22 @@
-[
-  {
-    "AllowedOrigins": [
-      "https://codex-3x3.pages.dev// this is currently just a copy and does not update as we go. we will have to integrate this into our CI/CD TODO:: integrate cors policy push for CI CD. will have to set up a bucket for testing also... PUT https://api.cloudflare.com/client/v4/accounts/abc123/r2/buckets/my-bucket/corsAuthorization: Bearer YOUR_TOKENContent-Type: application/json so on merge to main ensure file is as such on preview build ensure we",
-      "https://revelations.studio"
-    ],
-    "AllowedMethods": ["GET", "HEAD", "PUT"],
-    "AllowedHeaders": ["*"],
-    "MaxAgeSeconds": 3600
-  }
-]
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://*.revelations.studio",
+          "https://revelations.studio"
+        ],
+        "methods": ["GET", "HEAD", "PUT"],
+        "headers": ["*"]
+      },
+      "exposeHeaders": [
+        "Content-Range",
+        "Content-Length",
+        "Accept-Ranges",
+        "ETag",
+        "Content-Type"
+      ],
+      "maxAgeSeconds": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Promotes `dev` → `main`. Contents: exactly one commit (+ its merge), **Codex-fc5oh.16** — corrects the `codex-media-production` R2 CORS `AllowedOrigins` (stale apex/pages.dev → `https://*.revelations.studio` wildcard) so browser HLS byte-range segment fetches and direct-to-R2 uploads work cross-origin.

- Already applied to the prod bucket out-of-band + verified end-to-end (preflight 204, GET+Range 206, in-browser hls.js playback + seek).
- This PR just codifies the config in-repo (drift prevention).
- Diff scope: `infrastructure/wrangler/R2/cors-config-production.json` only.
- CI: authoritative pull_request run on #334 was green (static-analysis, Neon `test (20)`, all API + E2E API tests).

Follow-up (stays open on Codex-fc5oh.16): wire the CORS push into CI/CD + add a `codex-media-test` preview-bucket policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)