### PR TITLE
fix(studio): media status updates live after upload [P1]

### DIFF
--- a/apps/web/src/lib/components/studio/StudioMediaPage.svelte
+++ b/apps/web/src/lib/components/studio/StudioMediaPage.svelte
@@ -8,7 +8,7 @@
   MediaUpload.svelte).
 -->
 <script lang="ts">
-  import { goto, invalidateAll } from '$app/navigation';
+  import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import MediaUpload, { type UploadItem } from '$lib/components/studio/MediaUpload.svelte';
   import MediaLibraryCommandBar from '$lib/components/studio/media-library/MediaLibraryCommandBar.svelte';
@@ -39,9 +39,16 @@
     studioName: string;
     /** Optional class forwarded to the root for layout composition (R13) */
     class?: string;
+    /**
+     * Refresh the media list after a mutation. The media route has no
+     * +page.server.ts, so `invalidateAll()` does NOT re-run the `listMedia`
+     * remote query — the parent passes `() => mediaQuery.refresh()` here so
+     * upload/edit/delete actually update the grid without a hard reload.
+     */
+    onRefresh?: () => void | Promise<void>;
   }
 
-  const { data, studioName, class: className }: Props = $props();
+  const { data, studioName, class: className, onRefresh }: Props = $props();
 
   // ── Upload surface wiring ─────────────────────────────────────────────
   let uploadQueue: UploadItem[] = $state([]);
@@ -185,7 +192,7 @@
 
   // ── Event handlers ────────────────────────────────────────────────────
   function handleUploadComplete() {
-    void invalidateAll();
+    void onRefresh?.();
   }
 
   function handleEdit(id: string) {
@@ -197,7 +204,7 @@
 
   async function handleSave(id: string, updateData: { title?: string; description?: string | null }) {
     await updateMedia({ id, data: updateData });
-    void invalidateAll();
+    void onRefresh?.();
   }
 
   function handleDelete(id: string) {
@@ -212,7 +219,7 @@
       await deleteMedia(deleteTargetId);
       showDeleteConfirm = false;
       deleteTargetId = null;
-      void invalidateAll();
+      void onRefresh?.();
     } catch (error) {
       logger.error('Failed to delete media', {
         error: error instanceof Error ? error.message : String(error),

--- a/apps/web/src/lib/components/studio/media-library/MediaTile.svelte
+++ b/apps/web/src/lib/components/studio/media-library/MediaTile.svelte
@@ -12,7 +12,7 @@
   (lifted from MediaCard.svelte) — behaviour preserved verbatim.
 -->
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
   import { getTranscodingStatus } from '$lib/remote/media.remote';
   import { logger } from '$lib/observability';
@@ -95,12 +95,23 @@
     if (visible) pollProgress();
   }
 
-  onMount(() => {
-    if (media.status === 'transcoding') {
-      pollProgress();
-      pollInterval = setInterval(pollProgress, 5000);
-      document.addEventListener('visibilitychange', onVisibilityChange);
-    }
+  // Poll while the item is still processing. The backend sets status to
+  // 'uploaded' synchronously and only flips to 'transcoding' a few seconds
+  // later (async, after onMount would have run), so gate on BOTH states —
+  // otherwise a tile that mounts at 'uploaded' never starts polling and its
+  // status is frozen until a hard reload. Using a reactive $effect (not
+  // onMount) means it also starts when a freshly-uploaded row transitions into
+  // a processing state after mount, and tears down once it reaches ready/failed.
+  $effect(() => {
+    const s = effectiveStatus;
+    if (s !== 'uploaded' && s !== 'transcoding') return;
+    pollProgress();
+    pollInterval = setInterval(pollProgress, 5000);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      stopPolling();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   });
 
   onDestroy(() => stopPolling());

--- a/apps/web/src/routes/_creators/studio/media/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/media/+page.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation';
   import StudioMediaPage from '$lib/components/studio/StudioMediaPage.svelte';
 
   let { data } = $props();
 </script>
 
-<StudioMediaPage {data} studioName="My Studio" />
+<!--
+  This route DOES have a +page.server.ts load, so invalidateAll() re-runs it and
+  refreshes data.mediaItems. (The org studio media route has no server load and
+  passes mediaQuery.refresh() instead.)
+-->
+<StudioMediaPage
+  {data}
+  studioName="My Studio"
+  onRefresh={() => invalidateAll()}
+/>

--- a/apps/web/src/routes/_org/[slug]/studio/media/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/media/+page.svelte
@@ -60,7 +60,11 @@
     </div>
   </div>
 {:else}
-  <StudioMediaPage data={mediaData} studioName={data.org.name} />
+  <StudioMediaPage
+    data={mediaData}
+    studioName={data.org.name}
+    onRefresh={() => mediaQuery.refresh()}
+  />
 {/if}
 
 <style>


### PR DESCRIPTION
**Bug:** `Codex-eb00a.8` (P1) — after uploading audio, the tile stays at `uploaded` and never flips to `processing`/`ready` without a manual refresh.

## Root cause (two compounding bugs)
1. **Poll never starts.** `MediaTile` started polling only if the *initial* `media.status === 'transcoding'` (in `onMount`). But content-api sets status to `uploaded` synchronously and only flips to `transcoding` a few seconds later (async `waitUntil`). So `onMount` ran at `uploaded`, the guard was false, and no poll ever started.
2. **List never refetches.** `StudioMediaPage.handleUploadComplete` called `invalidateAll()`, but the org media route has **no `+page.server.ts`** and `listMedia` is a remote `query()` — `invalidateAll()` re-runs load functions, not standalone remote queries, so the list never refetched.

## Fix
1. `MediaTile`: replace the `onMount` gate with a **reactive `$effect`** keyed on `effectiveStatus` — polls while `uploaded` **or** `transcoding`, and cleans up (interval + `visibilitychange` listener) once it reaches `ready`/`failed`. Self-starts even when the row transitions into a processing state after mount.
2. Thread an `onRefresh` callback into `StudioMediaPage` and route **all three** list mutations (upload/edit/delete) through it — they all shared this staleness bug:
   - org route (no server load) → `mediaQuery.refresh()`
   - creators route (has server load) → `invalidateAll()`

   > Caught during the fix: the creators studio media page *does* have a `+page.server.ts`, so it correctly relied on `invalidateAll()` — wired its `onRefresh` explicitly so removing `invalidateAll` from the shared component didn't silently regress it.

## Verification
Typecheck ✅ · biome ✅. Behavioural (polling/timers) — **please sanity-check**: upload an audio file → tile goes `uploaded → processing → ready` without a manual refresh; edit/delete update the grid immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)