### PR TITLE
fix(branding): materialise logo file before web→org re-forward (prod MissingFileError)

### DIFF
--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -164,6 +164,80 @@ export function buildAuthForwardingCookie(sessionToken: string): string {
 }
 
 /**
+ * Re-forward a browser-uploaded file to a worker as a fresh multipart body.
+ *
+ * A File reconstructed off the inbound SvelteKit request does NOT reliably
+ * survive re-serialisation into a new outbound multipart body over a real
+ * cross-worker fetch in workerd: the part reaches the worker WITHOUT a
+ * `filename`, so it is parsed as a string form field rather than a File and
+ * rejected with MissingFileError (a 400) before any type/size logic runs.
+ * This is invisible locally — Node/undici preserves the part — and only
+ * reproduces in production. It bit the avatar path first, then the logo path
+ * (both Codex-sxm74); this helper is the single home for the fix so a third
+ * upload path cannot silently reintroduce it.
+ *
+ * The fix: read `file.arrayBuffer()` into a brand-new in-memory File and append
+ * it with an explicit filename, making the re-forward deterministic across
+ * runtimes.
+ *
+ * On failure, surfaces the worker's real (already `mapErrorToResponse`-
+ * sanitised) error message instead of masking every failure behind
+ * `failureMessage` — that opacity is exactly what hid the original prod 400.
+ * On success, unwraps the single-item procedure envelope (`{ data: T }` → `T`).
+ */
+async function forwardMultipartUpload<T>(options: {
+  url: string;
+  fieldName: string;
+  file: File;
+  fallbackFilename: string;
+  sessionCookie: string | undefined;
+  failureMessage: string;
+}): Promise<T> {
+  const {
+    url,
+    fieldName,
+    file,
+    fallbackFilename,
+    sessionCookie,
+    failureMessage,
+  } = options;
+
+  const bytes = await file.arrayBuffer();
+  const forwardFile = new File([bytes], file.name || fallbackFilename, {
+    type: file.type || 'application/octet-stream',
+  });
+  const formData = new FormData();
+  formData.append(fieldName, forwardFile, forwardFile.name);
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: sessionCookie
+      ? { Cookie: `${COOKIES.SESSION_NAME}=${sessionCookie}` }
+      : {},
+    body: formData,
+  });
+
+  if (!res.ok) {
+    let message = failureMessage;
+    try {
+      const body = (await res.json()) as { error?: { message?: string } };
+      if (body?.error?.message) message = body.error.message;
+    } catch {
+      // Non-JSON body — keep the generic message.
+    }
+    throw new ApiError(res.status, message);
+  }
+
+  const json = await res.json();
+  // Unwrap single-item envelope: { data: T } → T
+  const record = json as Record<string, unknown>;
+  if ('data' in record && record.data != null) {
+    return record.data as T;
+  }
+  return json as T;
+}
+
+/**
  * Create a server-side API client
  *
  * @param platform - The SvelteKit platform object with env bindings
@@ -509,60 +583,15 @@ export function createServerApi(
       /**
        * Upload avatar (multipart - uses raw fetch for FormData, then unwraps procedure envelope)
        */
-      uploadAvatar: async (file: File): Promise<AvatarUploadResponse> => {
-        const url = `${serverApiUrl(platform, 'identity')}/api/user/avatar`;
-
-        // Re-materialise the upload into a fresh in-memory File before
-        // forwarding. A File reconstructed off the inbound SvelteKit request
-        // does NOT reliably survive re-serialisation into a new outbound
-        // multipart body over a real cross-worker fetch in workerd: the part
-        // reaches identity-api without a `filename`, so it is parsed as a
-        // string form field rather than a File and rejected with
-        // MissingFileError (a 400). This was invisible locally — Node/undici
-        // preserves the part — and only reproduced in production (Codex-sxm74).
-        // Reading the bytes and appending a fresh File with an explicit
-        // filename makes the re-forward deterministic across runtimes.
-        const bytes = await file.arrayBuffer();
-        const forwardFile = new File([bytes], file.name || 'avatar', {
-          type: file.type || 'application/octet-stream',
-        });
-        const formData = new FormData();
-        formData.append('avatar', forwardFile, forwardFile.name);
-
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: sessionCookie
-            ? { Cookie: `${COOKIES.SESSION_NAME}=${sessionCookie}` }
-            : {},
-          body: formData,
-        });
-
-        if (!res.ok) {
-          // Surface identity-api's real error message (e.g. an invalid MIME
-          // type or oversize file) instead of masking every failure as a
-          // generic "Upload failed" — that opacity is exactly what hid the
-          // prod avatar 400 (Codex-sxm74). The error envelope is already
-          // sanitised by mapErrorToResponse(), so no internal detail leaks.
-          let message = 'Upload failed';
-          try {
-            const body = (await res.json()) as {
-              error?: { message?: string };
-            };
-            if (body?.error?.message) message = body.error.message;
-          } catch {
-            // Non-JSON body — keep the generic message.
-          }
-          throw new ApiError(res.status, message);
-        }
-
-        const json = await res.json();
-        // Unwrap single-item envelope: { data: T } → T
-        const record = json as Record<string, unknown>;
-        if ('data' in record && record.data != null) {
-          return record.data as AvatarUploadResponse;
-        }
-        return json as AvatarUploadResponse;
-      },
+      uploadAvatar: (file: File): Promise<AvatarUploadResponse> =>
+        forwardMultipartUpload<AvatarUploadResponse>({
+          url: `${serverApiUrl(platform, 'identity')}/api/user/avatar`,
+          fieldName: 'avatar',
+          file,
+          fallbackFilename: 'avatar',
+          sessionCookie,
+          failureMessage: 'Upload failed',
+        }),
 
       /**
        * Delete avatar
@@ -923,31 +952,15 @@ export function createServerApi(
       /**
        * Upload organization logo (multipart - uses raw fetch for FormData, then unwraps procedure envelope)
        */
