### PR TITLE
fix(onboarding): surface avatar validation rejection message (Codex-sf7zy)

### DIFF
--- a/apps/web/src/lib/components/ProfileForm.svelte
+++ b/apps/web/src/lib/components/ProfileForm.svelte
@@ -265,6 +265,12 @@
 
       <p class="avatar-help">{m.account_avatar_help()}</p>
 
+      <!-- Schema validation (HEIC/oversize) surfaces on the field's issues(),
+           not on .result — render it so the rejection message isn't swallowed
+           (Codex-sf7zy). -->
+      {#each avatarUploadForm.fields.avatar.issues() as issue}
+        <Alert variant="error">{issue.message}</Alert>
+      {/each}
       {#if avatarUploadForm.result?.error}
         <Alert variant="error">{avatarUploadForm.result.error}</Alert>
       {/if}

--- a/apps/web/src/routes/(platform)/become-creator/steps/StepProfile.svelte
+++ b/apps/web/src/routes/(platform)/become-creator/steps/StepProfile.svelte
@@ -98,17 +98,23 @@
         <span class="avatar__placeholder"></span>
       {/if}
     </div>
-    <form {...avatarUploadForm} class="avatar__form">
+    <form {...avatarUploadForm} enctype="multipart/form-data" class="avatar__form">
       <Label for="avatar">{m.onboarding_profile_avatar_label()}</Label>
 <!-- Explicit types (not image/*) so the OS picker prefers supported
            formats and iOS transcodes HEIC → JPEG on selection. -->
       <input
         id="avatar"
         class="avatar__input"
-        type="file"
-        name="avatar"
+        {...avatarUploadForm.fields.avatar.as('file')}
         accept="image/png,image/jpeg,image/webp,image/gif"
       />
+      <!-- Schema validation (HEIC/oversize) surfaces on the field's issues(),
+           NOT on .result — the handler never runs when validation fails. The
+           previous code only rendered .result.error, so those rejections were
+           silently swallowed (Codex-sf7zy). Render both channels. -->
+      {#each avatarUploadForm.fields.avatar.issues() as issue}
+        <p class="field__error">{issue.message}</p>
+      {/each}
       {#if avatarUploadForm.result && !avatarUploadForm.result.success}
         <p class="field__error">{avatarUploadForm.result.error}</p>
       {/if}


### PR DESCRIPTION
## Problem
The avatar upload schema (`avatar-upload.remote.ts`) rejects HEIC/oversize files via Zod `.refine()` with clear messages. But in SvelteKit remote forms, **schema-validation** failures surface on `avatarUploadForm.fields.avatar.issues()` and short-circuit *before* the handler runs — they do **not** populate `.result`. Both avatar UIs rendered only `.result.error`, so a HEIC/oversize selection was **silently swallowed**: the user picks a file, nothing uploads, no message. (Bug filed as Codex-sf7zy.)

## Fix
Render `fields.avatar.issues()` alongside the existing `.result.error` in **both** places (mirrors the `{#each field.issues() as issue}` idiom already used for the profile text fields):
- `become-creator/steps/StepProfile.svelte` (onboarding wizard) — also switched the hand-rolled `<input type=file name=avatar>` to the proper `{...avatarUploadForm.fields.avatar.as('file')}` binding + `enctype="multipart/form-data"`, matching ProfileForm.
- `lib/components/ProfileForm.svelte` (account page) — added the `.issues()` render (it already bound the field correctly but only showed `.result.error`).

## Verification
- `svelte-check`: both files type-clean (no new errors; repo's pre-existing errors are unrelated, tracked by Codex-zf9wf).
- No remote-form component-test harness exists in the repo, so the HEIC/oversize rejection path warrants a manual/visual check on the onboarding + account avatar flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)