### PR TITLE
ci(deploy): Codex-fc5oh.16 apply R2 media-bucket CORS on every deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -185,6 +185,28 @@ jobs:
           DATABASE_URL: ${{ steps.neon.outputs.DATABASE_URL }}
           DB_METHOD: ${{ vars.DB_METHOD }}
 
+      # Apply the R2 media-bucket CORS policy for the dev environment so browser
+      # HLS byte-range segment fetches + direct-to-R2 uploads work cross-origin
+      # from *.dev.revelations.studio. Mirror of the production step
+      # (Codex-fc5oh.16); uses dev origins. continue-on-error so a CORS-push
+      # failure (e.g. token missing R2 edit) never breaks the dev deploy.
+      - name: Configure R2 media bucket CORS
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUCKET: ${{ vars.R2_BUCKET_MEDIA }}
+        run: |
+          echo "🔧 Applying dev CORS policy to R2 bucket '$BUCKET'..."
+          if npx wrangler r2 bucket cors set "$BUCKET" \
+               --file infrastructure/wrangler/R2/cors-config-dev.json -y; then
+            echo "✅ R2 CORS policy applied to $BUCKET"
+            npx wrangler r2 bucket cors list "$BUCKET" || true
+          else
+            echo "::error title=R2 CORS not applied::Could not set CORS on '$BUCKET'. The CLOUDFLARE_API_TOKEN likely needs 'Workers R2 Storage: Edit'. Dev HLS streaming + direct-to-R2 uploads will break cross-origin until fixed (Codex-fc5oh.16)."
+            exit 1
+          fi
+
       # --- WORKER DEPLOYMENTS ---
 
       - name: Deploy media-api

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,6 +72,32 @@ jobs:
 
           echo "✅ Production DNS verified"
 
+      # Apply the R2 media-bucket CORS policy so browser HLS byte-range segment
+      # fetches AND direct-to-R2 uploads work cross-origin from
+      # *.revelations.studio. Codifies Codex-fc5oh.16: the policy previously
+      # drifted (stale apex/pages.dev origins) because it was only ever set by
+      # hand, which silently broke streaming for all long content in prod.
+      # continue-on-error: a CORS-push failure must NEVER break the app deploy —
+      # if CLOUDFLARE_API_TOKEN lacks "Workers R2 Storage: Edit" we surface a
+      # loud ::error:: annotation instead. Remove continue-on-error once the
+      # token is confirmed to carry R2 edit scope.
+      - name: Configure R2 media bucket CORS
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUCKET: ${{ vars.R2_BUCKET_MEDIA }}
+        run: |
+          echo "🔧 Applying CORS policy to R2 bucket '$BUCKET'..."
+          if npx wrangler r2 bucket cors set "$BUCKET" \
+               --file infrastructure/wrangler/R2/cors-config-production.json -y; then
+            echo "✅ R2 CORS policy applied to $BUCKET"
+            npx wrangler r2 bucket cors list "$BUCKET" || true
+          else
+            echo "::error title=R2 CORS not applied::Could not set CORS on '$BUCKET'. The CLOUDFLARE_API_TOKEN likely needs 'Workers R2 Storage: Edit'. HLS streaming + direct-to-R2 uploads will break cross-origin until fixed (Codex-fc5oh.16)."
+            exit 1
+          fi
+
       # Build all workers BEFORE touching database
       - name: Build all workers with Turborepo
         run: |

--- a/infrastructure/wrangler/R2/cors-config-dev.json
+++ b/infrastructure/wrangler/R2/cors-config-dev.json
@@ -1,0 +1,22 @@
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://*.dev.revelations.studio",
+          "https://dev.revelations.studio"
+        ],
+        "methods": ["GET", "HEAD", "PUT"],
+        "headers": ["*"]
+      },
+      "exposeHeaders": [
+        "Content-Range",
+        "Content-Length",
+        "Accept-Ranges",
+        "ETag",
+        "Content-Type"
+      ],
+      "maxAgeSeconds": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## Why
Follow-up to the R2 CORS origin fix (Codex-fc5oh.16). That policy was only ever set by hand, so it silently drifted to stale origins (apex/`pages.dev`) and broke cross-origin HLS segment fetches + direct-to-R2 uploads for **all** prod content until fixed manually. This codifies the push so it can't drift again.

## What
- **`deploy-production.yml`**: new "Configure R2 media bucket CORS" step (after DNS verify) — `wrangler r2 bucket cors set $R2_BUCKET_MEDIA --file infrastructure/wrangler/R2/cors-config-production.json`.
- **`deploy-dev.yml`**: same for the dev bucket (after dev migrations) from **new** `cors-config-dev.json` (`*.dev.revelations.studio`).
- Bucket name from env-scoped `vars.R2_BUCKET_MEDIA` (never hardcoded); `--file` selects the per-env origin scope.

## Safety
Both steps use `continue-on-error: true` so a CORS-push failure can **never** break the app deploy. If `CLOUDFLARE_API_TOKEN` lacks `Workers R2 Storage: Edit`, the step surfaces a loud `::error::` annotation instead of silently no-op'ing. Once the token is confirmed to carry R2 edit, `continue-on-error` can be dropped to make it a hard gate.

## Validation
- Both workflow YAMLs parse; CORS step present in each.
- `biome check` clean on both CORS JSON configs (exit 0).
- **Natural test**: merging this to `dev` triggers `deploy-dev`, whose CORS step will prove whether the CI token has R2 edit scope — before this ever reaches prod.

Closes the CI/CD remainder of Codex-fc5oh.16 (preview-bucket note: local dev streams via dev-cdn/Miniflare, not the real `codex-media-test` bucket, so no real-bucket CORS is needed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)