-      uploadLogo: (
-        id: string,
-        file: File
-      ): Promise<BrandingSettingsResponse> => {
-        const url = `${serverApiUrl(platform, 'org')}/api/organizations/${id}/settings/branding/logo`;
-        const formData = new FormData();
-        formData.append('logo', file);
-
-        return fetch(url, {
-          method: 'POST',
-          headers: sessionCookie
-            ? { Cookie: `${COOKIES.SESSION_NAME}=${sessionCookie}` }
-            : {},
-          body: formData,
-        }).then(async (res) => {
-          if (!res.ok) throw new ApiError(res.status, 'Logo upload failed');
-          const json = await res.json();
-          // Unwrap single-item envelope: { data: T } → T
-          const record = json as Record<string, unknown>;
-          if ('data' in record && record.data != null) {
-            return record.data as BrandingSettingsResponse;
-          }
-          return json as BrandingSettingsResponse;
-        });
-      },
+      uploadLogo: (id: string, file: File): Promise<BrandingSettingsResponse> =>
+        forwardMultipartUpload<BrandingSettingsResponse>({
+          url: `${serverApiUrl(platform, 'org')}/api/organizations/${id}/settings/branding/logo`,
+          fieldName: 'logo',
+          file,
+          fallbackFilename: 'logo',
+          sessionCookie,
+          failureMessage: 'Logo upload failed',
+        }),
 
       /**
        * Delete organization logo

--- a/workers/organization-api/src/logo-reforward.test.ts
+++ b/workers/organization-api/src/logo-reforward.test.ts
@@ -1,0 +1,104 @@
+/**
+ * workerd multipart round-trip — root-cause guard for the logo path (Codex-sxm74).
+ *
+ * Logo uploads 400'd in PRODUCTION only, for the SAME reason avatars did: the
+ * web layer re-forwards the browser-uploaded File to organization-api over a
+ * fresh cross-worker fetch, and in workerd a File reconstructed off the inbound
+ * SvelteKit request does not survive re-serialisation with its `filename`
+ * intact. When the outbound part carries no `filename`, workerd parses it as a
+ * string form field — not a File — so `multipartProcedure`'s `validateFiles`
+ * (`!(file instanceof File)`) rejects it with MissingFileError (400) BEFORE any
+ * MIME/size logic runs. Node/undici preserves the part, so this was invisible
+ * locally and only reproduced in prod.
+ *
+ * The fix (apps/web `forwardMultipartUpload`) re-materialises the bytes into a
+ * fresh in-memory File and appends it WITH an explicit filename. These tests
+ * pin the two runtime facts that fix relies on:
+ *   1. a part WITHOUT a filename parses as a string (the prod 400 trigger);
+ *   2. a fresh File appended WITH a filename serialises with `filename=` on the
+ *      wire and round-trips back as a File (what the fix guarantees).
+ *
+ * They run under the workers pool (workerd), not Node — the only faithful
+ * oracle for this bug.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// Minimal valid PNG magic bytes — enough for the receiver's MIME sniff.
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/**
+ * Build real multipart wire bytes for a `logo` part, optionally omitting the
+ * `filename` from its Content-Disposition (the shape a stripped re-forward
+ * produces on the wire).
+ */
+function multipartRequest(opts: { withFilename: boolean }): Request {
+  const boundary = '----WebKitFormBoundaryLogoAbCdEf';
+  const disposition = opts.withFilename
+    ? `Content-Disposition: form-data; name="logo"; filename="logo.png"\r\n`
+    : `Content-Disposition: form-data; name="logo"\r\n`;
+  const head =
+    `--${boundary}\r\n` + disposition + `Content-Type: image/png\r\n\r\n`;
+  const tail = `\r\n--${boundary}--\r\n`;
+  const body = new Uint8Array([
+    ...new TextEncoder().encode(head),
+    ...PNG_BYTES,
+    ...new TextEncoder().encode(tail),
+  ]);
+  return new Request('http://org/api/organizations/x/settings/branding/logo', {
+    method: 'POST',
+    headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+    body,
+  });
+}
+
+/** Force real multipart serialisation of a FormData body and return the wire text. */
+async function serialiseToWire(fd: FormData): Promise<string> {
+  const req = new Request('http://x/', { method: 'POST', body: fd });
+  return new TextDecoder().decode(await req.arrayBuffer());
+}
+
+describe('logo re-forward — workerd INBOUND parse', () => {
+  it('parses a part WITHOUT a filename as a STRING, not a File (the prod MissingFileError trigger)', async () => {
+    const logo = (
+      await multipartRequest({ withFilename: false }).formData()
+    ).get('logo');
+    // `validateFiles` does `!(file instanceof File)` → MissingFileError (400).
+    // A string here is exactly what produced the production 400.
+    expect(logo).not.toBeInstanceOf(File);
+    expect(typeof logo).toBe('string');
+  });
+
+  it('parses a part WITH a filename as a File (what the sender fix guarantees)', async () => {
+    const logo = (
+      await multipartRequest({ withFilename: true }).formData()
+    ).get('logo');
+    expect(logo).toBeInstanceOf(File);
+    expect((logo as File).name).toBe('logo.png');
+    expect((logo as File).type).toBe('image/png');
+  });
+});
+
+describe('logo re-forward — workerd OUTBOUND serialise', () => {
+  it('writes a filename= for a fresh File appended with an explicit name', async () => {
+    // Mirrors forwardMultipartUpload: fresh in-memory File + explicit filename.
+    const fresh = new File([PNG_BYTES], 'logo', { type: 'image/png' });
+    const fd = new FormData();
+    fd.append('logo', fresh, fresh.name);
+    const wire = await serialiseToWire(fd);
+    expect(wire).toContain('filename="logo"');
+  });
+
+  it('round-trips a fresh explicit-filename File back to a File across serialise→parse', async () => {
+    const fresh = new File([PNG_BYTES], 'logo', { type: 'image/png' });
+    const fd = new FormData();
+    fd.append('logo', fresh, fresh.name);
+    // Re-parse the serialised body exactly as organization-api would.
+    const roundTripped = (
+      await new Request('http://org/', { method: 'POST', body: fd }).formData()
+    ).get('logo');
+    expect(roundTripped).toBeInstanceOf(File);
+  });
+});


