### PR TITLE
Promote dev → main: Codex-fc5oh.16 R2 CORS auto-apply in deploy pipelines

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -185,6 +185,28 @@ jobs:
           DATABASE_URL: ${{ steps.neon.outputs.DATABASE_URL }}
           DB_METHOD: ${{ vars.DB_METHOD }}
 
+      # Apply the R2 media-bucket CORS policy for the dev environment so browser
+      # HLS byte-range segment fetches + direct-to-R2 uploads work cross-origin
+      # from *.dev.revelations.studio. Mirror of the production step
+      # (Codex-fc5oh.16); uses dev origins. continue-on-error so a CORS-push
+      # failure (e.g. token missing R2 edit) never breaks the dev deploy.
+      - name: Configure R2 media bucket CORS
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUCKET: ${{ vars.R2_BUCKET_MEDIA }}
+        run: |
+          echo "🔧 Applying dev CORS policy to R2 bucket '$BUCKET'..."
+          if npx wrangler r2 bucket cors set "$BUCKET" \
+               --file infrastructure/wrangler/R2/cors-config-dev.json -y; then
+            echo "✅ R2 CORS policy applied to $BUCKET"
+            npx wrangler r2 bucket cors list "$BUCKET" || true
+          else
+            echo "::error title=R2 CORS not applied::Could not set CORS on '$BUCKET'. The CLOUDFLARE_API_TOKEN likely needs 'Workers R2 Storage: Edit'. Dev HLS streaming + direct-to-R2 uploads will break cross-origin until fixed (Codex-fc5oh.16)."
+            exit 1
+          fi
+
       # --- WORKER DEPLOYMENTS ---
 
       - name: Deploy media-api

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,6 +72,32 @@ jobs:
 
           echo "✅ Production DNS verified"
 
+      # Apply the R2 media-bucket CORS policy so browser HLS byte-range segment
+      # fetches AND direct-to-R2 uploads work cross-origin from
+      # *.revelations.studio. Codifies Codex-fc5oh.16: the policy previously
+      # drifted (stale apex/pages.dev origins) because it was only ever set by
+      # hand, which silently broke streaming for all long content in prod.
+      # continue-on-error: a CORS-push failure must NEVER break the app deploy —
+      # if CLOUDFLARE_API_TOKEN lacks "Workers R2 Storage: Edit" we surface a
+      # loud ::error:: annotation instead. Remove continue-on-error once the
+      # token is confirmed to carry R2 edit scope.
+      - name: Configure R2 media bucket CORS
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUCKET: ${{ vars.R2_BUCKET_MEDIA }}
+        run: |
+          echo "🔧 Applying CORS policy to R2 bucket '$BUCKET'..."
+          if npx wrangler r2 bucket cors set "$BUCKET" \
+               --file infrastructure/wrangler/R2/cors-config-production.json -y; then
+            echo "✅ R2 CORS policy applied to $BUCKET"
+            npx wrangler r2 bucket cors list "$BUCKET" || true
+          else
+            echo "::error title=R2 CORS not applied::Could not set CORS on '$BUCKET'. The CLOUDFLARE_API_TOKEN likely needs 'Workers R2 Storage: Edit'. HLS streaming + direct-to-R2 uploads will break cross-origin until fixed (Codex-fc5oh.16)."
+            exit 1
+          fi
+
       # Build all workers BEFORE touching database
       - name: Build all workers with Turborepo
         run: |

--- a/infrastructure/wrangler/R2/cors-config-dev.json
+++ b/infrastructure/wrangler/R2/cors-config-dev.json
@@ -1,0 +1,22 @@
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://*.dev.revelations.studio",
+          "https://dev.revelations.studio"
+        ],
+        "methods": ["GET", "HEAD", "PUT"],
+        "headers": ["*"]
+      },
+      "exposeHeaders": [
+        "Content-Range",
+        "Content-Length",
+        "Accept-Ranges",
+        "ETag",
+        "Content-Type"
+      ],
+      "maxAgeSeconds": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Promotes `dev` → `main`. Contents: PR #336 only — codifies the R2 media-bucket CORS push into both deploy pipelines so the policy can't silently drift again (the root cause of Codex-fc5oh.16).

**Changes (3 files, +70):**
- `deploy-production.yml`: "Configure R2 media bucket CORS" step (after DNS verify) → `*.revelations.studio` on `$R2_BUCKET_MEDIA`.
- `deploy-dev.yml`: same for the dev bucket → new `cors-config-dev.json` (`*.dev.revelations.studio`).
- Both `continue-on-error` (a CORS-push failure never breaks the app deploy).

**Validated in dev:** the dev deploy ran the new step successfully — `✅ R2 CORS policy applied to codex-media-dev`, origins `*.dev.revelations.studio`. This also **proves the CI `CLOUDFLARE_API_TOKEN` has R2 edit scope**, so the prod step will apply cleanly on the next prod deploy.

CI: #336's authoritative pull_request run was green (static-analysis, Neon `test (20)`, E2E API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)