### PR TITLE
fix(studio): token-driven thin scrollbar on hover-expanded rail (Codex-eb00a.14)

### DIFF
--- a/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
+++ b/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
@@ -425,12 +425,31 @@
     border-right: var(--border-width) var(--border-style) var(--color-border);
     overflow-y: auto;
     overflow-x: hidden;
+
+    /* Thin token-driven scrollbar (mirrors Carousel). Without this a raw
+       native scrollbar paints a grey gutter over the rounded glass rail on
+       hover-expand (Codex-eb00a.14). */
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border) transparent;
     transition:
       width var(--duration-slow) var(--ease-spring),
       background-color var(--duration-normal) var(--ease-default),
       box-shadow var(--duration-normal) var(--ease-default),
       border-radius var(--duration-normal) var(--ease-default);
     view-transition-name: sidebar-nav;
+  }
+
+  .studio-rail::-webkit-scrollbar {
+    width: var(--space-1);
+  }
+
+  .studio-rail::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .studio-rail::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: var(--radius-full);
   }
 
   .studio-rail[data-expanded='true'] {


### PR DESCRIPTION
## What

`.studio-rail` (`StudioSidebar.svelte`) used `overflow-y: auto` with **no scrollbar styling**, so on hover-expand a raw native scrollbar painted a grey gutter over the rounded glass rail — visible against the `border-radius: 0 var(--radius-xl) var(--radius-xl) 0` glass treatment.

## Fix

Mirror the already-shipping **Carousel thin-scrollbar pattern**, adapted for a vertical scroller:

- **Firefox:** `scrollbar-width: thin` + `scrollbar-color: var(--color-border) transparent`
- **Chromium/Safari:** `::-webkit-scrollbar { width: var(--space-1) }`, transparent track, `--color-border` thumb with `--radius-full`

The transparent track is what lets the rounded glass rail show through instead of a gutter. All values are design tokens — no hardcoded px/hex.

## Scope

CSS-only, scoped to `.studio-rail`. 19 insertions, one file.

## Verification

- Syntactically verified against the working Carousel pattern (`carousel/Carousel.svelte:204-220`), adapted `height`→`width` for the vertical axis.
- ⚠️ **Not visually verified live** — dev stack wasn't running and spinning up the full worker fleet + auth for a P2 CSS scrollbar is disproportionate. Recommend a quick hover-expand check of the studio rail at review (log in as creator, open a studio, hover the collapsed rail so it expands, confirm the scrollbar is thin/token-styled and the glass corner is unobscured).

Bug: **Codex-eb00a.14** (smoke-test 2026-07-13). Base: `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)