### PR TITLE
fix(studio): new-content form no longer replays previous create [P1]

### DIFF
--- a/apps/web/src/lib/components/studio/ContentForm.svelte
+++ b/apps/web/src/lib/components/studio/ContentForm.svelte
@@ -259,7 +259,15 @@
   // re-render re-runs the handler → duplicate toast + duplicate goto.
   // A *new* result object (second submission) has a different identity,
   // so the handler fires again as expected.
-  let lastHandledResult: unknown = null;
+  //
+  // SEED with the singleton's CURRENT result (not null): form() is a
+  // module-level singleton whose `result` persists across navigation/unmount,
+  // so a fresh mount of /studio/content/new can still hold a PRIOR successful
+  // create. Seeding to `null` made the mount $effect below treat that stale
+  // result as new and immediately replay the create (toast + goto) with no
+  // user action. Seeding to the current result marks it already-handled, so
+  // only a result produced by an actual submission in THIS mount fires.
+  let lastHandledResult: unknown = untrack(() => form.result);
   $effect(() => {
     const result = form.result;
     if (!result?.success) return;


### PR DESCRIPTION
**Bug:** `Codex-eb00a.4` (P1) — clicking "New content" re-submits/duplicates the previous create.

## Root cause
`createContentForm` is a SvelteKit `form()` — a **module-level singleton** whose `.result` persists across navigation and unmount. The success guard `lastHandledResult` was a **component-local** that resets to `null` on every remount. So returning to `/studio/content/new` after a create saw the stale `form.result = { success, contentId }`, found `result !== null`, and immediately re-fired `handleCreateSuccess()` (toast + `goto`) — before any submission.

## Fix
Seed `lastHandledResult` with the singleton's *current* result via `untrack(() => form.result)`, so a pre-existing result is treated as already-handled. Only a result produced by a real submission in the current mount fires the handler. Covers create + edit modes (both use persistent `form()` singletons).

## Verification
Typecheck ✅ · biome ✅. Behavioural (depends on the `form()` runtime singleton, not unit-testable in isolation) — **please sanity-check**: create a piece → navigate back to "New content" → the form is empty and does **not** auto-navigate/toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)