### PR TITLE
fix(web): unify Explore + Library grids with browse card; fix imageless-article collapse

### DIFF
--- a/apps/web/src/lib/components/library/LibraryPageView.svelte
+++ b/apps/web/src/lib/components/library/LibraryPageView.svelte
@@ -222,6 +222,9 @@
         {#each items as item (item.content.id)}
           {@const access = stateForItem(item)}
           <ContentCard
+            variant={viewMode === 'list' ? 'list' : 'grid'}
+            shape={viewMode === 'list' ? undefined : '1:1'}
+            chrome="transparent"
             id={item.content.id}
             title={item.content.title}
             thumbnail={item.content.thumbnailUrl}

--- a/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
@@ -473,10 +473,12 @@
 
   <!-- Content Grid -->
   {#if displayItems.length > 0}
-    <div class="content-grid content-grid--masonry explore__grid" data-view={viewMode}>
+    <div class="content-grid explore__grid" data-view={viewMode}>
       {#each displayItems as item (item.id)}
         <ContentCard
-          autoPromoteAudio
+          variant={viewMode === 'list' ? 'list' : 'grid'}
+          shape={viewMode === 'list' ? undefined : '1:1'}
+          chrome="transparent"
           id={item.id}
           title={item.title}
           thumbnail={item.mediaItem?.thumbnailUrl ?? item.thumbnailUrl ?? null}
@@ -642,34 +644,10 @@
     background: var(--color-surface-elevated);
   }
 
-  /* ── List View ── */
-
-  .explore__grid[data-view='list'] :global(.content-card) {
-    flex-direction: row;
-  }
-
-  .explore__grid[data-view='list'] :global(.content-card__thumbnail) {
-    aspect-ratio: 16 / 9;
-    width: 200px;
-    min-width: 200px;
-    flex-shrink: 0;
-  }
-
-  .explore__grid[data-view='list'] :global(.content-card__body) {
-    flex: 1;
-    min-width: 0;
-  }
-
-  @media (--below-sm) {
-    .explore__grid[data-view='list'] :global(.content-card) {
-      flex-direction: column;
-    }
-
-    .explore__grid[data-view='list'] :global(.content-card__thumbnail) {
-      width: 100%;
-      min-width: 0;
-    }
-  }
+  /* List view layout is handled by the ContentCard `variant="list"` treatment
+     (horizontal row) — see the viewMode-driven props above. The grid container
+     collapses to a single column via the shared `.content-grid[data-view='list']`
+     utility, so no page-level card overrides are needed here. */
 
   /* ── Pagination ── */
   .explore__pagination {


### PR DESCRIPTION
## Problem

Imageless content cards render at the wrong size on **Explore** and **Library** — most visibly an imageless article (the "Oracle" one). Root cause: neither surface adopted the WP-7 `shape` system from the landing redesign.

- Both pass **no `shape`/`chrome`** to `ContentCard`. With no shape, an imageless article hits the "text-led" rule (`ContentCard.svelte:1492` → `.cc__thumb { display: none }`), so the media tile is **removed** and the card collapses to a short text-only block, mismatched against its video/audio neighbours.
- **Explore** additionally still used the retired `content-grid--masonry` (CSS-columns) layout that the landing redesign replaced with a uniform grid (and which carries the transform-in-multicol hover paint bug).

## Fix

Render both surfaces with the **same config as `BrowseModule`** — the "all grid content card" the redesign already ships and that renders imageless articles correctly:

| | grid view | list view |
|---|---|---|
| `variant` | `grid` | `list` |
| `shape` | `1:1` | _(none)_ |
| `chrome` | `transparent` | `transparent` |

- `shape="1:1"` → article `titleInCover` auto-on → branded `.cc__cover--article` fills the frame = **correct size + at-a-glance article indicator**; CSS-grid row-stretch keeps it level with video/audio tiles.
- `variant`/`shape` are viewMode-conditional so `data-shape='1:1'` (an unscoped selector) doesn't turn list rows into giant squares — list mode uses the card's own horizontal-row treatment.
- Explore: dropped `content-grid--masonry` → uniform `.content-grid`, and removed `autoPromoteAudio` so audio renders as square waveform tiles (matching browse) instead of rows that break the uniform grid.
- Removed dead `.content-card*` list-view CSS (stale class names + hardcoded `200px`) now that the card owns its list layout.

**Callers-only change — `ContentCard` is untouched**, so zero blast radius on the other 15 consumers.

## Verification

- `pnpm --filter web typecheck` (svelte-kit sync + tsc) — clean.
- `svelte-check` — **0 new diagnostics** (23 pre-existing on these two files, before and after).
- Relevant unit tests — **53 passing** (ContentCard, BrowseModule, Explore page.server + cache-coherency).
- biome — `.svelte` files are outside biome's include set (unchanged by this PR).
- ⚠️ **Live visual pass not done** — no Codex dev stack was reachable locally. The change is equivalent-by-construction to the already-approved `BrowseModule` grid. Recommend an eyeball on a running org (imageless article on `/explore` and `/library`, plus the grid/list toggle) before merge.

Follow-up to epic Codex-dr57r (WP-7). Closes Codex-idv0k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)