### PR TITLE
docs(connect): correct Connect-not-configured error comment (Codex-fc5oh.4)

### DIFF
--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -271,10 +271,12 @@ export class ConnectAccountService extends BaseService {
 
       return { accountId: stripeAccountId, onboardingUrl };
     } catch (error) {
-      // Translate the platform-not-enabled misconfiguration into a typed,
-      // operator-facing 503 so the studio shows an actionable message rather
-      // than a bare 500. Everything else falls through to handleError, which
-      // logs the full Stripe diagnostic surface and wraps as
+      // Translate the platform-not-enabled misconfiguration into a typed
+      // ServiceError. It keeps the honest HTTP 500 (the failure is genuinely
+      // server-side), but its distinct `code` + authored `message` let the
+      // studio show an actionable message and let operators grep this failure
+      // apart from ordinary 500s. Everything else falls through to handleError,
+      // which logs the full Stripe diagnostic surface and wraps as
       // InternalServiceError.
       if (this.isConnectPlatformNotEnabled(error)) {
         this.obs.error('Stripe Connect not enabled for the platform account', {


### PR DESCRIPTION
## What
One-line comment correction in `ConnectAccountService.createAccountForUser`'s catch block. The call-site comment claimed the platform-not-enabled failure is translated to *"operator-facing 503 rather than a bare 500"*. That contradicts the deliberate design documented on the `ConnectPlatformNotConfiguredError` class itself.

## Why
The error **keeps the honest HTTP 500** — the failure is genuinely server-side (the platform's own Stripe account isn't enrolled in Connect). What makes it non-opaque is the typed `code` (`CONNECT_PLATFORM_NOT_CONFIGURED`) + authored `message`, which `mapErrorToResponse` surfaces verbatim (safe — leaks no Stripe internals) so the studio shows an actionable message and operators can grep it apart from ordinary 500s. Distinction lives in the *code*, not the *status*. The stale comment was a latent trap for the next reader.

Comment-only change — no behaviour change.

## Context (Codex-fc5oh.4, WP-6)
The bead's substantive deliverables were already landed and are verified green locally:
- **Typed actionable error**: `ConnectPlatformNotConfiguredError` thrown via a narrow discriminator (`isConnectPlatformNotEnabled` — matches `StripeInvalidRequestError` + `/signed up for Connect/i` only, so ordinary bad-param 500s still bubble). Tested positive **and** negative: `connect-account-service.test.ts` (51/51 pass).
- **Connect enabled on the TEST Stripe account**: proven by the seed creating working test-mode Connect accounts (`charges: true, payouts: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)