### PR TITLE
fix(payouts): deterministic owner fallback in resolvePrimaryConnect (Codex-rjwdm)

### DIFF
--- a/packages/purchase/src/__tests__/purchase-service.test.ts
+++ b/packages/purchase/src/__tests__/purchase-service.test.ts
@@ -4794,6 +4794,58 @@ describe('PurchaseService Integration', () => {
       expect(account?.stripeAccountId).toBe(stripeAccountId);
     });
 
+    it('picks the earliest-joined owner deterministically for a multi-owner org (Codex-rjwdm)', async () => {
+      const [olderOwnerId, newerOwnerId] = await seedTestUsers(db, 2);
+      const [org] = await db
+        .insert(organizations)
+        .values({
+          name: 'RPC Multi-Owner Org',
+          slug: createUniqueSlug('rpc-multi-owner'),
+        })
+        .returning();
+      // Two owners with distinct join times. Insert the NEWER one FIRST so a
+      // resolver without a deterministic ORDER BY would tend to return it
+      // (insertion order) — the test then proves the `.orderBy(asc(createdAt))`
+      // tiebreak actually picks the earliest-joined owner, so org-fee routing
+      // can't flap between owners on the pin-null path.
+      await db.insert(schema.organizationMemberships).values([
+        {
+          ...createTestMembershipInput(org.id, newerOwnerId, { role: 'owner' }),
+          createdAt: new Date('2026-06-01T00:00:00.000Z'),
+        },
+        {
+          ...createTestMembershipInput(org.id, olderOwnerId, { role: 'owner' }),
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      ]);
+      // Both owners have their OWN Connect account, so a wrong pick returns the
+      // wrong account (not undefined) — makes the assertion non-vacuous.
+      const olderAcct = `acct_rpc_older_${createUniqueSlug('a')}`;
+      const newerAcct = `acct_rpc_newer_${createUniqueSlug('a')}`;
+      await db.insert(schema.stripeConnectAccounts).values([
+        {
+          userId: olderOwnerId,
+          organizationId: org.id,
+          stripeAccountId: olderAcct,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        },
+        {
+          userId: newerOwnerId,
+          organizationId: org.id,
+          stripeAccountId: newerAcct,
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        },
+      ]);
+
+      const account = await resolvePrimaryConnect(db, org.id);
+      expect(account?.userId).toBe(olderOwnerId);
+      expect(account?.stripeAccountId).toBe(olderAcct);
+    });
+
     it('returns undefined when the org has neither a primary pin nor an owner', async () => {
       const [org] = await db
         .insert(organizations)

--- a/packages/purchase/src/utils/resolve-primary-connect.ts
+++ b/packages/purchase/src/utils/resolve-primary-connect.ts
@@ -11,9 +11,11 @@
  * org → primary-or-owner user id → that user's single account.
  *
  * The account's own `organization_id` is NOT consulted — it is a nullable,
- * vestigial onboarding-origin field (WP1). The owner fallback is DETERMINISTIC
- * (role='owner'), unlike the prior arbitrary `.limit(1)` over that org column
- * which Codex-sec7i set out to eliminate. The pin still wins when present, so
+ * vestigial onboarding-origin field (WP1). The owner fallback is DETERMINISTIC:
+ * `role='owner'` ordered by `created_at ASC` (the earliest-joined owner wins),
+ * so a multi-owner org still resolves to a single stable account rather than an
+ * arbitrary one — unlike the prior bare `.limit(1)` which Codex-rjwdm flagged as
+ * non-deterministic across multi-owner orgs. The pin still wins when present, so
  * an org can route to a non-owner once onboarding/admin sets it.
  *
  * Returns undefined when the org has no resolvable primary/owner user, or that
@@ -26,7 +28,7 @@ import {
   organizations,
   stripeConnectAccounts,
 } from '@codex/database/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 
 type StripeConnectAccount = typeof stripeConnectAccounts.$inferSelect;
 
@@ -55,6 +57,10 @@ export async function resolvePrimaryConnect(
           eq(organizationMemberships.role, 'owner')
         )
       )
+      // Deterministic tiebreak across multi-owner orgs (Codex-rjwdm): the
+      // earliest-joined owner always wins, so org-fee money routing can't flap
+      // between owners on the pin-null path.
+      .orderBy(asc(organizationMemberships.createdAt))
       .limit(1);
     targetUserId = owner?.userId ?? null;
   }

--- a/packages/subscription/src/services/__tests__/subscription-service-orchestrator.test.ts
+++ b/packages/subscription/src/services/__tests__/subscription-service-orchestrator.test.ts
@@ -107,8 +107,20 @@ function makeDb(overrides: Record<string, unknown> = {}): DbSpy {
       // We return an object whose `where()` result is both a promise-like
       // (thenable → resolves to the array) AND carries a `.limit()` that
       // resolves to the same array. Drizzle's query builder works this way.
-      const makeWhereReturn = () => ({
+      const makeWhereReturn = (): {
+        limit: ReturnType<typeof vi.fn>;
+        orderBy: ReturnType<typeof vi.fn>;
+        then: (
+          r: (v: unknown) => void,
+          j?: (e: unknown) => void
+        ) => Promise<void>;
+        catch: (j: (e: unknown) => void) => Promise<unknown>;
+      } => ({
         limit: vi.fn(() => Promise.resolve(result)),
+        // resolvePrimaryConnect's owner fallback (Codex-rjwdm) chains
+        // `.where().orderBy().limit()`; return the same shape so the deterministic
+        // ordering passes through the mock (still resolves to the same array).
+        orderBy: vi.fn(() => makeWhereReturn()),
         // biome-ignore lint/suspicious/noThenProperty: mocking Drizzle's thenable query builder (awaited directly or chained with .limit())
         then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
           Promise.resolve(result).then(resolve, reject),


### PR DESCRIPTION
## Problem
`resolvePrimaryConnect` routes the org-fee slice of every payment to the org's settlement account. When no explicit pin is set it falls back to the org **owner** — but the query used a bare `.limit(1)` with **no ORDER BY**. Multi-owner orgs are allowed (`ensureNotLastOwner` only blocks removing the *last* owner), so the fallback could resolve to an **arbitrary** owner and flap between resolutions in the pin-null window → non-deterministic money routing. The docstring even overclaimed it was "DETERMINISTIC (role=owner)".

## Fix
`.orderBy(asc(organizationMemberships.createdAt))` — the **earliest-joined owner always wins** — plus a corrected docstring.

## Tests
- **Regression (purchase-service, real DB):** seeds an org with two owners, inserts the *newer* first, and asserts the resolver picks the *older*. **Proven non-vacuous** — removing the `.orderBy` line makes it fail (`expected olderOwner, got newerOwner`).
- **Mock passthrough (subscription-service-orchestrator):** `makeWhereReturn` now exposes `.orderBy` so the new chain method doesn't break the hand-rolled db mock — the documented `db-mock-chain-method-break` trap. This is the *only* mocked consumer; connect-account + purchase-service exercise the real resolver against a real DB. Verified: orchestrator 46/46, connect-account 51/51, resolvePrimaryConnect describe 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)