### PR TITLE
fix(avatar): sniff MIME when multipart re-forward strips Content-Type (Codex-sxm74)

### DIFF
--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -521,7 +521,23 @@ export function createServerApi(
             : {},
           body: formData,
         }).then(async (res) => {
-          if (!res.ok) throw new ApiError(res.status, 'Upload failed');
+          if (!res.ok) {
+            // Surface identity-api's real error message (e.g. an invalid MIME
+            // type or oversize file) instead of masking every failure as a
+            // generic "Upload failed" — that opacity is exactly what hid the
+            // prod avatar 400 (Codex-sxm74). The error envelope is already
+            // sanitised by mapErrorToResponse(), so no internal detail leaks.
+            let message = 'Upload failed';
+            try {
+              const body = (await res.json()) as {
+                error?: { message?: string };
+              };
+              if (body?.error?.message) message = body.error.message;
+            } catch {
+              // Non-JSON body — keep the generic message.
+            }
+            throw new ApiError(res.status, message);
+          }
           const json = await res.json();
           // Unwrap single-item envelope: { data: T } → T
           const record = json as Record<string, unknown>;

--- a/packages/validation/src/__tests__/image.test.ts
+++ b/packages/validation/src/__tests__/image.test.ts
@@ -1,5 +1,9 @@
 import { beforeAll, describe, expect, it } from 'vitest';
-import { validateImageSignature, validateImageUpload } from '../image';
+import {
+  detectImageMimeType,
+  validateImageSignature,
+  validateImageUpload,
+} from '../image';
 
 describe('Image Validation', () => {
   // Pre-warm isomorphic-dompurify (jsdom init is slow on first import)
@@ -84,6 +88,46 @@ describe('Image Validation', () => {
         0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
       ]);
       expect(validateImageSignature(pngSignature, 'image/jpeg')).toBe(false);
+    });
+  });
+
+  describe('detectImageMimeType', () => {
+    it('detects PNG from magic bytes', () => {
+      const png = new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
+      expect(detectImageMimeType(png)).toBe('image/png');
+    });
+
+    it('detects JPEG from magic bytes', () => {
+      const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      expect(detectImageMimeType(jpeg)).toBe('image/jpeg');
+    });
+
+    it('detects WebP from RIFF + WEBP marker', () => {
+      const webp = new Uint8Array([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]);
+      expect(detectImageMimeType(webp)).toBe('image/webp');
+    });
+
+    it('detects GIF from magic bytes', () => {
+      const gif = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+      expect(detectImageMimeType(gif)).toBe('image/gif');
+    });
+
+    it('returns null for non-image / unknown bytes', () => {
+      const exe = new Uint8Array([0x4d, 0x5a, 0x90, 0x00]); // MZ (.exe)
+      expect(detectImageMimeType(exe)).toBeNull();
+    });
+
+    it('does NOT sniff SVG — text formats must be declared explicitly', () => {
+      const svg = new TextEncoder().encode(
+        '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'
+      );
+      // detectImageMimeType only covers binary raster formats; SVG must arrive
+      // with an explicit image/svg+xml type so sanitisation is chosen on purpose.
+      expect(detectImageMimeType(svg)).toBeNull();
     });
   });
 

--- a/packages/validation/src/image.ts
+++ b/packages/validation/src/image.ts
@@ -89,6 +89,46 @@ export function validateImageSignature(
   return expectedMagicNumbers.every((byte, i) => buffer[i] === byte);
 }
 
