### PR TITLE
fix(payouts): size the creator-rail skeleton to the last-known count (Codex-0sz4j)

### DIFF
--- a/apps/web/src/lib/components/studio/payouts/CreatorBreakdownRail.svelte
+++ b/apps/web/src/lib/components/studio/payouts/CreatorBreakdownRail.svelte
@@ -16,6 +16,8 @@
   @prop activeFilters - Optional filter-state hint (display only)
 -->
 <script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/state';
   import { Skeleton } from '$lib/components/ui';
   import type {
     CreatorPayoutBreakdown,
@@ -49,6 +51,39 @@
       parts.push(activeFilters.range === 'all' ? 'all time' : `${activeFilters.range}d`);
     return parts.length > 0 ? parts.join(' · ') : null;
   });
+
+  // Skeleton count: default to the LAST-KNOWN creator count for this org's
+  // studio so the loading placeholder matches the resolved list and doesn't
+  // cause a layout shift when data arrives (Codex-0sz4j). Keyed by the studio
+  // hostname (org subdomain) so multi-org operators don't cross-contaminate;
+  // clamped to a sane ceiling and falls back to 3 on first visit.
+  const SKELETON_FALLBACK = 3;
+  const SKELETON_MAX = 10;
+
+  function skeletonStorageKey(): string {
+    return `codex-payout-rail-count:${page.url.hostname}`;
+  }
+
+  function readStoredSkeletonCount(): number {
+    if (!browser) return SKELETON_FALLBACK;
+    const n = Number.parseInt(localStorage.getItem(skeletonStorageKey()) ?? '', 10);
+    return Number.isFinite(n) && n > 0
+      ? Math.min(n, SKELETON_MAX)
+      : SKELETON_FALLBACK;
+  }
+
+  // Read once at init (browser-guarded → SSR-safe) so there's no flash of the
+  // fallback count before the stored value applies.
+  let skeletonCount = $state(readStoredSkeletonCount());
+
+  // Persist the actual creator count once the rail has loaded real rows.
+  $effect(() => {
+    if (!browser || loading || breakdown.length === 0) return;
+    localStorage.setItem(
+      skeletonStorageKey(),
+      String(Math.min(breakdown.length, SKELETON_MAX))
+    );
+  });
 </script>
 
 <aside class="rail" aria-label="Payouts by creator">
@@ -61,7 +96,7 @@
 
   {#if loading}
     <div class="rail__list" aria-busy="true">
-      {#each Array.from({ length: 3 }) as _, i (i)}
+      {#each Array.from({ length: skeletonCount }) as _, i (i)}
         <div class="rail__skeleton">
           <Skeleton width="60%" height="var(--space-5)" />
           <Skeleton width="40%" height="var(--space-7)" />


### PR DESCRIPTION
## Problem
`CreatorBreakdownRail` rendered exactly **3** skeleton tiles while loading. Orgs with a different number of paid creators got a visible layout shift (CLS) when the real rail resolved.

## Fix
Persist the actual creator count in `localStorage`, keyed by the **studio hostname** (org subdomain → org-isolated, so multi-org operators don't cross-contaminate), and use it as the skeleton count. Clamped to 10, falls back to 3 on first visit. Read once at init behind a `browser` guard (SSR-safe; no flash of the fallback before the stored value applies), and re-persisted via an `$effect` once real rows load.

Self-contained component change — no new prop plumbing, no design-token violations. Verified: Svelte autofixer clean (the `$effect` is a legitimate localStorage side-effect), `svelte-check` reports no errors in the file. CLS is visual (no automated test — the bead scopes it as UX-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)