### PR TITLE
fix(prod): bare-apex deploy URL + no-JS verify-email continue (Codex-fc5oh.10)

### DIFF
--- a/.github/scripts/manage-production-dns.sh
+++ b/.github/scripts/manage-production-dns.sh
@@ -249,7 +249,7 @@ elif [ "$ACTION" = "create" ]; then
   echo "   1. Deploy workers with 'wrangler deploy --env production'"
   echo "   2. Custom domains will be automatically attached by Cloudflare"
   echo "   3. SSL certificates will be provisioned automatically (may take 1-2 minutes)"
-  echo "   4. Verify with: curl https://codex.revelations.studio"
+  echo "   4. Verify with: curl https://revelations.studio"
 
 else
   echo "Invalid action: $ACTION"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,7 +30,7 @@ jobs:
        github.event.workflow_run.head_branch == 'main')
     environment:
       name: production
-      url: https://codex.revelations.studio
+      url: https://revelations.studio
       # IMPORTANT: Configure required reviewers in GitHub Settings → Environments → production
       # This requires manual approval before any production deployment
 
@@ -370,7 +370,7 @@ jobs:
         run: pnpm build:web
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          PUBLIC_APP_URL: https://codex.revelations.studio
+          PUBLIC_APP_URL: https://revelations.studio
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           TURBO_LOG_VERBOSITY: info

--- a/apps/web/src/routes/(auth)/verify-email/+page.svelte
+++ b/apps/web/src/routes/(auth)/verify-email/+page.svelte
@@ -24,9 +24,15 @@
 
 <AuthLayout title={data.status === 'success' ? 'Email Verified' : data.status === 'pending' ? 'Check Your Email' : 'Verification Failed'}>
   {#if data.status === 'success'}
-    <div class="auth-success">
-      <p>Your email has been verified. Redirecting to your library...</p>
+    <div class="auth-success" role="status">
+      <p>Your email has been verified.</p>
     </div>
+    <!-- Explicit link is the primary, JS-independent path forward. The
+         onMount setTimeout below is a progressive enhancement that auto-
+         advances JS users; without it (no/slow JS) this link still works. -->
+    <p class="auth-footer" style="margin-top: var(--space-4);">
+      <a href="/library" class="auth-link">Continue to your library</a>
+    </p>
   {:else}
     {#if data.status === 'pending'}
       <p class="auth-footer" style="margin-bottom: var(--space-4);">


### PR DESCRIPTION
## What

Closes the two items in **Codex-fc5oh.10** (WP-10, Production Readiness — Unblock New-Creator Journey).

### 1. Deploy URL → bare apex
`deploy-production.yml` built the SvelteKit app with `PUBLIC_APP_URL=https://codex.revelations.studio` and announced the GitHub `production` environment at the same host — but the canonical live apex is **bare `revelations.studio`** (PR #305). Absolute URLs baked at build time (emails, SEO, redirects) therefore pointed at the non-canonical alias.

- `environment.url` → `https://revelations.studio`
- `PUBLIC_APP_URL` build var → `https://revelations.studio`
- stale `curl` hint in `manage-production-dns.sh` → bare apex

Bare `revelations.studio` is **already** in the checkout redirect allowlist (`packages/validation/src/schemas/purchase.ts:30`), so switching `PUBLIC_APP_URL` introduces **no open-redirect regression**. The `codex.revelations.studio` alias remains a live CNAME → apex (wrangler route + parse-host tests unchanged), so this only changes the *canonical* URL, not the alias.

### 2. verify-email: no-JS "Continue"
The success path only advanced via `onMount(() => setTimeout(() => goto('/library'), 3000))` — which never runs without client JS, leaving a no-JS (or slow-JS) user staring at a dead-end "Redirecting…". Added an explicit `<a href="/library">Continue to your library</a>` in the SSR'd HTML as the primary path forward; the auto-redirect is now a pure progressive enhancement. Plain anchor (no `data-sveltekit-reload`) → SPA nav when JS is present, full-document nav when it isn't.

## Verification
- `svelte-check` unchanged at the **103 errors / 43 warnings** baseline — no new errors in the touched file.
- biome clean (lint-staged hook).
- Scope check: swept all `codex.revelations.studio` references; the remaining 30+ are legitimately about the CNAME alias, infra docs, GEMINI.md files, and tests asserting alias behavior — deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)