### PR TITLE
fix(ci): repair typecheck + e2e drift from recent onboarding/account work

### DIFF
--- a/apps/web/e2e/account/profile.spec.ts
+++ b/apps/web/e2e/account/profile.spec.ts
@@ -38,7 +38,7 @@ async function navigateToAccountPage(page: import('@playwright/test').Page) {
  * Helper: Wait for form submission to complete
  */
 async function waitForFormSave(page: import('@playwright/test').Page) {
-  const submitButton = page.locator('button[type="submit"]');
+  const submitButton = page.locator('[data-testid="profile-save"]');
   await page.waitForTimeout(500);
   await expect(submitButton).toBeVisible({ timeout: 5000 });
 }
@@ -110,7 +110,7 @@ test.describe('Account Profile Page - Read-Only', () => {
     await expect(page.locator('input[name="instagram"]')).toBeVisible();
 
     // Check save button
-    await expect(page.locator('button[type="submit"]')).toContainText(
+    await expect(page.locator('[data-testid="profile-save"]')).toContainText(
       'Save Changes'
     );
   });
@@ -187,7 +187,7 @@ test.describe('Account Profile Page - Validation', () => {
     await navigateToAccountPage(page);
 
     await page.fill('input[name="username"]', 'InvalidUser');
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
 
     const usernameInput = page.locator('input[name="username"]');
     await expect(usernameInput).toHaveAttribute('aria-invalid', 'true');
@@ -199,7 +199,7 @@ test.describe('Account Profile Page - Validation', () => {
     await navigateToAccountPage(page);
 
     await page.fill('input[name="username"]', 'user@name');
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
 
     const usernameInput = page.locator('input[name="username"]');
     await expect(usernameInput).toHaveAttribute('aria-invalid', 'true');
@@ -209,7 +209,7 @@ test.describe('Account Profile Page - Validation', () => {
     await navigateToAccountPage(page);
 
     await page.fill('input[name="username"]', 'a');
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
 
     const usernameInput = page.locator('input[name="username"]');
     await expect(usernameInput).toHaveAttribute('aria-invalid', 'true');
@@ -219,7 +219,7 @@ test.describe('Account Profile Page - Validation', () => {
     await navigateToAccountPage(page);
 
     await page.fill('input[name="username"]', 'a'.repeat(51));
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
 
     const usernameInput = page.locator('input[name="username"]');
     await expect(usernameInput).toHaveAttribute('aria-invalid', 'true', {
@@ -239,7 +239,7 @@ test.describe('Account Profile Page - Validation', () => {
     // user code. Either way the page MUST refuse to navigate away on an
     // invalid value, so submit and assert we're still on /account.
     await page.fill('input[name="website"]', 'not-a-valid-url');
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
 
     // Form should not have navigated AWAY from /account. SvelteKit Remote
     // Functions append a `?/remote=...` query param on form submission, so
@@ -259,7 +259,7 @@ test.describe('Account Profile Page - Validation', () => {
     // is that the page stays on /account — assert that instead. Same fix
     // pattern as the website-URL test (:230).
     await page.fill('input[name="twitter"]', 'twitter.com/user');
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
 
     await page.waitForTimeout(1_000);
     await expect(page).toHaveURL(/\/account(\?|$)/);
@@ -278,10 +278,10 @@ test.describe('Account Profile Page - Mutations', () => {
 
     const newDisplayName = 'Updated Name';
     await page.fill('input[name="displayName"]', newDisplayName);
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
     await waitForFormSave(page);
 
-    const submitButton = page.locator('button[type="submit"]');
+    const submitButton = page.locator('[data-testid="profile-save"]');
     await expect(submitButton).toBeVisible();
   });
 
@@ -293,7 +293,7 @@ test.describe('Account Profile Page - Mutations', () => {
     await navigateToAccountPage(page);
 
     await page.fill('input[name="displayName"]', 'New Name');
-    const submitButton = page.locator('button[type="submit"]');
+    const submitButton = page.locator('[data-testid="profile-save"]');
     await submitButton.click();
     await expect(submitButton).toBeVisible();
   });
@@ -307,9 +307,9 @@ test.describe('Account Profile Page - Mutations', () => {
 
     const newUsername = `newuser-${Date.now()}`;
     await page.fill('input[name="username"]', newUsername);
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
     await waitForFormSave(page);
-    await expect(page.locator('button[type="submit"]')).toBeVisible();
+    await expect(page.locator('[data-testid="profile-save"]')).toBeVisible();
   });
 
   test('can update bio with multiline text', async ({
@@ -321,9 +321,9 @@ test.describe('Account Profile Page - Mutations', () => {
 
     const newBio = 'Line 1\nLine 2\nLine 3';
     await page.fill('textarea[name="bio"]', newBio);
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
     await waitForFormSave(page);
-    await expect(page.locator('button[type="submit"]')).toBeVisible();
+    await expect(page.locator('[data-testid="profile-save"]')).toBeVisible();
   });
 
   test('can update social links', async ({ page, authenticateAsUser }) => {
@@ -340,9 +340,9 @@ test.describe('Account Profile Page - Mutations', () => {
       'input[name="instagram"]',
       'https://instagram.com/myhandle'
     );
-    await page.click('button[type="submit"]', { noWaitAfter: true });
+    await page.click('[data-testid="profile-save"]', { noWaitAfter: true });
     await waitForFormSave(page);
-    await expect(page.locator('button[type="submit"]')).toBeVisible();
+    await expect(page.locator('[data-testid="profile-save"]')).toBeVisible();
   });
 
   test('avatar preview shows when file is selected', async ({

--- a/apps/web/e2e/studio/content.spec.ts
+++ b/apps/web/e2e/studio/content.spec.ts
@@ -182,22 +182,35 @@ test.describe('Studio Content - Create Form', () => {
     await expect(page.locator('[role="radiogroup"]')).toBeAttached();
   });
 
-  test('price input defaults to 0', async ({ page }) => {
+  test('monetised access is gated until payouts are set up', async ({
+    page,
+  }) => {
     await navigateToStudioPage(
       page,
       sharedAuth.member.organization.slug,
       '/content/new'
     );
 
-    // Price is conditionally rendered behind `showPrice` (only true for paid
-    // or subscribers access). Default access is 'free' — pick 'One-time
-    // purchase' to surface the input before asserting its default value.
-    // The input is `step="0.01"`, so the rendered default is "0.00".
-    await page
-      .getByRole('radio', { name: /one-time purchase/i })
-      .check({ force: true });
-    const priceField = page.locator('input#price');
-    await expect(priceField).toHaveValue(/^0(\.0+)?$/);
+    // Codex-eb00a.10: monetised access options (one-time purchase /
+    // subscribers) are disabled until the creator has a payout-ready Stripe
+    // Connect account, mirroring the backend publish gate. A fresh studio user
+    // has no Connect account, so `getMyConnectStatus()` resolves not-ready and
+    // the paid option renders disabled with a "set up payouts" prompt.
+    //
+    // `connectReady` is optimistically true until the status query resolves, so
+    // poll on the disabled state (expect() retries) rather than asserting once.
+    const paidRadio = page.getByRole('radio', {
+      name: /one-time purchase/i,
+    });
+    await expect(paidRadio).toBeDisabled();
+
+    // The payouts prompt is shown alongside the gated options.
+    await expect(page.locator('.payouts-hint')).toBeVisible();
+
+    // The gate holds — the price input stays hidden because 'paid' can't be
+    // selected, so access remains the default 'free' (price is only rendered
+    // for paid/subscribers). Absent from the DOM, not merely hidden.
+    await expect(page.locator('input#price')).toHaveCount(0);
   });
 });
 

--- a/apps/web/src/lib/components/ProfileForm.svelte
+++ b/apps/web/src/lib/components/ProfileForm.svelte
@@ -402,7 +402,12 @@
         </div>
       </Card.Content>
       <Card.Footer>
-        <Button type="submit" variant="primary" loading={updateProfileForm.pending > 0}>
+        <Button
+          type="submit"
+          variant="primary"
+          data-testid="profile-save"
+          loading={updateProfileForm.pending > 0}
+        >
           {updateProfileForm.pending > 0 ? m.account_saving() : m.account_save_button()}
         </Button>
       </Card.Footer>

--- a/apps/web/src/routes/(platform)/become-creator/steps/StepPayouts.svelte.test.ts
+++ b/apps/web/src/routes/(platform)/become-creator/steps/StepPayouts.svelte.test.ts
@@ -15,7 +15,15 @@
  * navigating away and polluting sibling tests.
  */
 
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  test,
+  vi,
+} from 'vitest';
 import {
   mount,
   screen,
@@ -44,14 +52,14 @@ function baseProps() {
 describe('StepPayouts — connect redirect', () => {
   let component: ReturnType<typeof mount> | null = null;
   let originalLocation: Location;
-  let hrefSetter: ReturnType<typeof vi.fn>;
+  let hrefSetter: Mock<(value: string) => void>;
 
   beforeEach(() => {
     mockOnboard.mockReset();
 
     // Intercept assignment to window.location.href without navigating.
     originalLocation = window.location;
-    hrefSetter = vi.fn();
+    hrefSetter = vi.fn<(value: string) => void>();
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: new Proxy(originalLocation, {


### PR DESCRIPTION
## Why

The `#386` push run to `dev` failed **two** CI jobs — `static-analysis (Lint, Format & Type Check)` and `E2E Web Tests`. Investigation showed **three independent, real drifts** (not flake) introduced by recent onboarding/account work whose PRs didn't update the affected checks.

## Failures & fixes

### 1. Typecheck — `web#typecheck` (TS2348)
`StepPayouts.svelte.test.ts:60` — under **vitest 4**, a bare `vi.fn()` is typed `Mock<Procedure | Constructable>` (a union with a construct-only signature), so `hrefSetter(value)` is "not callable". Fixed by typing the mock with its call signature: `Mock<(value: string) => void>` + `vi.fn<(value: string) => void>()`.

### 2. E2E — Account Profile (6 tests)
`c7741aec` (self-service account deletion, Codex-eb00a.11) added a **"Delete my account"** submit button. `button[type="submit"]` now resolves to **2 elements**, so every `page.locator(...)` / `expect(...)` on it hits a Playwright strict-mode violation. (The `page.click(...)` sites are non-strict and passed only by DOM order.)

Fix: add a stable `data-testid="profile-save"` to the Save button in `ProfileForm.svelte` and point all 17 spec locators at it. Forwarding is proven — `login`/`register` use the identical `<Button data-testid>` pattern in passing e2e.

### 3. E2E — Studio Content (1 test)
`a789acd4` (gate monetised content on Connect readiness, Codex-eb00a.10) made the paid / "one-time purchase" access option **disabled** until the creator has a payout-ready Stripe Connect account. A fresh studio org has none, so the radio is disabled and `.check({ force: true })` can't flip it ("did not change its state").

Fix: repurpose the test to assert the **real gate** — paid radio `toBeDisabled()`, `.payouts-hint` visible, `input#price` absent. This is what an e2e on a fresh (no-payout) creator can truthfully verify, and it's a stronger regression guard for the gating feature than the old price-default assertion (which had no unit backing either).

## Verification
- ✅ `web#typecheck` clean locally (`svelte-kit sync && tsc --noEmit`)
- ✅ `biome check` clean on all edited files (+ lint-staged hook)
- ✅ `StepPayouts.svelte.test.ts` runs 3/3 green
- ✅ Both e2e specs collect cleanly (`playwright test --list`)
- ⏳ Full e2e run deferred to this PR's CI (local test stack not booted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)