### PR TITLE
fix(web): mobile-responsive studio pages (org + creator)

### DIFF
--- a/apps/web/src/lib/components/studio/CustomerDetailDrawer.svelte
+++ b/apps/web/src/lib/components/studio/CustomerDetailDrawer.svelte
@@ -273,7 +273,7 @@
     padding: var(--space-6);
   }
 
-  @media (max-width: 40rem) {
+  @media (--below-sm) {
     :global(.dialog-content.drawer-content) {
       max-width: 100%;
     }

--- a/apps/web/src/lib/components/studio/content-form/ShaderPicker.svelte
+++ b/apps/web/src/lib/components/studio/content-form/ShaderPicker.svelte
@@ -92,7 +92,7 @@
     gap: var(--space-3);
   }
 
-  @media (min-width: 640px) {
+  @media (--breakpoint-sm) {
     .shader-picker {
       grid-template-columns: repeat(4, 1fr);
     }

--- a/apps/web/src/routes/_creators/studio/earnings/+page.svelte
+++ b/apps/web/src/routes/_creators/studio/earnings/+page.svelte
@@ -423,18 +423,26 @@
             </div>
             {#each filtered as payout (payout.id)}
               <div class="payouts-table__row" role="row">
-                <span class="payouts-table__cell payouts-table__cell--date" role="cell">
+                <span
+                  class="payouts-table__cell payouts-table__cell--date"
+                  role="cell"
+                  data-label={m.earnings_payouts_col_date()}
+                >
                   {formatDate(payout.createdAt)}
                 </span>
-                <span class="payouts-table__cell payouts-table__cell--amount" role="cell">
+                <span
+                  class="payouts-table__cell payouts-table__cell--amount"
+                  role="cell"
+                  data-label={m.earnings_payouts_col_amount()}
+                >
                   {formatPence(payout.amountCents)}
                 </span>
-                <span class="payouts-table__cell" role="cell">
+                <span class="payouts-table__cell" role="cell" data-label={m.earnings_payouts_col_status()}>
                   <span class="status-badge {statusClass(payout.status)}" aria-label={statusLabel(payout.status)}>
                     {statusLabel(payout.status)}
                   </span>
                 </span>
-                <span class="payouts-table__cell" role="cell">
+                <span class="payouts-table__cell" role="cell" data-label={m.earnings_payouts_col_source()}>
                   {sourceLabel(payout.sourceType)}
                 </span>
               </div>
@@ -591,6 +599,19 @@
     display: flex;
     gap: var(--space-2);
     flex-shrink: 0;
+  }
+
+  /* The connect card is a body↔actions row on desktop; on phones the actions
+     (Stripe dashboard + refresh) overflow past the viewport, so stack the card
+     and let the buttons wrap full-width. */
+  @media (--below-sm) {
+    .connect-card {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .connect-card__actions {
+      flex-wrap: wrap;
+    }
   }
 
   /* ── KPI grid ───────────────────────────────────────────────────────────── */
@@ -778,6 +799,38 @@
   .payouts-table__cell--amount {
     font-variant-numeric: tabular-nums;
     font-weight: var(--font-medium);
+  }
+
+  /* On phones the four equal columns collapse to unreadable slivers, so each
+     row becomes a stacked label/value card. The header row is redundant once
+     each cell carries its own label via data-label, so it is hidden. ARIA
+     table semantics (role="table"/row/cell) are unaffected. */
+  @media (--below-sm) {
+    .payouts-table__head {
+      display: none;
+    }
+
+    .payouts-table__row {
+      grid-template-columns: 1fr;
+      gap: var(--space-2);
+      padding: var(--space-4);
+    }
+
+    .payouts-table__cell {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-3);
+    }
+
+    .payouts-table__cell::before {
+      content: attr(data-label);
+      font-size: var(--text-xs);
+      font-weight: var(--font-semibold);
+      color: var(--color-text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
   }
 
   /* ── Status badges ──────────────────────────────────────────────────────── */

--- a/apps/web/src/routes/_org/[slug]/studio/analytics/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/analytics/+page.svelte
@@ -430,13 +430,13 @@
     gap: var(--space-4);
   }
 
-  @media (max-width: 1024px) {
+  @media (--below-lg) {
     .kpi-row {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
-  @media (max-width: 560px) {
+  @media (--below-sm) {
     .kpi-row {
       grid-template-columns: minmax(0, 1fr);
     }

--- a/apps/web/src/routes/_org/[slug]/studio/monetisation/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/monetisation/+page.svelte
@@ -915,6 +915,22 @@
     background-color: var(--color-surface-secondary);
   }
 
+  /* On phones the single row overflows: the fixed toggle + prices + actions
+     squeeze .tier-info to 0 width, so the tier name spills over the toggle.
+     Wrap the row — name/description take the full first line, and the toggle,
+     prices and actions flow onto a second line. */
+  @media (--below-sm) {
+    .tier-item {
+      flex-wrap: wrap;
+      row-gap: var(--space-3);
+    }
+    /* Descendant selector raises specificity above the base `.tier-info`
+       rule's `flex: 1` (flex-basis: 0%), which otherwise wins on source order. */
+    .tier-item .tier-info {
+      flex-basis: 100%;
+    }
+  }
+
   .tier-info {
     display: flex;
     align-items: center;
@@ -1056,6 +1072,13 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: var(--space-4);
+  }
+
+  /* Two price inputs side-by-side crush below ~155px each on phones; stack. */
+  @media (--below-sm) {
+    .form-row {
+      grid-template-columns: 1fr;
+    }
   }
 
   .form-hint {

--- a/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
@@ -744,7 +744,7 @@
     top: var(--space-6);
   }
 
-  @media (max-width: 1024px) {
+  @media (--below-lg) {
     .payouts-grid {
       grid-template-columns: 1fr;
     }
@@ -782,7 +782,7 @@
     gap: var(--space-4);
   }
 
-  @media (max-width: 720px) {
+  @media (--below-md) {
     .kpi-row {
       grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## What & why

A mobile-responsiveness + breakpoint-token-consistency pass across **every** organization- and creator-studio page. The studio shell was already mobile-solid (hamburger + slide-in drawer below `--below-lg`); the drift was concentrated in data-heavy/complex-component pages — including three genuine bugs that only surfaced when rendering on a phone.

## Real mobile defects fixed (verified at 390px)

- **Creator earnings** — the payout "table" (`1fr 1fr 1fr 1fr`, no collapse, no scroll) crushed to unreadable slivers on phones → now reflows to **stacked label/value cards** below `--below-sm` via `data-label` + `::before` (ARIA `role="table"` semantics preserved).
- **Creator earnings** — the "Payout account connected" card's actions overflowed the viewport and were **clipped** by `main { overflow-x: clip }` (the "Refresh" button was unreachable) → card + actions now stack/wrap below `--below-sm`.
- **Org monetisation** — subscription tier rows squeezed `.tier-info` to **0 width**, so the tier name overlapped the toggle → the row now wraps below `--below-sm` with the name/description on its own line (needed a descendant selector to out-specify the base `flex: 1`). Price inputs (`.form-row`) also stack.

## Design-language consistency (hardcoded-px `@media` → breakpoint tokens)

- `payouts`: `max-width:1024px`→`--below-lg`, `720px`→`--below-md`
- `analytics`: `max-width:1024px`→`--below-lg`, `560px`→`--below-sm`
- `ShaderPicker`: `min-width:640px`→`--breakpoint-sm`
- `CustomerDetailDrawer`: `max-width:40rem`→`--below-sm`

**Intentionally not converted:** `analytics/CreatorRevenueTable` + `TopContentLeaderboard` keep their `@media (max-width:560px)`, which mirrors a paired `@container (max-width:560px)` — `postcss-custom-media` tokens can't be used in `@container`, so half-converting would desync them.

## Coverage — every studio page

- **Verified visually on mobile (16):** both shells + drawer nav; org dashboard, payouts, monetisation, subscribers, customers, sales, team, categories, content, content-editor, branding; creator earnings, content, negotiations, settings.
- **Statically confirmed mobile-safe (unchanged code):** org billing, settings, email-templates, monetisation/revenue-share (container-query), pricing-faq, media; creator dashboard, content/new, content/edit, negotiations/[proposalId]; `StudioMediaPage`/`MediaTileGrid` — all mobile-first (base = 1 col) or no un-collapsed grids. Content pages reuse `ContentForm` (verified visually).

## Test plan / verification

- `pnpm build` green; pre-commit biome clean on all 6 files.
- Driven at 390px via Playwright; stacked-card reflow confirmed by computed styles (`head display:none`, row `grid-template-columns` single-track, `::before` = `data-label`) and tier-row overflow confirmed eliminated (`scrollWidth == clientWidth`, `.tier-info` regains full width).

> Note: full authenticated verification of the remaining pages was blocked by a local Miniflare `CACHE_KV` health failure in a fresh worktree (breaks org-membership resolution and eventually login); those pages were verified by static block-context analysis of their responsive CSS instead. No page CSS in this diff depends on that.

## Follow-up (not in this PR)

Studio data tables now use three mobile strategies (new stacked-cards, `overflow-x` scroll, component tables). Unifying them is a larger, separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