### PR DESCRIPTION
## Problem

Logo upload for org branding **fails in production** (400), while working locally. This is the **same bug** that hit avatar uploads (Codex-sxm74) — but the avatar fix was only applied to the avatar path, never the logo path.

## Root cause

`api.org.uploadLogo` (`apps/web/src/lib/server/api.ts`) re-forwards the browser-uploaded `File` to organization-api over a second `fetch`, with a bare `formData.append('logo', file)`.

In **workerd** (production runtime), a `File` reconstructed off the inbound SvelteKit request does **not** survive re-serialisation into a new outbound multipart body with its `filename` intact. The part arrives at organization-api **without a `filename`**, so `multipartProcedure`'s `validateFiles` hits:

```ts
if (!file || !((file as unknown) instanceof File)) throw new MissingFileError(fieldName); // → 400
```

A filename-less part is parsed as a **string form field**, not a `File`, so it's rejected before any MIME/size logic runs. Node/undici (local dev) preserves the part, so it only reproduces in prod. The old generic `"Logo upload failed"` also masked org-api's real error — the same opacity that first hid the avatar 400.

## Fix

Extract the re-materialise-then-forward logic into **one shared `forwardMultipartUpload<T>` helper** and route **both** `uploadAvatar` and `uploadLogo` through it:

- read `file.arrayBuffer()` into a fresh in-memory `File` and append it with an explicit filename → deterministic across runtimes;
- surface the worker's real (already `mapErrorToResponse`-sanitised) error message;
- unwrap the single-item `{ data: T }` envelope.

Collapsing both paths into one helper means a **third** upload path can't silently reintroduce this.

## Test

`workers/organization-api/src/logo-reforward.test.ts` runs under **workerd** (the only faithful oracle) and pins the two runtime facts the fix relies on:
1. a part **without** a filename parses as a **string** — the prod `MissingFileError` trigger;
2. a fresh explicit-filename `File` serialises with `filename=` and round-trips back as a `File`.

## Verification

- `pnpm --filter web typecheck` ✅
- `pnpm --filter organization-api typecheck` ✅
- `pnpm --filter organization-api exec vitest run src/logo-reforward.test.ts` — 4/4 ✅
- biome check ✅

⚠️ By its nature this bug **only reproduces in production** — final confirmation needs a prod deploy (as with the avatar fix, verify a real logo upload returns 200, not 400).

Codex-sxm74

🤖 Generated with [Claude Code](https://claude.com/claude-code)