### PR TITLE
fix(connect): distinguish 'requirements unknown' from 'none' on Stripe failure (Codex-y2htq)

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -254,6 +254,14 @@ export interface ConnectAccountStatusResponse {
    * the UI shows status only, no requirements list).
    */
   requirements: ConnectRequirements | null;
+  /**
+   * True when the live Stripe requirements fetch FAILED (Codex-y2htq). Lets the
+   * UI distinguish "no outstanding requirements" (`requirements: null` +
+   * `false`/absent) from "we couldn't check right now" (`requirements: null` +
+   * `true`) and show a retry affordance instead of a false "all clear".
+   * Optional for backward-compat with older payloads.
+   */
+  requirementsFetchFailed?: boolean;
 }
 
 /**

--- a/packages/subscription/src/services/__tests__/connect-account-service.test.ts
+++ b/packages/subscription/src/services/__tests__/connect-account-service.test.ts
@@ -1159,6 +1159,7 @@ describe('ConnectAccountService', () => {
         payoutsEnabled: false,
         status: null,
         requirements: null,
+        requirementsFetchFailed: false,
       });
       // No Stripe call when there's no DB account
       expect(stripe.accounts.retrieve).not.toHaveBeenCalled();
@@ -1228,6 +1229,47 @@ describe('ConnectAccountService', () => {
       expect(result.requirements?.errors[0].requirement).toBe(
         'business_profile.url'
       );
+      // Successful Stripe retrieve → not a fetch failure (Codex-y2htq).
+      expect(result.requirementsFetchFailed).toBe(false);
+    });
+
+    it('flags requirementsFetchFailed=true when the Stripe retrieve fails (Codex-y2htq)', async () => {
+      const [failOrg] = await db
+        .insert(organizations)
+        .values(
+          createTestOrganizationInput({
+            slug: createUniqueSlug('status-fail'),
+            creatorId,
+          })
+        )
+        .returning();
+      await db.insert(stripeConnectAccounts).values(
+        createTestConnectAccountInput(failOrg.id, creatorId, {
+          status: 'active',
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        })
+      );
+      await db
+        .update(organizations)
+        .set({ primaryConnectAccountUserId: creatorId })
+        .where(eq(organizations.id, failOrg.id));
+
+      // Stripe unreachable on the cache-miss path.
+      (stripe.accounts.retrieve as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Stripe API unavailable')
+      );
+
+      const result = await service.getStatus(failOrg.id);
+
+      // DB-derived fields still surface (graceful degradation)...
+      expect(result.isConnected).toBe(true);
+      expect(result.status).toBe('active');
+      // ...but the failure is DISTINGUISHABLE from a clean account: requirements
+      // is null AND the flag is true, so the UI can show "couldn't refresh"
+      // rather than a false "all clear".
+      expect(result.requirements).toBeNull();
+      expect(result.requirementsFetchFailed).toBe(true);
     });
 
     it('normalises null arrays to [] so the UI can iterate without guards', async () => {
@@ -1617,6 +1659,7 @@ describe('ConnectAccountService', () => {
         payoutsEnabled: false,
         status: null,
         requirements: null,
+        requirementsFetchFailed: false,
       });
       expect(stripe.accounts.retrieve).not.toHaveBeenCalled();
     });

--- a/packages/subscription/src/services/connect-account-service.ts
+++ b/packages/subscription/src/services/connect-account-service.ts
@@ -77,6 +77,15 @@ export interface ConnectStatusPayload {
   payoutsEnabled: boolean;
   status: 'onboarding' | 'active' | 'restricted' | 'disabled' | null;
   requirements: ConnectRequirements | null;
+  /**
+   * True when the live Stripe `accounts.retrieve` call FAILED, so
+   * `requirements` reflects only what we know (nothing) rather than a
+   * confirmed "no outstanding requirements". Lets the UI distinguish
+   * "account is clean" (`requirements: null` + `false`) from "we couldn't
+   * check right now" (`requirements: null` + `true`) instead of collapsing
+   * both into an identical healthy-looking payload (Codex-y2htq).
+   */
+  requirementsFetchFailed: boolean;
 }
 
 /**
@@ -101,6 +110,7 @@ const DISCONNECTED_STATUS: ConnectStatusPayload = {
   payoutsEnabled: false,
   status: null,
   requirements: null,
+  requirementsFetchFailed: false,
 };
 
 /**
@@ -774,6 +784,7 @@ export class ConnectAccountService extends BaseService {
     // Read live requirements from Stripe. Stripe's `account.updated` webhook
     // is the canonical signal for change; we read on cache-miss only.
     let requirements: ConnectRequirements | null = null;
+    let requirementsFetchFailed = false;
     try {
       const stripeAccount = await this.stripe.accounts.retrieve(
         account.stripeAccountId
@@ -782,7 +793,10 @@ export class ConnectAccountService extends BaseService {
     } catch (error) {
       // Graceful degradation: surface what we know from the DB row even if
       // Stripe is unreachable. The UI degrades to "status only" rather than
-      // failing the page load.
+      // failing the page load. Flag the failure so the UI can distinguish
+      // "no outstanding requirements" from "couldn't check" (Codex-y2htq)
+      // instead of both looking like a clean `requirements: null`.
+      requirementsFetchFailed = true;
       this.obs.warn('Failed to fetch Stripe Connect requirements', {
         userId,
         stripeAccountId: account.stripeAccountId,
@@ -800,6 +814,7 @@ export class ConnectAccountService extends BaseService {
       // `handleAccountUpdated` — anything else is a data corruption bug.
       status: account.status as ConnectStatusPayload['status'],
       requirements,
+      requirementsFetchFailed,
     };
   }
 

--- a/workers/ecom-api/src/routes/__tests__/connect-me-routes.test.ts
+++ b/workers/ecom-api/src/routes/__tests__/connect-me-routes.test.ts
@@ -71,6 +71,7 @@ const STATUS_PAYLOAD = {
   payoutsEnabled: true,
   status: 'active' as const,
   requirements: null,
+  requirementsFetchFailed: false,
 };
 
 const VALID_ONBOARD = {


### PR DESCRIPTION
## Problem
`ConnectAccountService.fetchStatusFromStripeForUser` initialised `requirements = null` and, when the live `stripe.accounts.retrieve` call threw, only logged a WARN and returned `requirements: null` — **indistinguishable** from a genuinely clean account with no outstanding requirements. So the studio Connect-status surface showed a false *"all clear"* when it actually couldn't reach Stripe (a lossy-signal silent failure).

## Fix
Add `requirementsFetchFailed: boolean` to `ConnectStatusPayload` — set `true` in the catch, `false` otherwise (and in `DISCONNECTED_STATUS`). Now the UI can tell:
- `requirements: null` + `requirementsFetchFailed: false` → **account is clean**
- `requirements: null` + `requirementsFetchFailed: true` → **couldn't check — show retry**

Mirrored the optional field on the web `ConnectAccountStatusResponse` type so the studio can consume it (surfacing a retry affordance in the UI is a recommended follow-up).

## Tests
New `getStatus` failure-path test: `stripe.accounts.retrieve` rejects → asserts `requirements` null **and** `requirementsFetchFailed` true (graceful degradation preserved: `isConnected`/`status` still surface). Success path asserts `false`. **52/52 green**; `@codex/subscription` + `ecom-api` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)