### PR TITLE
fix(content): gate publishing monetised content on Stripe Connect readiness (Codex-eb00a.10)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -759,6 +759,8 @@
   "studio_content_form_access_followers_desc": "Must follow your organisation (free)",
   "studio_content_form_access_team": "Team only",
   "studio_content_form_access_team_desc": "Only team members (owners, admins, creators)",
+  "studio_content_form_access_payouts_hint": "Set up payouts before you can sell content or gate it behind a subscription.",
+  "studio_content_form_access_payouts_link": "Set up payouts",
   "studio_content_form_access_members": "Members only",
   "studio_content_form_access_members_desc": "Only your organisation team members can access",
   "studio_content_form_access_also_purchasable": "Also available for one-time purchase",

--- a/apps/web/src/lib/components/studio/ContentForm.svelte
+++ b/apps/web/src/lib/components/studio/ContentForm.svelte
@@ -27,6 +27,7 @@
     updateContentForm,
     deleteContent,
   } from '$lib/remote/content.remote';
+  import { getMyConnectStatus } from '$lib/remote/subscription.remote';
   import { togglePublishStatus, type ContentStatus } from './publish-toggle';
   import { toast } from '$lib/components/ui/Toast/toast-store';
   import type { ContentWithRelations, SubscriptionTier } from '$lib/types';
@@ -79,6 +80,19 @@
 
   const isEdit = $derived(!!content);
   const form = $derived(isEdit ? updateContentForm : createContentForm);
+
+  // Stripe Connect payout readiness gates the paid/subscriber access options
+  // (Codex-eb00a.10). The backend authoritatively blocks publishing monetised
+  // content without a payout-ready account; this drives the proactive prompt in
+  // AccessSection. Assume ready until the status resolves so connected creators
+  // never see a flash of disabled options.
+  const connectStatusQuery = getMyConnectStatus();
+  const connectReady = $derived(
+    connectStatusQuery.current
+      ? connectStatusQuery.current.chargesEnabled &&
+          connectStatusQuery.current.payoutsEnabled
+      : true
+  );
 
   // ── Local UI state ──────────────────────────────────────────────────────
   let showDeleteConfirm = $state(false);
@@ -563,6 +577,7 @@
           {priceVal}
           {selectedMinimumTierId}
           {derivedVisibility}
+          {connectReady}
           onAccessChange={handleAccessChange}
           onTierChange={handleTierChange}
         />

--- a/apps/web/src/lib/components/studio/content-form/AccessSection.svelte
+++ b/apps/web/src/lib/components/studio/content-form/AccessSection.svelte
@@ -32,6 +32,15 @@
     derivedVisibility: string;
     onAccessChange: (value: string) => void;
     onTierChange: (value: string | undefined) => void;
+    /**
+     * Whether the creator's Stripe Connect account can receive money. When
+     * false, the monetised access options (paid / subscribers) are disabled
+     * with a "set up payouts" prompt — mirroring the authoritative backend
+     * gate (ContentService.publish throws for monetised content without a
+     * payout-ready account). Defaults true so the form never blocks before
+     * status resolves.
+     */
+    connectReady?: boolean;
   }
 
   const {
@@ -43,16 +52,25 @@
     derivedVisibility,
     onAccessChange,
     onTierChange,
+    connectReady = true,
   }: Props = $props();
 
   const hasOrg = $derived(!!form.fields.organizationId?.value());
   const hasTiers = $derived(tiers.length > 0);
+
+  // Org content routes payout setup to the monetisation hub; personal creator
+  // content routes to the creator earnings page. Both are root-relative studio
+  // paths (slug is in the subdomain).
+  const payoutSetupHref = $derived(
+    hasOrg ? '/studio/monetisation' : '/studio/earnings'
+  );
 
   interface AccessOption {
     value: string;
     label: string;
     description: string;
     icon: typeof GlobeIcon;
+    disabled?: boolean;
   }
 
   const options = $derived.by((): AccessOption[] => {
@@ -68,6 +86,8 @@
         label: m.studio_content_form_access_paid(),
         description: m.studio_content_form_access_paid_desc(),
         icon: CreditCardIcon,
+        // Monetised — requires a payout-ready Connect account.
+        disabled: !connectReady,
       },
     ];
     if (hasOrg) {
@@ -84,6 +104,8 @@
         label: m.studio_content_form_access_subscribers(),
         description: m.studio_content_form_access_subscribers_desc(),
         icon: CoinsIcon,
+        // Monetised — requires a payout-ready Connect account.
+        disabled: !connectReady,
       });
     }
     if (hasOrg) {
@@ -96,6 +118,9 @@
     }
     return out;
   });
+
+  // Show the payouts prompt when a monetised option is present but blocked.
+  const showPayoutsHint = $derived(!connectReady);
 
   const showPrice = $derived(accessTypeVal === 'paid' || accessTypeVal === 'subscribers');
   // Tier applies to two access modes:
