### PR TITLE
fix(onboarding): avatar HEIC guard + Stripe account-link failure logging

### DIFF
--- a/apps/web/src/lib/remote/avatar-upload.remote.ts
+++ b/apps/web/src/lib/remote/avatar-upload.remote.ts
@@ -5,22 +5,40 @@
  * Validates file type and size before uploading.
  */
 
-import { z } from 'zod';
+import {
+  MAX_IMAGE_SIZE_BYTES,
+  SUPPORTED_IMAGE_MIME_TYPES,
+  z,
+} from '@codex/validation';
 import { form, getRequestEvent } from '$app/server';
 import { createServerApi } from '$lib/server/api';
 import { invalidateCache } from '$lib/server/cache';
 import { getProfile } from './account.remote';
 
+const MAX_IMAGE_SIZE_MB = Math.round(MAX_IMAGE_SIZE_BYTES / 1024 / 1024);
+
 /**
- * Avatar upload schema
+ * Avatar upload schema.
+ *
+ * Mirrors the server's `SUPPORTED_IMAGE_MIME_TYPES` / `MAX_IMAGE_SIZE_BYTES`
+ * (from `@codex/validation`) so the client rejects unsupported files with a
+ * clear, actionable message BEFORE the round-trip. The previous
+ * `type.startsWith('image/')` check let iPhone HEIC/HEIF photos through — the
+ * server then rejected them, surfacing as a confusing "failed upload".
+ *
+ * An empty `file.type` is allowed through: the browser occasionally omits it,
+ * and the server re-validates by magic bytes regardless.
  */
 const avatarUploadSchema = z.object({
   avatar: z
     .instanceof(File)
-    .refine((file) => file.type.startsWith('image/'), 'Must be an image file')
     .refine(
-      (file) => file.size <= 5 * 1024 * 1024,
-      'File must be less than 5MB'
+      (file) => !file.type || SUPPORTED_IMAGE_MIME_TYPES.has(file.type),
+      'Use a JPG, PNG, WebP, or GIF image — HEIC and other formats are not supported.'
+    )
+    .refine(
+      (file) => file.size <= MAX_IMAGE_SIZE_BYTES,
+      `Image must be ${MAX_IMAGE_SIZE_MB}MB or smaller.`
     ),
 });
 

--- a/apps/web/src/routes/(platform)/become-creator/steps/StepProfile.svelte
+++ b/apps/web/src/routes/(platform)/become-creator/steps/StepProfile.svelte
@@ -100,12 +100,14 @@
     </div>
     <form {...avatarUploadForm} class="avatar__form">
       <Label for="avatar">{m.onboarding_profile_avatar_label()}</Label>
+<!-- Explicit types (not image/*) so the OS picker prefers supported
+           formats and iOS transcodes HEIC → JPEG on selection. -->
       <input
         id="avatar"
         class="avatar__input"
         type="file"
         name="avatar"
-        accept="image/*"
+        accept="image/png,image/jpeg,image/webp,image/gif"
       />
       {#if avatarUploadForm.result && !avatarUploadForm.result.success}
         <p class="field__error">{avatarUploadForm.result.error}</p>

--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -808,16 +808,31 @@ export class ConnectAccountService extends BaseService {
     returnUrl: string,
     refreshUrl: string
   ): Promise<string> {
-    const accountLink = await this.stripe.accountLinks.create({
-      account: stripeAccountId,
-      return_url: returnUrl,
-      refresh_url: refreshUrl,
-      type: 'account_onboarding',
-      collection_options: {
-        fields: 'eventually_due',
-      },
-    });
+    try {
+      const accountLink = await this.stripe.accountLinks.create({
+        account: stripeAccountId,
+        return_url: returnUrl,
+        refresh_url: refreshUrl,
+        type: 'account_onboarding',
+        collection_options: {
+          fields: 'eventually_due',
+        },
+      });
 
-    return accountLink.url;
+      return accountLink.url;
+    } catch (error) {
+      // A rejected return_url/refresh_url is the most common failure here and is
+      // only visible at this call site — otherwise it bubbles to a generic 500
+      // with no trace of which URL Stripe refused. Log both URLs (not PII) and
+      // the raw Stripe reason, then rethrow UNCHANGED so the caller's mapping
+      // (ConnectPlatformNotConfiguredError / handleError) still applies.
+      this.obs.error('Stripe account link creation failed', {
+        stripeAccountId,
+        returnUrl,
+        refreshUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Scope

Originally opened as a Connect orphan-safety fix, but `dev` already merged an equivalent (and more complete) hardening in `1f8a0440` — persist-before-link, idempotency key, `onConflictDoNothing`, and a typed `ConnectPlatformNotConfiguredError`. This PR is **rebased onto that** and reduced to the net-new value only:

### Avatar (net-new)
Align the client upload validation + file picker with the server's real supported MIME set (PNG/JPEG/WebP/GIF). iPhone **HEIC/HEIF** photos previously passed the client's `type.startsWith('image/')` check and only 400'd at the server — surfacing as a confusing "failed upload". Now they're rejected early with a clear message, and the picker's `accept` prefers supported formats (prompting iOS to transcode HEIC→JPEG on selection).

### Connect diagnostics (net-new; gap in dev's version)
`createOnboardingLink` now logs `return_url`/`refresh_url` + the raw Stripe reason when `accountLinks.create` fails, then **rethrows the error unchanged** so dev's mapping (`ConnectPlatformNotConfiguredError` / `handleError`) still applies. A rejected `return_url` was otherwise invisible — it bubbled to a generic 500 with no trace of which URL Stripe refused. URLs are logs-only (not PII, never in client-facing error `context`).

## Verification
- `@codex/subscription` + `web` typecheck clean; Biome clean; subscription suite green (415 pass — one unrelated payout test flaked once under shared-Neon concurrency and passed on re-run).
- Reproduced live: `POST /connect/me/onboard` with the real `lvh.me` return URL → **201** + valid `connect.stripe.com/setup/…` link, exactly one DB row per Stripe account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)