### PR TITLE
fix(org-landing): gate Subscribe CTA on active tiers + subscriptions flag (Codex-eb00a.13)

### DIFF
--- a/apps/web/src/lib/utils/subscribe-cta.test.ts
+++ b/apps/web/src/lib/utils/subscribe-cta.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type SubscribeCtaVisibilityInput,
+  shouldShowSubscribeCta,
+} from './subscribe-cta';
+
+/** A visitor for whom the CTA SHOULD show; each test flips one field. */
+function shows(
+  overrides: Partial<SubscribeCtaVisibilityInput> = {}
+): SubscribeCtaVisibilityInput {
+  return {
+    hasOrgId: true,
+    subscriptionsEnabled: true,
+    hasActiveTiers: true,
+    accessChecked: true,
+    hasOrgAccess: false,
+    ...overrides,
+  };
+}
+
+describe('shouldShowSubscribeCta', () => {
+  it('shows for an anonymous visitor when the org has active tiers + subscriptions enabled', () => {
+    expect(shouldShowSubscribeCta(shows())).toBe(true);
+  });
+
+  // The reported bug: org with nothing to subscribe to still showed the CTA.
+  it('hides when the org has no active tiers (the reported bug)', () => {
+    expect(shouldShowSubscribeCta(shows({ hasActiveTiers: false }))).toBe(
+      false
+    );
+  });
+
+  it('hides when subscriptions are disabled for the org', () => {
+    expect(shouldShowSubscribeCta(shows({ subscriptionsEnabled: false }))).toBe(
+      false
+    );
+  });
+
+  it('hides until access probes have settled (no flash for subscribers)', () => {
+    expect(shouldShowSubscribeCta(shows({ accessChecked: false }))).toBe(false);
+  });
+
+  it('hides for a visitor who already has access (owner/member/subscriber)', () => {
+    expect(shouldShowSubscribeCta(shows({ hasOrgAccess: true }))).toBe(false);
+  });
+
+  it('hides when the org is not resolved', () => {
+    expect(shouldShowSubscribeCta(shows({ hasOrgId: false }))).toBe(false);
+  });
+});

--- a/apps/web/src/lib/utils/subscribe-cta.ts
+++ b/apps/web/src/lib/utils/subscribe-cta.ts
@@ -1,0 +1,39 @@
+/**
+ * Visibility decision for the org-landing Subscribe CTA (inline banner +
+ * bottom-of-viewport sticky bar).
+ *
+ * Bug Codex-eb00a.13: both surfaces were gated only on "does the visitor
+ * already have access?" (accessChecked && !hasOrgAccess), so an org with zero
+ * tiers and no Stripe account still rendered a "Become a member" CTA that sent
+ * visitors to a dead /pricing page.
+ *
+ * The fix additionally requires there to actually be something to subscribe to:
+ * the `enableSubscriptions` feature flag AND at least one active tier.
+ * `hasActiveTiers` is the practical public-surface proxy for Connect readiness —
+ * a tier can only be created after Connect onboarding, and the public org-info
+ * endpoint deliberately does not expose Stripe account status.
+ */
+export interface SubscribeCtaVisibilityInput {
+  /** The org resolved (`!!data.org?.id`). */
+  hasOrgId: boolean;
+  /** `enableSubscriptions` feature flag for the org. */
+  subscriptionsEnabled: boolean;
+  /** At least one active subscription tier exists. */
+  hasActiveTiers: boolean;
+  /** Access probes (membership + subscription) have settled. */
+  accessChecked: boolean;
+  /** The visitor already has access (owner/member/active subscriber). */
+  hasOrgAccess: boolean;
+}
+
+export function shouldShowSubscribeCta(
+  i: SubscribeCtaVisibilityInput
+): boolean {
+  return (
+    i.hasOrgId &&
+    i.subscriptionsEnabled &&
+    i.hasActiveTiers &&
+    i.accessChecked &&
+    !i.hasOrgAccess
+  );
+}

