### PR TITLE
fix(subscription): self-heal handleSubscriptionUpdated on missing row (Codex-1hvda)

### DIFF
--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -1181,6 +1181,132 @@ describe('SubscriptionService', () => {
       // wiring, so `invalidateIfConfigured` is a documented no-op — there
       // is no extra cache side effect to assert against here.
     });
+
+    // ─── Ordering race #3 self-heal (Codex-1hvda) ─────────────────────
+    // Stripe does not guarantee delivery order: customer.subscription.updated
+    // can arrive BEFORE customer.subscription.created. The handler previously
+    // dropped that event (`if (!sub) return`), silently losing the tier/status
+    // change AND its cache invalidation until the next version bump. It now
+    // self-heals via ensureSubscriptionDataPresent, then applies the UPDATE on
+    // top (a semantic upsert). The updated payload is passed as knownStripeSub,
+    // so the insert reads it directly — NO stripe.subscriptions.retrieve fires
+    // (unlike the invoice-handler self-heal paths).
+
+    it('self-heal: absent row + metadata present → inserts from the updated payload and returns the tuple (Codex-1hvda)', async () => {
+      const { org, tier1 } = await createFullOrg('wh-updated-selfheal');
+      const stripeSubId = `sub_updated_heal_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const result = await service.handleSubscriptionUpdated({
+        id: stripeSubId,
+        customer: `cus_${stripeSubId}`,
+        status: 'active',
+        cancel_at_period_end: false,
+        metadata: {
+          codex_user_id: otherCreatorId,
+          codex_organization_id: org.id,
+          codex_tier_id: tier1.id,
+        },
+        items: {
+          data: [
+            {
+              price: { recurring: { interval: 'month' } },
+              current_period_start: Math.floor(Date.now() / 1000),
+              current_period_end: Math.floor(Date.now() / 1000) + 86400,
+            },
+          ],
+        },
+      } as unknown as Stripe.Subscription);
+
+      // Handler heals the missing row and returns the canonical envelope.
+      expect(result).toEqual({ userId: otherCreatorId, orgId: org.id });
+
+      const { eq } = await import('drizzle-orm');
+      const [row] = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
+        .limit(1);
+      expect(row).toBeDefined();
+      expect(row.userId).toBe(otherCreatorId);
+      expect(row.organizationId).toBe(org.id);
+      expect(row.tierId).toBe(tier1.id);
+      expect(row.status).toBe('active');
+    });
+
+    it('self-heal: absent row + missing codex metadata → no insert, returns undefined (Codex-1hvda)', async () => {
+      // knownStripeSub is used, so the retrieve-404 path is unreachable here;
+      // the clean-exit is the missing-metadata guard returning null. The
+      // handler must exit exactly as the old drop branch did — no phantom row.
+      const stripeSubId = `sub_updated_nometa_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      const result = await service.handleSubscriptionUpdated({
+        id: stripeSubId,
+        customer: `cus_${stripeSubId}`,
+        status: 'active',
+        cancel_at_period_end: false,
+        metadata: {},
+        items: {
+          data: [{ current_period_start: 0, current_period_end: 0 }],
+        },
+      } as unknown as Stripe.Subscription);
+
+      expect(result).toBeUndefined();
+
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('self-heal: concurrent updated events for an absent row → exactly one row, both return the tuple (Codex-1hvda)', async () => {
+      const { org, tier1 } = await createFullOrg('wh-updated-heal-concurrent');
+      const stripeSubId = `sub_updated_heal_conc_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      const event = {
+        id: stripeSubId,
+        customer: `cus_${stripeSubId}`,
+        status: 'active',
+        cancel_at_period_end: false,
+        metadata: {
+          codex_user_id: otherCreatorId,
+          codex_organization_id: org.id,
+          codex_tier_id: tier1.id,
+        },
+        items: {
+          data: [
+            {
+              price: { recurring: { interval: 'month' } },
+              current_period_start: Math.floor(Date.now() / 1000),
+              current_period_end: Math.floor(Date.now() / 1000) + 86400,
+            },
+          ],
+        },
+      } as unknown as Stripe.Subscription;
+
+      // Both invocations SELECT-miss then race to INSERT; the unique constraint
+      // on stripe_subscription_id makes the loser re-SELECT (justInserted=false).
+      const [first, second] = await Promise.all([
+        service.handleSubscriptionUpdated(event),
+        service.handleSubscriptionUpdated(event),
+      ]);
+
+      expect(first).toEqual({ userId: otherCreatorId, orgId: org.id });
+      expect(second).toEqual({ userId: otherCreatorId, orgId: org.id });
+
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(subscriptions)
+        .where(eq(subscriptions.stripeSubscriptionId, stripeSubId));
+      expect(rows).toHaveLength(1);
+    });
   });
 
   // ─── handleSubscriptionDeleted ────────────────────────────────────

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -1808,13 +1808,22 @@ export class SubscriptionService extends BaseService {
   ): Promise<WebhookHandlerResult | void> {
     const stripeSubId = stripeSubscription.id;
 
-    const [sub] = await this.db
-      .select()
-      .from(subscriptions)
-      .where(eq(subscriptions.stripeSubscriptionId, stripeSubId))
-      .limit(1);
-
-    if (!sub) return;
+    // Ordering race #3 (Codex-1hvda): customer.subscription.updated can arrive
+    // BEFORE customer.subscription.created. The old code dropped the event
+    // (`if (!sub) return`), so the tier/status change AND its cache invalidation
+    // were silently lost until the next version bump — stale library/badge for
+    // minutes. Self-heal instead: ensureSubscriptionDataPresent inserts the row
+    // from the Stripe payload we already hold; the UPDATE below then applies the
+    // new tier/status/period on top (a semantic upsert). Passing knownStripeSub
+    // avoids a redundant Stripe retrieve.
+    const presence = await this.ensureSubscriptionDataPresent(stripeSubId, {
+      eventType: 'customer.subscription.updated',
+      knownStripeSub: stripeSubscription,
+    });
+    // null = permanent failure (Stripe 404 / missing metadata). Exit cleanly
+    // with 200 exactly as the previous drop branch did.
+    if (!presence) return;
+    const sub = presence.subscription;
 
     // Shared mapper prevents field drift (V1/V2/V5 in the audit). Passing
     // `sub.status` as the fallback preserves DB state if Stripe reports a


### PR DESCRIPTION
## What

Fixes **Codex-1hvda** (P1) — webhook ordering race #3, companion to the Codex-t7psp self-heal work.

Stripe does **not** guarantee webhook delivery order: on a fresh subscription, `customer.subscription.updated` can arrive **before** `customer.subscription.created`. `handleSubscriptionUpdated` did `if (!sub) return` on the missing-row lookup — so the tier/status change **and** its cache invalidation were silently dropped until the next version bump, leaving the user's library / subscription badge stale for minutes.

## Fix
Replaced the drop branch with the existing `ensureSubscriptionDataPresent` helper (landed under Codex-t7psp), passing the updated payload as `knownStripeSub`:

```ts
const presence = await this.ensureSubscriptionDataPresent(stripeSubId, {
  eventType: 'customer.subscription.updated',
  knownStripeSub: stripeSubscription,
});
if (!presence) return;          // Stripe missing-metadata → clean 200, as before
const sub = presence.subscription;
```

The existing `UPDATE` then applies the new tier/status/period on top — a **semantic upsert**. Using `knownStripeSub` means the insert reads the payload we already hold; **no extra `stripe.subscriptions.retrieve`** fires (this is what differs from the invoice-handler self-heal paths).

### Backward compatibility
The helper's missing-metadata guard returns `null`, so an `updated` event with no `codex_*` metadata still exits cleanly (`undefined`) with **no phantom insert** — the two pre-existing "ignore unknown subscription" tests (which fire empty-metadata events) still pass unchanged.

## Tests — real DB, +3, all green
- **absent row + metadata present** → inserts from the payload, returns `{ userId, orgId }`.
- **absent row + missing metadata** → no insert, returns `undefined` (the `knownStripeSub` analog of the Stripe-404 clean exit; `retrieve` is never called here, so 404 is unreachable).
- **concurrent updated events** → unique-violation self-heal, exactly one row, both return the tuple.

Non-vacuous by construction: the positive test asserts a row that can only exist *because* of the self-heal. Full package suite: **418 passed / 0 failed**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)