### PR TITLE
fix(deploy): fail-fast on unset media-api RunPod secrets (Codex-fc5oh.6)

### DIFF
--- a/.github/scripts/upload-worker-secrets.sh
+++ b/.github/scripts/upload-worker-secrets.sh
@@ -164,13 +164,20 @@ EOF
     ;;
 
   media-api)
+    # Fail-fast on unset/empty RunPod secrets. `set -e` does NOT catch unset vars
+    # (no `set -u`), so a missing GitHub secret would otherwise expand to "" and
+    # silently upload an EMPTY secret — the transcoding getter then throws inside
+    # waitUntil, invisibly (passes /health, fails only when a transcode dispatches).
+    # ${VAR:?msg} aborts the deploy with a clear message. media-api secrets are
+    # uploaded ONLY for production (deploy-production.yml), where all are required,
+    # so this guard never runs in preview/test. (Codex-fc5oh.6)
     SECRETS_JSON=$(cat <<EOF
 {
-  "DATABASE_URL":"${DATABASE_URL}",
-  "RUNPOD_API_KEY":"${RUNPOD_API_KEY}",
-  "RUNPOD_ENDPOINT_ID":"${RUNPOD_ENDPOINT_ID}",
-  "RUNPOD_WEBHOOK_SECRET":"${RUNPOD_WEBHOOK_SECRET}",
-  "WORKER_SHARED_SECRET":"${WORKER_SHARED_SECRET}"
+  "DATABASE_URL":"${DATABASE_URL:?DATABASE_URL is required for media-api}",
+  "RUNPOD_API_KEY":"${RUNPOD_API_KEY:?RUNPOD_API_KEY is required for media-api transcoding}",
+  "RUNPOD_ENDPOINT_ID":"${RUNPOD_ENDPOINT_ID:?RUNPOD_ENDPOINT_ID is required for media-api transcoding}",
+  "RUNPOD_WEBHOOK_SECRET":"${RUNPOD_WEBHOOK_SECRET:?RUNPOD_WEBHOOK_SECRET is required for media-api transcoding}",
+  "WORKER_SHARED_SECRET":"${WORKER_SHARED_SECRET:?WORKER_SHARED_SECRET is required for media-api}"
 }
 EOF
 )


### PR DESCRIPTION
## What

Code half of **Codex-fc5oh.6** (WP-4, Production Readiness — Unblock New-Creator Journey).

`upload-worker-secrets.sh` runs with `set -e` but **not** `set -u`. So an unset GitHub secret expanded to `""` and the script silently uploaded an **empty** secret to media-api. The `@codex/transcoding` getter then throws inside `waitUntil` — the failure is invisible end-to-end: the worker passes `/health` and only fails when a transcode is actually dispatched.

Guarded the media-api block's `RUNPOD_API_KEY` / `RUNPOD_ENDPOINT_ID` / `RUNPOD_WEBHOOK_SECRET` / `WORKER_SHARED_SECRET` / `DATABASE_URL` with `${VAR:?message}`, which aborts the deploy step with a clear message if the secret is **unset or empty**.

## Why it's safe across environments
`upload-worker-secrets.sh` is invoked with `media-api` **only** in `deploy-production.yml`, and **only** for the `production` environment — where all these secrets are genuinely required. No preview/test/dev workflow calls it for media-api, so the guard can't regress those.

## Verification
Tested under **real bash** (the script's `#!/bin/bash` interpreter — zsh differs here):
- unset var → abort, exit 1, clear stderr message ✓
- empty string → abort, exit 1 (catches the actual empty-upload bug) ✓
- all set → success, exit 0 ✓
- `bash -n` syntax clean ✓

## Deliberately out of scope
The WP's second half — a post-deploy CDN asset smoke-check — is coupled to R2 custom-domain **provisioning** (a Cloudflare ops action) tracked under the in-progress **Codex-fc5oh.2**. Adding a deploy-gating asset check now would fail against currently un-provisioned infra, so it's deferred to land with that R2 work. This PR is the independent, safe fail-fast half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)