### PR TITLE
fix(auth): call BetterAuth /request-password-reset — reset email never sent [P1]

### DIFF
--- a/apps/web/src/lib/remote/auth.remote.ts
+++ b/apps/web/src/lib/remote/auth.remote.ts
@@ -51,15 +51,21 @@ export const forgotPasswordForm = form(
     const { platform } = getRequestEvent();
 
     const authUrl = serverApiUrl(platform, 'auth');
-    const response = await fetch(`${authUrl}/api/auth/forget-password`, {
+    // BetterAuth's email/password reset endpoint is `/request-password-reset`.
+    // There is NO `/forget-password` in core (only the email-otp plugin's
+    // `/forget-password/email-otp`, which is not enabled), so the old path 404'd
+    // and no reset email was ever sent. Verified against better-auth@1.4.11.
+    const response = await fetch(`${authUrl}/api/auth/request-password-reset`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, redirectTo: '/reset-password' }),
     });
 
-    // Log failures server-side for monitoring (but don't expose to user)
+    // A non-2xx here is a genuine transport/config failure (unknown emails
+    // still return 200 by design), so log at error level — a silent success on
+    // a broken endpoint is exactly what hid this bug for months.
     if (!response.ok) {
-      logger.warn('Forgot password request failed', {
+      logger.error('Password reset request failed', {
         status: response.status,
         // Don't log email to avoid PII in logs
       });

--- a/packages/constants/src/security.ts
+++ b/packages/constants/src/security.ts
@@ -79,7 +79,8 @@ export const BRAND_COLORS = {
 export const BETTERAUTH_RATE_LIMITED_PATHS = [
   '/api/auth/sign-up/email',
   '/api/auth/sign-in/email',
-  '/api/auth/forget-password',
+  // BetterAuth core exposes `/request-password-reset` (NOT `/forget-password`).
+  '/api/auth/request-password-reset',
   '/api/auth/reset-password',
 ] as const;
 

--- a/workers/auth/CLAUDE.md
+++ b/workers/auth/CLAUDE.md
@@ -11,12 +11,12 @@ Authentication and session management via BetterAuth. The only worker that doesn
 | GET | `/api/auth/session` | Cookie | — | Returns `{ user, session }` or `null` |
 | POST | `/api/auth/sign-out` | Cookie | — | Clears session cookie |
 | POST | `/api/auth/verify-email` | Token | — | Verifies email, auto-signs-in |
-| POST | `/api/auth/send-reset-password-email` | None | `auth` (5/15min) | Sends password reset link (1h expiry) |
+| POST | `/api/auth/request-password-reset` | None | `auth` (5/15min) | Sends password reset link (1h expiry). BetterAuth core endpoint — NOT `/forget-password` (that only exists in the unused email-otp plugin) |
 | POST | `/api/auth/reset-password` | Token | — | Resets password |
 | GET | `/api/test/verification-token/:email` | None | — | DEV/TEST ONLY — returns KV-stored token |
 | POST | `/api/test/fast-register` | None | — | DEV/TEST ONLY — register + verify in one call |
 
-Rate-limited paths are: sign-up/email, sign-in/email, send-reset-password-email, reset-password.
+Rate-limited paths are: sign-up/email, sign-in/email, request-password-reset, reset-password.
 
 ## Architecture
 

--- a/workers/auth/src/__denoise_proofs__/iter-002/F1-auth-rate-limit-stale-paths.test.ts
+++ b/workers/auth/src/__denoise_proofs__/iter-002/F1-auth-rate-limit-stale-paths.test.ts
@@ -15,9 +15,9 @@
  * contained `/api/auth/email/login`, `/api/auth/email/register`, etc.,
  * but the actual BetterAuth POST endpoints are
  * `/api/auth/sign-in/email`, `/api/auth/sign-up/email`,
- * `/api/auth/forget-password`, `/api/auth/reset-password`. Result:
- * every auth endpoint was unrate-limited in production — brute-force
- * vulnerability.
+ * `/api/auth/request-password-reset`, `/api/auth/reset-password`.
+ * Result: every auth endpoint was unrate-limited in production —
+ * brute-force vulnerability.
  *
  * Fix: paths now live in `@codex/constants` as
  * `BETTERAUTH_RATE_LIMITED_PATHS_SET` and are imported by the auth
@@ -27,8 +27,8 @@
  * Source-of-truth grep evidence (apps/web/src):
  *   apps/web/src/routes/(auth)/login/+page.server.ts:48 → /api/auth/sign-in/email
  *   apps/web/src/routes/(auth)/register/+page.server.ts:57 → /api/auth/sign-up/email
- *   apps/web/src/routes/(auth)/forgot-password/+page.server.ts:29 → /api/auth/forget-password
- *   apps/web/src/lib/remote/auth.remote.ts:106 → /api/auth/sign-up/email
+ *   apps/web/src/lib/remote/auth.remote.ts (forgotPasswordForm) → /api/auth/request-password-reset
+ *   apps/web/src/lib/remote/auth.remote.ts (registerForm) → /api/auth/sign-up/email
  */
 import {
   BETTERAUTH_RATE_LIMITED_PATHS,
@@ -45,7 +45,10 @@ import { describe, expect, it } from 'vitest';
 const BETTERAUTH_RATE_LIMITED_POST_PATHS = [
   '/api/auth/sign-up/email',
   '/api/auth/sign-in/email',
-  '/api/auth/forget-password',
+  // BetterAuth core's reset-request endpoint is `/request-password-reset`
+  // (NOT `/forget-password`, which only exists in the unused email-otp plugin).
+  // Verified against better-auth@1.4.11. See Codex-eb00a.3.
+  '/api/auth/request-password-reset',
   '/api/auth/reset-password',
 ] as const;
 

--- a/workers/auth/src/__test__/middleware.test.ts
+++ b/workers/auth/src/__test__/middleware.test.ts
@@ -120,7 +120,7 @@ describe('Auth Worker Middleware - Unit Tests', () => {
       const canonical = [
         '/api/auth/sign-up/email',
         '/api/auth/sign-in/email',
-        '/api/auth/forget-password',
+        '/api/auth/request-password-reset',
         '/api/auth/reset-password',
       ];
       for (const path of canonical) {

--- a/workers/auth/src/__test__/rate-limiter-integration.test.ts
+++ b/workers/auth/src/__test__/rate-limiter-integration.test.ts
@@ -147,7 +147,7 @@ describe('createAuthRateLimiter — integration (Codex-ttavz.7)', () => {
     it('keeps separate budgets per path on the same IP', async () => {
       const ip = '198.51.100.60';
       const exhausted = '/api/auth/sign-up/email';
-      const fresh = '/api/auth/forget-password';
+      const fresh = '/api/auth/request-password-reset';
 
       // Drain exhausted path on this IP.
       for (let i = 0; i < BUDGET; i++) {

--- a/workers/auth/src/middleware/rate-limiter.ts
+++ b/workers/auth/src/middleware/rate-limiter.ts
@@ -2,7 +2,7 @@
  * Auth Rate Limiter Middleware
  *
  * Applies rate limiting specifically to the four user-facing
- * authentication surfaces (sign-up, sign-in, forget-password,
+ * authentication surfaces (sign-up, sign-in, request-password-reset,
  * reset-password) to prevent brute-force / credential-stuffing.
  *
  * The path Set is sourced from `@codex/constants`


### PR DESCRIPTION
**Bug:** `Codex-eb00a.3` (P1) — forgot-password never sends an email (reported for `bruce.r.mckay@gmail.com`).

## Root cause
The web app POSTed to **`/api/auth/forget-password`**, which does **not exist** in `better-auth@1.4.11` core (only the *unused* email-otp plugin defines `/forget-password/email-otp`). Verified directly against the installed package — the real endpoint is **`/api/auth/request-password-reset`**.

So the auth worker 404'd, BetterAuth's `sendResetPassword` callback was never reached, and the remote function **swallowed the 404 and returned a fake `{ success: true }`** (anti-enumeration). No reset email has *ever* been sent via this flow — a long-standing latent bug, not a 4-day regression. (Verification/welcome emails work because they go through correctly-wired callbacks.)

## Fix
- `auth.remote.ts` → `POST /api/auth/request-password-reset` (same body `{ email, redirectTo }`, which matches the 1.4.11 schema).
- Failure log `warn → error`: a non-2xx is now a real signal, so a broken endpoint can't hide behind the neutral success message again.
- `@codex/constants` `BETTERAUTH_RATE_LIMITED_PATHS`: fixed the same stale literal (single source of truth for the rate limiter — the corrected path stays 5/15min gated).
- Reconciled the duplicated literal in **both** live rate-limiter tests and the **iter-002 F1 drift-guard** proof (it enshrined the wrong path; it now correctly fails if anyone reverts the endpoint).
- Fixed `workers/auth/CLAUDE.md` — it documented a *fictional* `/send-reset-password-email`.

## Verified
- Endpoint confirmed against installed `better-auth@1.4.11` (`/request-password-reset`, body `{ email, redirectTo? }`).
- Only one live call site (the old `+page.server.ts` the denoise docs referenced was already migrated to this remote fn).
- Typecheck ✅ (apps/web, constants, auth) · biome ✅ · auth tests **26/26** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)