@@ -132,12 +157,17 @@
   >
     {#each options as option (option.value)}
       {@const Icon = option.icon}
-      <label class="access-card" data-selected={accessTypeVal === option.value || undefined}>
+      <label
+        class="access-card"
+        data-selected={accessTypeVal === option.value || undefined}
+        data-disabled={option.disabled || undefined}
+      >
         <input
           type="radio"
           name="_accessTypeRadio"
           value={option.value}
           checked={accessTypeVal === option.value}
+          disabled={option.disabled}
           onchange={() => onAccessChange(option.value)}
           class="sr-only"
         />
@@ -152,6 +182,15 @@
       </label>
     {/each}
   </div>
+
+  {#if showPayoutsHint}
+    <p class="payouts-hint">
+      {m.studio_content_form_access_payouts_hint()}
+      <a href={payoutSetupHref} class="payouts-link">
+        {m.studio_content_form_access_payouts_link()}
+      </a>
+    </p>
+  {/if}
 
   {#if showPrice}
     <div class="conditional-row">
@@ -254,6 +293,29 @@
   .access-card[data-selected] {
     border-color: var(--color-interactive);
     background-color: color-mix(in srgb, var(--color-interactive) 5%, var(--color-surface));
+  }
+
+  /* Monetised option blocked until payouts are set up. */
+  .access-card[data-disabled] {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled, 0.5);
+  }
+
+  .access-card[data-disabled]:hover {
+    border-color: var(--color-border);
+    transform: none;
+  }
+
+  .payouts-hint {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  .payouts-link {
+    color: var(--color-interactive);
+    font-weight: var(--font-medium);
+    text-decoration: underline;
   }
 
   .access-icon {

--- a/apps/web/src/paraglide/messages/en.js
+++ b/apps/web/src/paraglide/messages/en.js
@@ -6095,6 +6095,22 @@ export const studio_content_form_access_team_desc = () => `Only team members (ow
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
+export const studio_content_form_access_payouts_hint = () => `Set up payouts before you can sell content or gate it behind a subscription.`
+
+
+/**
+ * 
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const studio_content_form_access_payouts_link = () => `Set up payouts`
+
+
+/**
+ * 
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
 export const studio_content_form_access_members = () => `Members only`
 
 

--- a/e2e/tests/04-paid-content-purchase.test.ts
+++ b/e2e/tests/04-paid-content-purchase.test.ts
@@ -46,12 +46,13 @@ describe('Paid Content Purchase Flow', () => {
     const creatorEmail = `creator-paid-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
     const creatorPassword = 'SecurePassword123!';
 
-    const { cookie: creatorCookie } = await authFixture.registerUser({
-      email: creatorEmail,
-      password: creatorPassword,
-      name: 'Paid Content Creator',
-      role: 'creator',
-    });
+    const { cookie: creatorCookie, user: creator } =
+      await authFixture.registerUser({
+        email: creatorEmail,
+        password: creatorPassword,
+        name: 'Paid Content Creator',
+        role: 'creator',
+      });
 
     // Create organization (required for paid content in Phase 1)
     const orgResponse = await httpClient.post(
@@ -142,6 +143,18 @@ describe('Paid Content Purchase Flow', () => {
     );
     await expectSuccessResponse(contentResponse, 201);
     const content = unwrapApiResponse(await contentResponse.json());
+
+    // Seed a payout-ready Stripe Connect account for the creator so publishing
+    // MONETISED content passes the CREATOR_CONNECT_REQUIRED (422) gate.
+    await dbHttp.insert(schema.stripeConnectAccounts).values({
+      userId: creator.id,
+      organizationId: organization.id,
+      stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      status: 'active',
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      onboardingCompletedAt: new Date(),
+    });
 
     // Publish the content
     const publishResponse = await httpClient.post(
@@ -301,11 +314,12 @@ describe('Paid Content Purchase Flow', () => {
     // This test performs full setup + purchase + duplicate webhook test
     // Create creator and paid content
     const creatorEmail = `creator-idem-${Date.now()}@example.com`;
-    const { cookie: creatorCookie } = await authFixture.registerUser({
-      email: creatorEmail,
-      password: 'SecurePassword123!',
-      role: 'creator',
-    });
+    const { cookie: creatorCookie, user: creator } =
+      await authFixture.registerUser({
+        email: creatorEmail,
+        password: 'SecurePassword123!',
+        role: 'creator',
+      });
 
     // Create organization (required for paid content)
     const orgResponse = await httpClient.post(
@@ -379,6 +393,18 @@ describe('Paid Content Purchase Flow', () => {
       }
     );
     const content = unwrapApiResponse(await contentResponse.json());
+
+    // Seed a payout-ready Stripe Connect account for the creator so publishing
+    // MONETISED content passes the CREATOR_CONNECT_REQUIRED (422) gate.
+    await dbHttp.insert(schema.stripeConnectAccounts).values({
+      userId: creator.id,
+      organizationId: organization.id,
+      stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      status: 'active',
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      onboardingCompletedAt: new Date(),
+    });
 
     await httpClient.post(
       `${WORKER_URLS.content}/api/content/${content.id}/publish`,
@@ -491,11 +517,12 @@ describe('Paid Content Purchase Flow', () => {
   test('should return 409 when attempting to purchase already-owned content', async () => {
     // This test performs full setup + purchase + second checkout attempt
     // Setup: Create and publish paid content
-    const { cookie: creatorCookie } = await authFixture.registerUser({
-      email: `creator-409-${Date.now()}@example.com`,
-      password: 'SecurePassword123!',
-      role: 'creator',
-    });
+    const { cookie: creatorCookie, user: creator } =
+      await authFixture.registerUser({
+        email: `creator-409-${Date.now()}@example.com`,
+        password: 'SecurePassword123!',
+        role: 'creator',
+      });
 
     // Create organization (required for paid content)
     const orgResponse = await httpClient.post(
@@ -568,6 +595,18 @@ describe('Paid Content Purchase Flow', () => {
       }
     );
     const content = unwrapApiResponse(await contentResponse.json());
+
+    // Seed a payout-ready Stripe Connect account for the creator so publishing
+    // MONETISED content passes the CREATOR_CONNECT_REQUIRED (422) gate.
+    await dbHttp.insert(schema.stripeConnectAccounts).values({
+      userId: creator.id,
+      organizationId: organization.id,
+      stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      status: 'active',
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      onboardingCompletedAt: new Date(),
+    });
 
     await httpClient.post(
       `${WORKER_URLS.content}/api/content/${content.id}/publish`,

--- a/e2e/tests/05-purchase-history.test.ts
+++ b/e2e/tests/05-purchase-history.test.ts
@@ -51,12 +51,13 @@ describe('Purchase History API', () => {
     const creatorEmail = `creator-history-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
     console.log('[Setup] 1/12 Registering creator...');
 
-    const { cookie: _creatorCookie } = await authFixture.registerUser({
-      email: creatorEmail,
-      password: 'SecurePassword123!',
-      name: 'History Test Creator',
-      role: 'creator',
-    });
+    const { cookie: _creatorCookie, user: creator } =
+      await authFixture.registerUser({
+        email: creatorEmail,
+        password: 'SecurePassword123!',
+        name: 'History Test Creator',
+        role: 'creator',
+      });
     creatorCookie = _creatorCookie;
     console.log('[Setup] 1/12 Creator registered');
 
@@ -214,6 +215,19 @@ describe('Purchase History API', () => {
       contentId,
       content2Id
     );
+
+    // Seed a payout-ready Stripe Connect account for the creator so publishing
+    // MONETISED content passes the CREATOR_CONNECT_REQUIRED (422) gate. One
+    // creator publishes both paid items, so a single account is sufficient.
+    await dbHttp.insert(schema.stripeConnectAccounts).values({
+      userId: creator.id,
+      organizationId: organizationId,
+      stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      status: 'active',
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      onboardingCompletedAt: new Date(),
+    });
 
     // Publish both content items in parallel
     console.log('[Setup] 6/12 Publishing both content items in parallel...');

--- a/e2e/tests/06-admin-dashboard.test.ts
+++ b/e2e/tests/06-admin-dashboard.test.ts
@@ -152,11 +152,12 @@ describe('Admin Dashboard', () => {
 
         // 2. Create creator and content under this org
         const creatorEmail = `creator-revenue-${Date.now()}@example.com`;
-        const { cookie: creatorCookie } = await authFixture.registerUser({
-          email: creatorEmail,
-          password: 'SecurePassword123!',
-          role: 'creator',
-        });
+        const { cookie: creatorCookie, user: creator } =
+          await authFixture.registerUser({
+            email: creatorEmail,
+            password: 'SecurePassword123!',
+            role: 'creator',
+          });
 
         // Create media item
         const testMediaId = `e2e-revenue-${Date.now()}`;
@@ -211,6 +212,19 @@ describe('Admin Dashboard', () => {
           }
         );
         const content = unwrapApiResponse(await contentResponse.json());
+
+        // Seed a payout-ready Stripe Connect account for the creator so
+        // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+        // (422) gate.
+        await dbHttp.insert(schema.stripeConnectAccounts).values({
+          userId: creator.id,
+          organizationId: admin.organization.id,
+          stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          onboardingCompletedAt: new Date(),
+        });
 
         // Publish content
         await httpClient.post(
@@ -302,11 +316,12 @@ describe('Admin Dashboard', () => {
         });
 
         // Create purchase in admin1's org
-        const { cookie: creatorCookie } = await authFixture.registerUser({
-          email: `creator-scope-${Date.now()}@example.com`,
-          password: 'SecurePassword123!',
-          role: 'creator',
-        });
+        const { cookie: creatorCookie, user: creator } =
+          await authFixture.registerUser({
+            email: `creator-scope-${Date.now()}@example.com`,
+            password: 'SecurePassword123!',
+            role: 'creator',
+          });
 
         const testMediaId = `e2e-scope-${Date.now()}`;
         const mediaResponse = await httpClient.post(
@@ -359,6 +374,19 @@ describe('Admin Dashboard', () => {
           }
         );
         const content = unwrapApiResponse(await contentResponse.json());
+
+        // Seed a payout-ready Stripe Connect account for the creator so
+        // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+        // (422) gate.
+        await dbHttp.insert(schema.stripeConnectAccounts).values({
+          userId: creator.id,
+          organizationId: admin1.organization.id,
+          stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          onboardingCompletedAt: new Date(),
+        });
 
         await httpClient.post(
           `${WORKER_URLS.content}/api/content/${content.id}/publish`,
@@ -438,11 +466,12 @@ describe('Admin Dashboard', () => {
         });
 
         // Create content
-        const { cookie: creatorCookie } = await authFixture.registerUser({
-          email: `creator-distinct-${Date.now()}@example.com`,
-          password: 'SecurePassword123!',
-          role: 'creator',
-        });
+        const { cookie: creatorCookie, user: creator } =
+          await authFixture.registerUser({
+            email: `creator-distinct-${Date.now()}@example.com`,
+            password: 'SecurePassword123!',
+            role: 'creator',
+          });
 
         const testMediaId = `e2e-distinct-${Date.now()}`;
         const mediaResponse = await httpClient.post(
@@ -549,6 +578,20 @@ describe('Admin Dashboard', () => {
           }
         );
         const content2 = unwrapApiResponse(await content2Response.json());
+
+        // Seed a payout-ready Stripe Connect account for the creator so
+        // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+        // (422) gate. One creator publishes both paid items, so a single
+        // account is sufficient.
+        await dbHttp.insert(schema.stripeConnectAccounts).values({
+          userId: creator.id,
+          organizationId: admin.organization.id,
+          stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          onboardingCompletedAt: new Date(),
+        });
 
         // Publish both
         await httpClient.post(
@@ -1058,11 +1101,12 @@ describe('Admin Dashboard', () => {
         });
 
         // Create content and buyer
-        const { cookie: creatorCookie } = await authFixture.registerUser({
-          email: `creator-customers-${Date.now()}@example.com`,
-          password: 'SecurePassword123!',
-          role: 'creator',
-        });
+        const { cookie: creatorCookie, user: creator } =
+          await authFixture.registerUser({
+            email: `creator-customers-${Date.now()}@example.com`,
+            password: 'SecurePassword123!',
+            role: 'creator',
+          });
 
         const testMediaId = `e2e-customers-${Date.now()}`;
         const mediaResponse = await httpClient.post(
@@ -1114,6 +1158,19 @@ describe('Admin Dashboard', () => {
           }
         );
         const content = unwrapApiResponse(await contentResponse.json());
+
+        // Seed a payout-ready Stripe Connect account for the creator so
+        // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+        // (422) gate.
+        await dbHttp.insert(schema.stripeConnectAccounts).values({
+          userId: creator.id,
+          organizationId: admin.organization.id,
+          stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          onboardingCompletedAt: new Date(),
+        });
 
         await httpClient.post(
           `${WORKER_URLS.content}/api/content/${content.id}/publish`,
@@ -1183,11 +1240,12 @@ describe('Admin Dashboard', () => {
         });
 
         // Setup content and purchase (abbreviated)
-        const { cookie: creatorCookie } = await authFixture.registerUser({
-          email: `creator-details-${Date.now()}@example.com`,
-          password: 'SecurePassword123!',
-          role: 'creator',
-        });
+        const { cookie: creatorCookie, user: creator } =
+          await authFixture.registerUser({
+            email: `creator-details-${Date.now()}@example.com`,
+            password: 'SecurePassword123!',
+            role: 'creator',
+          });
 
         const testMediaId = `e2e-details-${Date.now()}`;
         const mediaResponse = await httpClient.post(
@@ -1239,6 +1297,19 @@ describe('Admin Dashboard', () => {
           }
         );
         const content = unwrapApiResponse(await contentResponse.json());
+
+        // Seed a payout-ready Stripe Connect account for the creator so
+        // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+        // (422) gate.
+        await dbHttp.insert(schema.stripeConnectAccounts).values({
+          userId: creator.id,
+          organizationId: admin.organization.id,
+          stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          onboardingCompletedAt: new Date(),
+        });
 
         await httpClient.post(
           `${WORKER_URLS.content}/api/content/${content.id}/publish`,
@@ -1307,11 +1378,12 @@ describe('Admin Dashboard', () => {
       });
 
       // Create initial purchase to establish customer relationship
-      const { cookie: creatorCookie } = await authFixture.registerUser({
-        email: `creator-grant-${Date.now()}@example.com`,
-        password: 'SecurePassword123!',
-        role: 'creator',
-      });
+      const { cookie: creatorCookie, user: creator } =
+        await authFixture.registerUser({
+          email: `creator-grant-${Date.now()}@example.com`,
+          password: 'SecurePassword123!',
+          role: 'creator',
+        });
 
       // First content (for initial purchase)
       const testMediaId1 = `e2e-grant-1-${Date.now()}`;
@@ -1364,6 +1436,20 @@ describe('Admin Dashboard', () => {
         }
       );
       const content1 = unwrapApiResponse(await content1Response.json());
+
+      // Seed a payout-ready Stripe Connect account for the creator so
+      // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+      // (422) gate. This creator publishes both paid items, so a single
+      // account is sufficient.
+      await dbHttp.insert(schema.stripeConnectAccounts).values({
+        userId: creator.id,
+        organizationId: admin.organization.id,
+        stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+        status: 'active',
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        onboardingCompletedAt: new Date(),
+      });
 
       await httpClient.post(
         `${WORKER_URLS.content}/api/content/${content1.id}/publish`,
@@ -1505,11 +1591,12 @@ describe('Admin Dashboard', () => {
       });
 
       // Setup (abbreviated)
-      const { cookie: creatorCookie } = await authFixture.registerUser({
-        email: `creator-idem-${Date.now()}@example.com`,
-        password: 'SecurePassword123!',
-        role: 'creator',
-      });
+      const { cookie: creatorCookie, user: creator } =
+        await authFixture.registerUser({
+          email: `creator-idem-${Date.now()}@example.com`,
+          password: 'SecurePassword123!',
+          role: 'creator',
+        });
 
       const testMediaId = `e2e-idem-${Date.now()}`;
       const mediaResponse = await httpClient.post(
@@ -1561,6 +1648,19 @@ describe('Admin Dashboard', () => {
         }
       );
       const content = unwrapApiResponse(await contentResponse.json());
+
+      // Seed a payout-ready Stripe Connect account for the creator so
+      // publishing MONETISED content passes the CREATOR_CONNECT_REQUIRED
+      // (422) gate.
+      await dbHttp.insert(schema.stripeConnectAccounts).values({
+        userId: creator.id,
+        organizationId: admin.organization.id,
+        stripeAccountId: `acct_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+        status: 'active',
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        onboardingCompletedAt: new Date(),
+      });
 
       await httpClient.post(
         `${WORKER_URLS.content}/api/content/${content.id}/publish`,

--- a/packages/access/src/__tests__/ContentAccessService.integration.test.ts
+++ b/packages/access/src/__tests__/ContentAccessService.integration.test.ts
@@ -28,12 +28,14 @@ import {
   organizationMemberships,
   organizations,
   purchases,
+  stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
 } from '@codex/database/schema';
 import { ObservabilityClient } from '@codex/observability';
 import type { PurchaseService } from '@codex/purchase';
 import {
+  createTestConnectAccountInput,
   createTestSubscriptionInput,
   createTestTierInput,
   createUniqueSlug,
@@ -104,6 +106,16 @@ describe('ContentAccessService Integration', () => {
 
     const userIds = await seedTestUsers(db, 2);
     [userId, otherUserId] = userIds;
+
+    // ContentService.publish now gates monetised content (paid w/ price>0 or
+    // subscribers) behind a payout-ready Stripe Connect account for the
+    // publishing creator. `userId` is the creator for every monetised publish
+    // in this suite, so seed one READY account here (keyed by userId; the
+    // uq_stripe_connect_user unique constraint means at most one per user).
+    await db
+      .insert(stripeConnectAccounts)
+      .values(createTestConnectAccountInput(null, userId))
+      .onConflictDoNothing();
 
     // Create test organization
     const [org] = await db

--- a/packages/content/src/__tests__/integration.test.ts
+++ b/packages/content/src/__tests__/integration.test.ts
@@ -16,8 +16,10 @@
  */
 
 import { CONTENT_STATUS, MEDIA_STATUS } from '@codex/constants';
+import { stripeConnectAccounts } from '@codex/database/schema';
 import { OrganizationService } from '@codex/organization';
 import {
+  createTestConnectAccountInput,
   createUniqueSlug,
   type Database,
   seedTestUsers,
@@ -46,6 +48,16 @@ describe('Integration Tests', () => {
 
     const userIds = await seedTestUsers(db, 2);
     [creatorId, otherCreatorId] = userIds;
+
+    // Publishing monetised content now requires a payout-ready Connect account
+    // (Codex-eb00a.10). Seed one for each creator so the paid-content publish
+    // workflows below reach 'published' rather than hitting the new gate.
+    await db
+      .insert(stripeConnectAccounts)
+      .values([
+        createTestConnectAccountInput(null, creatorId),
+        createTestConnectAccountInput(null, otherCreatorId),
+      ]);
   });
 
   afterAll(async () => {

--- a/packages/content/src/errors.ts
+++ b/packages/content/src/errors.ts
@@ -91,3 +91,29 @@ export class MediaOwnershipError extends ForbiddenError {
     super('User does not own this media item', { mediaItemId, userId });
   }
 }
+
+/**
+ * Thrown when a creator tries to publish monetised content (paid with a price,
+ * or subscriber-gated) before their Stripe Connect account can receive money.
+ *
+ * Without this gate, a buyer can pay for content whose creator has no payout
+ * destination — funds are collected and the creator payout is parked pending
+ * indefinitely (see PurchaseService). Publishing is the last point at which the
+ * content becomes purchasable, so it is the authoritative backend gate.
+ *
+ * `code: 'CREATOR_CONNECT_REQUIRED'` is shared with the subscription domain's
+ * equivalent so the frontend can recognise the "set up payouts" condition
+ * uniformly. Maps to HTTP 422 via BusinessLogicError.
+ */
+export class CreatorPayoutsRequiredError extends BusinessLogicError {
+  constructor(creatorId: string, accessType: string) {
+    super(
+      'Set up payouts before publishing paid or subscriber content. Complete Stripe Connect onboarding to receive payments.',
+      {
+        creatorId,
+        accessType,
+        code: 'CREATOR_CONNECT_REQUIRED',
+      }
+    );
+  }
+}

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -119,6 +119,7 @@ export {
   ContentNotFoundError,
   ContentServiceError,
   ContentTypeMismatchError,
+  CreatorPayoutsRequiredError,
   ForbiddenError,
   InternalServiceError,
   isContentServiceError,

--- a/packages/content/src/services/__tests__/content-service.test.ts
+++ b/packages/content/src/services/__tests__/content-service.test.ts
@@ -23,9 +23,11 @@ import {
   content,
   mediaItems,
   organizations,
+  stripeConnectAccounts,
   subscriptionTiers,
 } from '@codex/database/schema';
 import {
+  createTestConnectAccountInput,
   createTestMediaItemInput,
   createTestOrganizationInput,
   createTestTierInput,
@@ -41,6 +43,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   ContentNotFoundError,
   ContentTypeMismatchError,
+  CreatorPayoutsRequiredError,
   MediaNotFoundError,
   MediaNotReadyError,
   SlugConflictError,
@@ -1119,6 +1122,135 @@ describe('ContentService', () => {
       // Assert
       expect(published.status).toBe('published');
       expect(published.publishedAt).not.toBeNull();
+    });
+  });
+
+  describe('publish — Stripe Connect payout gate (Codex-eb00a.10)', () => {
+    // Each test controls its own Connect precondition; reset between tests so a
+    // seeded ready-account from one test can't leak into the "no account" cases
+    // (uq_stripe_connect_user makes double-inserts fail otherwise).
+    afterEach(async () => {
+      await db.delete(stripeConnectAccounts);
+    });
+
+    async function createPaidWritten(slugPrefix: string): Promise<string> {
+      const created = await service.create(
+        {
+          title: 'Paid Article',
+          slug: createUniqueSlug(slugPrefix),
+          contentType: 'written',
+          contentBody: 'Paid body',
+          visibility: 'public',
+          accessType: 'paid',
+          priceCents: 500,
+          tags: [],
+        } as unknown as CreateContentInput,
+        creatorId
+      );
+      return created.id;
+    }
+
+    it('blocks publishing PAID content when the creator has no Connect account', async () => {
+      const id = await createPaidWritten('paid-no-connect');
+
+      await expect(service.publish(id, creatorId)).rejects.toBeInstanceOf(
+        CreatorPayoutsRequiredError
+      );
+
+      // Content must remain a draft — the block is a hard gate, not a warning.
+      const stillDraft = await service.get(id, creatorId);
+      expect(stillDraft.status).toBe('draft');
+    });
+
+    it('blocks publishing PAID content when Connect exists but is not payout-ready', async () => {
+      // Onboarding-in-progress account: charges/payouts still disabled.
+      await db.insert(stripeConnectAccounts).values(
+        createTestConnectAccountInput(null, creatorId, {
+          status: 'onboarding',
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          onboardingCompletedAt: null,
+        })
+      );
+      const id = await createPaidWritten('paid-not-ready');
+
+      await expect(service.publish(id, creatorId)).rejects.toBeInstanceOf(
+        CreatorPayoutsRequiredError
+      );
+    });
+
+    it('blocks when charges enabled but payouts disabled (mirrors backend requireActiveConnect)', async () => {
+      await db.insert(stripeConnectAccounts).values(
+        createTestConnectAccountInput(null, creatorId, {
+          status: 'restricted',
+          chargesEnabled: true,
+          payoutsEnabled: false,
+        })
+      );
+      const id = await createPaidWritten('paid-payouts-off');
+
+      await expect(service.publish(id, creatorId)).rejects.toBeInstanceOf(
+        CreatorPayoutsRequiredError
+      );
+    });
+
+    it('publishes PAID content when the creator Connect account is charges + payouts ready', async () => {
+      // createTestConnectAccountInput defaults to a ready account
+      // (status 'active', chargesEnabled + payoutsEnabled true).
+      await db
+        .insert(stripeConnectAccounts)
+        .values(createTestConnectAccountInput(null, creatorId));
+      const id = await createPaidWritten('paid-ready');
+
+      const published = await service.publish(id, creatorId);
+
+      expect(published.status).toBe('published');
+      expect(published.publishedAt).not.toBeNull();
+    });
+
+    it('blocks publishing SUBSCRIBER-gated content without a ready Connect account', async () => {
+      // Subscriber content must be org-scoped; seed the draft row directly
+      // (service.create rejects orgless tier-gated content).
+      const [org] = await db
+        .insert(organizations)
+        .values(createTestOrganizationInput())
+        .returning();
+      const [seeded] = await db
+        .insert(content)
+        .values({
+          creatorId,
+          organizationId: org.id,
+          title: 'Subscriber Article',
+          slug: createUniqueSlug('sub-no-connect'),
+          contentType: 'written',
+          contentBody: 'Members only',
+          accessType: 'subscribers',
+          status: 'draft',
+        })
+        .returning();
+
+      await expect(
+        service.publish(seeded.id, creatorId)
+      ).rejects.toBeInstanceOf(CreatorPayoutsRequiredError);
+    });
+
+    it('does NOT gate FREE content — publishes with no Connect account at all', async () => {
+      const created = await service.create(
+        {
+          title: 'Free Article',
+          slug: createUniqueSlug('free-no-connect'),
+          contentType: 'written',
+          contentBody: 'Free body',
+          visibility: 'public',
+          priceCents: 0,
+          tags: [],
+        },
+        creatorId
+      );
+
+      const published = await service.publish(created.id, creatorId);
+
+      expect(published.status).toBe('published');
     });
   });
 

--- a/packages/content/src/services/content-service.ts
+++ b/packages/content/src/services/content-service.ts
@@ -29,7 +29,11 @@ import {
   scopedNotDeleted,
   withCreatorScope,
 } from '@codex/database';
-import { content, mediaItems } from '@codex/database/schema';
+import {
+  content,
+  mediaItems,
+  stripeConnectAccounts,
+} from '@codex/database/schema';
 import {
   type ImageProcessingResult,
   ImageProcessingService,
@@ -43,6 +47,7 @@ import {
   BusinessLogicError,
   ContentNotFoundError,
   ContentTypeMismatchError,
+  CreatorPayoutsRequiredError,
   InternalServiceError,
   MediaNotFoundError,
   MediaNotReadyError,
@@ -93,6 +98,32 @@ export class ContentService extends BaseService {
       }
     }
     return { contentBody: raw, contentBodyJson: null };
+  }
+
+  /**
+   * Whether the creator's Stripe Connect account can receive money.
+   *
+   * DB-only readiness check: `charges_enabled` + `payouts_enabled` on
+   * `stripe_connect_accounts` are kept in sync by Stripe's `account.updated`
+   * webhook, so this needs no live Stripe call (content-api has no
+   * STRIPE_SECRET_KEY binding) and mirrors the backend gate the subscription
+   * domain uses (`chargesEnabled && payoutsEnabled`). One account per user is
+   * enforced by a unique(userId) constraint, so `.limit(1)` is exact.
+   */
+  private async isCreatorConnectReady(
+    tx: DatabaseTransaction,
+    creatorId: string
+  ): Promise<boolean> {
+    const [account] = await tx
+      .select({
+        chargesEnabled: stripeConnectAccounts.chargesEnabled,
+        payoutsEnabled: stripeConnectAccounts.payoutsEnabled,
+      })
+      .from(stripeConnectAccounts)
+      .where(eq(stripeConnectAccounts.userId, creatorId))
+      .limit(1);
+
+    return !!account && account.chargesEnabled && account.payoutsEnabled;
   }
 
   /**
@@ -492,6 +523,28 @@ export class ContentService extends BaseService {
           }
           if (existing.mediaItem.status !== MEDIA_STATUS.READY) {
             throw new MediaNotReadyError(existing.mediaItem.id);
+          }
+        }
+
+        // Monetised content requires a payout-ready Connect account before it
+        // can go live. Paid (with a price) and subscriber-gated content both
+        // collect money; publishing without a payout destination strands buyer
+        // funds in a pending payout indefinitely. Free / followers / team
+        // content is unaffected.
+        const isMonetised =
+          (existing.accessType === CONTENT_ACCESS_TYPE.PAID &&
+            (existing.priceCents ?? 0) > 0) ||
+          existing.accessType === CONTENT_ACCESS_TYPE.SUBSCRIBERS;
+        if (isMonetised) {
+          const connectReady = await this.isCreatorConnectReady(
+            tx as DatabaseTransaction,
+            creatorId
+          );
+          if (!connectReady) {
+            throw new CreatorPayoutsRequiredError(
+              creatorId,
+              existing.accessType
+            );
           }
         }
 

--- a/packages/purchase/src/__tests__/purchase-service-fee-config.integration.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service-fee-config.integration.test.ts
@@ -16,8 +16,9 @@
  */
 
 import { ContentService, MediaItemService } from '@codex/content';
-import { organizations } from '@codex/database/schema';
+import { organizations, stripeConnectAccounts } from '@codex/database/schema';
 import {
+  createTestConnectAccountInput,
   createUniqueSlug,
   type Database,
   seedTestUsers,
@@ -69,6 +70,15 @@ describe('PurchaseService × FeeConfigService integration', () => {
 
     const userIds = await seedTestUsers(db, 2);
     [creatorId, customerId] = userIds;
+
+    // ContentService.publish now gates monetised content behind a payout-ready
+    // Stripe Connect account for the publishing creator. `creatorId` publishes
+    // every paid content in this suite — seed one READY account (keyed by
+    // userId; uq_stripe_connect_user allows at most one per user).
+    await db
+      .insert(stripeConnectAccounts)
+      .values(createTestConnectAccountInput(null, creatorId))
+      .onConflictDoNothing();
 
     const [org] = await db
       .insert(organizations)

--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -20,6 +20,7 @@ import { ContentService, MediaItemService } from '@codex/content';
 import * as schema from '@codex/database/schema';
 import { organizations } from '@codex/database/schema';
 import {
+  createTestConnectAccountInput,
   createTestMembershipInput,
   createUniqueSlug,
   type Database,
@@ -170,6 +171,20 @@ describe('PurchaseService Integration', () => {
       .where(eq(schema.stripeConnectAccounts.userId, otherUserId));
   });
 
+  // ContentService.publish now gates monetised content (paid w/ price>0 or
+  // subscribers) behind a payout-ready Stripe Connect account for the
+  // publishing creator. These behaviour tests were written before that gate
+  // and publish first, wiring Connect (or asserting its absence) afterwards.
+  // Seed a READY account for the creator right before each monetised publish;
+  // onConflictDoNothing keeps it idempotent with any per-test Connect seed
+  // (uq_stripe_connect_user — at most one account per user).
+  async function seedReadyConnect(creatorId: string) {
+    await db
+      .insert(schema.stripeConnectAccounts)
+      .values(createTestConnectAccountInput(null, creatorId))
+      .onConflictDoNothing();
+  }
+
   describe('createCheckoutSession', () => {
     it('creates checkout session for valid paid content', async () => {
       // Create media and content
@@ -207,6 +222,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       // Mock Stripe response
@@ -293,6 +309,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(paidContent.id, userId);
 
       // Clear any cached Customer id from a prior test, then mock Stripe
@@ -387,6 +404,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(paidContent.id, userId);
 
       // Pre-stamp a cached Customer id so resolveOrCreateCustomer takes the
@@ -462,6 +480,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(paidContent.id, userId);
 
       // Force NULL stripe_customer_id so resolveOrCreateCustomer calls list.
@@ -525,6 +544,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(paidContent.id, userId);
 
       const { NotFoundError } = await import('../errors');
@@ -680,6 +700,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       // Complete a purchase first
@@ -745,6 +766,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_revenue_${Date.now()}`;
@@ -816,6 +838,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_idempotent_${Date.now()}`;
@@ -884,6 +907,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_access_${Date.now()}`;
@@ -948,9 +972,10 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
-      await contentService.publish(content.id, userId);
-
       // Seed org's Connect account row. The userId is the org owner.
+      // Seeded BEFORE publish so ContentService.publish's payout-ready gate is
+      // satisfied by THIS account (its stripeAccountId is what the test asserts
+      // as the transfer destination).
       // Idempotent: tests in this describe block share the same userId so
       // subsequent calls reuse the existing row instead of conflicting on
       // uq_stripe_connect_user (one account per user, Codex-69t7c).
@@ -968,11 +993,14 @@ describe('PurchaseService Integration', () => {
         .onConflictDoUpdate({
           target: [schema.stripeConnectAccounts.userId],
           set: {
+            stripeAccountId,
             chargesEnabled: opts.chargesEnabled ?? true,
             payoutsEnabled: true,
             status: 'active',
           },
         });
+
+      await contentService.publish(content.id, userId);
 
       // Pin the org's canonical Connect account so resolvePrimaryConnect routes
       // the org slice (Codex-69t7c: org→account via primaryConnectAccountUserId).
@@ -1185,11 +1213,10 @@ describe('PurchaseService Integration', () => {
         userId: otherUserId,
         organizationId: org2.id,
         stripeAccountId,
-        // Status enum: 'onboarding' | 'active' | 'restricted' | 'disabled'
-        // Use 'onboarding' to model "Connect created but not chargesEnabled yet".
-        status: 'onboarding',
-        chargesEnabled: false,
-        payoutsEnabled: false,
+        // Ready for publish; the runtime offline state is applied post-publish.
+        status: 'active',
+        chargesEnabled: true,
+        payoutsEnabled: true,
       });
 
       // Build a feeConfig stub that returns a non-zero org_fee_pct so the
@@ -1246,6 +1273,16 @@ describe('PurchaseService Integration', () => {
         otherUserId
       );
       await contentService.publish(content.id, otherUserId);
+      // Gate satisfied at publish time with a READY account; now model the
+      // offline Connect the runtime purchase path is meant to exercise.
+      await db
+        .update(schema.stripeConnectAccounts)
+        .set({
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          status: 'onboarding',
+        })
+        .where(eq(schema.stripeConnectAccounts.userId, otherUserId));
 
       const chargeId = `ch_offline_${Date.now()}`;
       const purchase = await service.completePurchase(
@@ -1431,7 +1468,14 @@ describe('PurchaseService Integration', () => {
         },
         ownerUserId
       );
+      // Satisfy the publish gate with a temporary READY account, then delete
+      // it to restore this test's premise: the org owner has NO Connect
+      // account at all at purchase time (distinct from the offline case).
+      await seedReadyConnect(ownerUserId);
       await contentService.publish(content.id, ownerUserId);
+      await db
+        .delete(schema.stripeConnectAccounts)
+        .where(eq(schema.stripeConnectAccounts.userId, ownerUserId));
 
       const chargeId = `ch_no_connect_${Date.now()}`;
       const purchase = await service.completePurchase(
@@ -1491,9 +1535,9 @@ describe('PurchaseService Integration', () => {
           userId: otherUserId,
           organizationId: localOrg.id,
           stripeAccountId: `acct_wp10_${titleSuffix}_${Date.now()}`,
-          status: 'onboarding',
-          chargesEnabled: false,
-          payoutsEnabled: false,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
         });
 
         const media = await mediaService.create(
@@ -1528,6 +1572,16 @@ describe('PurchaseService Integration', () => {
           otherUserId
         );
         await contentService.publish(testContent.id, otherUserId);
+        // Gate satisfied at publish time with a READY account; now model the
+        // offline Connect the runtime purchase path is meant to exercise.
+        await db
+          .update(schema.stripeConnectAccounts)
+          .set({
+            chargesEnabled: false,
+            payoutsEnabled: false,
+            status: 'onboarding',
+          })
+          .where(eq(schema.stripeConnectAccounts.userId, otherUserId));
 
         const localStubStripe = {
           ...mockStripe,
@@ -1990,6 +2044,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
       return { content };
     }
@@ -2383,6 +2438,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const chargeId = `ch_idem_${Date.now()}`;
@@ -2733,9 +2789,9 @@ describe('PurchaseService Integration', () => {
         userId,
         organizationId: pendingOrg.id,
         stripeAccountId: `acct_pending_${Date.now()}`,
-        status: 'onboarding',
-        chargesEnabled: false, // ← key: not ready
-        payoutsEnabled: false,
+        status: 'active',
+        chargesEnabled: true, // ready for publish; downgraded to offline after publish
+        payoutsEnabled: true,
       });
 
       const reversalCalls: string[] = [];
@@ -2788,6 +2844,16 @@ describe('PurchaseService Integration', () => {
         userId
       );
       await contentService.publish(content.id, userId);
+      // Gate satisfied at publish time with a READY account; now model the
+      // offline Connect the runtime purchase path is meant to exercise.
+      await db
+        .update(schema.stripeConnectAccounts)
+        .set({
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          status: 'onboarding',
+        })
+        .where(eq(schema.stripeConnectAccounts.userId, userId));
 
       const chargeId = `ch_pending_${Date.now()}`;
       const paymentIntentId = `pi_pending_${Date.now()}`;
@@ -2882,6 +2948,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       // Complete purchase
@@ -2936,6 +3003,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       // No purchase made
@@ -2982,6 +3050,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       // userId purchases (creator buying their own content for test purposes)
@@ -3044,6 +3113,7 @@ describe('PurchaseService Integration', () => {
           userId
         );
 
+        await seedReadyConnect(userId);
         await contentService.publish(content.id, userId);
 
         const purchase = await purchaseService.completePurchase(
@@ -3165,6 +3235,7 @@ describe('PurchaseService Integration', () => {
           },
           userId
         );
+        await seedReadyConnect(userId);
         await contentService.publish(c.id, userId);
         return c.id;
       }
@@ -3397,6 +3468,7 @@ describe('PurchaseService Integration', () => {
         },
         userId
       );
+      await seedReadyConnect(userId);
       await contentService.publish(c.id, userId);
       statsContentId = c.id;
 
@@ -3510,6 +3582,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const purchase = await purchaseService.completePurchase(
@@ -3569,6 +3642,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const purchase = await purchaseService.completePurchase(
@@ -3770,6 +3844,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_refund_full_${Date.now()}`;
@@ -3832,6 +3907,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_refund_idem_${Date.now()}`;
@@ -3891,6 +3967,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_refund_meta_${Date.now()}`;
@@ -3976,6 +4053,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_rollback_${Date.now()}`;
@@ -4102,6 +4180,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_revoke_${Date.now()}`;
@@ -4170,6 +4249,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_atomic_${Date.now()}`;
@@ -4251,6 +4331,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_dispute_${Date.now()}`;
@@ -4331,6 +4412,7 @@ describe('PurchaseService Integration', () => {
         userId
       );
 
+      await seedReadyConnect(userId);
       await contentService.publish(content.id, userId);
 
       const paymentIntentId = `pi_dispute_idem_${Date.now()}`;
@@ -4782,6 +4864,7 @@ describe('PurchaseService Integration', () => {
         },
         creatorUserId
       );
+      await seedReadyConnect(creatorUserId);
       await contentService.publish(content.id, creatorUserId);
 
       if (seedConnect) {


### PR DESCRIPTION
## Bug (Codex-eb00a.10 — smoke-test finding #11 `paid-content-without-stripe`)

Nothing tied paid access to Stripe Connect readiness. A creator could publish **paid** (or **subscriber-gated**) content with **no payout-ready account**; buyers could then pay, and `PurchaseService` parked the creator payout *pending indefinitely* — **funds collected with no payout destination**.

## Fix — two layers (API-authoritative + UI prompt)

### Backend (authoritative)
`ContentService.publish` now blocks monetised content — `accessType: 'paid'` with `priceCents > 0`, or `accessType: 'subscribers'` — unless the creator's Connect account is payout-ready, throwing **`CreatorPayoutsRequiredError`** (`BusinessLogicError` → **HTTP 422**, code `CREATOR_CONNECT_REQUIRED`). Free / followers / team content is unaffected.

Enforcement lives in the **service** (so the *API endpoint* returns the 422) — a mobile client gets the guarantee without any extra client work, matching the codebase's API-level-enforcement pattern.

**Readiness is a DB-only check** on `stripe_connect_accounts.chargesEnabled && payoutsEnabled`. Those columns are kept in sync by Stripe's `account.updated` webhook, so no live Stripe call is needed. This is essential because **content-api has no `STRIPE_SECRET_KEY` binding** (only ecom-api does) — `ctx.services.connect` would throw here. Reading the shared `@codex/database` schema also keeps `@codex/content` free of a `@codex/subscription` dependency.

**Performance:** a single indexed lookup on the `uq_stripe_connect_user` unique constraint, only on *monetised* publishes (a low-frequency creator action, not a hot read path). No cache — a cache would add webhook-invalidation complexity for no real gain.

### UI (proactive prompt)
`ContentForm` derives `connectReady` from `getMyConnectStatus()` and passes it to `AccessSection`, which **disables the paid + subscriber access cards** and shows a **"Set up payouts"** link — `/studio/monetisation` for org content, `/studio/earnings` for personal creator content. Assumed ready until status resolves, so connected creators never see a flash of disabled cards.

## Blast radius (why so many test files)

`publish()` is shared, so adding this precondition surfaced everywhere monetised content is published. Every such test now seeds a payout-ready Connect account (`createTestConnectAccountInput`) **before** the publish:

- `packages/content` — gate unit tests + integration workflow
- `packages/access` — `ContentAccessService` integration (1 `beforeAll` seed covers all its monetised publishes)
- `packages/purchase` — 29 pre-publish seeds; the tests that specifically exercise *"creator not connected **at purchase** time"* **seed-ready → publish → downgrade/delete** so their real scenario is preserved
- `e2e/` — `04-paid-content-purchase`, `05-purchase-history`, `06-admin-dashboard`, following the proven `11-payout-flows` DB-seed pattern. Free-content publishes left untouched.

**No assertions were weakened; no tests skipped.**

## Tests

New gate cases in `content-service.test.ts` (each flips one precondition — non-vacuous):
- paid, no Connect account → 422
- paid, account exists but charges/payouts disabled → 422
- paid, charges on but payouts off (mirrors backend `requireActiveConnect`) → 422
- paid, fully ready → **publishes**
- subscriber-gated, no Connect → 422
- **free, no Connect at all → publishes** (proves the gate doesn't over-block)

Local results: `@codex/content` **160 pass**, `@codex/access` **185 pass**, `@codex/purchase` **243 pass**. svelte-check clean on the UI files (pre-existing `visibility`/type-union drift on ContentForm is untouched). e2e verified by pattern + typecheck (full run is CI-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)