### PR TITLE
fix(studio): read-after-write retry for fresh-owner membership guard (Codex-jko8i)

### DIFF
--- a/apps/web/src/lib/server/membership-retry.test.ts
+++ b/apps/web/src/lib/server/membership-retry.test.ts
@@ -1,0 +1,106 @@
+/**
+ * resolveMembershipWithRetry unit tests (Codex-jko8i).
+ *
+ * Locks the read-after-write retry contract for the studio guard:
+ *  - a non-null role short-circuits immediately (no wasted backoff);
+ *  - a role that appears on a later attempt (fresh-owner lag) is returned;
+ *  - an always-null role (genuine non-member) exhausts the backoff and returns
+ *    null so the guard still redirects to access-denied.
+ *
+ * `sleep` is injected so the suite runs without real timers.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type MembershipRole,
+  resolveMembershipWithRetry,
+} from './membership-retry';
+
+const noSleep = vi.fn(async () => {});
+
+describe('resolveMembershipWithRetry', () => {
+  it('returns immediately when the role is present on the first read (no backoff)', async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchMembership = vi
+      .fn<() => Promise<MembershipRole>>()
+      .mockResolvedValue({ role: 'owner', joinedAt: '2026-01-01' });
+
+    const result = await resolveMembershipWithRetry(fetchMembership, {
+      delaysMs: [80, 160, 240],
+      sleep,
+    });
+
+    expect(result.role).toBe('owner');
+    expect(fetchMembership).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries while role is null and returns the role once it becomes visible (fresh-owner lag)', async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchMembership = vi
+      .fn<() => Promise<MembershipRole>>()
+      .mockResolvedValueOnce({ role: null, joinedAt: null })
+      .mockResolvedValueOnce({ role: null, joinedAt: null })
+      .mockResolvedValueOnce({ role: 'owner', joinedAt: '2026-01-01' });
+
+    const result = await resolveMembershipWithRetry(fetchMembership, {
+      delaysMs: [80, 160, 240],
+      sleep,
+    });
+
+    expect(result.role).toBe('owner');
+    // initial + 2 retries = 3 reads; 2 backoffs consumed.
+    expect(fetchMembership).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 80);
+    expect(sleep).toHaveBeenNthCalledWith(2, 160);
+  });
+
+  it('exhausts the backoff and returns null for a genuine non-member', async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchMembership = vi
+      .fn<() => Promise<MembershipRole>>()
+      .mockResolvedValue({ role: null, joinedAt: null });
+
+    const result = await resolveMembershipWithRetry(fetchMembership, {
+      delaysMs: [80, 160, 240],
+      sleep,
+    });
+
+    expect(result.role).toBeNull();
+    // initial + 3 retries = 4 reads; all 3 backoffs consumed.
+    expect(fetchMembership).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a definitive non-privileged role (member is not null)', async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchMembership = vi
+      .fn<() => Promise<MembershipRole>>()
+      .mockResolvedValue({ role: 'member', joinedAt: '2026-01-01' });
+
+    const result = await resolveMembershipWithRetry(fetchMembership, {
+      delaysMs: [80, 160, 240],
+      sleep,
+    });
+
+    // 'member' is a real, visible role — no retry; the guard decides access.
+    expect(result.role).toBe('member');
+    expect(fetchMembership).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('uses the default backoff shape when none is provided', async () => {
+    const fetchMembership = vi
+      .fn<() => Promise<MembershipRole>>()
+      .mockResolvedValue({ role: null, joinedAt: null });
+
+    const result = await resolveMembershipWithRetry(fetchMembership, {
+      sleep: noSleep,
+    });
+
+    expect(result.role).toBeNull();
+    // Default [80,160,240] → 1 initial + 3 retries.
+    expect(fetchMembership).toHaveBeenCalledTimes(4);
+  });
+});

--- a/apps/web/src/lib/server/membership-retry.ts
+++ b/apps/web/src/lib/server/membership-retry.ts
@@ -1,0 +1,63 @@
+/**
+ * Membership read-after-write retry (Codex-jko8i).
+ *
+ * Immediately after org creation (become-creator → `/studio`), the just-committed
+ * owner membership row can be momentarily invisible to a follow-up read on a
+ * different per-request DB pool connection (Neon read-your-writes lag, ~first
+ * 500ms). Without a retry, the studio guard reads `role: null` and bounces a
+ * brand-new owner to `/?error=access_denied`. A short bounded retry closes that
+ * window.
+ *
+ * WHY HERE, not in `OrganizationService.getMyMembership`: that method returns
+ * `role: null` **legitimately** for genuine non-members (it is a membership
+ * *check*, used across public/graceful-degradation paths). Retrying inside it
+ * would make every non-member lookup wait through the full backoff before
+ * returning its correct `null`. In the studio guard, a `null` role for an
+ * authenticated user who has navigated to `/studio` is the *unexpected* case —
+ * the only place a brief retry is justified.
+ */
+
+export interface MembershipRole {
+  role: string | null;
+  joinedAt: string | null;
+}
+
+export interface ResolveMembershipOptions {
+  /**
+   * Backoff delays (ms) between attempts. The number of entries is the number
+   * of RETRIES; total attempts = delaysMs.length + 1 (one initial read). Default
+   * [80, 160, 240] → up to 4 reads over ~480ms, covering the observed lag window.
+   */
+  delaysMs?: number[];
+  /** Injectable sleep — override in tests to avoid real timers. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resolve a membership, re-reading while `role` is null.
+ *
+ * Returns as soon as a non-null role appears (fresh owner's row became visible),
+ * or the last result (`role: null`) once the backoff is exhausted (genuine
+ * non-member → caller redirects to access-denied as before).
+ *
+ * `fetchMembership` MUST perform an UNCACHED read (the raw API client, not the
+ * cached remote `query()`), or every attempt returns the same stale result.
+ */
+export async function resolveMembershipWithRetry(
+  fetchMembership: () => Promise<MembershipRole>,
+  opts: ResolveMembershipOptions = {}
+): Promise<MembershipRole> {
+  const delaysMs = opts.delaysMs ?? [80, 160, 240];
+  const sleep = opts.sleep ?? defaultSleep;
+
+  let result = await fetchMembership();
+  for (const delay of delaysMs) {
+    if (result?.role != null) return result;
+    await sleep(delay);
+    result = await fetchMembership();
+  }
+  return result ?? { role: null, joinedAt: null };
+}

--- a/apps/web/src/routes/_org/[slug]/studio/+layout.server.ts
+++ b/apps/web/src/routes/_org/[slug]/studio/+layout.server.ts
@@ -8,9 +8,10 @@
  */
 import { redirect } from '@sveltejs/kit';
 import { logger } from '$lib/observability';
-import { getMyMembership, getMyOrganizations } from '$lib/remote/org.remote';
+import { getMyOrganizations } from '$lib/remote/org.remote';
 import { createServerApi } from '$lib/server/api';
 import { CACHE_HEADERS } from '$lib/server/cache';
+import { resolveMembershipWithRetry } from '$lib/server/membership-retry';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({
@@ -51,14 +52,25 @@ export const load: LayoutServerLoad = async ({
     threshold: 2000,
   });
 
+  // Raw API client (uncached) — reused for the membership retry below AND the
+  // draft-count call further down.
+  const api = createServerApi(platform, cookies);
+
   const [membershipResult, orgsResult] = await Promise.all([
-    getMyMembership(org.id).catch((err: unknown) => {
-      logger.error('studio-layout:getMyMembership failed', {
-        orgId: org.id,
-        error: String(err),
-      });
-      return { role: null, joinedAt: null };
-    }),
+    // Read-after-write retry (Codex-jko8i): a freshly-created owner's membership
+    // row can be momentarily invisible on the follow-up read right after org
+    // creation, which would otherwise bounce them to access_denied. We call the
+    // RAW api client (NOT the cached remote getMyMembership query(), which would
+    // dedupe repeat reads) so each retry attempt is a fresh DB read.
+    resolveMembershipWithRetry(() => api.org.getMyMembership(org.id)).catch(
+      (err: unknown) => {
+        logger.error('studio-layout:getMyMembership failed', {
+          orgId: org.id,
+          error: String(err),
+        });
+        return { role: null, joinedAt: null };
+      }
+    ),
     getMyOrganizations().catch((err: unknown) => {
       logger.error('studio-layout:getMyOrganizations failed', {
         orgId: org.id,
@@ -79,7 +91,6 @@ export const load: LayoutServerLoad = async ({
   // Draft count: lightweight call after auth check — limit=1 just to get pagination.total
   let draftCount = 0;
   try {
-    const api = createServerApi(platform, cookies);
     const draftParams = new URLSearchParams();
     draftParams.set('organizationId', org.id);
     draftParams.set('status', 'draft');


### PR DESCRIPTION
## What

Fixes **Codex-jko8i** (P1). Right after org creation (become-creator → `/studio`), the just-committed **owner** membership row can be momentarily invisible to the follow-up read on a different per-request DB pool connection (Neon read-your-writes lag, ~first 500ms). The studio layout guard read `role: null` and redirected a brand-new owner to `/?error=access_denied`.

## Fix
Extracted `resolveMembershipWithRetry` (`apps/web/src/lib/server/membership-retry.ts`) — a bounded backoff (`[80,160,240]`ms → 4 reads over ~480ms) that re-reads while `role` is null and returns as soon as a role appears. The studio guard (`_org/[slug]/studio/+layout.server.ts`) now wraps its membership read in it.

### Two deliberate design choices
1. **Retry in the guard path, not the shared service.** `OrganizationService.getMyMembership` returns `role: null` **legitimately** for non-members (it's a membership *check* used on public/graceful-degradation paths). Retrying there would add ~480ms to *every* non-member lookup. In the guard, a null role for an *authenticated* user on `/studio` is the unexpected case worth a brief retry.
2. **Uncached read.** The retry calls the **raw** `api.org.getMyMembership` — the cached remote `getMyMembership` `query()` would dedupe repeat reads within the request, defeating the retry. The api client is hoisted and reused for the existing draft-count call.

Genuine non-members still resolve to `null` after the backoff and redirect exactly as before (a security-neutral delay on a rare, auth-gated path).

## Tests — +5 unit (injected sleep, no real timers)
Immediate return on present role (no backoff); retry-until-visible (fresh-owner lag → 3 reads, 2 sleeps); exhaust→null (non-member → 4 reads, 3 sleeps); no-retry on a definitive `'member'` role; default backoff shape. Non-vacuous by construction (assert exact read/sleep counts). `svelte-check` unchanged at the **103/43** baseline.

## Not included
Making the e2e `createFreshOwnerWithBypass` helper use `dbWs` (it uses `dbHttp`) — an optional test-harness alignment left out to avoid touching shared e2e specs; the guard retry is the substantive fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)