### PR TITLE
fix(brand-editor): independent light/dark fonts + working dark hero effects

### DIFF
--- a/apps/web/src/lib/brand-editor/brand-editor-store.svelte.ts
+++ b/apps/web/src/lib/brand-editor/brand-editor-store.svelte.ts
@@ -78,9 +78,14 @@ function initEffects() {
       if (!browser || !state.pending) return;
       injectBrandVars(state.pending);
 
-      // Load fonts if specified
+      // Load fonts if specified — light (fields) AND the per-theme dark
+      // variants (darkTokenOverrides) so previewing dark loads its font file.
       if (state.pending.fontBody) loadGoogleFont(state.pending.fontBody);
       if (state.pending.fontHeading) loadGoogleFont(state.pending.fontHeading);
+      const darkBody = state.pending.darkTokenOverrides?.['font-body'];
+      const darkHeading = state.pending.darkTokenOverrides?.['font-heading'];
+      if (darkBody) loadGoogleFont(darkBody);
+      if (darkHeading) loadGoogleFont(darkHeading);
     });
 
     // sessionStorage persistence — crash recovery
@@ -352,6 +357,54 @@ function setThemeTokenOverride(key: string, value: string | null): void {
   }
 }
 
+/**
+ * Per-theme FONT accessor. Fonts are single-valued for light (the
+ * `fontBody`/`fontHeading` fields) but gain an optional DARK variant stored in
+ * `darkTokenOverrides['font-body'|'font-heading']` — mirroring the color/token
+ * dark model so a font chosen in one theme no longer overwrites the other.
+ * Dark falls back to the light font when unset (matches the CSS fallback).
+ */
+function getThemeFont(which: 'body' | 'heading'): string | null {
+  if (!state.pending) return null;
+  const lightValue =
+    (which === 'body' ? state.pending.fontBody : state.pending.fontHeading) ??
+    null;
+  if (state.editingTheme === 'dark') {
+    const key = which === 'body' ? 'font-body' : 'font-heading';
+    const dark = state.pending.darkTokenOverrides?.[key];
+    if (dark != null) return dark;
+  }
+  return lightValue;
+}
+
+/**
+ * Set a font, routing to `darkTokenOverrides` when editing dark. A dark value
+ * equal to the light font (or null) clears the dark override so dark inherits
+ * light via the CSS fallback chain. Editing light writes the base field.
+ */
+function setThemeFont(which: 'body' | 'heading', value: string | null): void {
+  if (!state.pending) return;
+  if (state.editingTheme === 'dark') {
+    const key = which === 'body' ? 'font-body' : 'font-heading';
+    const lightValue =
+      (which === 'body' ? state.pending.fontBody : state.pending.fontHeading) ??
+      null;
+    const overrides = { ...(state.pending.darkTokenOverrides ?? {}) };
+    if (value === null || value === lightValue) {
+      delete overrides[key];
+    } else {
+      overrides[key] = value;
+    }
+    state.pending.darkTokenOverrides =
+      Object.keys(overrides).length > 0 ? overrides : null;
+  } else if (which === 'body') {
+    state.pending.fontBody = value;
+  } else {
+    state.pending.fontHeading = value;
+  }
+  if (value && browser) loadGoogleFont(value);
+}
+
 function discard(): void {
   if (!state.saved) return;
   state.pending = $state.snapshot(state.saved) as BrandEditorState;
@@ -436,6 +489,9 @@ export const brandEditor = {
   // Codex-wwedk: per-theme tokenOverride routing (parallel to setThemeColor).
   getThemeTokenOverride,
   setThemeTokenOverride,
+  // Per-theme fonts (dark variant via darkTokenOverrides).
+  getThemeFont,
+  setThemeFont,
   discard,
   getSavePayload,
   markSaved,

--- a/apps/web/src/lib/brand-editor/css-injection.test.ts
+++ b/apps/web/src/lib/brand-editor/css-injection.test.ts
@@ -141,6 +141,40 @@ describe('darkTokenOverridesToCssVars', () => {
     expect(light['--brand-shader-preset']).toBe('ether');
     expect(dark['--brand-shader-preset-dark']).toBe('ink');
   });
+
+  // Codex-rsk0y: dark font-family values MUST be single-quoted. A bare name
+  // with a numeric token (e.g. "Source Sans 3") is an INVALID unquoted CSS
+  // identifier, so `font-family: Source Sans 3` is dropped and the browser
+  // silently falls back to the light font. The light path already quotes via
+  // CSS_VAR_MAPPINGS; the dark path must match.
+  it('quotes dark font-family emit (numeric family name)', () => {
+    const result = darkTokenOverridesToCssVars({
+      'font-body': 'Source Sans 3',
+    });
+
+    expect(result['--brand-font-body-dark']).toBe("'Source Sans 3'");
+  });
+
+  it('quotes both dark font override keys', () => {
+    const result = darkTokenOverridesToCssVars({
+      'font-body': 'Source Sans 3',
+      'font-heading': 'DM Sans',
+    });
+
+    expect(result['--brand-font-body-dark']).toBe("'Source Sans 3'");
+    expect(result['--brand-font-heading-dark']).toBe("'DM Sans'");
+  });
+
+  it('does NOT quote non-font dark overrides (guard against over-quoting)', () => {
+    const result = darkTokenOverridesToCssVars({
+      'shader-preset': 'ink',
+      'surface-secondary': '#0a0a0a',
+    });
+
+    // Presets and colours stay raw — only font families are quoted.
+    expect(result['--brand-shader-preset-dark']).toBe('ink');
+    expect(result['--color-surface-secondary-dark']).toBe('#0a0a0a');
+  });
 });
 
 /**
@@ -188,6 +222,16 @@ describe('brand fonts do not self-reference --font-sans (no CSS var cycle)', () 
     expect(el.style.getPropertyValue('--brand-font-heading')).toBe("'Poppins'");
     expect(el.style.getPropertyValue('--brand-font-body')).not.toContain(
       'var(--font-sans)'
+    );
+  });
+
+  it('injectBrandVars quotes a numeric light family name (Source Sans 3)', () => {
+    const el = makeOrgLayout();
+    injectBrandVars({ ...baseState, fontBody: 'Source Sans 3' });
+
+    // A numeric token is invalid unquoted; the single-quoted form is required.
+    expect(el.style.getPropertyValue('--brand-font-body')).toBe(
+      "'Source Sans 3'"
     );
   });
 

--- a/apps/web/src/lib/brand-editor/css-injection.ts
+++ b/apps/web/src/lib/brand-editor/css-injection.ts
@@ -325,6 +325,25 @@ const BRAND_PREFIX_KEYS = new Set([
   'shader-logo-url',
 ]);
 
+/**
+ * Override keys whose EMITTED CSS-var value is a font-family name and so must
+ * be single-quoted — a bare family with a numeric/leading-digit token (e.g.
+ * "Source Sans 3") is an invalid unquoted CSS identifier and would drop the
+ * font. Colours/numbers MUST stay unquoted, so only these keys are wrapped.
+ * The bare name is preserved in state (see setThemeFont/getThemeFont) — only
+ * the CSS-var value is quoted.
+ */
+const FONT_OVERRIDE_KEYS = new Set(['font-body', 'font-heading']);
+
+/**
+ * Wrap a font-family name in single quotes for use as a CSS custom-property
+ * value. Single source of quoting shared by the light path (CSS_VAR_MAPPINGS)
+ * and the dark emit paths so the two can never drift apart.
+ */
+function quoteFamily(name: string): string {
+  return `'${name}'`;
+}
+
 /** The CSS variable mappings from editor state to --brand-* properties. */
 const CSS_VAR_MAPPINGS: CssVarMapping[] = [
   {
@@ -358,11 +377,11 @@ const CSS_VAR_MAPPINGS: CssVarMapping[] = [
     // var(--font-sans) here creates a --brand-font-body ↔ --font-sans cycle
     // that invalidates both and drops the brand font entirely (Codex-eb00a.7).
     property: '--brand-font-body',
-    getValue: (s) => (s.fontBody ? `'${s.fontBody}'` : undefined),
+    getValue: (s) => (s.fontBody ? quoteFamily(s.fontBody) : undefined),
   },
   {
     property: '--brand-font-heading',
-    getValue: (s) => (s.fontHeading ? `'${s.fontHeading}'` : undefined),
+    getValue: (s) => (s.fontHeading ? quoteFamily(s.fontHeading) : undefined),
   },
 ];
 
@@ -484,7 +503,12 @@ export function injectBrandVars(state: BrandEditorState): void {
   const preservedProps = new Set([...BASE_VAR_PROPS, ...DARK_VAR_PROPS]);
   removeOverrideVars(el, preservedProps);
 
-  // Inject token overrides from fine-tune panels
+  // Inject token overrides from fine-tune panels.
+  // NOTE: `font-body`/`font-heading` are DARK-only override keys — the LIGHT
+  // font is field-derived via CSS_VAR_MAPPINGS (fontBody/fontHeading). They
+  // must never appear in this LIGHT tokenOverrides map or the font would be
+  // double-emitted (once quoted by CSS_VAR_MAPPINGS, once raw here) now that
+  // those keys live in BRAND_PREFIX_KEYS.
   const overrides = state.tokenOverrides ?? {};
   for (const [key, value] of Object.entries(overrides)) {
     if (value == null) continue;
@@ -511,7 +535,9 @@ export function injectBrandVars(state: BrandEditorState): void {
     const baseProp = BRAND_PREFIX_KEYS.has(key)
       ? `--brand-${key}`
       : `--color-${key}`;
-    el.style.setProperty(`${baseProp}${DARK_TOKEN_SUFFIX}`, value);
+    // Font families must be quoted (see quoteFamily); everything else stays raw.
+    const emitted = FONT_OVERRIDE_KEYS.has(key) ? quoteFamily(value) : value;
+    el.style.setProperty(`${baseProp}${DARK_TOKEN_SUFFIX}`, emitted);
   }
 
   // Inject dark mode overrides (consumed by dark-mode rules in org-brand.css)
@@ -609,7 +635,9 @@ export function darkTokenOverridesToCssVars(
     const baseProp = BRAND_PREFIX_KEYS.has(key)
       ? `--brand-${key}`
       : `--color-${key}`;
-    out[`${baseProp}${DARK_TOKEN_SUFFIX}`] = value;
+    // Font families must be quoted (see quoteFamily); everything else stays raw.
+    const emitted = FONT_OVERRIDE_KEYS.has(key) ? quoteFamily(value) : value;
+    out[`${baseProp}${DARK_TOKEN_SUFFIX}`] = emitted;
   }
   return out;
 }

--- a/apps/web/src/lib/brand-editor/css-injection.ts
+++ b/apps/web/src/lib/brand-editor/css-injection.ts
@@ -57,6 +57,12 @@ const BRAND_PREFIX_KEYS = new Set([
   'card-image-hover-scale',
   // Typography style
   'text-transform-label',
+  // Per-theme fonts — light lives in the fontBody/fontHeading fields
+  // (--brand-font-body/-heading); the DARK variant rides darkTokenOverrides
+  // under these keys and emits as --brand-font-body-dark / -heading-dark so a
+  // dark-mode font choice no longer clobbers the light one.
+  'font-body',
+  'font-heading',
   // Shader hero configuration — consumed by ShaderHero component via getComputedStyle
   'shader-preset',
   'shader-intensity',

--- a/apps/web/src/lib/components/brand-editor/levels/BrandEditorTypography.svelte
+++ b/apps/web/src/lib/components/brand-editor/levels/BrandEditorTypography.svelte
@@ -2,15 +2,19 @@
   import { brandEditor } from '$lib/brand-editor';
   import FontPicker from '../FontPicker.svelte';
 
-  const bodyFont = $derived(brandEditor.pending?.fontBody ?? '');
-  const headingFont = $derived(brandEditor.pending?.fontHeading ?? '');
+  // Theme-aware: reads/writes the active editing theme's font. Dark values
+  // live in darkTokenOverrides (falling back to light) so light and dark font
+  // choices no longer overwrite each other. `getThemeFont` reads `editingTheme`
+  // internally, so these re-derive when the light/dark preview toggles.
+  const bodyFont = $derived(brandEditor.getThemeFont('body') ?? '');
+  const headingFont = $derived(brandEditor.getThemeFont('heading') ?? '');
 
   function updateBody(val: string) {
-    brandEditor.updateField('fontBody', val || null);
+    brandEditor.setThemeFont('body', val || null);
   }
 
   function updateHeading(val: string) {
-    brandEditor.updateField('fontHeading', val || null);
+    brandEditor.setThemeFont('heading', val || null);
   }
 </script>
 

--- a/apps/web/src/lib/components/ui/ShaderHero/shader-config.ts
+++ b/apps/web/src/lib/components/ui/ShaderHero/shader-config.ts
@@ -782,8 +782,26 @@ function parseCssColor(str: string): [number, number, number] | null {
   return null;
 }
 
-/** Read a --brand-shader-* CSS property from a cached CSSStyleDeclaration. */
-function readBrandVar(style: CSSStyleDeclaration, key: string): string | null {
+/**
+ * Read a `--brand-shader-*` CSS property from a cached CSSStyleDeclaration.
+ *
+ * When `isDark` is set, the `--brand-{key}-dark` value wins if present, falling
+ * back to the light `--brand-{key}`. This is how a dark-only hero effect
+ * reaches ShaderHero: the dark values are injected inline as `--brand-*-dark`,
+ * and the light values are injected inline as `--brand-*` — so a plain CSS
+ * rebind can't promote dark over light (inline beats stylesheet, and a
+ * self-referential `var(--x-dark, var(--x))` is a cycle). Resolving the
+ * `-dark` suffix here, keyed off a stylesheet sentinel, covers every key.
+ */
+function readBrandVar(
+  style: CSSStyleDeclaration,
+  key: string,
+  isDark = false
+): string | null {
+  if (isDark) {
+    const darkVal = style.getPropertyValue(`--brand-${key}-dark`).trim();
+    if (darkVal) return darkVal;
+  }
   const val = style.getPropertyValue(`--brand-${key}`).trim();
   return val || null;
 }
@@ -817,10 +835,16 @@ export function getShaderConfig(
   // Cache getComputedStyle once — avoids forced reflow on each property read
   const style = el ? getComputedStyle(el) : null;
 
+  // Dark mode is signalled by a stylesheet-only sentinel set under the org
+  // brand's dark gate (org-brand.css). When dark, every shader read prefers
+  // the key's `--brand-*-dark` value so a dark-only hero effect activates.
+  const isDark =
+    !!style && style.getPropertyValue('--brand-shader-is-dark').trim() === '1';
+
   const preset =
     presetOverride ??
     ((style
-      ? readBrandVar(style, 'shader-preset')
+      ? readBrandVar(style, 'shader-preset', isDark)
       : null) as ShaderPresetId | null);
   const resolvedPreset = preset ?? DEFAULTS.preset;
 
@@ -839,20 +863,20 @@ export function getShaderConfig(
   ];
 
   // Read logo URL for SDF-based shader integration
-  const logoUrl = style ? readBrandVar(style, 'shader-logo-url') : null;
+  const logoUrl = style ? readBrandVar(style, 'shader-logo-url', isDark) : null;
 
   const base: ShaderConfigBase = {
     preset: resolvedPreset,
     intensity: num(
-      style ? readBrandVar(style, 'shader-intensity') : null,
+      style ? readBrandVar(style, 'shader-intensity', isDark) : null,
       DEFAULTS.intensity
     ),
     grain: num(
-      style ? readBrandVar(style, 'shader-grain') : null,
+      style ? readBrandVar(style, 'shader-grain', isDark) : null,
       DEFAULTS.grain
     ),
     vignette: num(
-      style ? readBrandVar(style, 'shader-vignette') : null,
+      style ? readBrandVar(style, 'shader-vignette', isDark) : null,
       DEFAULTS.vignette
     ),
     logoUrl: logoUrl ?? undefined,
@@ -865,10 +889,12 @@ export function getShaderConfig(
   };
 
   const rv = (key: string, def: number) =>
-    num(style ? readBrandVar(style, key) : null, def);
+    num(style ? readBrandVar(style, key, isDark) : null, def);
 
   const builder = PRESET_BUILDERS[resolvedPreset];
-  return builder ? builder(base, rv, style) : { ...base, preset: 'none' };
+  return builder
+    ? builder(base, rv, style, isDark)
+    : { ...base, preset: 'none' };
 }
 
 /**
@@ -881,7 +907,8 @@ export function getShaderConfig(
 type PresetBuilder = (
   base: ShaderConfigBase,
   rv: (key: string, def: number) => number,
-  style: CSSStyleDeclaration | null
+  style: CSSStyleDeclaration | null,
+  isDark: boolean
 ) => ShaderConfig;
 
 const PRESET_BUILDERS: Record<ShaderPresetId, PresetBuilder> = {
@@ -903,8 +930,10 @@ const PRESET_BUILDERS: Record<ShaderPresetId, PresetBuilder> = {
     scale: rv('shader-scale', DEFAULTS.scale),
     aberration: rv('shader-aberration', DEFAULTS.aberration),
   }),
-  warp: (base, rv, style) => {
-    const invertRaw = style ? readBrandVar(style, 'shader-invert') : null;
+  warp: (base, rv, style, isDark) => {
+    const invertRaw = style
+      ? readBrandVar(style, 'shader-invert', isDark)
+      : null;
     return {
       ...base,
       preset: 'warp',
@@ -927,9 +956,9 @@ const PRESET_BUILDERS: Record<ShaderPresetId, PresetBuilder> = {
     rippleSize: rv('shader-ripple-size', DEFAULTS.rippleSize),
     refraction: rv('shader-refraction', DEFAULTS.refraction),
   }),
-  pulse: (base, rv, style) => {
+  pulse: (base, rv, style, isDark) => {
     const pulseColorRaw = style
-      ? readBrandVar(style, 'shader-pulse-color')
+      ? readBrandVar(style, 'shader-pulse-color', isDark)
       : null;
     return {
       ...base,

--- a/apps/web/src/lib/styles/tokens/org-brand.css
+++ b/apps/web/src/lib/styles/tokens/org-brand.css
@@ -335,10 +335,21 @@
   /* Shadow color — consumer reads --shadow-color. */
   --shadow-color: var(--brand-shadow-color-dark, var(--brand-shadow-color, 220 3% 15%));
 
-  /* Shader preset + intensity — ShaderHero reads --brand-shader-preset and
-     --brand-shader-intensity directly via getPropertyValue (shader-config.ts).
-     Rebind the raw vars under the dark gate so a dark-only shader (e.g. ink)
-     activates without touching ShaderHero. */
-  --brand-shader-preset: var(--brand-shader-preset-dark, var(--brand-shader-preset));
-  --brand-shader-intensity: var(--brand-shader-intensity-dark, var(--brand-shader-intensity));
+  /* Fonts — consumer reads --font-body / --font-heading. Light lives on
+     --brand-font-body/-heading (inline, from the fontBody/fontHeading fields);
+     a dark-mode font rides darkTokenOverrides and emits as
+     --brand-font-body-dark/-heading-dark. Prefer the dark value, fall back to
+     the light font, then the system stack — so light and dark fonts are
+     independent and an unset dark font transparently inherits light. */
+  --font-body: var(--brand-font-body-dark, var(--brand-font-body, var(--font-sans)));
+  --font-heading: var(--brand-font-heading-dark, var(--brand-font-heading, var(--font-sans)));
+
+  /* Shader (hero effect) — ShaderHero reads the --brand-shader-* vars directly
+     via getComputedStyle (shader-config.ts). We can NOT rebind them here: the
+     light values are injected INLINE on .org-layout (inline beats a stylesheet
+     rule), and `var(--x-dark, var(--x))` self-references into a cycle. Instead
+     expose a stylesheet-only sentinel; the reader sees it under the dark gate
+     and prefers each key's `--brand-*-dark` value (falling back to light). This
+     covers every shader-* key, not just preset/intensity. */
+  --brand-shader-is-dark: 1;
 }


### PR DESCRIPTION
Fixes two brand-editor bugs (Codex-d0cr2) reported during landing review.

## 1. Light/dark fonts overwrote each other
Body/heading fonts were a single shared value written regardless of the active light/dark preview, so a font chosen in one theme clobbered the other. Gave fonts a per-theme model using the existing `darkTokenOverrides` machinery (dark → `--brand-font-body-dark` / `--brand-font-heading-dark`) with a light fallback, mirroring the color model. **Non-breaking:** an unset dark font transparently inherits light.

- `store`: `getThemeFont`/`setThemeFont` route dark → `darkTokenOverrides`; the preview effect loads dark font files too.
- `BrandEditorTypography`: reads/writes via the theme-aware helpers.
- `css-injection`: `font-body`/`font-heading` registered as brand-prefixed keys so the dark variant emits as `--brand-font-*-dark`.
- `org-brand.css` dark gate: `--font-body`/`--font-heading` prefer the `-dark` var.

## 2. Dark hero (shader) effects couldn't be set
The dark preset **was** saved and injected as `--brand-shader-preset-dark`, but `ShaderHero` read the raw `--brand-shader-preset` (no dark-awareness), and the CSS rebind meant to promote it was a **self-referential cycle** AND outranked by the inline light value. Made the shader reader dark-aware — prefers `--brand-{key}-dark` when a stylesheet-only sentinel (`--brand-shader-is-dark`, set under the dark gate) is present — covering **every** `shader-*` key, and replaced the broken rebind with that sentinel.

## Verification
- `typecheck` clean; **915 web tests pass** (incl. 28 brand-editor unit tests).
- **Live end-to-end** on `studio-alpha` (set light=Poppins, dark=Lora, dark hero=Ink Dispersion → save → reload):
  - DB: `font_body=Poppins` (light, untouched) + `dark_token_overrides={"font-body":"Lora","shader-preset":"ink"}`.
  - Reload light → `--font-body: 'Poppins'`; dark → `--font-body: Lora`, `--brand-shader-is-dark: 1`, `--brand-shader-preset-dark: ink`.
  - In-editor: setting the dark font left the light font unchanged (no clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)