### PR TITLE
fix(brand): brand fonts never apply — break --brand-font-body/--font-sans CSS var cycle [P1]

### DIFF
--- a/apps/web/src/lib/brand-editor/css-injection.test.ts
+++ b/apps/web/src/lib/brand-editor/css-injection.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   darkTokenOverridesToCssVars,
+  injectBrandVars,
+  previewFont,
+  revertFontPreview,
   tokenOverridesToCssVars,
 } from './css-injection';
+import type { BrandEditorState } from './types';
 
 /**
  * Unit tests for the token-overrides → CSS-vars mapping used by both
@@ -136,5 +140,78 @@ describe('darkTokenOverridesToCssVars', () => {
     // and the dark CSS gate uses the dark variant.
     expect(light['--brand-shader-preset']).toBe('ether');
     expect(dark['--brand-shader-preset-dark']).toBe('ink');
+  });
+});
+
+/**
+ * Codex-eb00a.7: the emitted --brand-font-body/-heading value must be the BARE
+ * family name. org-brand.css redeclares `--font-sans` as
+ * `var(--brand-font-body, 'Inter'), 'Inter-fallback', …`, so appending
+ * `var(--font-sans)` here forms a --brand-font-body ↔ --font-sans cycle that
+ * invalidates both → `font-family: var(--font-sans)` falls back to the inherited
+ * font and the brand font never applies. These guard every emitter that could
+ * reintroduce the cycle (save injection + live preview).
+ */
+describe('brand fonts do not self-reference --font-sans (no CSS var cycle)', () => {
+  const baseState: BrandEditorState = {
+    primaryColor: '#3355ff',
+    secondaryColor: null,
+    accentColor: null,
+    backgroundColor: null,
+    fontBody: null,
+    fontHeading: null,
+    radius: 0.5,
+    density: 1,
+    logoUrl: null,
+    tokenOverrides: {},
+    darkOverrides: null,
+    darkTokenOverrides: null,
+    heroLayout: 'default',
+  };
+
+  function makeOrgLayout(): HTMLElement {
+    const el = document.createElement('div');
+    el.className = 'org-layout';
+    document.body.appendChild(el);
+    return el;
+  }
+
+  afterEach(() => {
+    for (const el of document.querySelectorAll('.org-layout')) el.remove();
+  });
+
+  it('injectBrandVars emits bare family names (save path)', () => {
+    const el = makeOrgLayout();
+    injectBrandVars({ ...baseState, fontBody: 'Lora', fontHeading: 'Poppins' });
+
+    expect(el.style.getPropertyValue('--brand-font-body')).toBe("'Lora'");
+    expect(el.style.getPropertyValue('--brand-font-heading')).toBe("'Poppins'");
+    expect(el.style.getPropertyValue('--brand-font-body')).not.toContain(
+      'var(--font-sans)'
+    );
+  });
+
+  it('previewFont emits a bare family name (hover-preview path)', () => {
+    const el = makeOrgLayout();
+    previewFont('body', 'Playfair Display');
+
+    expect(el.style.getPropertyValue('--brand-font-body')).toBe(
+      "'Playfair Display'"
+    );
+    expect(el.style.getPropertyValue('--brand-font-body')).not.toContain(
+      'var(--font-sans)'
+    );
+  });
+
+  it('revertFontPreview restores a bare family name', () => {
+    const el = makeOrgLayout();
+    revertFontPreview('heading', 'Space Grotesk');
+
+    expect(el.style.getPropertyValue('--brand-font-heading')).toBe(
+      "'Space Grotesk'"
+    );
+    expect(el.style.getPropertyValue('--brand-font-heading')).not.toContain(
+      'var(--font-sans)'
+    );
   });
 });

--- a/apps/web/src/lib/brand-editor/css-injection.ts
+++ b/apps/web/src/lib/brand-editor/css-injection.ts
@@ -346,14 +346,17 @@ const CSS_VAR_MAPPINGS: CssVarMapping[] = [
     getValue: (s) => String(s.density),
   },
   {
+    // NOTE: value is the bare family name — do NOT append `, var(--font-sans)`.
+    // org-brand.css redeclares `--font-sans` as
+    // `var(--brand-font-body, 'Inter'), 'Inter-fallback', …`, so appending
+    // var(--font-sans) here creates a --brand-font-body ↔ --font-sans cycle
+    // that invalidates both and drops the brand font entirely (Codex-eb00a.7).
     property: '--brand-font-body',
-    getValue: (s) =>
-      s.fontBody ? `'${s.fontBody}', var(--font-sans)` : undefined,
+    getValue: (s) => (s.fontBody ? `'${s.fontBody}'` : undefined),
   },
   {
     property: '--brand-font-heading',
-    getValue: (s) =>
-      s.fontHeading ? `'${s.fontHeading}', var(--font-sans)` : undefined,
+    getValue: (s) => (s.fontHeading ? `'${s.fontHeading}'` : undefined),
   },
 ];
 
