### PR TITLE
fix(access): accept physical audio HLS rungs (64k/128k) in variant proxy

### DIFF
--- a/apps/web/src/lib/components/VideoPlayer/VideoPlayer.svelte
+++ b/apps/web/src/lib/components/VideoPlayer/VideoPlayer.svelte
@@ -462,6 +462,17 @@
     clearBuffering();
   }
 
+  /**
+   * Backstop for a missed `canplay`. `loadeddata` fires once the first frame
+   * is decoded (readyState ≥ HAVE_CURRENT_DATA). `canplay` is the primary
+   * signal that lifts the loading curtain, but it can be dropped on HLS.js/MSE
+   * source swaps and media-error recovery — without this fallback the branded
+   * gradient can sit over a ready (or playing) video indefinitely.
+   */
+  function handleLoadedData() {
+    loading = false;
+  }
+
   function clearBuffering() {
     if (bufferingTimer) {
       clearTimeout(bufferingTimer);
@@ -485,6 +496,11 @@
   }
 
   function handlePlaying() {
+    // Frames are actively rendering — initial load is definitively over.
+    // Clearing `loading` here (not just `buffering`) is the last-resort
+    // backstop against a missed `canplay`/`loadeddata` leaving the skeleton
+    // stranded over a playing video.
+    loading = false;
     clearBuffering();
   }
 
@@ -1019,6 +1035,7 @@
         preload="metadata"
         poster={poster}
         oncanplay={handleCanPlay}
+        onloadeddata={handleLoadedData}
         onerror={handleError}
         onplay={handlePlay}
         onpause={handlePause}

--- a/apps/web/src/routes/(platform)/about/+page.server.ts
+++ b/apps/web/src/routes/(platform)/about/+page.server.ts
@@ -6,5 +6,9 @@ import { CACHE_HEADERS } from '$lib/server/cache';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ setHeaders }) => {
-  setHeaders(CACHE_HEADERS.STATIC_PUBLIC);
+  // Rendered under the (platform) layout, which injects the auth-aware user
+  // section — so even this near-static page varies by auth. Shared caches key
+  // by URL, NOT by Cookie, so a `public` copy would show signed-in users the
+  // logged-out header. PRIVATE keeps it out of shared caches.
+  setHeaders(CACHE_HEADERS.PRIVATE);
 };