+/**
+ * Raster image types that can be reliably detected from their binary
+ * signature. SVG is intentionally excluded — it is text (`<?xml`/`<svg`) and
+ * must be declared explicitly so the SVG-sanitisation path is chosen
+ * deliberately, never inferred from sniffed bytes.
+ */
+const SNIFFABLE_IMAGE_MIME_TYPES: readonly AllowedMimeType[] = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+];
+
+/**
+ * Detects an image's MIME type from its magic bytes (content sniffing).
+ *
+ * Where {@link validateImageSignature} verifies a *claimed* type, this *infers*
+ * the type when none is reliably declared — e.g. a cross-worker multipart
+ * re-forward where the part's `Content-Type` was stripped and the runtime
+ * substituted `application/octet-stream`. workerd emits that generic type
+ * whenever a `File` whose `.type` was empty is (re)serialised onto a multipart
+ * body, so a valid image can arrive at a receiving worker with no usable type.
+ *
+ * Only the binary raster formats are sniffed (see {@link SNIFFABLE_IMAGE_MIME_TYPES});
+ * their signatures are unambiguous and non-overlapping in the leading bytes.
+ *
+ * @param buffer - File content as a byte array (only the header is inspected)
+ * @returns the detected MIME type, or `null` if it matches no sniffable format
+ */
+export function detectImageMimeType(
+  buffer: Uint8Array
+): AllowedMimeType | null {
+  for (const mimeType of SNIFFABLE_IMAGE_MIME_TYPES) {
+    if (validateImageSignature(buffer, mimeType)) {
+      return mimeType;
+    }
+  }
+  return null;
+}
+
 export interface ImageValidationConfig {
   maxSizeBytes?: number;
   allowedMimeTypes: AllowedMimeType[];

--- a/packages/worker-utils/src/procedure/__tests__/multipart-validate-files.test.ts
+++ b/packages/worker-utils/src/procedure/__tests__/multipart-validate-files.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for `validateFiles` — the multipart file validator used by
+ * `multipartProcedure()`.
+ *
+ * Regression guard for Codex-sxm74: a valid image forwarded worker→worker can
+ * arrive with its `Content-Type` reduced to `application/octet-stream` (workerd
+ * emits that generic type when a `File` whose `.type` was empty is serialised
+ * onto a multipart body). The old validator checked the declared type against a
+ * strict allowlist and rejected such uploads with a 400 — the prod avatar bug.
+ * `validateFiles` now sniffs the magic bytes as a fallback.
+ *
+ * On PRE-FIX code the "accepts …" cases below throw `InvalidFileTypeError`.
+ */
+
+import { ValidationError } from '@codex/service-errors';
+import { describe, expect, it } from 'vitest';
+import { validateFiles } from '../multipart-procedure';
+
+const IMAGE_ALLOWLIST = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+] as const;
+
+const AVATAR_SCHEMA = {
+  avatar: {
+    required: true,
+    maxSize: 5 * 1024 * 1024,
+    allowedMimeTypes: IMAGE_ALLOWLIST,
+  },
+} as const;
+
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const EXE_BYTES = new Uint8Array([0x4d, 0x5a, 0x90, 0x00]); // MZ (.exe)
+
+function formDataWith(file: File): FormData {
+  const fd = new FormData();
+  fd.append('avatar', file);
+  return fd;
+}
+
+describe('validateFiles — MIME sniffing fallback (Codex-sxm74)', () => {
+  it('accepts a JPEG whose type was stripped to application/octet-stream', async () => {
+    const file = new File([JPEG_BYTES], 'photo.jpg', {
+      type: 'application/octet-stream',
+    });
+
+    const result = await validateFiles(formDataWith(file), AVATAR_SCHEMA);
+
+    // Recovered from magic bytes so the downstream service gets the real type.
+    expect(result.avatar.type).toBe('image/jpeg');
+    expect(result.avatar.name).toBe('photo.jpg');
+  });
+
+  it('accepts a PNG whose type is empty (workerd inbound parse of a part with no Content-Type)', async () => {
+    const file = new File([PNG_BYTES], 'photo.png', { type: '' });
+
+    const result = await validateFiles(formDataWith(file), AVATAR_SCHEMA);
+
+    expect(result.avatar.type).toBe('image/png');
+  });
+
+  it('honours a correctly-declared type without sniffing (no regression)', async () => {
+    const file = new File([PNG_BYTES], 'photo.png', { type: 'image/png' });
+
+    const result = await validateFiles(formDataWith(file), AVATAR_SCHEMA);
+
+    expect(result.avatar.type).toBe('image/png');
+  });
+
+  it('still REJECTS a non-image masquerading as octet-stream (sniff does not weaken the allowlist)', async () => {
+    const file = new File([EXE_BYTES], 'malware.jpg', {
+      type: 'application/octet-stream',
+    });
+
+    await expect(
+      validateFiles(formDataWith(file), AVATAR_SCHEMA)
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('still REJECTS a declared, disallowed type (e.g. image/tiff)', async () => {
+    const file = new File([PNG_BYTES], 'image.tiff', { type: 'image/tiff' });
+
+    await expect(
+      validateFiles(formDataWith(file), AVATAR_SCHEMA)
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects an oversized file (size checked before the body is read)', async () => {
+    const file = new File([JPEG_BYTES], 'photo.jpg', { type: 'image/jpeg' });
+    const schema = {
+      avatar: {
+        required: true,
+        maxSize: 3, // smaller than JPEG_BYTES
+        allowedMimeTypes: IMAGE_ALLOWLIST,
+      },
+    } as const;
+
+    await expect(
+      validateFiles(formDataWith(file), schema)
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects a missing required file', async () => {
+    await expect(
+      validateFiles(new FormData(), AVATAR_SCHEMA)
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+});

--- a/packages/worker-utils/src/procedure/multipart-procedure.ts
+++ b/packages/worker-utils/src/procedure/multipart-procedure.ts
@@ -38,6 +38,7 @@
 import type { ObservabilityClient } from '@codex/observability';
 import { mapErrorToResponse, ValidationError } from '@codex/service-errors';
 import type { HonoEnv } from '@codex/shared-types';
+import { detectImageMimeType } from '@codex/validation';
 import type { Context } from 'hono';
 import { validateInput } from './helpers';
 import type {
@@ -254,7 +255,7 @@ export function multipartProcedure<
 // File Validation Helper
 // ============================================================================
 
-async function validateFiles<T extends FileSchema | undefined>(
+export async function validateFiles<T extends FileSchema | undefined>(
   formData: FormData,
   schema: T
 ): Promise<InferFiles<T>> {
@@ -278,29 +279,54 @@ async function validateFiles<T extends FileSchema | undefined>(
 
     const validFile = file as unknown as File;
 
-    // Validate MIME type
+    // Validate file size FIRST — `File.size` is known from the multipart
+    // headers, so we reject oversized uploads before reading the body into
+    // memory (a full read of a near-limit file would otherwise risk OOM).
+    if (config.maxSize && validFile.size > config.maxSize) {
+      throw new FileTooLargeError(fieldName, validFile.size, config.maxSize);
+    }
+
+    // Read file content (size is now bounded by the check above).
+    const buffer = await validFile.arrayBuffer();
+
+    // Resolve the effective MIME type against the allowlist. We trust the
+    // declared `File.type`, but when it is missing or the generic multipart
+    // default — `application/octet-stream`, which workerd emits when a File
+    // whose `.type` was empty is serialised across a worker→worker fetch — we
+    // fall back to sniffing the magic bytes. Without this, a valid image whose
+    // Content-Type was stripped upstream (e.g. the SvelteKit→identity avatar
+    // re-forward) is wrongly rejected as an invalid type. Sniffing only
+    // *accepts* a type the caller already allows, so it cannot be used to
+    // smuggle a non-image past the allowlist.
+    let effectiveType = validFile.type;
     if (
       config.allowedMimeTypes &&
-      !config.allowedMimeTypes.includes(validFile.type)
+      !config.allowedMimeTypes.includes(effectiveType) &&
+      (effectiveType === '' || effectiveType === 'application/octet-stream')
+    ) {
+      const sniffedType = detectImageMimeType(new Uint8Array(buffer));
+      if (sniffedType && config.allowedMimeTypes.includes(sniffedType)) {
+        effectiveType = sniffedType;
+      }
+    }
+
+    // Validate the resolved MIME type against the allowlist.
+    if (
+      config.allowedMimeTypes &&
+      !config.allowedMimeTypes.includes(effectiveType)
     ) {
       throw new InvalidFileTypeError(
         fieldName,
+        // Report what actually arrived on the wire (pre-sniff) so logs reflect
+        // the real cause, e.g. an empty or `application/octet-stream` type.
         validFile.type,
         config.allowedMimeTypes
       );
     }
 
-    // Validate file size
-    if (config.maxSize && validFile.size > config.maxSize) {
-      throw new FileTooLargeError(fieldName, validFile.size, config.maxSize);
-    }
-
-    // Read file content
-    const buffer = await validFile.arrayBuffer();
-
     result[fieldName] = {
       name: validFile.name,
-      type: validFile.type,
+      type: effectiveType,
       size: validFile.size,
       buffer,
     };

--- a/packages/worker-utils/vitest.config.worker-utils.ts
+++ b/packages/worker-utils/vitest.config.worker-utils.ts
@@ -11,5 +11,6 @@ export default packageVitestConfig({
     '@codex/observability': '../observability/src',
     '@codex/identity': '../identity/src',
     '@codex/image-processing': '../image-processing/src',
+    '@codex/validation': '../validation/src',
   },
 });

--- a/workers/identity-api/src/avatar-reforward.test.ts
+++ b/workers/identity-api/src/avatar-reforward.test.ts
@@ -1,0 +1,92 @@
+/**
+ * workerd multipart round-trip — root-cause guard for Codex-sxm74.
+ *
+ * Avatar uploads 400'd in PRODUCTION only. These tests pin the workerd runtime
+ * behaviour that made the bug environment-specific (Node/undici does not behave
+ * this way), and document why the fix lives in the receiver's MIME sniffing.
+ *
+ * Chain:
+ *   1. INBOUND parse — a browser omits (or a re-forward strips) the part's
+ *      `Content-Type` → workerd yields a File with `type === ''`.
+ *   2. OUTBOUND serialise — the web layer re-appends that File to a fresh
+ *      FormData and fetches identity-api; workerd writes
+ *      `Content-Type: application/octet-stream` for the empty-typed part.
+ *   3. identity-api parses that part → `file.type === 'application/octet-stream'`,
+ *      which is NOT in the image allowlist → InvalidFileTypeError (400).
+ *
+ * `validateFiles` (@codex/worker-utils) now sniffs the magic bytes to recover
+ * the real type; these tests guard the runtime assumptions that fix relies on.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+
+/** Build real multipart wire bytes, optionally including the part Content-Type. */
+function multipartRequest(opts: { partContentType?: string }): Request {
+  const boundary = '----WebKitFormBoundaryAbCdEf123';
+  const ct = opts.partContentType
+    ? `Content-Type: ${opts.partContentType}\r\n`
+    : '';
+  const head =
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="avatar"; filename="photo.jpg"\r\n` +
+    ct +
+    `\r\n`;
+  const tail = `\r\n--${boundary}--\r\n`;
+  const body = new Uint8Array([
+    ...new TextEncoder().encode(head),
+    ...JPEG_BYTES,
+    ...new TextEncoder().encode(tail),
+  ]);
+  return new Request('http://identity/api/user/avatar', {
+    method: 'POST',
+    headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+    body,
+  });
+}
+
+/** Force real multipart serialisation of a FormData body and return the wire text. */
+async function serialiseToWire(fd: FormData): Promise<string> {
+  const req = new Request('http://x/', { method: 'POST', body: fd });
+  return new TextDecoder().decode(await req.arrayBuffer());
+}
+
+describe('workerd multipart INBOUND parse', () => {
+  it('preserves a part Content-Type into File.type', async () => {
+    const avatar = (
+      await multipartRequest({ partContentType: 'image/jpeg' }).formData()
+    ).get('avatar');
+    expect(avatar).toBeInstanceOf(File);
+    expect((avatar as File).type).toBe('image/jpeg');
+  });
+
+  it('yields an EMPTY File.type when the part has no Content-Type (the prod trigger)', async () => {
+    const avatar = (await multipartRequest({}).formData()).get('avatar');
+    expect(avatar).toBeInstanceOf(File);
+    // Still a File (not a string) — so the receiver fails at the type check,
+    // not with MissingFileError.
+    expect((avatar as File).type).toBe('');
+  });
+});
+
+describe('workerd multipart OUTBOUND serialise', () => {
+  it('writes application/octet-stream for a File whose type is empty', async () => {
+    const fd = new FormData();
+    fd.append('avatar', new File([JPEG_BYTES], 'photo.jpg', { type: '' }));
+    const wire = await serialiseToWire(fd);
+    // This is the exact byte-level root cause: the receiver sees octet-stream,
+    // never the empty string.
+    expect(wire).toContain('Content-Type: application/octet-stream');
+  });
+
+  it('preserves a present File.type across serialisation', async () => {
+    const fd = new FormData();
+    fd.append(
+      'avatar',
+      new File([JPEG_BYTES], 'photo.jpg', { type: 'image/jpeg' })
+    );
+    const wire = await serialiseToWire(fd);
+    expect(wire).toContain('Content-Type: image/jpeg');
+  });
+});


### PR DESCRIPTION
## Problem (P1, Codex-sxm74)

Avatar uploads 400'd **in production only** — valid JPG/PNG images rejected as "Upload failed" across the whole app (account page + become-creator wizard). `POST /api/user/avatar` (identity-api) returned **400 in ~4ms**, rejected at multipart input-validation *before* any image processing.

## Root cause (byte-level proven in workerd)

The bead hypothesised "workerd drops the Content-Type on re-forward". Byte-level characterisation in the real workerd runtime showed a more precise chain:

1. A `File` whose `.type` is **empty** (the browser omits, or an upstream re-forward strips, the part's `Content-Type`) …
2. … is serialised by **workerd** onto the outbound multipart body as `Content-Type: application/octet-stream` (not empty).
3. identity-api's `validateFiles` checked that generic type against the image allowlist → not present → `InvalidFileTypeError` → **400**.

Node/undici (local dev) never produces the empty type, so the failure was environment-specific. Re-serialisation *preserves* a type that is present — so a web-side "reconstruct with `{type: file.type}`" could not have fixed it (the type is already gone). The load-bearing fix must be **receiver-side**.

## Fix

- **`@codex/validation`** — new `detectImageMimeType(bytes)`: infers a raster image type (PNG/JPEG/WebP/GIF) from magic bytes. SVG intentionally excluded (text; must be declared so sanitisation is chosen deliberately).
- **`@codex/worker-utils` `validateFiles`** — when the declared type is missing or `application/octet-stream`, fall back to sniffing; accept **only** a type the caller already allows (cannot smuggle a non-image). Aligns with the service layer's `validateImageFile`, which already tolerates an empty type. Size is now checked *before* the body is read (no OOM). This covers all 3 upload paths (avatar, org logo, content thumbnail).
- **web `uploadAvatar`** — surface identity-api's real (already-sanitised) error message instead of masking every failure as generic "Upload failed".

## Tests (fails-before / passes-after)

- **validation**: `detectImageMimeType` — sniffs raster formats, excludes SVG, returns null on non-image.
- **worker-utils**: `validateFiles` accepts octet-stream/empty-type + valid magic bytes; still rejects non-images masquerading as octet-stream, disallowed declared types, oversize, and missing files. Fails-before proven by disabling the sniff → exactly the two accept-cases fail, security guards stay green.
- **identity-api (workerd)**: pins the runtime root cause — empty `.type` → `application/octet-stream` on the wire; present type preserved.

Gate: typecheck 27/27 · validation 435 · identity-api 47 · worker-utils 101 · biome clean.

## Verification status

Fix proven at the workerd byte level with fails-before/passes-after tests. Full end-to-end prod confirmation (deploy + drive a real upload + `wrangler tail`) is pending — it needs a prod deploy + a prod DB `email_verified` flip, which require explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)