@@ -391,7 +394,9 @@ export function previewFont(mode: 'body' | 'heading', family: string): void {
   if (!el) return;
   const prop =
     mode === 'heading' ? '--brand-font-heading' : '--brand-font-body';
-  el.style.setProperty(prop, `'${family}', var(--font-sans)`);
+  // Bare family name only — appending var(--font-sans) creates a cycle with
+  // org-brand.css's --font-sans redeclaration and drops the font (Codex-eb00a.7).
+  el.style.setProperty(prop, `'${family}'`);
   loadGoogleFont(family);
 }
 
@@ -408,7 +413,8 @@ export function revertFontPreview(
   const prop =
     mode === 'heading' ? '--brand-font-heading' : '--brand-font-body';
   if (currentValue) {
-    el.style.setProperty(prop, `'${currentValue}', var(--font-sans)`);
+    // Bare family name only (see previewFont) — no var(--font-sans) cycle.
+    el.style.setProperty(prop, `'${currentValue}'`);
   } else {
     el.style.removeProperty(prop);
   }

--- a/apps/web/src/routes/(auth)/+layout.svelte
+++ b/apps/web/src/routes/(auth)/+layout.svelte
@@ -78,8 +78,8 @@
   style:--brand-accent={brandAccent}
   style:--brand-bg={brandBackground}
   style:--brand-radius={brandRadius}
-  style:--brand-font-body={brandFontBody ? `'${brandFontBody}', var(--font-sans)` : undefined}
-  style:--brand-font-heading={brandFontHeading ? `'${brandFontHeading}', var(--font-sans)` : undefined}
+  style:--brand-font-body={brandFontBody ? `'${brandFontBody}'` : undefined}
+  style:--brand-font-heading={brandFontHeading ? `'${brandFontHeading}'` : undefined}
   style:--brand-shader-logo-url={brandLogoUrl}
   style={tokenOverrideStyle}
 >

--- a/apps/web/src/routes/_org/[slug]/+layout.svelte
+++ b/apps/web/src/routes/_org/[slug]/+layout.svelte
@@ -467,8 +467,8 @@
   style:--brand-bg-dark={brandBackgroundDark}
   style:--brand-density={brandDensity}
   style:--brand-radius={brandRadius}
-  style:--brand-font-body={brandFontBody ? `'${brandFontBody}', var(--font-sans)` : undefined}
-  style:--brand-font-heading={brandFontHeading ? `'${brandFontHeading}', var(--font-sans)` : undefined}
+  style:--brand-font-body={brandFontBody ? `'${brandFontBody}'` : undefined}
+  style:--brand-font-heading={brandFontHeading ? `'${brandFontHeading}'` : undefined}
   style:--brand-shader-logo-url={brandLogoUrl}
   style={serverTokenOverrideStyle}
 >


### PR DESCRIPTION
**Bug:** `Codex-eb00a.7` (P1) — brand editor font changes don't apply after a fresh reload.

## Root cause
A CSS custom-property **cycle**:
- `org-brand.css` redeclares org-scope `--font-sans` as `var(--brand-font-body, 'Inter'), 'Inter-fallback', …`
- every emitter set `--brand-font-body` to `'Family', var(--font-sans)`

So `--brand-font-body` → `--font-sans` → `--brand-font-body`. Both resolve to *invalid at computed-value time*, so `font-family: var(--font-sans)` falls back to the inherited font — the brand font never renders. (Introduced by brand-editor v2, commit c7c27ca5, which added the org-scope `--font-sans` redeclaration.)

## Fix
Emit the **bare family name** (`'Family'`) at every emitter. `--font-sans` already supplies the full Inter fallback stack when it consumes `--brand-font-body`, so nothing loses its fallback.

Fixed **all 5 emitters** — the original triage found 3, I found 2 more:
1. `_org/[slug]/+layout.svelte` inline style
2. `(auth)/+layout.svelte` inline style
3. `css-injection.ts` `CSS_VAR_MAPPINGS` (save injection)
4. `css-injection.ts` **`previewFont`** ← missed by triage (hover-preview was also broken)
5. `css-injection.ts` **`revertFontPreview`** ← missed by triage

## Tests
`css-injection.test.ts` — 3 DOM guards (save path + hover-preview + revert) asserting the emitted value is the bare family and contains no `var(--font-sans)`. Verified to **fail** when the cyclic value is reintroduced.

Typecheck ✅ · biome ✅ · css-injection tests **13/13** ✅

> Note: `(auth)` layout has no Google-Fonts `<link>`, so brand fonts still won't *load* there (pre-existing, separate from this cycle bug) — flagging for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)