--- a/apps/web/src/routes/_org/[slug]/(space)/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/+page.svelte
@@ -41,6 +41,7 @@
     unfollowOrganization,
   } from '$lib/remote/org.remote';
   import { useAccessContext } from '$lib/utils/access-context.svelte';
+  import { shouldShowSubscribeCta } from '$lib/utils/subscribe-cta';
   import { StructuredData } from '$lib/components/seo';
   import type { PageData } from './$types';
 
@@ -227,8 +228,24 @@
       (hasActiveMembership || hasActiveSubscription)
   );
 
+  // Only surface the Subscribe CTA when the org actually has something to
+  // subscribe to. Gating on active tiers + the enableSubscriptions flag (in
+  // addition to the existing "visitor lacks access" checks) stops orgs with
+  // zero tiers / no Stripe account from advertising a dead /pricing page.
+  // access.tiers defaults to [] and resolves async, so hasActiveTiers starts
+  // false and the CTA simply defers until tiers are known — matching the
+  // accessChecked-defers-render philosophy.
+  const subscriptionsEnabled = $derived(data.enableSubscriptions ?? true);
+  const hasActiveTiers = $derived(access.tiers.length > 0);
+
   const shouldShowSubscribeCTA = $derived(
-    !!data.org?.id && accessChecked && !hasOrgAccess
+    shouldShowSubscribeCta({
+      hasOrgId: !!data.org?.id,
+      subscriptionsEnabled,
+      hasActiveTiers,
+      accessChecked,
+      hasOrgAccess,
+    })
   );
 
   $effect(() => {


### PR DESCRIPTION
## Bug (Codex-eb00a.13 — smoke-test finding #3 `subscribe-component-shows-without-subscription`)

The public org landing page rendered **both** the inline `SubscribeCTA` banner and the bottom-of-viewport `SubscribeStickyBar` gated only on `!!data.org?.id && accessChecked && !hasOrgAccess` — i.e. purely "does the visitor already have access?". It never checked whether the org had **anything to subscribe to**. An org with zero tiers and no Stripe account still showed a "Become a member → Subscribe" CTA that sent visitors to a `/pricing` page which itself renders an EmptyState. A broken public conversion surface.

## Fix

Add a tiers + feature gate, mirroring the gating the `/pricing` page already does (`!enableSubscriptions` / `tiers.length === 0`):

- **`$lib/utils/subscribe-cta.ts`** — `shouldShowSubscribeCta(input)` pure predicate.
- **(space)/+page.svelte** —
  - `subscriptionsEnabled = data.enableSubscriptions ?? true` (already on the parent org layout)
  - `hasActiveTiers = access.tiers.length > 0` (from the already-streamed `subscriptionContext`; `access.tiers` defaults to `[]`, so the CTA simply **defers** until tiers are known — matching the existing `accessChecked`-defers-render philosophy, no flash)
  - `shouldShowSubscribeCTA` now routes through the helper; both the inline banner and the sticky bar consume it, so both suppress together.

**Why tiers-as-proxy:** on this platform a tier can only be created *after* Connect onboarding, and the public org-info endpoint deliberately does not expose Stripe `chargesEnabled`. So `active tiers + enableSubscriptions` is a correct, self-contained gate with **no new server round-trip**. (If a stricter signal is ever wanted, surface `acceptsSubscriptions` from `getPublicInfo` and AND it in — a follow-up; this already eliminates the reported bug.)

## Tests

`subscribe-cta.test.ts` — 6-case truth table; each case flips exactly one field from the "should show" shape (incl. the exact reported bug: `hasActiveTiers: false → hidden`). Non-vacuous. `6/6 passing`.

## Verification notes

- ✅ `vitest` subscribe-cta suite green
- ✅ `svelte-check` — no new errors in changed files (pre-existing content-card typing errors on this page are untouched / out of scope)
- ✅ biome clean
- ⚠️ Runtime check: on an org with zero tiers, neither the banner nor the sticky bar should render; on an org with active tiers + subscriptions enabled, an anonymous visitor sees both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)