### PR TITLE
fix(payouts): identify soft-deleted creators in breakdown rail (Codex-biiqd)

### DIFF
--- a/apps/web/src/lib/components/studio/payouts/CreatorBreakdownCard.svelte
+++ b/apps/web/src/lib/components/studio/payouts/CreatorBreakdownCard.svelte
@@ -35,7 +35,14 @@
   const { breakdown }: Props = $props();
 
   const displayName = $derived(
-    breakdown.name ?? breakdown.email ?? 'Unknown creator'
+    breakdown.name ??
+      breakdown.email ??
+      // Soft-deleted user: the LEFT JOIN in getPayoutsByCreatorBreakdown
+      // returns name=null + email=null. Show a userId fragment instead of a
+      // bare "Unknown creator" so two deleted recipients are distinguishable
+      // and an operator can pivot to the DB row for audit/compliance
+      // ("who is this payout going to?") — Codex-biiqd.
+      `Deleted user (…${breakdown.userId.slice(-6)})`
   );
 
   // Show the source split row only when at least one half is non-zero.

--- a/apps/web/src/lib/components/studio/payouts/CreatorBreakdownCard.svelte.test.ts
+++ b/apps/web/src/lib/components/studio/payouts/CreatorBreakdownCard.svelte.test.ts
@@ -88,9 +88,9 @@ describe('CreatorBreakdownCard', () => {
   // Expected: render an identifying fragment (e.g. last 6 chars of userId, or
   //           a "Deleted user (usr_…xyz)" pattern) so the operator can pivot.
   //
-  // Marked `it.fails` so CI tracks the bug; when fixed, vitest flips this red
-  // and the fixer removes `.fails`.
-  test.fails('F-19: shows identifying fragment for soft-deleted creator (currently shows only "Unknown creator")', () => {
+  // FIXED (Codex-biiqd): the card now renders `Deleted user (…{last6})` when
+  // both name and email are null. Flipped from `test.fails` to `test`.
+  test('F-19: shows identifying fragment for soft-deleted creator', () => {
     const result = mount(CreatorBreakdownCard, {
       target: document.body,
       props: {


### PR DESCRIPTION
## Problem
When a creator is soft-deleted from `users` but still has outstanding payouts, the LEFT JOIN in `getPayoutsByCreatorBreakdown` returns `name=null` + `email=null`. `CreatorBreakdownCard` fell back to the literal **"Unknown creator"** — so:
- Two deleted recipients render identically in the payouts rail.
- The operator can't grep the DB row by what they see on screen.
- Audit/compliance trail breaks: *"who is this £270 going to?"*

## Fix
Fall back to **`Deleted user (…{last 6 of userId})`** when both name and email are null. `userId` is already on `CreatorPayoutBreakdown`, so this is a self-contained one-line change in the card — no query/type change.

## Test
Flipped the pre-scaffolded `test.fails('F-19: shows identifying fragment for soft-deleted creator')` regression to a passing `test`. It seeds a deleted user (`userId: 'usr_deleted_abc123def456'`, name/email null) and asserts a userId fragment renders. Non-vacuous: it passed as `test.fails` under the old "Unknown creator" behavior and passes as `test` under the fix. **2/2 green** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)