### PR TITLE
fix(onboarding): become-creator payouts redirect to onboardingUrl, not /undefined (Codex-et1tx)

### DIFF
--- a/apps/web/src/routes/(platform)/become-creator/steps/StepPayouts.svelte
+++ b/apps/web/src/routes/(platform)/become-creator/steps/StepPayouts.svelte
@@ -14,6 +14,7 @@
 <script lang="ts">
   import { Alert, Button } from '$lib/components/ui';
   import { connectMeOnboard } from '$lib/remote/subscription.remote';
+  import type { ConnectOnboardResponse } from '$lib/types';
   import * as m from '$paraglide/messages';
 
   interface Props {
@@ -35,12 +36,16 @@
     connectError = null;
     try {
       const origin = window.location.origin;
-      const result = await connectMeOnboard({
+      // Annotate the result: the remote command() boundary widens the return
+      // type, so without this a wrong field name (e.g. the historical
+      // `result.url`) would not fail tsc. The server returns
+      // ConnectOnboardResponse = { accountId, onboardingUrl }. (Codex-et1tx)
+      const result: ConnectOnboardResponse = await connectMeOnboard({
         returnUrl: `${origin}/become-creator?step=payouts&connect=success`,
         refreshUrl: `${origin}/become-creator?step=payouts&connect=refresh`,
       });
       // Full external navigation to Stripe-hosted onboarding.
-      window.location.href = result.url;
+      window.location.href = result.onboardingUrl;
     } catch {
       connectError = m.onboarding_payouts_error();
       connecting = false;
@@ -86,7 +91,13 @@
         <Button type="button" variant="ghost" onclick={onSkip} disabled={connecting}>
           {m.onboarding_payouts_skip()}
         </Button>
-        <Button type="button" variant="primary" onclick={connect} loading={connecting}>
+        <Button
+          type="button"
+          variant="primary"
+          onclick={connect}
+          loading={connecting}
+          data-testid="payouts-connect"
+        >
           {connecting
             ? m.onboarding_payouts_connecting()
             : m.onboarding_payouts_connect_cta()}

--- a/apps/web/src/routes/(platform)/become-creator/steps/StepPayouts.svelte.test.ts
+++ b/apps/web/src/routes/(platform)/become-creator/steps/StepPayouts.svelte.test.ts
@@ -1,0 +1,152 @@
+/**
+ * StepPayouts component tests (Codex-et1tx).
+ *
+ * Locks the become-creator payouts redirect contract: after a successful
+ * `connectMeOnboard`, the wizard must navigate the browser to the Stripe-hosted
+ * onboarding URL returned as `onboardingUrl`.
+ *
+ * Regression guard: the shipped bug read `result.url` (undefined) instead of
+ * `result.onboardingUrl`, sending the creator to `/undefined` (404). The
+ * remote command() boundary widens the return type, so `.url` did NOT fail
+ * tsc — only a runtime assertion like this can catch a reintroduction.
+ *
+ * window.location.href is stubbed via a Proxy (mirrors SubscribeButton's
+ * "Update payment" test) so the assertion runs without jsdom actually
+ * navigating away and polluting sibling tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  mount,
+  screen,
+  unmount,
+} from '$tests/utils/component-test-utils.svelte';
+
+vi.mock('$lib/remote/subscription.remote', () => ({
+  connectMeOnboard: vi.fn(),
+}));
+
+import { connectMeOnboard } from '$lib/remote/subscription.remote';
+import StepPayouts from './StepPayouts.svelte';
+
+const mockOnboard = connectMeOnboard as unknown as ReturnType<typeof vi.fn>;
+
+function baseProps() {
+  return {
+    payoutsEnabled: false,
+    connectReturnBanner: null,
+    onContinue: vi.fn(),
+    onSkip: vi.fn(),
+    onBack: vi.fn(),
+  };
+}
+
+describe('StepPayouts — connect redirect', () => {
+  let component: ReturnType<typeof mount> | null = null;
+  let originalLocation: Location;
+  let hrefSetter: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOnboard.mockReset();
+
+    // Intercept assignment to window.location.href without navigating.
+    originalLocation = window.location;
+    hrefSetter = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value);
+            return true;
+          }
+          return Reflect.set(target, prop, value);
+        },
+        get(target, prop) {
+          return Reflect.get(target, prop);
+        },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+    document.body.innerHTML = '';
+  });
+
+  test('successful onboard navigates to the returned onboardingUrl (not /undefined)', async () => {
+    const onboardingUrl =
+      'https://connect.stripe.com/setup/e/acct_1TrE829Rq1gYsipU/abc123';
+    mockOnboard.mockResolvedValueOnce({
+      accountId: 'acct_1TrE829Rq1gYsipU',
+      onboardingUrl,
+    });
+
+    component = mount(StepPayouts, {
+      target: document.body,
+      props: baseProps(),
+    });
+
+    const connect = screen.getByTestId('payouts-connect') as HTMLButtonElement;
+    expect(connect).toBeTruthy();
+    connect.click();
+
+    // Flush the connect() async flow (await connectMeOnboard → set href).
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockOnboard).toHaveBeenCalledTimes(1);
+    // The redirect target is the Stripe onboarding URL, verbatim.
+    expect(hrefSetter).toHaveBeenCalledWith(onboardingUrl);
+    // Explicit regression guard against the `result.url` bug.
+    expect(hrefSetter).not.toHaveBeenCalledWith(undefined);
+  });
+
+  test('connect() sends wizard return/refresh URLs back to the payouts step', async () => {
+    mockOnboard.mockResolvedValueOnce({
+      accountId: 'acct_x',
+      onboardingUrl: 'https://connect.stripe.com/setup/e/acct_x/y',
+    });
+
+    component = mount(StepPayouts, {
+      target: document.body,
+      props: baseProps(),
+    });
+
+    (screen.getByTestId('payouts-connect') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const arg = mockOnboard.mock.calls[0]?.[0] as {
+      returnUrl: string;
+      refreshUrl: string;
+    };
+    expect(arg.returnUrl).toContain(
+      '/become-creator?step=payouts&connect=success'
+    );
+    expect(arg.refreshUrl).toContain(
+      '/become-creator?step=payouts&connect=refresh'
+    );
+  });
+
+  test('onboard failure surfaces an error and does NOT navigate', async () => {
+    mockOnboard.mockRejectedValueOnce(new Error('boom'));
+
+    component = mount(StepPayouts, {
+      target: document.body,
+      props: baseProps(),
+    });
+
+    (screen.getByTestId('payouts-connect') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No redirect on failure; an error alert is shown instead.
+    expect(hrefSetter).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Fixes **Codex-et1tx** (P1). In the become-creator wizard, the payouts step redirected to `https://revelations.studio/undefined` (404) after a *successful* Stripe Connect onboard, instead of Stripe's hosted onboarding page.

## Root cause
`StepPayouts.svelte` read `result.url`, but `connectMeOnboard` → `POST /connect/me/onboard` returns `ConnectOnboardResponse = { accountId, onboardingUrl }` — there is **no `url`** field, so the redirect target was `undefined`.

## Why it stayed hidden
1. Onboard always 500'd in prod until Connect was enabled on the platform account (Codex-fc5oh.4), so `window.location.href = result.url` **never executed** until Connect was turned on (2026-07-09).
2. The SvelteKit remote `command()` boundary widens the return type on the client, so `result.url` did **not** fail `tsc` despite `ConnectOnboardResponse` having no such field.

## Fix
- `StepPayouts.svelte` → `result.onboardingUrl`.
- Annotate `const result: ConnectOnboardResponse` **at the call site** — the reliable place to restore compile-time safety, since the `command()` boundary erases the inferred type before it reaches the client. A future `.url`-style typo now fails `tsc` here.
- `data-testid="payouts-connect"` for a stable test hook (forwarded via Button's `...restProps`).
- **New** `StepPayouts.svelte.test.ts` (3 tests): the redirect target is the returned `onboardingUrl` verbatim (and explicitly *never* `undefined`); wizard return/refresh URLs are forwarded; a failed onboard surfaces an error alert and does **not** navigate.

## Verification
- 3/3 new tests pass.
- **Proven non-vacuous**: reintroducing `result.url` turns the redirect test red (hrefSetter receives `undefined`); restored → green.
- `svelte-check` unchanged at the **103 / 43** baseline.

Sibling surfaces (studio monetisation `:333`, creators earnings `:138`) already read `onboardingUrl` — StepPayouts was the lone outlier. Not a PR #345 regression; pre-existing, unmasked by enabling Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)