### PR TITLE
fix(subscription): claw back creator/org transfers on subscription refund (Codex-13v21)

### DIFF
--- a/packages/subscription/src/services/__tests__/subscription-service.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service.test.ts
@@ -9358,6 +9358,166 @@ describe('SubscriptionService', () => {
       }
     });
   });
+
+  // ─── reverseSubscriptionPayoutsForCharge (Codex-13v21) ────────────────
+  // Subscription-invoice refund clawback — the mirror of the purchase-side
+  // reversePayoutsForPurchase. Reverses creator/org transfers for a refunded
+  // subscription charge and flips the ledger rows; scoped to
+  // sourceType='subscription' so it can NEVER touch one-time-purchase rows
+  // (which processRefund already handles) — no double-clawback.
+  describe('reverseSubscriptionPayoutsForCharge (Codex-13v21)', () => {
+    async function seedSubPayouts(
+      chargeId: string,
+      opts: {
+        sourceType?: 'subscription' | 'purchase';
+        status?: string;
+      } = {}
+    ) {
+      const { org, tier1 } = await createFullOrg(
+        `sub-clawback-${Math.random().toString(36).slice(2, 8)}`
+      );
+      const [sub] = await db
+        .insert(subscriptions)
+        .values(
+          createTestSubscriptionInput(otherCreatorId, org.id, tier1.id, {
+            status: 'active',
+          })
+        )
+        .returning();
+      const sourceType = opts.sourceType ?? 'subscription';
+      const status = opts.status ?? 'paid';
+      // platform_fee (no transfer) + organization_fee + creator (transfers).
+      // Gross = 100 + 135 + 765 = 1000.
+      await db.insert(payoutsTable).values([
+        {
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 100,
+          payoutType: 'platform_fee',
+          status,
+          stripeChargeId: chargeId,
+          sourceType,
+          resolvedAt: new Date(),
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 135,
+          payoutType: 'organization_fee',
+          status,
+          stripeTransferId: `tr_org_${chargeId}`,
+          stripeChargeId: chargeId,
+          sourceType,
+          resolvedAt: new Date(),
+        },
+        {
+          userId: otherCreatorId,
+          organizationId: org.id,
+          subscriptionId: sub.id,
+          amountCents: 765,
+          payoutType: 'creator_payout_to_owner',
+          status,
+          stripeTransferId: `tr_creator_${chargeId}`,
+          stripeChargeId: chargeId,
+          sourceType,
+          resolvedAt: new Date(),
+        },
+      ]);
+      return { org, sub };
+    }
+
+    function stubCreateReversal() {
+      const createReversal = vi.fn().mockResolvedValue({ id: 'trr_test' });
+      (
+        stripe.transfers as unknown as { createReversal: typeof createReversal }
+      ).createReversal = createReversal;
+      return createReversal;
+    }
+
+    it('reverses each transfer-bearing slice and flips all rows to reversed', async () => {
+      const chargeId = `ch_clawback_${Date.now()}`;
+      await seedSubPayouts(chargeId);
+      const createReversal = stubCreateReversal();
+
+      await service.reverseSubscriptionPayoutsForCharge(chargeId, {
+        refundAmountCents: 1000,
+        stripeRefundId: 're_full',
+      });
+
+      // Two transfers reversed (org + creator); platform_fee has no transfer.
+      expect(createReversal).toHaveBeenCalledTimes(2);
+      const reversedIds = createReversal.mock.calls.map((c) => c[0]).sort();
+      expect(reversedIds).toEqual(
+        [`tr_creator_${chargeId}`, `tr_org_${chargeId}`].sort()
+      );
+      const amounts = createReversal.mock.calls
+        .map((c) => (c[1] as { amount: number }).amount)
+        .sort((a, b) => a - b);
+      expect(amounts).toEqual([135, 765]);
+
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.stripeChargeId, chargeId));
+      expect(rows).toHaveLength(3);
+      expect(rows.every((r) => r.status === 'reversed')).toBe(true);
+    });
+
+    it('no-ops when no subscription payouts exist for the charge', async () => {
+      const createReversal = stubCreateReversal();
+      await service.reverseSubscriptionPayoutsForCharge(
+        `ch_absent_${Date.now()}`,
+        { refundAmountCents: 500, stripeRefundId: 're_x' }
+      );
+      expect(createReversal).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — already-reversed rows are skipped', async () => {
+      const chargeId = `ch_idem_${Date.now()}`;
+      await seedSubPayouts(chargeId, { status: 'reversed' });
+      const createReversal = stubCreateReversal();
+      await service.reverseSubscriptionPayoutsForCharge(chargeId, {
+        refundAmountCents: 1000,
+        stripeRefundId: 're_again',
+      });
+      expect(createReversal).not.toHaveBeenCalled();
+    });
+
+    it('reverses proportionally on a partial refund', async () => {
+      const chargeId = `ch_partial_${Date.now()}`;
+      await seedSubPayouts(chargeId);
+      const createReversal = stubCreateReversal();
+      // Half of gross 1000 = 500 → floor(135*500/1000)=67, floor(765*500/1000)=382.
+      await service.reverseSubscriptionPayoutsForCharge(chargeId, {
+        refundAmountCents: 500,
+        stripeRefundId: 're_partial',
+      });
+      const amounts = createReversal.mock.calls
+        .map((c) => (c[1] as { amount: number }).amount)
+        .sort((a, b) => a - b);
+      expect(amounts).toEqual([67, 382]);
+    });
+
+    it('does NOT touch one-time-purchase payout rows for the same charge (no double-clawback)', async () => {
+      const chargeId = `ch_purchase_src_${Date.now()}`;
+      await seedSubPayouts(chargeId, { sourceType: 'purchase' });
+      const createReversal = stubCreateReversal();
+      await service.reverseSubscriptionPayoutsForCharge(chargeId, {
+        refundAmountCents: 1000,
+        stripeRefundId: 're_purchase',
+      });
+      // sourceType='purchase' → excluded → no reversal, rows untouched.
+      expect(createReversal).not.toHaveBeenCalled();
+      const { eq } = await import('drizzle-orm');
+      const rows = await db
+        .select()
+        .from(payoutsTable)
+        .where(eq(payoutsTable.stripeChargeId, chargeId));
+      expect(rows.every((r) => r.status === 'paid')).toBe(true);
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/subscription/src/services/subscription-service.ts
+++ b/packages/subscription/src/services/subscription-service.ts
@@ -4391,6 +4391,183 @@ export class SubscriptionService extends BaseService {
   }
 
   /**
+   * Reverse the subscription payout transfers for a refunded invoice charge
+   * (Codex-13v21). Mirror of `PurchaseService.reversePayoutsForPurchase` for the
+   * subscription pipeline: when a subscription invoice charge is refunded, the
+   * creator/org transfers made at invoice.payment_succeeded must be clawed back —
+   * Stripe does NOT auto-reverse separate `transfers.create` calls, so without
+   * this the platform absorbs the full gross while creators keep their slice.
+   *
+   * Scopes to `sourceType='subscription'` rows for the charge. One-time purchase
+   * rows carry `sourceType='purchase'` (handled by PurchaseService.processRefund),
+   * so calling BOTH on every `charge.refunded` never double-reverses the same
+   * transfer.
+   *
+   * Partial refunds reverse each slice proportionally
+   * (`floor(row.amountCents * refundAmountCents / grossCents)`); residual rounding
+   * stays on the platform balance. Idempotency key `${transferId}_reversal_<suffix>`
+   * makes webhook replays and repeated partial refunds safe.
+   *
+   * Idempotent: rows already `reversed`/`cancelled_by_refund` are skipped.
+   *
+   * insufficient_funds (creator already withdrew their slice): logged loudly with
+   * a correlatable errorId, leaving the row `paid` (the original transfer really
+   * succeeded). NOTE: the purchase path records a `refund_reviews` ops-queue row
+   * here, but `refund_reviews.purchaseId` is NOT NULL and cannot yet represent a
+   * subscription obligation — generalising that table is a tracked follow-up
+   * (Codex-13v21 design). Until then the obligation is visible in logs only.
+   */
+  async reverseSubscriptionPayoutsForCharge(
+    chargeId: string,
+    refund: { refundAmountCents: number | null; stripeRefundId: string | null }
+  ): Promise<void> {
+    const rows = await this.db
+      .select()
+      .from(payouts)
+      .where(
+        and(
+          eq(payouts.stripeChargeId, chargeId),
+          eq(payouts.sourceType, 'subscription')
+        )
+      );
+
+    // Common case for a one-time-purchase charge (or an already-swept charge):
+    // no subscription rows → no-op.
+    if (rows.length === 0) return;
+
+    // Gross = the charged amount, reconstructed as the sum of the recorded
+    // slices (platform + org + creator). Denominator for a proportional refund.
+    const grossCents = rows.reduce((sum, r) => sum + r.amountCents, 0);
+
+    const { refundAmountCents, stripeRefundId } = refund;
+    const isPartial =
+      refundAmountCents !== null &&
+      refundAmountCents > 0 &&
+      grossCents > 0 &&
+      refundAmountCents < grossCents;
+    const partialRatioNumerator = isPartial ? refundAmountCents : null;
+    const reversalAmount = (rowAmountCents: number): number =>
+      partialRatioNumerator !== null
+        ? Math.floor((rowAmountCents * partialRatioNumerator) / grossCents)
+        : rowAmountCents;
+    const idempotencySuffix = stripeRefundId
+      ? `_${stripeRefundId}`
+      : refundAmountCents !== null
+        ? `_${refundAmountCents}`
+        : '';
+
+    for (const row of rows) {
+      if (row.status === 'reversed' || row.status === 'cancelled_by_refund') {
+        continue;
+      }
+
+      let skipStatusFlip = false;
+      if (row.stripeTransferId) {
+        const amount = reversalAmount(row.amountCents);
+        if (amount === 0) {
+          skipStatusFlip = true;
+          this.obs.info(
+            'Subscription reversal amount floored to zero, platform absorbs',
+            {
+              chargeId,
+              payoutId: row.id,
+              rowAmountCents: row.amountCents,
+              refundAmountCents,
+            }
+          );
+        } else {
+          try {
+            await this.stripe.transfers.createReversal(
+              row.stripeTransferId,
+              {
+                amount,
+                metadata: {
+                  subscription_id: row.subscriptionId ?? '',
+                  charge_id: chargeId,
+                  payout_id: row.id,
+                  type: 'refund_reversal',
+                },
+              },
+              {
+                idempotencyKey: `${row.stripeTransferId}_reversal${idempotencySuffix}`,
+              }
+            );
+          } catch (reverseErr) {
+            const code = (reverseErr as { code?: string } | null)?.code;
+            const errorId = crypto.randomUUID();
+            this.obs.error(
+              'Failed to reverse subscription transfer for refund',
+              {
+                errorId,
+                chargeId,
+                payoutId: row.id,
+                stripeTransferId: row.stripeTransferId,
+                attemptedReversalCents: amount,
+                code: code ?? null,
+                error:
+                  reverseErr instanceof Error
+                    ? reverseErr.message
+                    : String(reverseErr),
+              }
+            );
+            if (code === 'insufficient_funds') {
+              // Creator already withdrew their slice; the customer refund still
+              // completed from the platform balance, so the platform now holds
+              // an unresolved clawback obligation. Leave the row 'paid'.
+              // NOTE (Codex-13v21): no refund_reviews row yet — that table's
+              // purchaseId is NOT NULL; subscription support is a tracked
+              // schema follow-up. Surfaced loudly meanwhile.
+              this.obs.error(
+                'Subscription clawback obligation unresolved (insufficient_funds) — NOT yet queued in refund_reviews',
+                {
+                  errorId,
+                  chargeId,
+                  payoutId: row.id,
+                  creatorUserId: row.userId,
+                  attemptedReversalCents: amount,
+                }
+              );
+              skipStatusFlip = true;
+            }
+            // Per-row error isolation — continue with remaining slices.
+          }
+        }
+      }
+
+      if (skipStatusFlip) continue;
+
+      const nextStatus =
+        row.status === 'pending' || row.status === 'failed'
+          ? ('cancelled_by_refund' as const)
+          : ('reversed' as const);
+
+      try {
+        await this.db
+          .update(payouts)
+          .set({
+            status: nextStatus,
+            resolvedAt: row.resolvedAt ?? new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(payouts.id, row.id));
+      } catch (updateErr) {
+        this.obs.error(
+          'Failed to update subscription payouts row after refund',
+          {
+            chargeId,
+            payoutId: row.id,
+            nextStatus,
+            error:
+              updateErr instanceof Error
+                ? updateErr.message
+                : String(updateErr),
+          }
+        );
+      }
+    }
+  }
+
+  /**
    * Execute revenue transfers to org and creator(s) after invoice payment.
    * Uses source_transaction to link transfers to the charge.
    * Creators without active Connect accounts have their share accumulated.

--- a/workers/ecom-api/src/handlers/__tests__/payment-webhook-dispute.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/payment-webhook-dispute.test.ts
@@ -39,6 +39,11 @@ vi.mock('@codex/database', () => ({
 
 vi.mock('@codex/subscription', () => ({
   invalidateForUser: vi.fn(),
+  // handlePaymentWebhook constructs a SubscriptionService for all payment
+  // events (used by charge.refunded clawback, Codex-13v21).
+  SubscriptionService: vi.fn(() => ({
+    reverseSubscriptionPayoutsForCharge: vi.fn(),
+  })),
 }));
 
 vi.mock('@codex/purchase', () => ({

--- a/workers/ecom-api/src/handlers/__tests__/payment-webhook-refund.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/payment-webhook-refund.test.ts
@@ -49,6 +49,11 @@ vi.mock('@codex/database', () => ({
 
 vi.mock('@codex/subscription', () => ({
   invalidateForUser: vi.fn(),
+  // handlePaymentWebhook constructs a SubscriptionService to reverse
+  // subscription payouts on charge.refunded (Codex-13v21).
+  SubscriptionService: vi.fn(() => ({
+    reverseSubscriptionPayoutsForCharge: vi.fn(),
+  })),
 }));
 
 vi.mock('@codex/purchase', () => ({

--- a/workers/ecom-api/src/handlers/__tests__/subscription-webhook-invalidation.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/subscription-webhook-invalidation.test.ts
@@ -193,6 +193,8 @@ describe('handleSubscriptionWebhook — cache invalidation', () => {
       handleSubscriptionDeleted: mockHandleDeleted,
       handleInvoicePaymentSucceeded: mockHandleInvoiceSuccess,
       handleInvoicePaymentFailed: mockHandleInvoiceFailed,
+      // charge.refunded clawback (Codex-13v21) — handlePaymentWebhook calls this.
+      reverseSubscriptionPayoutsForCharge: vi.fn(),
     }));
   });
 

--- a/workers/ecom-api/src/handlers/__tests__/subscription-webhook-revocation.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/subscription-webhook-revocation.test.ts
@@ -220,6 +220,8 @@ describe('handleSubscriptionWebhook — access revocation', () => {
       handleSubscriptionResumed: mockHandleResumed,
       handleInvoicePaymentSucceeded: mockHandleInvoiceSuccess,
       handleInvoicePaymentFailed: mockHandleInvoiceFailed,
+      // charge.refunded clawback (Codex-13v21) — handlePaymentWebhook calls this.
+      reverseSubscriptionPayoutsForCharge: vi.fn(),
     }));
   });
 

--- a/workers/ecom-api/src/handlers/payment-webhook.ts
+++ b/workers/ecom-api/src/handlers/payment-webhook.ts
@@ -21,7 +21,7 @@ import { AccessRevocation } from '@codex/access';
 import { VersionedCache } from '@codex/cache';
 import { STRIPE_EVENTS } from '@codex/constants';
 import { PurchaseService } from '@codex/purchase';
-import { invalidateForUser } from '@codex/subscription';
+import { invalidateForUser, SubscriptionService } from '@codex/subscription';
 import { createWebhookDbClient, sendEmailToWorker } from '@codex/worker-utils';
 import type { Context } from 'hono';
 import type Stripe from 'stripe';
@@ -138,18 +138,30 @@ function extractPaymentIntentId(
 async function handleChargeRefunded(
   event: Stripe.Event,
   service: PurchaseService,
+  subscriptionService: SubscriptionService,
   c: Context<StripeWebhookEnv>
 ): Promise<void> {
   const obs = c.get('obs');
   const charge = event.data.object as Stripe.Charge;
   const paymentIntentId = extractPaymentIntentId(charge.payment_intent);
+  const latestRefund = charge.refunds?.data?.[0];
+
+  // Subscription-invoice clawback (Codex-13v21): reverse the creator/org
+  // transfers made at invoice.payment_succeeded for this charge. Keyed by
+  // charge.id + sourceType='subscription', so it no-ops for one-time-purchase
+  // charges (those are handled by processRefund below) — calling both never
+  // double-reverses. Runs regardless of payment_intent presence because
+  // subscription payouts are keyed by charge, not payment_intent.
+  await subscriptionService.reverseSubscriptionPayoutsForCharge(charge.id, {
+    refundAmountCents: charge.amount_refunded,
+    stripeRefundId: latestRefund?.id ?? null,
+  });
 
   if (!paymentIntentId) {
     obs?.warn('Refund event missing payment_intent', { chargeId: charge.id });
     return;
   }
 
-  const latestRefund = charge.refunds?.data?.[0];
   const refundResult = await service.processRefund(paymentIntentId, {
     stripeRefundId: latestRefund?.id,
     refundAmountCents: charge.amount_refunded,
@@ -249,10 +261,14 @@ export async function handlePaymentWebhook(
       { db, environment: c.env.ENVIRONMENT || 'development' },
       stripe
     );
+    const subscriptionService = new SubscriptionService(
+      { db, environment: c.env.ENVIRONMENT || 'development' },
+      stripe
+    );
 
     switch (event.type) {
       case STRIPE_EVENTS.CHARGE_REFUNDED:
-        await handleChargeRefunded(event, service, c);
+        await handleChargeRefunded(event, service, subscriptionService, c);
         break;
 
       case STRIPE_EVENTS.CHARGE_DISPUTE_CREATED:


### PR DESCRIPTION
## What

Closes the **subscription-side residual** of Codex-13v21 (refund/dispute clawback). The purchase side was already fixed (Codex-h69cg: `reversePayoutsForPurchase` + `refund_reviews` fallback — the ratified *hybrid* policy). But **subscription invoice refunds leaked**: `charge.refunded` → `handleChargeRefunded` → `PurchaseService.processRefund` looks only in `purchases`, so a subscription invoice charge no-op'd and the creator/org transfers made at `invoice.payment_succeeded` were never reversed — the platform absorbed the gross.

## Fix
New `SubscriptionService.reverseSubscriptionPayoutsForCharge(chargeId, { refundAmountCents, stripeRefundId })`, mirroring `reversePayoutsForPurchase`:
- finds payouts by `stripeChargeId` + `sourceType='subscription'` — purchase rows carry `sourceType='purchase'` (verified: all purchase inserts set it), so running **both** paths on every `charge.refunded` **never double-reverses** the same transfer;
- reverses each transfer-bearing slice via `stripe.transfers.createReversal` with a deterministic idempotency key (`${transferId}_reversal_<suffix>`); **partial** refunds reverse proportionally against the reconstructed gross;
- **idempotent** — skips `reversed`/`cancelled_by_refund` rows;
- `insufficient_funds` → loud, correlatable error (row stays `paid`).

`handlePaymentWebhook` constructs `SubscriptionService`; `handleChargeRefunded` calls the clawback with `charge.id` **before** the `payment_intent` guard (subscription payouts are keyed by charge, not payment_intent). It runs alongside `processRefund`; each no-ops for the other's charge type.

## Tests — +5 real-DB (subscription)
Full reversal (org + creator reversed, platform_fee flipped, all rows → `reversed`); no-op when no subscription rows; idempotent (already-reversed skipped); proportional partial refund; and the **double-clawback guard** proving `sourceType='purchase'` rows are untouched. **Proven non-vacuous**: breaking the `sourceType` filter reds 3 tests. Updated 4 ecom-api webhook test mocks. Suites green: **@codex/subscription 420**, **ecom-api 389**; `tsc` clean on both.

## Deliberately deferred (tracked on Codex-13v21)
`refund_reviews` ops-queue **parity** for subscriptions: that table's `purchaseId` is `NOT NULL` and needs a schema generalisation before it can hold a subscription obligation. Until then `insufficient_funds` is **logged loudly**, not queued. The primary leak — reverse transfers when funds are available — is closed here; the residual is the rare "creator already withdrew" sub-case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)