### PR TITLE
fix(content): render TipTap bodies via @tiptap/html/server — prod 500 [P0]

### DIFF
--- a/apps/web/src/lib/editor/render.test.ts
+++ b/apps/web/src/lib/editor/render.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { renderContentBody } from './render';
+
+/**
+ * Guards the prod 500 on /content/liberty (Codex-eb00a.2): the content-detail
+ * SSR load renders TipTap JSON bodies via `generateHTML`, which must come from
+ * `@tiptap/html/server` — the browser `@tiptap/html` build throws when `window`
+ * is undefined (Cloudflare Workers / workerd), 500-ing the whole page.
+ *
+ * These run under jsdom (where `window` exists), so the "no-window" test below
+ * simulates workerd explicitly — that is the only case that distinguishes the
+ * browser build from the server build here.
+ */
+
+const paragraphDoc = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph', content: [{ type: 'text', text: 'Liberty body' }] },
+  ],
+};
+
+describe('renderContentBody', () => {
+  it('renders a TipTap JSON body to sanitized HTML', async () => {
+    const html = await renderContentBody({ contentBodyJson: paragraphDoc });
+    expect(html).toContain('Liberty body');
+    expect(html).toContain('<p>');
+  });
+
+  it('renders legacy markdown when there is no JSON body', async () => {
+    const html = await renderContentBody({ contentBody: '# Heading' });
+    expect(html).toContain('Heading');
+  });
+
+  it('returns null when there is no body at all', async () => {
+    expect(await renderContentBody({})).toBeNull();
+  });
+
+  it('soft-degrades to null instead of throwing when the doc cannot render', async () => {
+    // Unknown node type makes ProseMirror's fromJSON throw; the loader must
+    // never 500 because of one malformed body.
+    const bad = { type: 'doc', content: [{ type: '__no_such_node__' }] };
+    await expect(
+      renderContentBody({ contentBodyJson: bad })
+    ).resolves.toBeNull();
+  });
+
+  it('renders even when global window is undefined (workerd SSR)', async () => {
+    // Reproduces the prod condition: the browser @tiptap/html build throws on
+    // `typeof window === "undefined"`; the /server build does not. If this
+    // returns null, the browser import has regressed (throw → degrade → null).
+    const g = globalThis as unknown as { window?: unknown };
+    const saved = g.window;
+    g.window = undefined;
+    try {
+      const html = await renderContentBody({ contentBodyJson: paragraphDoc });
+      expect(html).toContain('Liberty body');
+    } finally {
+      g.window = saved;
+    }
+  });
+});

--- a/apps/web/src/lib/editor/render.ts
+++ b/apps/web/src/lib/editor/render.ts
@@ -5,34 +5,56 @@
  * (TipTap JSON or legacy markdown) into HTML for display.
  */
 
+import { logger } from '$lib/observability';
 import { getRenderExtensions } from './extensions.js';
 
 /**
  * Render content body to HTML.
  * Handles TipTap JSON (contentBodyJson) and legacy markdown (contentBody).
  * Works for any content type — not restricted to written content.
+ *
+ * Runs during SSR on the Cloudflare Workers runtime (workerd). A render
+ * failure is soft-degraded to `null` (no body) rather than allowed to throw:
+ * the loaders that call this treat a null body as "no body to show", so a
+ * single malformed doc can never take down the whole content page with a 500.
  */
 export async function renderContentBody(content: {
   contentBodyJson?: Record<string, unknown> | null;
   contentBody?: string | null;
 }): Promise<string | null> {
-  if (content.contentBodyJson) {
-    const { generateHTML } = await import('@tiptap/html');
-    const DOMPurify = (await import('isomorphic-dompurify')).default;
-    const rawHtml = generateHTML(
-      content.contentBodyJson,
-      getRenderExtensions('full')
-    );
-    return DOMPurify.sanitize(rawHtml);
-  }
+  try {
+    if (content.contentBodyJson) {
+      // MUST use the `/server` entry, not `@tiptap/html`: the browser build
+      // throws `if (typeof window === 'undefined')`, and workerd's
+      // `nodejs_compat` polyfills `process` but NOT `window`, so the browser
+      // build 500s on every SSR render. The `/server` build guards on
+      // `process.versions.node` + happy-dom, both available under nodejs_compat.
+      const { generateHTML } = await import('@tiptap/html/server');
+      const DOMPurify = (await import('isomorphic-dompurify')).default;
+      const rawHtml = generateHTML(
+        content.contentBodyJson,
+        getRenderExtensions('full')
+      )
+        // happy-dom (the /server serializer) stamps the default XHTML namespace
+        // on top-level elements; it is inert in an HTML document, so strip it.
+        .replaceAll(' xmlns="http://www.w3.org/1999/xhtml"', '');
+      return DOMPurify.sanitize(rawHtml);
+    }
 
-  if (content.contentBody) {
-    const { marked } = await import('marked');
-    const DOMPurify = (await import('isomorphic-dompurify')).default;
-    const rawHtml = marked.parse(content.contentBody, {
-      async: false,
-    }) as string;
-    return DOMPurify.sanitize(rawHtml);
+    if (content.contentBody) {
+      const { marked } = await import('marked');
+      const DOMPurify = (await import('isomorphic-dompurify')).default;
+      const rawHtml = marked.parse(content.contentBody, {
+        async: false,
+      }) as string;
+      return DOMPurify.sanitize(rawHtml);
+    }
+  } catch (error) {
+    // Defense-in-depth: never let a body-render failure crash the page.
+    logger.error('Failed to render content body', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
   }
 
   return null;


### PR DESCRIPTION
**Bug:** `Codex-eb00a.2` (P0) — `https://of-blood-and-bones.revelations.studio/content/liberty` returns a hard **500**.

## Root cause
`renderContentBody()` rendered TipTap JSON via `generateHTML` from **`@tiptap/html`** (the *browser* build), which does `if (typeof window === 'undefined') throw`. Under `adapter-cloudflare` (workerd), `nodejs_compat` polyfills `process` but **not** `window`, so every SSR render of a JSON body throws. `liberty` is the only free item on that org with a `contentBodyJson`, so it's the one that reaches the eager public render path — unguarded, so it 500s the whole page.

Invisible locally because Node/jsdom define `window`.

## Fix
- Import `generateHTML` from **`@tiptap/html/server`** (guards on `process.versions.node` + happy-dom, both present under `nodejs_compat`).
- Strip the inert `xmlns="http://www.w3.org/1999/xhtml"` happy-dom stamps on top-level blocks (byte-equivalent to the old browser output).
- Wrap rendering in `try/catch` → soft-degrade to `null` + `logger.error` (defense-in-depth: a malformed body can never 500 the page again).

## Tests
`render.test.ts` — happy path, markdown, no-body, malformed→null soft-degrade, and a **workerd-simulating** test (`window` unset) that I verified **fails on the browser import** and passes on `/server`. jsdom has `window`, so that last test is the only one that catches this class of regression.

Typecheck ✅ · biome ✅ · `render.test.ts` 5/5 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)