--- a/apps/web/src/routes/_creators/[username]/+page.server.ts
+++ b/apps/web/src/routes/_creators/[username]/+page.server.ts
@@ -123,12 +123,12 @@ export const load: PageServerLoad = async ({
   }
   const organizations = [...orgMap.values()];
 
-  // Set the public cache header only on the success path. Payload includes
-  // `user: locals.user`, so the response varies by auth — REVALIDATE lets the
-  // CDN serve the shared anonymous version while forcing the browser to
-  // revalidate once the user signs in. Setting AFTER the awaits prevents the
-  // CDN from caching a 4xx/5xx error response with these public-cache headers.
-  setHeaders(CACHE_HEADERS.DYNAMIC_PUBLIC_REVALIDATE);
+  // Payload includes `user: locals.user`, so the response varies by auth.
+  // Shared caches (Cloudflare edge, miniflare) key by URL, NOT by Cookie, so a
+  // `public` response cached for an anonymous visitor is served to signed-in
+  // users too — the stale "Sign in" render. PRIVATE keeps auth-varying pages
+  // out of shared caches. See docs/caching-strategy.md §HTTP/CDN caching.
+  setHeaders(CACHE_HEADERS.PRIVATE);
 
   return {
     username,

--- a/apps/web/src/routes/_creators/[username]/content/+page.server.ts
+++ b/apps/web/src/routes/_creators/[username]/content/+page.server.ts
@@ -4,7 +4,8 @@
  * Fetches a creator's published content with search, type filtering, and pagination.
  * Reuses the creator profile lookup from the parent page, then queries content
  * scoped by creatorId with URL-driven filters.
- * Sets DYNAMIC_PUBLIC cache headers for edge caching.
+ * Sets PRIVATE cache headers — the page is auth-varying (creator layout
+ * injects `user`), so it must not be shared-cached.
  */
 import { createServerApi } from '$lib/server/api';
 import { CACHE_HEADERS } from '$lib/server/cache';
@@ -102,10 +103,12 @@ export const load: PageServerLoad = async ({
     }
   }
 
-  // Set the public cache header only on the success path. If any await above
-  // throws an unhandled error, SvelteKit's default no-cache headers apply to
-  // the error response instead of poisoning the CDN with a publicly-cached 4xx/5xx.
-  setHeaders(CACHE_HEADERS.DYNAMIC_PUBLIC);
+  // Auth-varying HTML — the creator layout injects the auth-aware `user`
+  // section, so the response differs by auth state. Shared caches key by URL,
+  // NOT by Cookie, so a `public` copy cached for an anonymous visitor is served
+  // to signed-in users too. PRIVATE keeps it out of shared caches.
+  // See docs/caching-strategy.md §HTTP/CDN caching.
+  setHeaders(CACHE_HEADERS.PRIVATE);
 
   return {
     username,

--- a/apps/web/src/routes/_creators/[username]/content/[contentSlug]/+page.server.ts
+++ b/apps/web/src/routes/_creators/[username]/content/[contentSlug]/+page.server.ts
@@ -81,15 +81,14 @@ export const load: PageServerLoad = async ({
   }
 
   // Cache header is applied ONLY on the success path right before each return.
-  // Setting it eagerly here would cause `error(404)` and unhandled rejections
-  // in awaits below (renderContentBody, loadAccessAndProgress) to inherit
-  // `Cache-Control: public, max-age=...`, poisoning the CDN with the error
-  // response. REVALIDATE variant forces browsers to revalidate on every
-  // request so a buyer returning from Stripe doesn't see the anonymous
-  // response cached earlier.
-  const successCacheHeaders = locals.user
-    ? CACHE_HEADERS.PRIVATE
-    : CACHE_HEADERS.DYNAMIC_PUBLIC_REVALIDATE;
+  // This page renders auth-aware HTML (the creator layout injects `user` and
+  // the CTA switches on isAuthenticated), so the SAME URL yields different
+  // markup per auth state. Shared caches (Cloudflare edge, miniflare) key by
+  // URL, NOT by Cookie, so any `public` response cached for an anonymous
+  // visitor is served to signed-in users too. PRIVATE keeps it out of shared
+  // caches; the public content list (incl. this slug lookup) is KV-cached in
+  // content-api so the DB stays shielded. See docs/caching-strategy.md.
+  const successCacheHeaders = CACHE_HEADERS.PRIVATE;
 
   // Body gating: only render the body once access is confirmed. Free content
   // renders immediately (SEO + first-paint). Everything else (followers /

--- a/apps/web/src/routes/_org/[slug]/(space)/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/+page.server.ts
@@ -223,7 +223,6 @@ function buildSections(all: ContentItem[]): FeedSection[] {
 
 export const load: PageServerLoad = async ({
   params: routeParams,
-  locals,
   setHeaders,
   parent,
 }) => {
@@ -251,15 +250,12 @@ export const load: PageServerLoad = async ({
   // Set cache headers only after the critical awaits. If `parent()` throws
   // (e.g. an auth/branding load failure), the resulting error response
   // inherits SvelteKit's default no-cache headers instead of poisoning the
-  // CDN with the public-cache policy. REVALIDATE variant forces browsers to
-  // revalidate on every request so a user who signs in (or buys/subscribes)
-  // doesn't get served the anonymous response cached during an earlier
-  // logged-out visit to the same URL.
-  setHeaders(
-    locals.user
-      ? CACHE_HEADERS.PRIVATE
-      : CACHE_HEADERS.DYNAMIC_PUBLIC_REVALIDATE
-  );
+  // CDN with the public-cache policy. This page is auth-varying (the layout
+  // injects `user`), and shared caches key by URL, NOT by Cookie — so a
+  // `public` response cached for an anonymous visitor is served to signed-in
+  // users too. PRIVATE keeps it out of shared caches.
+  // See docs/caching-strategy.md §HTTP/CDN caching.
+  setHeaders(CACHE_HEADERS.PRIVATE);
 
   // Categories for the hero pill row + sticky pill bar. Derived from
   // `allContent` (already on this request) rather than `stats.categories`

--- a/apps/web/src/routes/_org/[slug]/(space)/content/[contentSlug]/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/content/[contentSlug]/+page.server.ts
@@ -35,16 +35,16 @@ export const load: PageServerLoad = async ({
   const { org } = parentData;
   const { contentSlug } = params;
 
-  // Cache header is applied ONLY on the success path right before each return.
-  // Setting it eagerly here would cause `error(404)` and unhandled rejections
-  // in awaits below to inherit `Cache-Control: public, max-age=...`, poisoning
-  // the CDN with the error response. Public visitors get CDN caching;
-  // authenticated responses vary by access state. REVALIDATE variant forces
-  // browsers to revalidate on every request so a buyer returning from Stripe
-  // doesn't see the anonymous response cached earlier.
-  const successCacheHeaders = locals.user
-    ? CACHE_HEADERS.PRIVATE
-    : CACHE_HEADERS.DYNAMIC_PUBLIC_REVALIDATE;
+  // This page renders auth-aware HTML — the org layout injects `user`, and the
+  // CTA switches on isAuthenticated — so the SAME URL yields different markup
+  // per auth state. Shared caches (Cloudflare edge, miniflare in CI) key by
+  // URL, NOT by Cookie, so any `public` response cached for an anonymous
+  // visitor is served to signed-in users too — the "You need to sign in" bug
+  // for owners. PRIVATE keeps every auth-varying page out of shared caches. The
+  // DB stays shielded: the public content list (incl. this slug lookup) is
+  // KV-cached in content-api, so PRIVATE costs an SSR render, not a query.
+  // See docs/caching-strategy.md §HTTP/CDN caching.
+  const successCacheHeaders = CACHE_HEADERS.PRIVATE;
 
   // Fetch content via public endpoint with org.id + slug — 1 API call.
   // The old getContentBySlug() made 2 sequential HTTP calls:

--- a/apps/web/src/routes/_org/[slug]/(space)/creators/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/creators/+page.server.ts
@@ -3,7 +3,8 @@
  *
  * Fetches paginated list of public creators for the organization.
  * Uses the GET /api/organizations/public/:slug/creators endpoint.
- * Sets DYNAMIC_PUBLIC cache headers for edge caching.
+ * Sets PRIVATE cache headers — the page is auth-varying (org layout injects
+ * `user`), so it must not be shared-cached.
  */
 import { getPublicCreators } from '$lib/remote/org.remote';
 import { CACHE_HEADERS } from '$lib/server/cache';
@@ -24,11 +25,12 @@ export const load: PageServerLoad = async ({ url, setHeaders, parent }) => {
     limit: PAGE_LIMIT,
   });
 
-  // Set the public cache header only on the success path. If any await above
-  // throws, the resulting 4xx/5xx error response inherits SvelteKit's default
-  // (no-cache) headers instead of the public CDN policy — which would otherwise
-  // poison the CDN with the error page for every visitor for `max-age` seconds.
-  setHeaders(CACHE_HEADERS.DYNAMIC_PUBLIC);
+  // Auth-varying HTML — the org layout injects the auth-aware `user` section,
+  // so the SAME URL differs by auth state. Shared caches (Cloudflare edge,
+  // miniflare) key by URL, NOT by Cookie, so a `public` copy cached for an
+  // anonymous visitor is served to signed-in users too. PRIVATE keeps it out
+  // of shared caches. See docs/caching-strategy.md §HTTP/CDN caching.
+  setHeaders(CACHE_HEADERS.PRIVATE);
 
   return {
     creators: {

--- a/apps/web/src/routes/_org/[slug]/(space)/explore/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/explore/+page.server.ts
@@ -197,10 +197,12 @@ export const load: PageServerLoad = async ({
       creatorId: creator?.id,
       featured,
     });
-    // Set the public cache header only after the fetch succeeds. If
-    // getPublicContent throws (4xx/5xx), the error response inherits the
-    // default no-cache headers instead of poisoning the CDN.
-    setHeaders(CACHE_HEADERS.DYNAMIC_PUBLIC);
+    // Auth-varying HTML (the org layout injects `user`), so this must not be
+    // shared-cached: shared caches key by URL, NOT by Cookie, and would serve
+    // the anonymous copy to signed-in users. The list DATA is still KV-cached
+    // in content-api (and above), so PRIVATE costs an SSR render, not a query.
+    // See docs/caching-strategy.md §HTTP/CDN caching.
+    setHeaders(CACHE_HEADERS.PRIVATE);
   }
 
   return {

--- a/apps/web/src/routes/_org/[slug]/(space)/explore/__tests__/page.server.test.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/explore/__tests__/page.server.test.ts
@@ -263,7 +263,7 @@ describe('explore +page.server.ts — cache wiring', () => {
   });
 
   describe('cache-header poisoning regression (Codex-vn49p)', () => {
-    it('sets DYNAMIC_PUBLIC only AFTER getPublicContent resolves on the unauthenticated path', async () => {
+    it('sets a PRIVATE (non-shared) cache header AFTER getPublicContent resolves on the unauthenticated path', async () => {
       const callOrder: string[] = [];
       getPublicContentMock.mockImplementationOnce(async () => {
         callOrder.push('getPublicContent');
@@ -282,12 +282,14 @@ describe('explore +page.server.ts — cache wiring', () => {
       const { load } = await import('../+page.server');
       await load(input);
 
-      // Ordering matters: a thrown error from getPublicContent must NOT
-      // leave DYNAMIC_PUBLIC headers on the wire (CDN poisoning bug).
+      // This page is auth-varying (the org layout injects `user`), so it now
+      // emits a PRIVATE (non-shared-cacheable) header instead of a `public`
+      // one — shared caches key by URL not Cookie and would serve the anon
+      // copy to signed-in users. setHeaders still runs after the fetch.
       expect(callOrder).toEqual(['getPublicContent', 'setHeaders']);
       expect(setHeadersSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          'cache-control': expect.stringContaining('public'),
+          'cache-control': expect.stringContaining('private'),
         })
       );
     });

--- a/apps/web/src/routes/_org/[slug]/(space)/pricing/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/pricing/+page.server.ts
@@ -19,15 +19,12 @@ export const load: PageServerLoad = async ({
 }) => {
   const { org } = await parent();
 
-  // REVALIDATE variant forces browsers to revalidate on every request so a
-  // user who signs in (or subscribes) doesn't see the anonymous tier list
-  // cached from an earlier logged-out visit (which would hide their current
-  // subscription state in the payload).
-  setHeaders(
-    locals.user
-      ? CACHE_HEADERS.PRIVATE
-      : CACHE_HEADERS.DYNAMIC_PUBLIC_REVALIDATE
-  );
+  // Auth-varying HTML: the payload carries the viewer's subscription state and
+  // the layout injects `user`. Shared caches key by URL, NOT by Cookie, so a
+  // `public` copy cached for an anonymous visitor is served to signed-in users
+  // — hiding their real subscription state. PRIVATE keeps it out of shared
+  // caches. See docs/caching-strategy.md §HTTP/CDN caching.
+  setHeaders(CACHE_HEADERS.PRIVATE);
 
   const api = createServerApi(platform, cookies);
 

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -1,15 +1,86 @@
 # Caching Strategy
 
-## The Four Layers
+## The Layers
 
 ```
-Browser HTTP Cache         → static assets only, not API data
-SvelteKit query()          → request-scoped dedup within one SSR render
-@codex/cache (KV)          → server-side, cross-request, cross-worker
-TanStack DB (localStorage) → client-side local-first, persists across tabs
+HTTP / CDN cache (Cache-Control) → SSR HTML + public API JSON, at browser AND Cloudflare edge
+SvelteKit query()                → request-scoped dedup within one SSR render
+@codex/cache (KV)                → server-side, cross-request, cross-worker
+TanStack DB (localStorage)       → client-side local-first, persists across tabs
 ```
 
-These are complementary, not overlapping. Each solves a different problem.
+These are complementary, not overlapping. Each solves a different problem. The
+HTTP/CDN layer is the one most easily misused — it is the only layer that can
+serve one user's render to another user — so it has its own section below.
+
+---
+
+## HTTP / CDN Cache (Cache-Control)
+
+Set via `setHeaders(CACHE_HEADERS.*)` in `+page.server.ts` loads
+(`apps/web/src/lib/server/cache.ts`). Governs the **browser cache** and the
+**Cloudflare edge cache** for the rendered HTML document (and, on content-api,
+the public JSON). It does NOT touch `@codex/cache` (KV) or the client
+collections — those are the separate layers below.
+
+### Presets
+
+| Preset | `Cache-Control` | Use for |
+|---|---|---|
+| `STATIC_PUBLIC` | `public, max-age=3600, s-maxage=3600, swr=86400` | Truly static, auth-agnostic responses (sitemaps) |
+| `DYNAMIC_PUBLIC` | `public, max-age=300, s-maxage=300, swr=3600` | Public, auth-agnostic API JSON |
+| `DYNAMIC_PUBLIC_REVALIDATE` | `public, max-age=0, s-maxage=300, swr=3600` | Deprecated — see the rule below |
+| `PRIVATE` | `private, no-cache` | **Anything whose SSR output varies by auth** |
+
+### The golden rule (MANDATORY)
+
+**If a page's SSR output varies by auth state, it MUST be `PRIVATE`.**
+
+Every page under the `(platform)`, `_org/[slug]`, and `_creators` layouts is
+auth-varying, because those layouts inject the auth-aware `user` (the sidebar
+user section). A page need not branch on `locals.user` itself — inheriting the
+layout's `user` is enough.
+
+**Why `public` is unsafe here:** shared caches (Cloudflare edge, miniflare's CF
+emulation in CI, any intermediate proxy) key entries by **URL — NOT by Cookie**.
+A `public` response cached during an anonymous visit is then served to
+*authenticated* visitors of the same URL, who get the logged-out render — the
+"You need to sign in" bug for content owners. Verified in production 2026-07-16:
+an anonymous content page returned `cf-cache-status: HIT` with anon HTML, and
+Cloudflare had rewritten origin `max-age=0` → `max-age=14400` (its default
+Browser Cache TTL), defeating the browser-revalidate half of
+`DYNAMIC_PUBLIC_REVALIDATE`. That preset fixes only the private browser cache,
+never the shared edge — do not use it for auth-varying pages.
+
+### Shield the DB at the data layer, not the HTML layer
+
+Making an auth-varying page `PRIVATE` removes its edge cache — but that must NOT
+translate into per-request DB load. The **public data** underneath is auth-safe
+and belongs in the KV layer; cache the data (version-invalidated), never the
+auth-varying HTML. Example: content-detail SSR fetches the content list by slug;
+that query is KV-cached in content-api (`getCachedPublicContent`, keyed by
+`COLLECTION_ORG_CONTENT(orgId)` with the slug folded into the data-slot key), so
+the `PRIVATE` page costs an SSR render, not a Neon query — for anonymous AND
+authenticated viewers.
+
+### Decision record — auth-caching fix (2026-07-16)
+
+- **Chosen (A):** auth-varying loads → `PRIVATE`; shield the DB via the KV data
+  cache (slug lookups now cached). In code, testable, version-invalidated.
+- **Rejected (B):** a Cloudflare "bypass cache on session cookie" rule. Correct,
+  but relocates a correctness invariant into un-versioned dashboard config CI
+  can't see, which fails silently on a cookie-name change (BetterAuth's
+  `__Secure-` prefix has broken prod before).
+- **Deferred (C):** make the SSR shell auth-agnostic and hydrate auth
+  client-side so pages become genuinely public + edge-cacheable. Best long-term
+  perf, but a cross-cutting refactor plus a first-paint flash. Revisit only if
+  measurement shows the lost anonymous edge cache actually hurts.
+
+### Poisoning guard
+
+The `public` presets must be set only AFTER every `await` that can throw — a
+thrown `error()` otherwise inherits the `public` header and the CDN caches the
+*error page* for every visitor. `PRIVATE` is safe to set anywhere.
 
 ---
 
@@ -183,6 +254,15 @@ A safety cap (`DEFAULT_MAX_LIBRARY_FANOUT = 500`) skips the per-user fanout
 for unbounded audiences (popular follower-gated content) and logs a warning
 — the platform layout's `visibilitychange → invalidate('cache:versions')`
 loop catches up on the user's next focus event.
+
+**Catalogue bump on edit + thumbnail (2026-07-16):** `PATCH /content/:id`
+(update) and the thumbnail upload/delete endpoints now also call
+`bumpOrgContentVersion` → invalidate `COLLECTION_ORG_CONTENT(orgId)`.
+Previously only publish/unpublish/delete did, so an edit or thumbnail swap left
+the cached public list — and, once slug lookups became KV-cached, the
+content-detail page — stale until the 5-min TTL. This keeps the `PRIVATE`-page
+DB-shield (see §HTTP/CDN Cache) coherent: the slug-keyed detail slot shares the
+org version key, so any content mutation stales it atomically.
 
 Membership (`inviteMember`, `updateMemberRole`, `removeMember`) and follower
 (`followOrganization`, `unfollowOrganization`) mutations bump the single

--- a/infrastructure/runpod/handler/main.py
+++ b/infrastructure/runpod/handler/main.py
@@ -791,8 +791,14 @@ def transcode_audio_hls(input_path: str, output_dir: str) -> list[str]:
             f.write(f"#EXT-X-STREAM-INF:BANDWIDTH={bandwidth}\n")
             f.write(f"{variant_name}/index.m3u8\n")
 
-    # Report 'audio' as the ready variant (matches hlsVariantSchema enum).
-    # Individual bitrate levels (128k/64k) are internal to the master playlist.
+    # Report 'audio' as the LOGICAL ready variant (matches hlsVariantSchema —
+    # the readyVariants label set surfaced to the client quality picker).
+    #
+    # The PHYSICAL rungs (128k/64k) are the directory names written into the
+    # master playlist above, so the client fetches them back through the
+    # variant-playlist proxy as `/hls/<rung>/index.m3u8`. Those names MUST stay
+    # in `hlsVariantPathSchema` (packages/validation/src/schemas/transcoding.ts)
+    # or the proxy 403s ("Invalid request") and audio playback breaks.
     return ["audio"] if variant_playlists else []
 
 

--- a/packages/validation/src/schemas/access.test.ts
+++ b/packages/validation/src/schemas/access.test.ts
@@ -234,6 +234,28 @@ describe('Content Access Validation Schemas', () => {
       expect(result).toEqual({ id: validUUID, variant: '1080p' });
     });
 
+    // Regression: audio media's master playlist references PHYSICAL bitrate
+    // rungs (`128k` / `64k`), not the logical `audio` label. Validating the
+    // proxy `:variant` param against the logical enum 403'd all audio playback
+    // ("Invalid request"). See infrastructure/runpod/handler/main.py
+    // AUDIO_VARIANTS + hlsVariantPathSchema.
+    it.each([
+      '720p',
+      '480p',
+      'source',
+      '128k',
+      '64k',
+    ] as const)("accepts physical variant directory '%s'", (variant) => {
+      const result = hlsVariantParamsSchema.parse({ id: validUUID, variant });
+      expect(result).toEqual({ id: validUUID, variant });
+    });
+
+    it("rejects the logical-only 'audio' label (no physical audio/ directory)", () => {
+      expect(() =>
+        hlsVariantParamsSchema.parse({ id: validUUID, variant: 'audio' })
+      ).toThrow(ZodError);
+    });
+
     it('rejects an unknown variant', () => {
       expect(() =>
         hlsVariantParamsSchema.parse({ id: validUUID, variant: '4320p' })

--- a/packages/validation/src/schemas/access.ts
+++ b/packages/validation/src/schemas/access.ts
@@ -5,7 +5,7 @@ import {
   uuidSchema,
 } from '../primitives';
 import { paginationSchema } from '../shared/pagination-schema';
-import { hlsVariantSchema } from './transcoding';
+import { hlsVariantPathSchema, hlsVariantSchema } from './transcoding';
 
 /**
  * Validation schemas for content access endpoints
@@ -58,12 +58,18 @@ export const hlsProxyQuerySchema = z.object({
 
 /**
  * Route-params schema for the HLS variant playlist proxy. `variant` is bounded
- * to the canonical HLS quality rungs (reuses `hlsVariantSchema`) so the proxy
- * can never be coerced into building an arbitrary R2 key path.
+ * to the PHYSICAL HLS directory names the transcoder emits into the master
+ * playlist (`hlsVariantPathSchema`) so the proxy can never be coerced into
+ * building an arbitrary R2 key path.
+ *
+ * Uses `hlsVariantPathSchema`, NOT the logical `hlsVariantSchema`: audio media
+ * has no physical `audio/` directory — the master references bitrate rungs
+ * (`128k` / `64k`) directly, so validating against the logical set 403'd all
+ * audio playback (the client follows master → `<rung>/index.m3u8`).
  */
 export const hlsVariantParamsSchema = z.object({
   id: uuidSchema,
-  variant: hlsVariantSchema,
+  variant: hlsVariantPathSchema,
 });
 
 export type HlsProxyQuery = z.infer<typeof hlsProxyQuerySchema>;

--- a/packages/validation/src/schemas/transcoding.ts
+++ b/packages/validation/src/schemas/transcoding.ts
@@ -72,7 +72,14 @@ export const thumbnailSizeSchema = z.enum(THUMBNAIL_SIZES);
 export type ThumbnailSize = z.infer<typeof thumbnailSizeSchema>;
 
 /**
- * HLS variant names (quality levels)
+ * HLS variant names (quality levels) — the LOGICAL variant labels reported in
+ * `readyVariants` (webhook payload, DB, streaming response, client quality
+ * picker). For audio the transcoder collapses its bitrate rungs to the single
+ * logical label `audio` (see infrastructure/runpod/handler/main.py
+ * `transcode_audio_hls` → `return ["audio"]`).
+ *
+ * NOTE: this is NOT the same set as the PHYSICAL R2 directory names the master
+ * playlist references — use `hlsVariantPathSchema` for that. See its docblock.
  */
 export const hlsVariantSchema = z.enum([
   '1080p',
@@ -81,6 +88,34 @@ export const hlsVariantSchema = z.enum([
   '360p',
   'source',
   'audio',
+]);
+
+/**
+ * PHYSICAL HLS variant directory names — the path segment the transcoder emits
+ * into `master.m3u8` (`<variant>/index.m3u8`) and creates as an R2 directory.
+ * These are what the token-authenticated variant-playlist proxy receives as its
+ * `:variant` route param, so this enum is the allowlist that stops the proxy
+ * being coerced into building an arbitrary R2 key path.
+ *
+ * This DIFFERS from `hlsVariantSchema` (the logical `readyVariants` set):
+ *   - video rungs coincide (`720p` label == `720p` directory), plus `source`;
+ *   - audio has NO physical `audio/` directory — it is split into bitrate rungs
+ *     `128k` / `64k` (RunPod `AUDIO_VARIANTS`), which the master references
+ *     directly. Reusing the logical enum here 403'd all audio playback.
+ *
+ * Python mirror: infrastructure/runpod/handler/main.py — `HLS_VARIANTS` keys
+ * (video) + the `source` fallback + `AUDIO_VARIANTS` keys (audio). `1080p` and
+ * `360p` are kept for forward-compat (the v1 ladder dropped them; re-adding is
+ * a config-only change and the proxy must not 403 if they return).
+ */
+export const hlsVariantPathSchema = z.enum([
+  '1080p',
+  '720p',
+  '480p',
+  '360p',
+  'source',
+  '128k',
+  '64k',
 ]);
 
 /**

--- a/workers/content-api/src/routes/__tests__/public-cache.test.ts
+++ b/workers/content-api/src/routes/__tests__/public-cache.test.ts
@@ -102,6 +102,21 @@ describe('buildPublicContentCacheType', () => {
       buildPublicContentCacheType({ sort: 'newest', page: 2 })
     );
   });
+
+  it('folds slug into the key so distinct slugs get distinct data slots', () => {
+    const withSlug = buildPublicContentCacheType({
+      sort: 'newest',
+      slug: 'liberty',
+    });
+    const otherSlug = buildPublicContentCacheType({
+      sort: 'newest',
+      slug: 'freedom',
+    });
+    const noSlug = buildPublicContentCacheType({ sort: 'newest' });
+    expect(withSlug).toContain(':slug:liberty');
+    expect(withSlug).not.toBe(otherSlug);
+    expect(withSlug).not.toBe(noSlug);
+  });
 });
 
 describe('shouldCachePublicContentQuery', () => {
@@ -117,10 +132,10 @@ describe('shouldCachePublicContentQuery', () => {
     ).toBe(false);
   });
 
-  it('bypasses cache when slug is present (exact-lookup path)', () => {
+  it('caches slug lookups (content-detail path; slug folds into the data-slot key)', () => {
     expect(
       shouldCachePublicContentQuery({ orgId: 'org-1', slug: 'my-content' })
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('bypasses cache when creatorId filter is present (lower-volume)', () => {
@@ -271,6 +286,27 @@ describe('getCachedPublicContent', () => {
     await getCachedPublicContent(cache, 'org-2', { orgId: 'org-2' }, fB);
     expect(fA).toHaveBeenCalledTimes(2);
     expect(fB).toHaveBeenCalledTimes(1);
+  });
+
+  it('SLUG PATH: caches a slug lookup and re-fetches after org invalidate', async () => {
+    // Content-detail SSR fetches by slug. This proves the slug slot both
+    // caches AND is invalidated by the same org version bump that
+    // publish/update/unpublish/delete/thumbnail fire — so a cached detail
+    // page never outlives a content mutation (the invalidation contract).
+    const orgId = 'org-1';
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue({ items: [{ id: '1' }], pagination: { total: 1 } });
+    const slugQuery = { orgId, slug: 'liberty', limit: 1 };
+
+    await getCachedPublicContent(cache, orgId, slugQuery, fetcher);
+    await getCachedPublicContent(cache, orgId, slugQuery, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1); // second call served from cache
+
+    await cache.invalidate(CacheType.COLLECTION_ORG_CONTENT(orgId));
+
+    await getCachedPublicContent(cache, orgId, slugQuery, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2); // org bump reached the slug slot
   });
 
   it('uses the 300s default TTL', async () => {

--- a/workers/content-api/src/routes/content.ts
+++ b/workers/content-api/src/routes/content.ts
@@ -49,7 +49,6 @@ import {
   multipartProcedure,
   PaginatedResult,
   procedure,
-  sendEmailToWorker,
 } from '@codex/worker-utils';
 import { Hono } from 'hono';
 import { cleanupContentThumbnailOnDelete } from './content-cleanup';
@@ -251,6 +250,18 @@ app.patch(
         result.id,
         result.organizationId,
         'content_updated',
+        ctx.obs
+      );
+      // Bump the org content collection version too. An edit changes the
+      // public payload (title, description, price, thumbnail, accessType), and
+      // the KV-cached public list AND slug-keyed detail page live under
+      // COLLECTION_ORG_CONTENT(orgId). Without this bump they serve stale copy
+      // until the 5-min TTL. Previously only publish/unpublish/delete bumped
+      // it, so edits went stale on the catalogue until the next lifecycle event.
+      bumpOrgContentVersion(
+        ctx.env,
+        ctx.executionCtx,
+        result.organizationId,
         ctx.obs
       );
       return result;
@@ -498,6 +509,15 @@ app.post(
         })
       );
 
+      // Thumbnail is part of the public content payload, so cached list/detail
+      // pages must pick up the new image. Bump the org content version.
+      bumpOrgContentVersion(
+        ctx.env,
+        ctx.executionCtx,
+        content.organizationId,
+        ctx.obs
+      );
+
       return {
         thumbnailUrl: result.url,
         size: result.size,
@@ -535,6 +555,15 @@ app.delete(
       await ctx.services.imageProcessing.deleteContentThumbnail(
         contentId,
         content.creatorId
+      );
+
+      // Reverting to the auto-generated thumbnail changes the public payload —
+      // bump the org content version so cached list/detail pages refresh.
+      bumpOrgContentVersion(
+        ctx.env,
+        ctx.executionCtx,
+        content.organizationId,
+        ctx.obs
       );
 
       return null;

--- a/workers/content-api/src/routes/public-cache.ts
+++ b/workers/content-api/src/routes/public-cache.ts
@@ -52,26 +52,38 @@ interface PublicContentCacheQuery {
 export function buildPublicContentCacheType(
   query: Pick<
     PublicContentCacheQuery,
-    'sort' | 'limit' | 'page' | 'contentType'
+    'sort' | 'limit' | 'page' | 'contentType' | 'slug'
   >
 ): string {
-  return `content:public:${query.sort ?? 'newest'}:${query.limit ?? 20}:${query.page ?? 1}:${query.contentType ?? 'all'}`;
+  const base = `content:public:${query.sort ?? 'newest'}:${query.limit ?? 20}:${query.page ?? 1}:${query.contentType ?? 'all'}`;
+  // Slug is an exact-lookup dimension (content-detail pages). Include it in
+  // the type suffix so distinct slugs occupy distinct data slots under the
+  // shared org version key — without this they would collide. All slots
+  // still share `COLLECTION_ORG_CONTENT(orgId)`, so one publish/update-side
+  // invalidate stales every combo (list AND detail) atomically.
+  return query.slug ? `${base}:slug:${query.slug}` : base;
 }
 
 /**
  * Returns true when the query is eligible for KV caching.
  *
- * Search, slug, and creatorId are bypassed:
+ * Search and creatorId are bypassed:
  * - search: unbounded variant space, would pollute KV
- * - slug: exact-lookup path; cache key doesn't include slug so different
- *   slugs would collide
  * - creatorId: lower-volume per-creator filter; skipping avoids key
  *   explosion
+ *
+ * Slug lookups (content-detail pages) ARE cached now that
+ * `buildPublicContentCacheType` folds the slug into the data-slot key
+ * (previously excluded only because the key omitted it → collisions). This
+ * shields the DB for content-detail SSR — the slug path never used the
+ * catalogue list cache — and is invalidated by the same org version bump as
+ * every other combo. See the auth-caching decision record in
+ * docs/caching-strategy.md.
  */
 export function shouldCachePublicContentQuery(
   query: PublicContentCacheQuery
 ): boolean {
-  return !query.search && !query.slug && !query.creatorId;
+  return !query.search && !query.creatorId;
 }
 
 /**


### PR DESCRIPTION
## Production bug

Audio playback fails in production with **403 \"Invalid request\"** on the HLS variant-playlist proxy:

```
GET /api/access/content/:id/hls/64k/index.m3u8?token=… → 403 Invalid request
```

Reported on `of-blood-and-bones.revelations.studio/content/liberty` (audio content, Safari native HLS).

## Root cause — internal contract drift (not a bad client request)

Audio HLS playback is a two-step chain:

1. Client loads the **master** playlist `/hls/master.m3u8` → **200** (that route has no variant validation).
2. The master references **physical** R2 directories `64k/index.m3u8` and `128k/index.m3u8` (RunPod `AUDIO_VARIANTS`, `main.py`).
3. Client follows to `/hls/64k/index.m3u8` → proxy validates the `:variant` path segment against `hlsVariantSchema` = `['1080p','720p','480p','360p','source','audio']` → `64k` isn't in it → **403**.

One enum was doing two incompatible jobs:
- **logical** `readyVariants` labels (the transcoder reports `["audio"]` for audio) — surfaced to the client quality picker;
- **physical** R2 directory names used as the proxy path allowlist.

Video worked by coincidence (logical `720p` == physical dir `720p`). Audio always broke because logical `audio` ≠ physical `64k`/`128k`. The master loading fine then the *next* request 403'ing is the classic "playback starts then dies" signature.

## Fix

Separate the two concepts:
- **add `hlsVariantPathSchema`** — the physical R2 directory allowlist (`1080p/720p/480p/360p/source/128k/64k`), used only by the proxy `:variant` param;
- **keep `hlsVariantSchema`** (logical) for `readyVariants` — unchanged, so the webhook / DB / streaming-response contract is untouched (smallest blast radius);
- point `hlsVariantParamsSchema.variant` at the physical schema;
- correct the misleading `main.py` comment that caused the drift.

The allowlist stays a strict finite enum (not a loosened string) — `hls-rewrite.ts` feeds `uri.split('/')[0]` straight into the R2 key builder, so it's a real path-traversal guard.

## Impact / deploy

- **No re-transcode needed** — the `64k`/`128k` R2 objects already exist; existing audio content plays immediately once `content-api` is deployed (it bundles `@codex/validation` at build time).
- `1080p`/`360p` retained in the physical enum for the "re-adding a rung is config-only" forward-compat noted in the ladder comment.

## Tests

- `packages/validation/src/schemas/access.test.ts`: accepts `720p/480p/source/128k/64k`; still rejects the logical-only `audio` label and unknown `4320p`.
- Full `@codex/validation` suite: **441 passing**. Typecheck clean on `@codex/validation`, `@codex/access`, `content-api`. Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)