### PR TITLE
fix(avatar): materialise file before web→identity re-forward — prod MissingFileError (Codex-sxm74 follow-up)

### DIFF
--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -509,43 +509,59 @@ export function createServerApi(
       /**
        * Upload avatar (multipart - uses raw fetch for FormData, then unwraps procedure envelope)
        */
-      uploadAvatar: (file: File): Promise<AvatarUploadResponse> => {
+      uploadAvatar: async (file: File): Promise<AvatarUploadResponse> => {
         const url = `${serverApiUrl(platform, 'identity')}/api/user/avatar`;
-        const formData = new FormData();
-        formData.append('avatar', file);
 
-        return fetch(url, {
+        // Re-materialise the upload into a fresh in-memory File before
+        // forwarding. A File reconstructed off the inbound SvelteKit request
+        // does NOT reliably survive re-serialisation into a new outbound
+        // multipart body over a real cross-worker fetch in workerd: the part
+        // reaches identity-api without a `filename`, so it is parsed as a
+        // string form field rather than a File and rejected with
+        // MissingFileError (a 400). This was invisible locally — Node/undici
+        // preserves the part — and only reproduced in production (Codex-sxm74).
+        // Reading the bytes and appending a fresh File with an explicit
+        // filename makes the re-forward deterministic across runtimes.
+        const bytes = await file.arrayBuffer();
+        const forwardFile = new File([bytes], file.name || 'avatar', {
+          type: file.type || 'application/octet-stream',
+        });
+        const formData = new FormData();
+        formData.append('avatar', forwardFile, forwardFile.name);
+
+        const res = await fetch(url, {
           method: 'POST',
           headers: sessionCookie
             ? { Cookie: `${COOKIES.SESSION_NAME}=${sessionCookie}` }
             : {},
           body: formData,
-        }).then(async (res) => {
-          if (!res.ok) {
-            // Surface identity-api's real error message (e.g. an invalid MIME
-            // type or oversize file) instead of masking every failure as a
-            // generic "Upload failed" — that opacity is exactly what hid the
-            // prod avatar 400 (Codex-sxm74). The error envelope is already
-            // sanitised by mapErrorToResponse(), so no internal detail leaks.
-            let message = 'Upload failed';
-            try {
-              const body = (await res.json()) as {
-                error?: { message?: string };
-              };
-              if (body?.error?.message) message = body.error.message;
-            } catch {
-              // Non-JSON body — keep the generic message.
-            }
-            throw new ApiError(res.status, message);
-          }
-          const json = await res.json();
-          // Unwrap single-item envelope: { data: T } → T
-          const record = json as Record<string, unknown>;
-          if ('data' in record && record.data != null) {
-            return record.data as AvatarUploadResponse;
-          }
-          return json as AvatarUploadResponse;
         });
+
+        if (!res.ok) {
+          // Surface identity-api's real error message (e.g. an invalid MIME
+          // type or oversize file) instead of masking every failure as a
+          // generic "Upload failed" — that opacity is exactly what hid the
+          // prod avatar 400 (Codex-sxm74). The error envelope is already
+          // sanitised by mapErrorToResponse(), so no internal detail leaks.
+          let message = 'Upload failed';
+          try {
+            const body = (await res.json()) as {
+              error?: { message?: string };
+            };
+            if (body?.error?.message) message = body.error.message;
+          } catch {
+            // Non-JSON body — keep the generic message.
+          }
+          throw new ApiError(res.status, message);
+        }
+
+        const json = await res.json();
+        // Unwrap single-item envelope: { data: T } → T
+        const record = json as Record<string, unknown>;
+        if ('data' in record && record.data != null) {
+          return record.data as AvatarUploadResponse;
+        }
+        return json as AvatarUploadResponse;
       },
 
       /**


### PR DESCRIPTION
## Follow-up to #347 — the real prod failure

Prod verification of #347 (Playwright, real upload, `wrangler tail identity-api-production`) showed the sniff fix was **necessary but not sufficient**: `POST /api/user/avatar` still returned **400 in ~3ms**. The error-surfacing from #347 (now live) exposed the real reason in the remote-form body:

> `Required file 'avatar' is missing`  ← **MissingFileError**, not InvalidFileType.

### Root cause

`MissingFileError` fires at `!(file instanceof File)` — the receiver parsed the `avatar` part as a **string field, not a file**, which happens when the outbound multipart part has **no `filename`** in its `Content-Disposition`. A `File` reconstructed off the inbound SvelteKit request does **not** survive re-serialisation into a new outbound multipart body over a real cross-worker `fetch` in workerd — the filename (and body) don't round-trip. Node/undici preserves the part, so this was invisible locally *and* in in-harness `Request` round-trips (the exact false-negative the bead warned about). The prod tail was the only faithful oracle.

The receiver-side sniff from #347 can't help here — there's no File to sniff.

### Fix

Read `file.arrayBuffer()` into a fresh in-memory `File` and append it with an explicit filename before forwarding:

```ts
const bytes = await file.arrayBuffer();
const forwardFile = new File([bytes], file.name || 'avatar', { type: file.type || 'application/octet-stream' });
formData.append('avatar', forwardFile, forwardFile.name);
```

The #347 receiver-side sniff + error-surfacing stay as defence-in-depth (and the error-surfacing is what made this diagnosable in the first place).

### Verification

Documented prod before/after on Codex-sxm74: **400 MissingFileError → 200** with a processed avatar URL, confirmed via `wrangler tail identity-api-production`. (Web-layer re-forward cannot be faithfully reproduced in any local harness — Node preserves the part — so prod is the acceptance oracle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)