### PR TITLE
fix(ui): popovers/menus dismiss on outside click [P1]

### DIFF
--- a/apps/web/src/lib/components/ui/DropdownMenu/DropdownMenu.svelte
+++ b/apps/web/src/lib/components/ui/DropdownMenu/DropdownMenu.svelte
@@ -16,7 +16,12 @@
 		preventScroll,
 		loop,
 		closeOnItemClick,
-		closeOnOutsideClick,
+		// Default to Melt's own default (true). Destructuring with no default
+		// leaves this `undefined`, and the $effect below then does
+		// `.set(undefined)` — which disables Melt's interact-outside listener
+		// (`enabled: closeOnInteractOutside`), so the menu never closes on an
+		// outside click (avatar / studio-switcher popovers).
+		closeOnOutsideClick = true,
 		// Melt UI's portal option accepts `string | HTMLElement | null` — boolean
 		// `true` is a no-op (usePortal returns early). Default to `'body'` so the
 		// menu escapes overflow/transform ancestors (e.g. studio sidebar's

--- a/apps/web/src/lib/components/ui/Popover/Popover.svelte
+++ b/apps/web/src/lib/components/ui/Popover/Popover.svelte
@@ -15,7 +15,10 @@
 		disableFocusTrap,
 		arrowSize,
 		escapeBehavior,
-		closeOnOutsideClick,
+		// Default to Melt's own default (true). Without it this is `undefined`
+		// and the $effect below `.set(undefined)`s it, disabling the
+		// interact-outside listener so the popover never closes on outside click.
+		closeOnOutsideClick = true,
 		preventScroll,
 		preventTextSelectionOverflow,
 		portal = true, // Portal to body required for Storybook iframe rendering


### PR DESCRIPTION
**Bug:** `Codex-eb00a.6` (P1) — avatar popover, studio-switcher, and sidebar menus don't close when you click outside them.

## Root cause
`DropdownMenu.svelte` and `Popover.svelte` destructure `closeOnOutsideClick` from `$props()` with **no default** → `undefined`. Their mount `$effect` then runs `options.closeOnOutsideClick.set(undefined)`, **overwriting Melt's own `true` default**. Melt's modal action gates the interact-outside listener on `enabled: closeOnInteractOutside`, so `undefined` (falsy) leaves the listener unattached — clicks outside never dismiss. (Portalling was a red herring; other clobbered options have internal `?? default` fallbacks, which is why only outside-click surfaced.)

## Fix
Default `closeOnOutsideClick = true` in both wrappers — matches Melt's default and the sibling `portal`/`forceVisible = true` defaults already in the same destructure. Consumers explicitly passing `false` are unaffected.

Affected consumers (all pass no prop): SidebarRailUserSection (avatar), StudioSwitcher, StudioSidebar, VideoPlayer, `_creators/+layout` (DropdownMenu); AnalyticsCommandBar, EditorToolbar (Popover).

## Verification
Typecheck ✅ · biome ✅. Behavioural (Melt interaction), so **please sanity-check in the running app**: open the avatar/studio-switcher popover → click outside → it closes; Esc still closes; item-click still dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)