### PR TITLE
fix(purchase): self-heal handleChargeRefunded on missing purchase row (Codex-aa08z)

### DIFF
--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -89,6 +89,7 @@ describe('PurchaseService Integration', () => {
         sessions: {
           create: vi.fn(),
           retrieve: vi.fn(), // For verifyCheckoutSession
+          list: vi.fn(), // For ensurePurchaseDataPresent refund self-heal (Codex-aa08z)
         },
       },
       paymentIntents: {
@@ -5629,6 +5630,165 @@ describe('PurchaseService Integration', () => {
       expect(orgFeeRow).toBeDefined();
       expect(orgFeeRow?.amountCents).toBe(900); // 10% of post-platform 9000
       expect(orgFeeRow?.organizationId).toBe(mixedOrg.id);
+    });
+  });
+
+  // ─── Ordering race #4: refund before completion (Codex-aa08z) ───────
+  // charge.refunded can arrive BEFORE checkout.session.completed. processRefund
+  // used to find no row, WARN + return 200 → refund lost. It now self-heals via
+  // ensurePurchaseDataPresent, which rebuilds the row from the Stripe checkout
+  // session. MINIMAL by design: no transfers/payouts fire (no funds ever moved),
+  // so this is independent of the after-transfer clawback policy (Codex-13v21).
+  describe('processRefund — self-heal ordering race #4 (Codex-aa08z)', () => {
+    // The self-heal validates session metadata against the SAME
+    // checkoutSessionMetadataSchema the production webhook uses, whose
+    // userIdSchema is alphanumeric-only (real BetterAuth ids). seedTestUsers
+    // mints hyphenated `test-user-…` ids that the schema rejects, so the
+    // positive path needs a customer whose id matches production shape.
+    async function seedAlnumCustomer(): Promise<string> {
+      const id = `custaa08z${Date.now()}${Math.random()
+        .toString(36)
+        .slice(2, 7)}`.replace(/[^a-zA-Z0-9]/g, '');
+      await db.insert(schema.users).values({
+        id,
+        name: 'Refund Race Customer',
+        email: `refund-race-${id}@example.com`,
+        emailVerified: true,
+        image: null,
+        avatarUrl: null,
+        role: 'customer',
+        stripeCustomerId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      return id;
+    }
+
+    async function makePaidArticle(slugPrefix: string) {
+      return contentService.create(
+        {
+          organizationId,
+          title: 'Refund Race Article',
+          slug: createUniqueSlug(slugPrefix),
+          contentType: 'written',
+          contentBody: 'Refund-race test body.',
+          visibility: 'purchased_only',
+          accessType: 'paid',
+          priceCents: 2999,
+        },
+        userId
+      );
+    }
+
+    it('rebuilds the purchase from the checkout session, records the refund, and fires NO transfers', async () => {
+      const content = await makePaidArticle('refund-race-heal');
+      const customerId = await seedAlnumCustomer();
+      const paymentIntentId = `pi_refund_race_${Date.now()}`;
+
+      // No purchase row yet — checkout.session.completed hasn't arrived. The
+      // session exists in Stripe carrying the metadata + amount.
+      (
+        mockStripe.checkout.sessions.list as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce({
+        data: [
+          {
+            id: `cs_${paymentIntentId}`,
+            amount_total: 2999,
+            metadata: {
+              customerId,
+              contentId: content.id,
+              organizationId,
+            },
+          },
+        ],
+      });
+      const transferCreate = vi.fn();
+      (mockStripe as unknown as { transfers: unknown }).transfers = {
+        create: transferCreate,
+      };
+
+      const result = await purchaseService.processRefund(paymentIntentId, {
+        stripeRefundId: 're_race_1',
+        refundAmountCents: 2999,
+        refundReason: 'requested_by_customer',
+      });
+
+      const [row] = await db
+        .select()
+        .from(schema.purchases)
+        .where(eq(schema.purchases.stripePaymentIntentId, paymentIntentId));
+      expect(row).toBeDefined();
+      expect(row.customerId).toBe(customerId);
+      expect(row.contentId).toBe(content.id);
+      expect(row.status).toBe('refunded');
+      expect(row.refundAmountCents).toBe(2999);
+      expect(row.stripeRefundId).toBe('re_race_1');
+      // Fee columns carry a balancing default split (satisfies the CHECK
+      // amount = platform + org + creator), but crucially NO transfer executed
+      // and NO payouts ledger rows were written — the money never moved.
+      expect(
+        row.platformFeeCents + row.organizationFeeCents + row.creatorPayoutCents
+      ).toBe(2999);
+      expect(transferCreate).not.toHaveBeenCalled();
+      const payoutRows = await db
+        .select()
+        .from(schema.payouts)
+        .where(eq(schema.payouts.purchaseId, row.id));
+      expect(payoutRows).toHaveLength(0);
+      // Library-cache bump signal returned for the purchaser.
+      expect(result?.userId).toBe(customerId);
+    });
+
+    it('returns void without inserting when no checkout session exists for the payment_intent', async () => {
+      const paymentIntentId = `pi_no_session_${Date.now()}`;
+      (
+        mockStripe.checkout.sessions.list as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce({ data: [] });
+
+      const result = await purchaseService.processRefund(paymentIntentId, {
+        refundAmountCents: 500,
+      });
+
+      expect(result).toBeUndefined();
+      const rows = await db
+        .select()
+        .from(schema.purchases)
+        .where(eq(schema.purchases.stripePaymentIntentId, paymentIntentId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('fast-path: an existing purchase is refunded without listing Stripe sessions', async () => {
+      const content = await makePaidArticle('refund-race-fastpath');
+      const paymentIntentId = `pi_refund_exists_${Date.now()}`;
+
+      // Insert via completePurchase WITHOUT stripeChargeId → skips payouts, so no
+      // transfer mocks are needed. Row exists before the refund arrives.
+      await purchaseService.completePurchase(paymentIntentId, {
+        customerId: otherUserId,
+        contentId: content.id,
+        organizationId,
+        amountPaidCents: 1000,
+        currency: 'gbp',
+      });
+
+      const listSpy = mockStripe.checkout.sessions.list as ReturnType<
+        typeof vi.fn
+      >;
+      listSpy.mockClear();
+
+      const result = await purchaseService.processRefund(paymentIntentId, {
+        refundAmountCents: 1000,
+        stripeRefundId: 're_exists',
+      });
+
+      // Fast path: row already present → NO Stripe session lookup.
+      expect(listSpy).not.toHaveBeenCalled();
+      const [row] = await db
+        .select()
+        .from(schema.purchases)
+        .where(eq(schema.purchases.stripePaymentIntentId, paymentIntentId));
+      expect(row.status).toBe('refunded');
+      expect(result?.userId).toBe(otherUserId);
     });
   });
 });

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -48,6 +48,7 @@ import type {
   SalesStatsQueryInput,
 } from '@codex/validation';
 import {
+  checkoutSessionMetadataSchema,
   createCheckoutSchema,
   createPortalSessionSchema,
   extractPlainText,
@@ -1496,10 +1497,122 @@ export class PurchaseService extends BaseService {
   }
 
   /**
+   * Ensure a purchase row exists for a payment_intent, self-healing the
+   * ordering race #4 (Codex-aa08z) where `charge.refunded` arrives BEFORE
+   * `checkout.session.completed` (the event that normally INSERTs the row).
+   *
+   * Without this, `processRefund` found no row, logged WARN + returned 200, so
+   * the refund was never recorded — refund tracking lost, access left granted.
+   *
+   * Fast path: row already present (normal ordering / replay) → return it.
+   *
+   * Slow path: rebuild from the Stripe checkout session. The PaymentIntent does
+   * not carry our metadata, so we list sessions by `payment_intent`; the session
+   * carries { customerId, contentId, organizationId } (validated against the
+   * SAME `checkoutSessionMetadataSchema` the booking webhook uses) + amount_total.
+   *
+   * MINIMAL by design (Codex-aa08z decision): we INSERT only the purchase row —
+   * we deliberately do NOT run `writePurchasePayouts`. A refund arriving before
+   * completion means NO funds were ever transferred to Connect accounts, so there
+   * is nothing to pay out and nothing to claw back. The fee columns carry a
+   * default split purely to satisfy the `amount = platform + org + creator` CHECK
+   * (bookkeeping — no payout executes). The later `checkout.session.completed`
+   * no-ops via `completePurchase`'s idempotency check, so no transfer ever fires
+   * for this refunded sale. The after-transfer clawback case (refund AFTER
+   * transfers settled) is the separate, still-open policy decision Codex-13v21 —
+   * intentionally NOT touched here.
+   *
+   * Returns the purchase, or `null` when the session/metadata cannot be resolved
+   * (caller then exits cleanly with 200, exactly as the old drop branch did).
+   * Bubbles transient Stripe/DB errors so the webhook 5xx's and Stripe retries.
+   */
+  async ensurePurchaseDataPresent(
+    paymentIntentId: string
+  ): Promise<Purchase | null> {
+    // Fast path: row already exists (normal delivery order, or a replay).
+    const existing = await this.db.query.purchases.findFirst({
+      where: eq(purchases.stripePaymentIntentId, paymentIntentId),
+    });
+    if (existing) return existing;
+
+    // Slow path: reconstruct from the checkout session that created this PI.
+    const sessions = await this.stripe.checkout.sessions.list({
+      payment_intent: paymentIntentId,
+      limit: 1,
+    });
+    // Optional-chain the response shape: a malformed/empty Stripe reply should
+    // clean-exit (return null → caller 200s), never throw.
+    const session = sessions?.data?.[0];
+    if (!session) {
+      this.obs.warn(
+        'Purchase self-heal: no checkout session found for payment_intent',
+        { paymentIntentId }
+      );
+      return null;
+    }
+
+    const parsed = checkoutSessionMetadataSchema.safeParse(
+      session.metadata ?? {}
+    );
+    const amountPaidCents = session.amount_total;
+    if (!parsed.success || amountPaidCents === null) {
+      this.obs.warn(
+        'Purchase self-heal: checkout session missing/invalid metadata or amount',
+        { paymentIntentId, sessionId: session.id }
+      );
+      return null;
+    }
+    const { customerId, contentId, organizationId } = parsed.data;
+
+    // The purchases CHECK constraint requires
+    // amount = platformFee + organizationFee + creatorPayout, so we cannot leave
+    // the fee columns at 0. Compute a split with DEFAULT percentages (org leg 0
+    // for orgless content). This is bookkeeping only: the row is refunded
+    // immediately and writePurchasePayouts is NEVER called, so no funds move and
+    // the exact per-org fee config is immaterial — the split just has to balance.
+    const split = calculateRevenueSplit(
+      amountPaidCents,
+      DEFAULT_PLATFORM_FEE_PERCENTAGE,
+      organizationId ? DEFAULT_ORG_FEE_PERCENTAGE : 0
+    );
+
+    try {
+      const [inserted] = await this.db
+        .insert(purchases)
+        .values({
+          customerId,
+          contentId,
+          organizationId,
+          amountPaidCents,
+          currency: CURRENCY.GBP,
+          stripePaymentIntentId: paymentIntentId,
+          status: PURCHASE_STATUS.COMPLETED,
+          purchasedAt: new Date(),
+          platformFeeCents: split.platformFeeCents,
+          organizationFeeCents: split.organizationFeeCents,
+          creatorPayoutCents: split.creatorPayoutCents,
+        })
+        .returning();
+      // `.returning()` always yields the inserted row here; `?? null` only
+      // satisfies the array-index `| undefined` that TS infers.
+      return inserted ?? null;
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        // Concurrent completePurchase / self-heal raced us to insert — re-select.
+        const raced = await this.db.query.purchases.findFirst({
+          where: eq(purchases.stripePaymentIntentId, paymentIntentId),
+        });
+        if (raced) return raced;
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Process a refund from a charge.refunded webhook event.
    *
    * Flow:
-   * 1. Look up purchase by stripePaymentIntentId
+   * 1. Ensure the purchase row exists (self-heal ordering race #4, Codex-aa08z)
    * 2. Update purchase status to 'refunded'
    * 3. Revoke content access (soft delete)
    *
@@ -1514,9 +1627,10 @@ export class PurchaseService extends BaseService {
     }
   ): Promise<{ userId: string } | void> {
     try {
-      const purchase = await this.db.query.purchases.findFirst({
-        where: eq(purchases.stripePaymentIntentId, paymentIntentId),
-      });
+      // Self-heal ordering race #4 (Codex-aa08z): if charge.refunded beat
+      // checkout.session.completed, the row won't exist yet — rebuild it from
+      // the Stripe checkout session so the refund is recorded (no transfers).
+      const purchase = await this.ensurePurchaseDataPresent(paymentIntentId);
 
       if (!purchase) {
         this.obs.warn('Refund for unknown purchase', { paymentIntentId });


### PR DESCRIPTION
## What

Fixes **Codex-aa08z** (P1) — webhook ordering race #4, the purchase-domain companion to the subscription self-heal work.

`charge.refunded` can arrive **before** `checkout.session.completed` (the event that INSERTs the purchase row). `processRefund` found no row, logged WARN + returned 200 → the refund was **never recorded**: refund tracking lost, content access left granted, payout accounting inconsistent.

## Fix — `PurchaseService.ensurePurchaseDataPresent(paymentIntentId)`
- **fast path**: row already present → return it (no Stripe call).
- **slow path**: rebuild from the Stripe **checkout session** (listed by `payment_intent` — the PaymentIntent doesn't carry our metadata). Validates `session.metadata` against the **same `checkoutSessionMetadataSchema`** the booking webhook uses; on missing session / invalid metadata → warn + return `null` (caller 200s, exactly as the old drop branch did).
- **unique-violation** on insert → re-select (a concurrent `completePurchase` raced us).

`processRefund` now calls it before the missing-row check. The session-list response is optional-chained so a malformed/empty Stripe reply clean-exits rather than throwing.

## Minimal by design (approved decision)
The self-heal **INSERTs only the purchase row and never runs `writePurchasePayouts`**. A refund arriving *before* completion means **no funds were ever transferred** to Connect accounts — nothing to pay out, nothing to claw back. The later `checkout.session.completed` no-ops via `completePurchase`'s idempotency, so no transfer ever fires for this refunded sale.

Fee columns carry a **default split** purely to satisfy the DB CHECK `amount = platform + org + creator` — bookkeeping only, since no payout executes. This deliberately sidesteps the **after-transfer clawback** case (refund *after* transfers settled), which is the separate, still-open policy decision **Codex-13v21**.

## Tests — real DB, +3
- **positive self-heal**: row rebuilt from the session, refund recorded, split balances the CHECK, **NO transfer** fired, **NO payouts ledger rows** written.
- **no session** for the payment_intent → returns void, no insert.
- **fast-path**: an existing purchase is refunded without any Stripe session lookup.

**Proven non-vacuous**: bypassing the self-heal (reverting to the plain lookup) turns the positive test red. Full `@codex/purchase` suite **246/246 green**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)