### PR TITLE
fix(studio): full-width sales/payouts + first-creator empty states (Codex-eb00a.16)

### DIFF
--- a/apps/web/src/lib/components/studio/payouts/CreatorBreakdownRail.svelte
+++ b/apps/web/src/lib/components/studio/payouts/CreatorBreakdownRail.svelte
@@ -71,7 +71,10 @@
     </div>
   {:else if breakdown.length === 0}
     <p class="rail__empty">
-      No creators have been paid under these filters yet.
+      This breaks payouts down by creator. No creators have been paid under
+      these filters yet — as the sole creator you're your own beneficiary, so
+      your share lands here once your first invoice is paid. Invite other
+      creators via revenue-share to see the split across the team.
     </p>
   {:else}
     <div class="rail__list">

--- a/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
@@ -492,13 +492,21 @@
         {:else if isEmpty}
           <EmptyState
             title="No payouts yet"
-            description="Payouts will appear here once subscription invoices land and Stripe transfers the org and creator shares."
+            description="Payouts appear here once subscription invoices land and Stripe transfers each share. Every sale splits into a platform fee, an org fee, and a creator share — as the sole creator you're your own beneficiary, so 100% of the creator share is yours today. Invite other creators via revenue-share and they'll appear in the By-creator breakdown."
             icon={BanknoteIcon}
           >
             {#snippet action()}
-              <a href="/studio/monetisation" class="empty-link">
-                <Button variant="secondary">Go to Monetisation</Button>
-              </a>
+              <div class="empty-actions">
+                <a href="/studio/monetisation" class="empty-link">
+                  <Button variant="secondary">Go to Monetisation</Button>
+                </a>
+                <a
+                  href="/studio/monetisation/revenue-share"
+                  class="empty-link"
+                >
+                  <Button variant="secondary">Revenue share</Button>
+                </a>
+              </div>
             {/snippet}
           </EmptyState>
         {:else}
@@ -706,7 +714,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
-    max-width: 1280px;
+    width: 100%;
+    /* --container-studio is intentionally unset in tokens → resolves to
+       max-width:none = full studio width, matching the dashboard/content
+       pages. Replaces a hardcoded 1280px cap (design-token violation). */
+    max-width: var(--container-studio);
   }
 
   /* Two-column shell: main content on the left (KPIs + filters +
@@ -933,6 +945,13 @@
 
   .pagination-total {
     color: var(--color-text-muted);
+  }
+
+  .empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-3);
   }
 
   .empty-link {

--- a/apps/web/src/routes/_org/[slug]/studio/sales/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/sales/+page.svelte
@@ -336,15 +336,30 @@
             {/each}
           </div>
         {:else if isEmpty}
-          <EmptyState
-            title={statusFilter !== 'all' || rangeFilter !== '30'
-              ? 'No sales match'
-              : 'No sales yet'}
-            description={statusFilter !== 'all' || rangeFilter !== '30'
-              ? 'Try widening the date range or clearing the status filter.'
-              : 'Sales will appear here once customers buy your content.'}
-            icon={ReceiptIcon}
-          />
+          {#if statusFilter !== 'all' || rangeFilter !== '30'}
+            <EmptyState
+              title="No sales match"
+              description="Try widening the date range or clearing the status filter."
+              icon={ReceiptIcon}
+            />
+          {:else}
+            <EmptyState
+              title="No sales yet"
+              description="Sales appear here once customers buy your content. Set up pricing and tiers on the Monetisation page, then publish something to sell."
+              icon={ReceiptIcon}
+            >
+              {#snippet action()}
+                <div class="empty-actions">
+                  <a href="/studio/monetisation" class="empty-link">
+                    <Button variant="primary">Set up pricing &amp; tiers</Button>
+                  </a>
+                  <a href="/studio/content" class="empty-link">
+                    <Button variant="secondary">Manage content</Button>
+                  </a>
+                </div>
+              {/snippet}
+            </EmptyState>
+          {/if}
         {:else}
           <div class="table-wrapper">
             <Table.Root>
@@ -452,7 +467,23 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
-    max-width: 1200px;
+    width: 100%;
+    /* --container-studio is intentionally unset in tokens → resolves to
+       max-width:none = full studio width, matching the dashboard/content
+       pages. Replaces a hardcoded 1200px cap (design-token violation). */
+    max-width: var(--container-studio);
+  }
+
+  .empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-3);
+  }
+
+  .empty-link {
+    text-decoration: none;
+    color: inherit;
   }
 
   .sales-header {


### PR DESCRIPTION
## What

Two independent, low-risk defects on the owner-only studio **Sales** and **Payouts** pages.

### 1. Not full-width (+ design-token violation)
Both pages hardcoded a `max-width` cap — `.sales { max-width: 1200px }`, `.payouts { max-width: 1280px }` — so on a wide monitor the studio main column exceeds those caps and the pages render capped + left-aligned while their siblings (dashboard, analytics, customers, content) fill the column. The raw px also violates the mandatory design-token rule.

**Fix:** `width: 100%; max-width: var(--container-studio)` on both. `--container-studio` is *intentionally* undefined in the token set (verified: no definition anywhere in `src/`), so it resolves to `max-width: none` = full studio width — the exact idiom the dashboard/content pages already use and document. Removes the hardcoded px.

### 2. Generic first-creator empty states
- **Sales:** split the filtered case ("No sales match") from the first-time case; first-time now cross-links to **Monetisation** (set up pricing/tiers) and **Content** (publish something to sell).
- **Payouts:** description now explains the payout model — each sale splits into a platform fee, an org fee, and a creator share, and a solo owner is their own sole beneficiary (100% of the creator share) — and adds a **Revenue-share** cross-link beside Monetisation.
- **CreatorBreakdownRail:** the bare "No creators have been paid…" one-liner now explains what the rail is for and the solo-owner case, pointing at revenue-share for the team split.

## Notes
- **No backend/component changes.** Reuses the `EmptyState` `action` snippet and the existing `.empty-link` reset; adds a small `.empty-actions` flex row to hold two CTAs.
- Both cross-link routes (`/studio/monetisation/revenue-share`, `/studio/team`) were verified to exist.

## Verification
- `svelte-check`: none of the three files appears in the error list; total unchanged at the known **103-error / 43-warning** baseline → no new type/template errors.
- ⚠️ **Not visually verified live** — owner-only studio pages, dev stack wasn't running. Suggested review checks: (a) on a wide viewport both pages now fill the studio column; (b) with zero sales/payouts, the enriched empty states + CTAs render; (c) the two-CTA `.empty-actions` row wraps cleanly on narrow widths.

Bug: **Codex-eb00a.16** (smoke-test 2026-07-13). Base: `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)