### PR TITLE
Brand Editor Phase 0 (Codex-cijzb): token wiring + import gate

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Biome Check (Lint & Format)
         run: pnpm check:ci
 
+      # Codex-cijzb WP-0.2: the brand-editor UI must never be statically
+      # imported from a public (customer-facing) route — that would bundle
+      # the heavy editor into the public chunk. See
+      # apps/web/scripts/check-brand-editor-boundary.mjs for the full rule.
+      - name: Brand Editor import boundary check
+        run: pnpm --filter web run check:brand-boundary
+
       - name: Generate Paraglide i18n files
         run: pnpm --filter web exec paraglide-js compile --project ./project.inlang --outdir ./src/paraglide
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "test:visual:update": "playwright test --project=visual --update-snapshots",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "check:brand-boundary": "node scripts/check-brand-editor-boundary.mjs",
     "lint": "biome lint --write .",
     "format": "biome format --write .",
     "typecheck": "svelte-kit sync && tsc --noEmit",

--- a/apps/web/scripts/check-brand-editor-boundary.mjs
+++ b/apps/web/scripts/check-brand-editor-boundary.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Brand-editor import boundary guardrail (WP-0.2, Codex-cijzb).
+ *
+ * `$lib/components/brand-editor/**` is the heavy brand-editor UI (panel,
+ * header, color pickers, font picker, etc). A STATIC `import ... from` of
+ * any of it inside a customer-facing (public) route file bundles the editor
+ * into that page's Vite chunk and ships unused editor code to every
+ * visitor. This script fails CI if that ever happens.
+ *
+ * Allowed (NOT flagged):
+ *   - `$lib/brand-editor` (no `/components/`) — the store + css-injection
+ *     helpers the public org layout legitimately imports to apply branding.
+ *   - `import('$lib/components/brand-editor/...')` (dynamic, parens) — a
+ *     lazy, separate chunk. See `src/routes/_org/[slug]/+layout.svelte`
+ *     (BrandEditorMount) for the reference pattern.
+ *   - Studio route files (any path with a `studio` segment) — studio is an
+ *     admin-only `ssr = false` SPA that ships in its own bundle, never in
+ *     the public one. Excluded from the scan entirely.
+ *
+ * Banned (flagged, exit 1):
+ *   - `import ... from '$lib/components/brand-editor/...'` (static, single
+ *     or double quotes) anywhere else under `src/routes`.
+ *
+ * Grep-style, not AST-based — matches the rest of this repo's script-based
+ * gates (e.g. scripts/denoise/find-consumers.ts). It will miss an import
+ * disguised inside a string/template literal, and it only flags `import`,
+ * not `export ... from`. No public route currently needs either form, so
+ * this is a deliberate scope limit, not an oversight.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROUTES_ROOT = fileURLToPath(new URL('../src/routes', import.meta.url));
+const WEB_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+const ROUTE_FILE_EXTENSIONS = new Set(['.svelte', '.ts', '.js']);
+const EXCLUDED_DIR_NAMES = new Set(['studio', 'node_modules']);
+const BANNED_MODULE = '$lib/components/brand-editor';
+
+// Static `import <specifier> from '<module>'` OR side-effect `import '<module>'`
+// (any quote style, matched pair via the \1 backreference). Requires whitespace
+// directly after `import`, so dynamic `import('...')` calls and `typeof
+// import('...')` type queries — which have no whitespace before the paren —
+// never match; those are lazy-chunk loads, not static bundle-time imports.
+const STATIC_IMPORT_RE = /import\s+(?:[^'";]*?\s+from\s+)?(['"])([^'"]+)\1/g;
+
+function isBannedModule(modulePath) {
+  return modulePath === BANNED_MODULE || modulePath.startsWith(`${BANNED_MODULE}/`);
+}
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (EXCLUDED_DIR_NAMES.has(entry.name)) continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, files);
+      continue;
+    }
+    const dot = entry.name.lastIndexOf('.');
+    const ext = dot === -1 ? '' : entry.name.slice(dot);
+    if (ROUTE_FILE_EXTENSIONS.has(ext)) files.push(fullPath);
+  }
+  return files;
+}
+
+function findViolations(filePath) {
+  const content = readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+  const violations = [];
+
+  for (const match of content.matchAll(STATIC_IMPORT_RE)) {
+    const modulePath = match[2];
+    if (!isBannedModule(modulePath)) continue;
+
+    const line = content.slice(0, match.index).split('\n').length;
+    const lineText = lines[line - 1]?.trim() ?? '';
+    // Skip obvious comment lines (`// ...` or JSDoc `* ...`). This is a
+    // grep-style scan, not an AST walk, so it can't fully distinguish code
+    // from comments — this covers the common "documented example" case.
+    if (lineText.startsWith('//') || lineText.startsWith('*')) continue;
+
+    violations.push({ line, text: match[0].replace(/\s+/g, ' ').trim() });
+  }
+
+  return violations;
+}
+
+function main() {
+  const files = walk(ROUTES_ROOT);
+  const violations = [];
+
+  for (const file of files) {
+    for (const violation of findViolations(file)) {
+      violations.push({ file: relative(WEB_ROOT, file), ...violation });
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('Brand-editor import boundary violation(s):\n');
+    for (const v of violations) {
+      console.error(`${v.file}:${v.line}: ${v.text}`);
+    }
+    console.error(
+      `\n${violations.length} violation(s). Public route files may not statically import from ` +
+        `'${BANNED_MODULE}/...' — it bundles the heavy editor UI into the public chunk. Use a ` +
+        `dynamic import('${BANNED_MODULE}/...') instead (see ` +
+        `src/routes/_org/[slug]/+layout.svelte), or import '$lib/brand-editor' (no /components/) ` +
+        `if you only need the store/css-injection helpers.`
+    );
+    process.exit(1);
+  }
+
+  console.log(`OK: no static '${BANNED_MODULE}/...' imports in ${files.length} public route file(s).`);
+}
+
+main();

--- a/apps/web/src/lib/brand-editor/css-injection.ts
+++ b/apps/web/src/lib/brand-editor/css-injection.ts
@@ -20,7 +20,7 @@ import type { BrandEditorState, CssVarMapping } from './types';
 
 /** Override keys that get --brand- prefix (consumed by org-brand.css rules).
  *  All other override keys get --color- prefix (direct token replacement). */
-const BRAND_PREFIX_KEYS = new Set([
+export const BRAND_PREFIX_KEYS = new Set([
   'text-scale',
   'heading-weight',
   'body-weight',

--- a/apps/web/src/lib/brand-editor/writable-token-consumers.test.ts
+++ b/apps/web/src/lib/brand-editor/writable-token-consumers.test.ts
@@ -1,0 +1,153 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { BRAND_PREFIX_KEYS } from './css-injection';
+
+/**
+ * WP-0.1 guard — every CSS-derived editor-writable token must have a real consumer.
+ *
+ * The brand editor lets an org write `--brand-{key}` inputs (enumerated by
+ * BRAND_PREFIX_KEYS in css-injection.ts). `org-brand.css` derives the
+ * consumer-facing tokens from those inputs, e.g.
+ *   `--color-heading: var(--brand-heading-color, …)`
+ * A derived token is only useful if a COMPONENT actually reads it via `var()`.
+ * Otherwise the editor control is a dead knob — which is exactly the bug WP-0.1
+ * fixes: `--color-heading` was derived from the "Heading Color" control but no
+ * card/content title consumed it (class selectors like `.cc__title` /
+ * `.card-title` outranked the `[data-org-brand] :is(h1..h6)` rule once Svelte
+ * added its scoping class), so the heading colour was invisible on the product.
+ *
+ * This test derives the canonical set of CSS-derived, editor-writable consumer
+ * tokens PROGRAMMATICALLY — BRAND_PREFIX_KEYS × the derivations parsed out of
+ * org-brand.css — with no hardcoded token list, then asserts each one has ≥1
+ * `var(--token)` reference somewhere in `apps/web/src` OUTSIDE the brand
+ * editor's own files and OUTSIDE the derivation file (org-brand.css). Any
+ * orphan fails the test with a clear list.
+ *
+ * Scope: CSS-derived tokens only. Shader/hero keys that ShaderHero reads via
+ * `getComputedStyle('--brand-shader-*')` are a different (JS) consumption model
+ * and are intentionally out of scope here.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url)); // …/src/lib/brand-editor
+const SRC_DIR = resolve(HERE, '../..'); // …/src
+const ORG_BRAND_CSS = join(SRC_DIR, 'lib', 'styles', 'tokens', 'org-brand.css');
+
+// ── Parse org-brand.css: build the editor-input → consumer-token map ────────
+const cssText = readFileSync(ORG_BRAND_CSS, 'utf8');
+
+// Custom-property DECLARATIONS only: `--foo: <rhs>;` (a real CSS property such
+// as `color: var(--color-heading)` is NOT a declaration and is skipped — that
+// distinction is what keeps --color-heading OUT of `intermediateTokens`).
+const DECL_RE = /(--[\w-]+)\s*:\s*([^;]*);/g;
+
+// Tokens referenced on the RHS of a custom-property declaration are
+// "intermediate": they feed another token INSIDE org-brand.css rather than a
+// component (e.g. --text-scale → --text-*, --heading-weight → --font-bold,
+// --font-sans → --font-body). They are not component-facing consumer tokens, so
+// they must not be asserted as needing a component consumer.
+const intermediateTokens = new Set<string>();
+// brand key (bare, e.g. "heading-color") → consumer tokens it derives.
+const derivedByKey = new Map<string, Set<string>>();
+
+for (const decl of cssText.matchAll(DECL_RE)) {
+  const lhs = decl[1];
+  const rhs = decl[2];
+  for (const ref of rhs.matchAll(/var\(\s*(--[\w-]+)/g)) {
+    intermediateTokens.add(ref[1]);
+  }
+  for (const ref of rhs.matchAll(
+    /var\(\s*--brand-([\w-]+?)(?:-dark)?\s*[,)]/g
+  )) {
+    const key = ref[1];
+    if (!BRAND_PREFIX_KEYS.has(key)) continue;
+    let set = derivedByKey.get(key);
+    if (!set) {
+      set = new Set();
+      derivedByKey.set(key, set);
+    }
+    set.add(lhs);
+  }
+}
+
+// Canonical set: consumer tokens derived from an editor `--brand-{key}` input,
+// minus intermediates that org-brand.css consumes internally.
+const canonicalTokens = [
+  ...new Set([...derivedByKey.values()].flatMap((set) => [...set])),
+]
+  .filter((token) => !intermediateTokens.has(token))
+  .sort();
+
+// ── Collect candidate consumer files across src ────────────────────────────
+function isEditorOrDerivationFile(path: string): boolean {
+  // The editor's own files (store dir `lib/brand-editor` AND panel components
+  // `lib/components/brand-editor`) and the derivation file itself never count
+  // as product consumers.
+  return (
+    path.split(sep).includes('brand-editor') ||
+    path.endsWith(join('tokens', 'org-brand.css'))
+  );
+}
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    // Skip node_modules and dotfiles/dirs (.svelte-kit, .turbo, …).
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, out);
+    } else if (/\.(svelte|css|ts)$/.test(entry) && !/\.test\.ts$/.test(entry)) {
+      // Skip test files — a token referenced only in a test is not a real
+      // product consumer (and avoids this guard file satisfying itself).
+      out.push(full);
+    }
+  }
+}
+
+const allFiles: string[] = [];
+walk(SRC_DIR, allFiles);
+const consumerFiles = allFiles.filter((f) => !isEditorOrDerivationFile(f));
+
+function hasConsumer(token: string): boolean {
+  const esc = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // `var(--token` with a trailing boundary so `--x` never matches `--x-y`
+  // (e.g. --color-player-text must not be satisfied by --color-player-text-muted).
+  const re = new RegExp(`var\\(\\s*${esc}(?![\\w-])`);
+  return consumerFiles.some((file) => re.test(readFileSync(file, 'utf8')));
+}
+
+describe('brand-editor writable tokens have real consumers', () => {
+  it('derives a non-empty canonical set from the editor config + org-brand.css', () => {
+    expect(canonicalTokens.length).toBeGreaterThan(0);
+    // The WP-0.1 target: editor writes --brand-heading-color; org-brand.css
+    // derives --color-heading. It MUST appear in the canonical set, else the
+    // derivation-parsing logic has drifted and the guard would be toothless.
+    expect(canonicalTokens).toContain('--color-heading');
+    // Vestigial tokens must never resurface as editor-writable consumer tokens.
+    expect(canonicalTokens).not.toContain('--color-text-heading');
+    expect(canonicalTokens.filter((t) => t.startsWith('--card-media'))).toEqual(
+      []
+    );
+  });
+
+  it('the orphan-detection mechanism can fail (a non-existent token has no consumer)', () => {
+    // Proves hasConsumer() genuinely returns false for an unconsumed token, so
+    // the orphan assertion below is a real gate rather than a vacuous pass.
+    expect(hasConsumer('--codex-guard-token-that-should-not-exist')).toBe(
+      false
+    );
+  });
+
+  it('--color-heading is consumed by a component (WP-0.1 fix)', () => {
+    expect(hasConsumer('--color-heading')).toBe(true);
+  });
+
+  it('every CSS-derived editor-writable token has ≥1 consumer outside the editor + org-brand.css', () => {
+    const orphans = canonicalTokens.filter((token) => !hasConsumer(token));
+    expect(
+      orphans,
+      `Orphan editor-writable tokens — derived in org-brand.css from a brand-editor input but no component reads them via var(). Either wire a consumer or drop the control:\n  ${orphans.join('\n  ')}`
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/components/ui/Card/CardTitle.svelte
+++ b/apps/web/src/lib/components/ui/Card/CardTitle.svelte
@@ -20,6 +20,8 @@
     font-size: var(--text-lg);
     font-weight: var(--font-semibold);
     line-height: var(--leading-tight);
-    color: var(--color-text);
+    /* Consume the org-brand heading colour (brand editor "Heading Color");
+       falls back to body text when unset or outside a branded org. */
+    color: var(--color-heading, var(--color-text));
   }
 </style>

--- a/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
+++ b/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
@@ -1096,6 +1096,11 @@
     font-size: var(--text-base);
     font-weight: var(--font-semibold);
     line-height: var(--leading-tight);
+    /* Org-brand heading colour (brand editor "Heading Color"); falls back to
+       body text when unset or outside a branded org. The title-in-cover rules
+       further down intentionally win at higher specificity so titles overlaid
+       on cover art keep the near-white --media-glyph. */
+    color: var(--color-heading, var(--color-text));
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;

--- a/apps/web/src/lib/styles/tokens/org-brand.css
+++ b/apps/web/src/lib/styles/tokens/org-brand.css
@@ -171,7 +171,19 @@
   --font-normal: var(--body-weight, 400);
 }
 
-[data-org-brand] :is(h1, h2, h3, h4, h5, h6) {
+/* Heading colour applies to real heading elements AND to class-based titles.
+   Card/content titles (`.cc__title`, `.card-title`, …) are class selectors that
+   — once Svelte appends its scoping class — outrank a bare `:is(h1..h6)` rule
+   (0,1,1), so the brand editor's heading colour never reached the titles users
+   actually see. Broadening the group to title-like classes is a systemic
+   backstop so future title classes inherit --color-heading too. Scoped under
+   [data-org-brand] so only branded orgs are affected. Specificity stays (0,2,0):
+   component rules that set an explicit title colour at higher specificity — e.g.
+   ContentCard's title-in-cover `--media-glyph` overrides at (0,3,0) — still win,
+   so titles overlaid on cover art keep their near-white ink. */
+[data-org-brand] :is(h1, h2, h3, h4, h5, h6),
+[data-org-brand] [class*='__title'],
+[data-org-brand] [class*='-title'] {
   color: var(--color-heading);
 }
 

--- a/docs/design/brand-editor-mockups.html
+++ b/docs/design/brand-editor-mockups.html
@@ -1,0 +1,1209 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Brand Editor — UI/UX directions</title>
+<style>
+/* =========================================================================
+   CODEX TOKENS (mirrored from apps/web/src/lib/styles/tokens + themes).
+   Every surface paints ONLY with semantic tokens; the --brand-* inputs feed
+   an OKLCH derivation (mirror of org-brand.css) so the live previews re-theme
+   from a single colour control — the signature of this exploration.
+   Fonts: CSP blocks font CDNs, so we use a system stack that reads like the
+   real Inter/JetBrains-Mono pairing rather than risk a silent fallback.
+   ========================================================================= */
+:root{
+  --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, Consolas, monospace;
+
+  /* type scale (fixed, non-fluid — this is a tool doc, not a fluid page) */
+  --text-xs:.75rem; --text-sm:.8125rem; --text-base:.9375rem; --text-lg:1.0625rem;
+  --text-xl:1.25rem; --text-2xl:1.5rem; --text-3xl:2rem; --text-4xl:2.75rem;
+  --fw-normal:400; --fw-medium:500; --fw-semibold:600; --fw-bold:700;
+  --lead-tight:1.2; --lead-snug:1.35; --lead-normal:1.55;
+  --track-wider:.06em; --track-tight:-.02em;
+
+  /* spacing (0.25rem unit) */
+  --s0-5:.125rem; --s1:.25rem; --s1-5:.375rem; --s2:.5rem; --s2-5:.625rem;
+  --s3:.75rem; --s4:1rem; --s5:1.25rem; --s6:1.5rem; --s7:1.75rem; --s8:2rem;
+  --s10:2.5rem; --s12:3rem; --s16:4rem; --s20:5rem;
+
+  --radius-xs:.125rem; --radius-sm:.25rem; --radius-md:.5rem; --radius-lg:.75rem;
+  --radius-xl:1rem; --radius-full:9999px;
+
+  /* neutrals (Codex neutral ramp) */
+  --n0:#fff; --n50:#fafafa; --n100:#f5f5f5; --n200:#e5e5e5; --n300:#d4d4d4;
+  --n400:#a3a3a3; --n500:#737373; --n600:#525252; --n700:#404040;
+  --n800:#262626; --n900:#171717; --n950:#0e0e0e;
+
+  /* semantic — LIGHT (default) */
+  --bg:var(--n50);
+  --surface:#fff;
+  --surface-2:var(--n100);
+  --surface-3:var(--n200);
+  --elevated:#fff;
+  --text:var(--n900);
+  --text-2:var(--n600);
+  --text-3:var(--n500);
+  --text-muted:var(--n400);
+  --border:var(--n200);
+  --border-strong:var(--n300);
+  --border-subtle:var(--n100);
+
+  /* accent for THIS doc's own chrome — a cool slate-teal, deliberately NOT
+     the terracotta brand, so doc-chrome never reads as "part of a preview". */
+  --doc-accent:#177e89;
+  --doc-accent-2:#0d5b64;
+
+  --shadow-color:220 3% 15%; --shadow-strength:1%;
+  --shadow-sm:0 1px 2px 0 hsl(var(--shadow-color)/calc(var(--shadow-strength) + 9%)),0 1px 3px 1px hsl(var(--shadow-color)/calc(var(--shadow-strength) + 4%));
+  --shadow-md:0 1px 3px 0 hsl(var(--shadow-color)/calc(var(--shadow-strength) + 9%)),0 4px 6px -1px hsl(var(--shadow-color)/calc(var(--shadow-strength) + 4%));
+  --shadow-lg:0 1px 3px 0 hsl(var(--shadow-color)/calc(var(--shadow-strength) + 9%)),0 8px 14px -2px hsl(var(--shadow-color)/calc(var(--shadow-strength) + 4%));
+  --shadow-xl:0 1px 4px 0 hsl(var(--shadow-color)/calc(var(--shadow-strength) + 9%)),0 16px 30px -4px hsl(var(--shadow-color)/calc(var(--shadow-strength) + 4%));
+
+  --glass:rgba(255,255,255,.72);
+  --glass-border:rgba(255,255,255,.55);
+  --blur:20px;
+
+  /* BRAND inputs (what the editor sets). Default = Codex terracotta. */
+  --brand-color:#c24129;
+  --brand-secondary:#525252;
+  --brand-accent:#f59e0b;
+  --brand-radius:.5rem;
+
+  --ease-smooth:cubic-bezier(.16,1,.3,1);
+  --ease-out:cubic-bezier(0,0,.2,1);
+  --dur:.2s;
+}
+
+/* Brand derivation — mirror of the real org-brand.css OKLCH relative-color
+   engine. Scoped to .preview so it re-themes independently of doc chrome. */
+.preview{
+  --p-500:var(--brand-color);
+  --p-600:oklch(from var(--brand-color) calc(l - .08) c h);
+  --p-700:oklch(from var(--brand-color) calc(l - .15) c h);
+  --p-100:oklch(from var(--brand-color) .94 calc(c * .25) h);
+  --p-50: oklch(from var(--brand-color) .97 calc(c * .15) h);
+  --interactive:var(--brand-color);
+  --interactive-hover:oklch(from var(--brand-color) calc(l - .08) c h);
+  --interactive-subtle:oklch(from var(--brand-color) .97 calc(c * .15) h);
+  --focus:var(--brand-color);
+  --on-brand:oklch(from var(--brand-color) clamp(0,(.62 - l) * 1000,1) 0 0);
+  --pv-accent:var(--brand-accent);
+  --pv-radius:var(--brand-radius);
+  --pv-surface:#fff;
+  --pv-surface-2:var(--n100);
+  --pv-text:var(--n900);
+  --pv-text-2:var(--n600);
+  --pv-border:var(--n200);
+  --scrim:color-mix(in oklab, black 60%, var(--brand-color));
+}
+:root[data-theme="dark"] .preview,
+.preview[data-pv-theme="dark"]{
+  --p-500:oklch(from var(--brand-color) calc(l + .06) c h);
+  --interactive:oklch(from var(--brand-color) calc(l + .06) c h);
+  --interactive-hover:oklch(from var(--brand-color) calc(l + .14) c h);
+  --interactive-subtle:oklch(from var(--brand-color) .2 calc(c * .3) h);
+  --pv-surface:#1c1c1e;
+  --pv-surface-2:#28282b;
+  --pv-text:#f5f5f5;
+  --pv-text-2:#b5b5b8;
+  --pv-border:#3a3a3d;
+}
+
+/* ---- THEME: dark tokens for the DOC itself ---- */
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:var(--n950); --surface:#161618; --surface-2:#1e1e21; --surface-3:#2a2a2e;
+    --elevated:#202024;
+    --text:var(--n50); --text-2:var(--n300); --text-3:var(--n400); --text-muted:var(--n600);
+    --border:#2c2c30; --border-strong:#3a3a40; --border-subtle:#232327;
+    --doc-accent:#3bc9db; --doc-accent-2:#63d3e0;
+    --shadow-color:220 40% 2%; --shadow-strength:25%;
+    --glass:rgba(24,24,27,.72); --glass-border:rgba(255,255,255,.10);
+  }
+}
+:root[data-theme="dark"]{
+  --bg:var(--n950); --surface:#161618; --surface-2:#1e1e21; --surface-3:#2a2a2e;
+  --elevated:#202024;
+  --text:var(--n50); --text-2:var(--n300); --text-3:var(--n400); --text-muted:var(--n600);
+  --border:#2c2c30; --border-strong:#3a3a40; --border-subtle:#232327;
+  --doc-accent:#3bc9db; --doc-accent-2:#63d3e0;
+  --shadow-color:220 40% 2%; --shadow-strength:25%;
+  --glass:rgba(24,24,27,.72); --glass-border:rgba(255,255,255,.10);
+}
+:root[data-theme="light"]{
+  --bg:var(--n50); --surface:#fff; --surface-2:var(--n100); --surface-3:var(--n200);
+  --elevated:#fff;
+  --text:var(--n900); --text-2:var(--n600); --text-3:var(--n500); --text-muted:var(--n400);
+  --border:var(--n200); --border-strong:var(--n300); --border-subtle:var(--n100);
+  --doc-accent:#177e89; --doc-accent-2:#0d5b64;
+  --shadow-color:220 3% 15%; --shadow-strength:1%;
+  --glass:rgba(255,255,255,.72); --glass-border:rgba(255,255,255,.55);
+}
+
+*{box-sizing:border-box;}
+html{-webkit-text-size-adjust:100%;}
+body{
+  margin:0; background:var(--bg); color:var(--text);
+  font-family:var(--font-sans); font-size:var(--text-base); line-height:var(--lead-normal);
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+}
+h1,h2,h3,h4{margin:0; line-height:var(--lead-tight); text-wrap:balance; letter-spacing:var(--track-tight);}
+p{margin:0;}
+a{color:inherit;}
+button{font:inherit; cursor:pointer;}
+:focus-visible{outline:2px solid var(--doc-accent); outline-offset:2px; border-radius:var(--radius-sm);}
+.mono{font-family:var(--font-mono); font-variant-numeric:tabular-nums;}
+
+/* ================= DOC CHROME ================= */
+.topbar{
+  position:sticky; top:0; z-index:50;
+  display:flex; align-items:center; gap:var(--s4);
+  padding:var(--s3) var(--s5);
+  background:var(--glass); backdrop-filter:blur(var(--blur)); -webkit-backdrop-filter:blur(var(--blur));
+  border-bottom:1px solid var(--border);
+}
+.brandmark{display:flex; align-items:center; gap:var(--s2-5); min-width:0;}
+.brandmark__dot{
+  width:1.6rem; height:1.6rem; border-radius:var(--radius-sm); flex:none;
+  background:conic-gradient(from 210deg, #c24129, #f59e0b, #c24129);
+  box-shadow:var(--shadow-sm);
+}
+.brandmark__t{font-weight:var(--fw-bold); letter-spacing:var(--track-tight); font-size:var(--text-base); white-space:nowrap;}
+.brandmark__s{color:var(--text-3); font-size:var(--text-xs); white-space:nowrap;}
+.topbar__spacer{flex:1;}
+.iconbtn{
+  display:inline-flex; align-items:center; justify-content:center; gap:var(--s2);
+  height:2rem; padding:0 var(--s3); border-radius:var(--radius-md);
+  background:var(--surface-2); color:var(--text-2); border:1px solid var(--border);
+  font-size:var(--text-sm); font-weight:var(--fw-medium); transition:var(--dur);
+}
+.iconbtn:hover{color:var(--text); border-color:var(--border-strong);}
+
+/* tabs */
+.tabs{
+  position:sticky; top:3.4rem; z-index:40;
+  display:flex; gap:var(--s1); flex-wrap:wrap; align-items:center;
+  padding:var(--s2) var(--s5);
+  background:color-mix(in oklab, var(--bg) 88%, transparent);
+  backdrop-filter:blur(var(--blur)); -webkit-backdrop-filter:blur(var(--blur));
+  border-bottom:1px solid var(--border-subtle);
+}
+.tab{
+  display:inline-flex; align-items:center; gap:var(--s2);
+  padding:var(--s1-5) var(--s3); border-radius:var(--radius-full);
+  background:transparent; border:1px solid transparent; color:var(--text-2);
+  font-size:var(--text-sm); font-weight:var(--fw-medium); transition:var(--dur);
+}
+.tab:hover{background:var(--surface-2); color:var(--text);}
+.tab[aria-selected="true"]{background:var(--text); color:var(--bg);}
+.tab__k{font-family:var(--font-mono); font-size:var(--text-xs); opacity:.6;}
+.tab[aria-selected="true"] .tab__k{opacity:.7;}
+
+/* panels */
+.wrap{max-width:1240px; margin:0 auto; padding:var(--s8) var(--s5) var(--s20);}
+.panel{display:none;}
+.panel.is-active{display:block; animation:fade .4s var(--ease-smooth) both;}
+@keyframes fade{from{opacity:0; transform:translateY(8px);}to{opacity:1; transform:none;}}
+@media (prefers-reduced-motion:reduce){
+  .panel.is-active{animation:none;}
+  *{scroll-behavior:auto !important;}
+}
+
+.eyebrow{
+  font-family:var(--font-mono); font-size:var(--text-xs); text-transform:uppercase;
+  letter-spacing:var(--track-wider); color:var(--doc-accent); font-weight:var(--fw-semibold);
+}
+.lede{color:var(--text-2); font-size:var(--text-lg); max-width:68ch; line-height:var(--lead-snug);}
+.section-h{font-size:var(--text-3xl); font-weight:var(--fw-bold); margin-top:var(--s2);}
+.hr{height:1px; background:var(--border); border:0; margin:var(--s10) 0;}
+
+/* generic cards used in doc prose */
+.grid{display:grid; gap:var(--s4);}
+.cols-2{grid-template-columns:repeat(2,1fr);}
+.cols-3{grid-template-columns:repeat(3,1fr);}
+.cols-4{grid-template-columns:repeat(4,1fr);}
+@media (max-width:900px){.cols-2,.cols-3,.cols-4{grid-template-columns:1fr;}}
+.card{
+  background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-lg);
+  padding:var(--s5); box-shadow:var(--shadow-sm);
+}
+.card h3{font-size:var(--text-lg); font-weight:var(--fw-semibold); margin-bottom:var(--s2);}
+.card p{color:var(--text-2); font-size:var(--text-sm); line-height:var(--lead-normal);}
+.pill{
+  display:inline-flex; align-items:center; gap:var(--s1-5); padding:var(--s0-5) var(--s2);
+  border-radius:var(--radius-full); font-size:var(--text-xs); font-weight:var(--fw-semibold);
+  border:1px solid var(--border); color:var(--text-2); background:var(--surface-2);
+}
+.pill--rec{color:var(--doc-accent); border-color:color-mix(in oklab,var(--doc-accent) 40%,var(--border)); background:color-mix(in oklab,var(--doc-accent) 8%,transparent);}
+.pill--warn{color:#b45309; border-color:#fde68a; background:#fffbeb;}
+:root[data-theme="dark"] .pill--warn{color:#fbbf24; border-color:#78500a; background:#2a1f07;}
+
+/* annotation callouts */
+.note{
+  display:flex; gap:var(--s3); padding:var(--s3) var(--s4);
+  border-left:3px solid var(--doc-accent); background:var(--surface-2);
+  border-radius:0 var(--radius-md) var(--radius-md) 0; font-size:var(--text-sm); color:var(--text-2);
+}
+.note b{color:var(--text);}
+.note__n{
+  flex:none; width:1.4rem; height:1.4rem; border-radius:var(--radius-full);
+  background:var(--doc-accent); color:#fff; font-family:var(--font-mono); font-size:var(--text-xs);
+  font-weight:var(--fw-bold); display:grid; place-items:center;
+}
+
+/* =======================================================================
+   REUSABLE LIVE PREVIEW — a compact, realistic Codex org surface.
+   Painted only with derived --p-*/--interactive/--pv-* tokens, so setting
+   --brand-color on .preview re-themes everything. Two densities: 'full'
+   (canvas) and 'mini' (thumbnail).
+   ======================================================================= */
+.preview{
+  background:var(--pv-surface); color:var(--pv-text);
+  border-radius:var(--radius-lg); overflow:hidden; position:relative;
+  border:1px solid var(--pv-border);
+  font-size:var(--text-sm);
+}
+.pv-nav{
+  display:flex; align-items:center; gap:var(--s3); padding:var(--s3) var(--s4);
+  border-bottom:1px solid var(--pv-border); background:var(--pv-surface);
+}
+.pv-logo{display:flex; align-items:center; gap:var(--s2); font-weight:var(--fw-bold); letter-spacing:var(--track-tight);}
+.pv-logo__mk{width:1.25rem; height:1.25rem; border-radius:calc(var(--pv-radius) * .5); background:var(--interactive);}
+.pv-nav__links{display:flex; gap:var(--s3); color:var(--pv-text-2); font-size:var(--text-xs); font-weight:var(--fw-medium);}
+.pv-nav__links span:first-child{color:var(--pv-text);}
+.pv-nav__sp{flex:1;}
+.pv-nav__cta{
+  padding:var(--s1) var(--s3); border-radius:var(--pv-radius); background:var(--interactive);
+  color:var(--on-brand); font-size:var(--text-xs); font-weight:var(--fw-semibold); border:none;
+}
+.pv-nav__avatar{width:1.5rem; height:1.5rem; border-radius:var(--radius-full); background:var(--pv-surface-2); border:1px solid var(--pv-border);}
+
+.pv-hero{
+  position:relative; padding:var(--s8) var(--s5); overflow:hidden;
+  background:
+    radial-gradient(120% 120% at 80% -10%, oklch(from var(--brand-color) l c h / .38), transparent 60%),
+    linear-gradient(160deg, oklch(from var(--brand-color) calc(l - .1) c h), oklch(from var(--brand-accent) calc(l - .05) c h));
+  color:#fff;
+}
+.pv-hero__eyebrow{font-family:var(--font-mono); font-size:var(--text-xs); text-transform:uppercase; letter-spacing:var(--track-wider); opacity:.85;}
+.pv-hero__title{font-size:var(--text-3xl); font-weight:var(--fw-bold); margin:var(--s2) 0; max-width:16ch; line-height:1.05;}
+.pv-hero__desc{max-width:44ch; opacity:.9; font-size:var(--text-sm); line-height:var(--lead-snug);}
+.pv-hero__row{display:flex; gap:var(--s2); margin-top:var(--s4); flex-wrap:wrap;}
+.pv-btn{padding:var(--s2) var(--s4); border-radius:var(--pv-radius); font-size:var(--text-xs); font-weight:var(--fw-semibold); border:none;}
+.pv-btn--solid{background:#fff; color:var(--p-700);}
+.pv-btn--glass{background:rgba(255,255,255,.16); color:#fff; border:1px solid rgba(255,255,255,.4); backdrop-filter:blur(6px);}
+.pv-hero__stats{display:flex; gap:var(--s6); margin-top:var(--s5);}
+.pv-stat b{display:block; font-size:var(--text-xl); font-weight:var(--fw-bold);}
+.pv-stat span{font-size:var(--text-xs); opacity:.8; text-transform:uppercase; letter-spacing:var(--track-wider);}
+
+.pv-body{padding:var(--s5) var(--s4) var(--s6);}
+.pv-body__h{display:flex; align-items:baseline; justify-content:space-between; margin-bottom:var(--s3);}
+.pv-body__h h4{font-size:var(--text-base); font-weight:var(--fw-semibold);}
+.pv-body__h a{font-size:var(--text-xs); color:var(--interactive); font-weight:var(--fw-semibold);}
+.pv-cards{display:grid; grid-template-columns:repeat(3,1fr); gap:var(--s3);}
+.pv-card{border-radius:var(--pv-radius); overflow:hidden; background:var(--pv-surface-2); border:1px solid var(--pv-border); transition:transform var(--dur) var(--ease-out), box-shadow var(--dur);}
+.pv-card:hover{transform:translateY(-3px) scale(var(--card-hover-scale,1.02)); box-shadow:var(--shadow-lg);}
+.pv-card__media{aspect-ratio:16/10; position:relative; background:linear-gradient(135deg, oklch(from var(--brand-color) calc(l - .05) calc(c*.7) h), oklch(from var(--brand-accent) calc(l - .1) c h));}
+.pv-card__media::after{content:""; position:absolute; inset:0; background:linear-gradient(to top, var(--scrim), transparent 65%);}
+.pv-card__badge{position:absolute; top:var(--s2); left:var(--s2); z-index:1; padding:2px var(--s1-5); border-radius:var(--radius-full); font-size:.625rem; font-weight:var(--fw-bold); background:rgba(0,0,0,.4); color:#fff; text-transform:uppercase; letter-spacing:.04em;}
+.pv-card__b{padding:var(--s2-5);}
+.pv-card__t{font-size:var(--text-xs); font-weight:var(--fw-semibold); color:var(--pv-text);}
+.pv-card__m{font-size:.6875rem; color:var(--pv-text-2); margin-top:2px;}
+
+.pv-player{
+  display:flex; align-items:center; gap:var(--s3); padding:var(--s2-5) var(--s4);
+  background:var(--p-700); color:#fff; border-top:1px solid rgba(255,255,255,.12);
+}
+.pv-player__play{width:1.75rem; height:1.75rem; border-radius:var(--radius-full); background:#fff; color:var(--p-700); display:grid; place-items:center; font-size:.7rem; border:none;}
+.pv-player__bar{flex:1; height:4px; border-radius:2px; background:rgba(255,255,255,.25); position:relative;}
+.pv-player__bar::before{content:""; position:absolute; inset:0 55% 0 0; background:#fff; border-radius:2px;}
+.pv-player__t{font-size:var(--text-xs); opacity:.85; font-variant-numeric:tabular-nums;}
+
+/* mini preview (thumbnail scale) */
+.preview--mini{font-size:.7rem;}
+.preview--mini .pv-hero{padding:var(--s5) var(--s4);}
+.preview--mini .pv-hero__title{font-size:var(--text-xl);}
+.preview--mini .pv-hero__stats,.preview--mini .pv-body__h a,.preview--mini .pv-nav__links{display:none;}
+.preview--mini .pv-cards{grid-template-columns:repeat(3,1fr);}
+
+/* swatch strip for a palette */
+.swatches{display:flex; border-radius:var(--radius-md); overflow:hidden; border:1px solid var(--border);}
+.swatches i{height:2rem; flex:1;}
+.swatches i:first-child{flex:2.2;}
+
+/* small helpers */
+.stack{display:flex; flex-direction:column;}
+.gap2{gap:var(--s2);} .gap3{gap:var(--s3);} .gap4{gap:var(--s4);} .gap6{gap:var(--s6);}
+.row{display:flex; align-items:center;}
+.muted{color:var(--text-3);}
+.tiny{font-size:var(--text-xs);}
+.kbd{font-family:var(--font-mono); font-size:var(--text-xs); padding:1px 6px; border:1px solid var(--border-strong); border-bottom-width:2px; border-radius:var(--radius-sm); background:var(--surface-2); color:var(--text-2);}
+</style>
+
+<header class="topbar">
+  <div class="brandmark">
+    <span class="brandmark__dot" aria-hidden="true"></span>
+    <div class="stack">
+      <span class="brandmark__t">Brand Editor</span>
+      <span class="brandmark__s">UI/UX directions · investigation 2026-07-18</span>
+    </div>
+  </div>
+  <div class="topbar__spacer"></div>
+  <label class="iconbtn" for="brandSeed" title="Drag to re-theme every live preview on this page">
+    <span aria-hidden="true">◐</span> Brand colour
+    <input id="brandSeed" type="color" value="#c24129" style="width:1.4rem;height:1.4rem;border:none;background:none;padding:0;cursor:pointer;">
+  </label>
+  <button class="iconbtn" id="themeBtn" aria-label="Toggle light or dark theme">
+    <span id="themeIcon" aria-hidden="true">☾</span> <span id="themeLbl">Dark</span>
+  </button>
+</header>
+
+<nav class="tabs" role="tablist" aria-label="Concepts">
+  <button class="tab" role="tab" aria-selected="true"  aria-controls="p-overview" id="t-overview">Overview</button>
+  <button class="tab" role="tab" aria-selected="false" aria-controls="p-a" id="t-a">A · Refined Panel</button>
+  <button class="tab" role="tab" aria-selected="false" aria-controls="p-b" id="t-b">B · Studio Canvas <span class="tab__k">rec</span></button>
+  <button class="tab" role="tab" aria-selected="false" aria-controls="p-c" id="t-c">C · Inspector <span class="tab__k">future</span></button>
+  <button class="tab" role="tab" aria-selected="false" aria-controls="p-d" id="t-d">D · Guided</button>
+</nav>
+
+<main class="wrap">
+
+  <!-- ============================ OVERVIEW ============================ -->
+  <section class="panel is-active" id="p-overview" role="tabpanel" aria-labelledby="t-overview">
+    <p class="eyebrow">The problem, in one screen</p>
+    <h1 class="section-h">A powerful theming engine behind a cramped drill-down.</h1>
+    <p class="lede" style="margin-top:var(--s4)">
+      Seven inputs fan out into ~50 tokens through OKLCH relative colour — the palette below is derived live from a single seed.
+      Drag the <b>Brand colour</b> control in the top bar and watch the whole preview re-theme. The engine isn't the bottleneck.
+      The 360&nbsp;px floating panel that drives it is.
+    </p>
+
+    <div class="grid cols-2" style="margin-top:var(--s8); align-items:start;">
+      <div class="stack gap4">
+        <div class="preview" data-pv>
+          <div class="pv-nav">
+            <span class="pv-logo"><span class="pv-logo__mk"></span> Northwind</span>
+            <span class="pv-nav__links"><span>Watch</span><span>Series</span><span>Live</span></span>
+            <span class="pv-nav__sp"></span>
+            <button class="pv-nav__cta">Subscribe</button>
+            <span class="pv-nav__avatar"></span>
+          </div>
+          <div class="pv-hero">
+            <span class="pv-hero__eyebrow">Featured series</span>
+            <h3 class="pv-hero__title">The Deep Field</h3>
+            <p class="pv-hero__desc">Six episodes tracing the edge of the observable universe, scored live.</p>
+            <div class="pv-hero__row">
+              <button class="pv-btn pv-btn--solid">▶ Play</button>
+              <button class="pv-btn pv-btn--glass">+ Watchlist</button>
+            </div>
+            <div class="pv-hero__stats">
+              <span class="pv-stat"><b>6</b><span>Episodes</span></span>
+              <span class="pv-stat"><b>4.9k</b><span>Members</span></span>
+              <span class="pv-stat"><b>HDR</b><span>Quality</span></span>
+            </div>
+          </div>
+          <div class="pv-body">
+            <div class="pv-body__h"><h4>Continue watching</h4><a>See all</a></div>
+            <div class="pv-cards">
+              <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Ep 3</span></div><div class="pv-card__b"><div class="pv-card__t">Redshift</div><div class="pv-card__m">28 min left</div></div></div>
+              <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">New</span></div><div class="pv-card__b"><div class="pv-card__t">Parallax</div><div class="pv-card__m">Series · 6 ep</div></div></div>
+              <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Live</span></div><div class="pv-card__b"><div class="pv-card__t">Night Sky Q&amp;A</div><div class="pv-card__m">Starts 9pm</div></div></div>
+            </div>
+          </div>
+          <div class="pv-player">
+            <button class="pv-player__play">▶</button>
+            <span class="pv-player__t">12:04</span>
+            <span class="pv-player__bar"></span>
+            <span class="pv-player__t">27:41</span>
+          </div>
+        </div>
+        <p class="tiny muted">A single mock org surface — nav, hero, card grid, and player chrome — painted only with derived tokens. This exact component is reused as the live canvas in every concept below.</p>
+      </div>
+
+      <div class="stack gap4">
+        <div class="card">
+          <h3>What one seed colour drives</h3>
+          <p style="margin-bottom:var(--s3)">Every band re-derives from the seed via <span class="mono tiny">oklch(from …)</span> — hovers, subtle fills, focus rings, and auto-contrast text-on-brand.</p>
+          <div class="swatches" data-derive aria-hidden="true">
+            <i data-t="p700"></i><i data-t="p600"></i><i data-t="p500"></i><i data-t="p100"></i><i data-t="p50"></i><i data-t="accent"></i>
+          </div>
+          <p class="tiny muted" style="margin-top:var(--s2)">primary-700 · 600 · 500 · 100 · 50 · accent</p>
+        </div>
+
+        <div class="card">
+          <h3>The three failures a redesign must fix</h3>
+          <div class="stack gap3" style="margin-top:var(--s2)">
+            <div class="note"><span class="note__n">1</span><span><b>Occlusion &amp; scope.</b> The panel covers the preview, and the preview is only ever the landing page — never grids, detail pages, the player, or forms.</span></div>
+            <div class="note"><span class="note__n">2</span><span><b>No map.</b> Back-button-only across 12 levels — no breadcrumb, search, or jump. Getting from Colours to Typography means returning Home first.</span></div>
+            <div class="note"><span class="note__n">3</span><span><b>One width, every task.</b> Picking a brand colour and tuning a shader's caustics share the same 360&nbsp;px column.</span></div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Four directions</h3>
+          <div class="stack gap2 tiny" style="margin-top:var(--s2); color:var(--text-2)">
+            <div class="row gap3"><span class="pill">A</span> Refined Panel — evolve today's panel; lowest risk.</div>
+            <div class="row gap3"><span class="pill pill--rec">B</span> Studio Canvas — rail + full live canvas. <b style="color:var(--doc-accent)">Near-term recommendation.</b></div>
+            <div class="row gap3"><span class="pill pill--rec">C</span> Inspector — tree → canvas → contextual inspector. The per-component future.</div>
+            <div class="row gap3"><span class="pill">D</span> Guided — presets &amp; seed-first for non-designers.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <hr class="hr">
+    <p class="eyebrow">How to read this</p>
+    <h2 class="section-h" style="font-size:var(--text-2xl)">Each tab is a working mock, not a wireframe.</h2>
+    <p class="lede" style="margin-top:var(--s3)">Switch tabs (or press <span class="kbd">1</span>–<span class="kbd">5</span>). The Brand colour and theme controls in the top bar drive every preview at once, so you can judge each layout against the same live surface. Concepts B and C share one spine — a navigable structure beside a live canvas — so B can be built such that C is an additive step, not a rewrite.</p>
+  </section>
+
+  <!-- Concept panels are injected below via edits -->
+  <section class="panel" id="p-a" role="tabpanel" aria-labelledby="t-a" hidden>
+    <style>
+    .dockgrid{display:grid; grid-template-columns:1fr 340px; min-height:560px;}
+    @media (max-width:860px){.dockgrid{grid-template-columns:1fr;} .dpanel{display:none;}}
+    .dockstage{background:
+      repeating-linear-gradient(45deg, transparent 0 11px, color-mix(in oklab, var(--text) 3%, transparent) 11px 12px), var(--bg);
+      padding:var(--s5); display:flex; align-items:flex-start; justify-content:center; overflow:auto;}
+    .dockstage .device{max-width:560px; box-shadow:var(--shadow-xl);}
+    .dpanel{display:flex; flex-direction:column; background:var(--glass); backdrop-filter:blur(var(--blur)); -webkit-backdrop-filter:blur(var(--blur)); border-left:1px solid var(--border);}
+    .dpanel__head{padding:var(--s3); border-bottom:1px solid var(--border-subtle);}
+    .dpanel__bar{display:flex; align-items:center; gap:var(--s2);}
+    .dpanel__bc{display:flex; align-items:center; gap:var(--s1-5); font-size:var(--text-sm); font-weight:var(--fw-semibold); flex:1; min-width:0;}
+    .dpanel__bc .crumb{color:var(--text-3); font-weight:var(--fw-medium);}
+    .dpanel__bc .crumb button{border:none; background:none; color:var(--text-3); font:inherit;}
+    .dpanel__bc .crumb button:hover{color:var(--text);}
+    .dpanel__icons{display:flex; gap:var(--s1);}
+    .dpanel__ic{width:1.6rem; height:1.6rem; border-radius:var(--radius-sm); border:none; background:none; color:var(--text-3); display:grid; place-items:center;}
+    .dpanel__ic:hover{background:var(--surface-2); color:var(--text);}
+    .dpanel__ic--active{background:var(--surface-2); color:var(--text);}
+    .dpanel__search{display:flex; align-items:center; gap:var(--s2); width:100%; margin-top:var(--s2-5); padding:var(--s2) var(--s2-5); border:1px solid var(--border); border-radius:var(--radius-md); background:var(--surface); color:var(--text-3); font-size:var(--text-sm);}
+    .dpanel__scroll{flex:1; overflow-y:auto; padding:var(--s2) var(--s3);}
+    .acc{border-bottom:1px solid var(--border-subtle);}
+    .acc__row{display:flex; align-items:center; gap:var(--s2-5); width:100%; padding:var(--s3) var(--s1); border:none; background:none; color:var(--text); text-align:left; font-size:var(--text-sm); font-weight:var(--fw-medium);}
+    .acc__ico{width:1.35rem; text-align:center; opacity:.85;}
+    .acc__row .rail__sw{margin-left:auto;}
+    .acc__row .chev{margin-left:auto; color:var(--text-muted); transition:transform var(--dur);}
+    .acc__row[aria-expanded="true"] .chev{transform:rotate(90deg);}
+    .acc__body{padding:0 var(--s1) var(--s3);}
+    .subnav{display:flex; align-items:center; justify-content:space-between; padding:var(--s2) var(--s2-5); border:1px dashed var(--border-strong); border-radius:var(--radius-md); font-size:var(--text-xs); color:var(--text-2); margin-top:var(--s1);}
+    </style>
+
+    <p class="eyebrow">Direction A · lowest-risk evolution</p>
+    <h1 class="section-h">Refined Panel — the same box, unlost.</h1>
+    <p class="lede" style="margin-top:var(--s4)">
+      If re-architecting isn't on the table yet, the floating panel can still lose its worst habits. Dock it to the edge so it stops
+      covering the page; give it a real breadcrumb, a search box, and inline accordion sections instead of a back-button maze; and add
+      per-field reset plus a change review. Ships inside the current architecture — same store, same injection — with no backend work.
+    </p>
+
+    <div class="app" style="margin-top:var(--s6)">
+      <div class="app__titlebar">
+        <span class="app__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+        <span class="app__path">northwind.codex.tv / ?brandEditor</span>
+        <span class="app__badge"><span aria-hidden="true">◧</span> Docked right</span>
+      </div>
+      <div class="dockgrid">
+        <div class="dockstage">
+          <div class="device">
+            <div class="preview" data-pv>
+              <div class="pv-nav">
+                <span class="pv-logo"><span class="pv-logo__mk"></span> Northwind</span>
+                <span class="pv-nav__links"><span>Watch</span><span>Series</span></span>
+                <span class="pv-nav__sp"></span>
+                <button class="pv-nav__cta">Subscribe</button>
+                <span class="pv-nav__avatar"></span>
+              </div>
+              <div class="pv-hero">
+                <span class="pv-hero__eyebrow">Featured series</span>
+                <h3 class="pv-hero__title">The Deep Field</h3>
+                <p class="pv-hero__desc">Six episodes tracing the edge of the observable universe.</p>
+                <div class="pv-hero__row">
+                  <button class="pv-btn pv-btn--solid">▶ Play</button>
+                  <button class="pv-btn pv-btn--glass">+ Watchlist</button>
+                </div>
+              </div>
+              <div class="pv-body">
+                <div class="pv-body__h"><h4>Continue watching</h4><a>See all</a></div>
+                <div class="pv-cards">
+                  <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Ep 3</span></div><div class="pv-card__b"><div class="pv-card__t">Redshift</div><div class="pv-card__m">28 min left</div></div></div>
+                  <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">New</span></div><div class="pv-card__b"><div class="pv-card__t">Parallax</div><div class="pv-card__m">6 ep</div></div></div>
+                  <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Live</span></div><div class="pv-card__b"><div class="pv-card__t">Night Sky</div><div class="pv-card__m">9pm</div></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- refined docked panel -->
+        <aside class="dpanel" aria-label="Brand editor">
+          <div class="dpanel__head">
+            <div class="dpanel__bar">
+              <nav class="dpanel__bc" aria-label="Breadcrumb">
+                <span class="crumb"><button>Brand</button> ›</span> Colours
+              </nav>
+              <div class="dpanel__icons">
+                <button class="dpanel__ic dpanel__ic--active" title="Dock right" aria-label="Dock right">◧</button>
+                <button class="dpanel__ic" title="Float" aria-label="Float panel">▢</button>
+                <button class="dpanel__ic" title="Minimise" aria-label="Minimise">–</button>
+                <button class="dpanel__ic" title="Close" aria-label="Close">✕</button>
+              </div>
+            </div>
+            <div class="dpanel__search"><span aria-hidden="true">⌕</span> Search all settings <span class="kbd" style="margin-left:auto">/</span></div>
+          </div>
+
+          <div class="dpanel__scroll">
+            <!-- Colours: expanded accordion -->
+            <div class="acc">
+              <button class="acc__row" aria-expanded="true"><span class="acc__ico">◑</span> Colours <span class="rail__sw"><i style="background:var(--brand-color)"></i><i style="background:var(--brand-secondary)"></i><i style="background:var(--brand-accent)"></i></span><span class="chev">›</span></button>
+              <div class="acc__body">
+                <div class="fld" style="margin-bottom:var(--s2-5)">
+                  <div class="stack gap2">
+                    <div class="swrow"><span class="swrow__chip" style="background:var(--brand-color)"></span><span class="swrow__name">Primary</span><span class="swrow__hex" data-hex>#c24129</span></div>
+                    <div class="swrow"><span class="swrow__chip" style="background:var(--brand-secondary)"></span><span class="swrow__name">Secondary</span><span class="swrow__hex">#525252</span></div>
+                    <div class="swrow"><span class="swrow__chip" style="background:var(--brand-accent)"></span><span class="swrow__name">Accent</span><span class="swrow__hex">#f59e0b</span></div>
+                  </div>
+                </div>
+                <div class="subnav"><span>Fine-tune colours</span><span aria-hidden="true">›</span></div>
+              </div>
+            </div>
+            <!-- collapsed sections -->
+            <div class="acc"><button class="acc__row" aria-expanded="false"><span class="acc__ico">Aa</span> Typography <span class="rail__val" style="margin-left:auto; margin-right:var(--s2)">Inter</span><span class="chev">›</span></button></div>
+            <div class="acc"><button class="acc__row" aria-expanded="false"><span class="acc__ico">⬡</span> Shape &amp; density <span class="rail__val" style="margin-left:auto; margin-right:var(--s2)">0.5rem</span><span class="chev">›</span></button></div>
+            <div class="acc"><button class="acc__row" aria-expanded="false"><span class="acc__ico">◐</span> Shadows <span class="chev">›</span></button></div>
+            <div class="acc"><button class="acc__row" aria-expanded="false"><span class="acc__ico">⊞</span> Hero layout &amp; effects <span class="chev">›</span></button></div>
+            <div class="acc"><button class="acc__row" aria-expanded="false"><span class="acc__ico">✦</span> Presets <span class="chev">›</span></button></div>
+          </div>
+
+          <div class="rail__foot">
+            <div class="ledger"><span class="ledger__dot"></span> 2 changes · <a style="color:var(--interactive); font-weight:var(--fw-semibold)">Review &amp; reset</a></div>
+            <div class="btnrow">
+              <button class="btn btn--ghost">Reset</button>
+              <button class="btn btn--primary">Save</button>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+
+    <div class="grid cols-2" style="margin-top:var(--s6)">
+      <div class="note"><span class="note__n">1</span><span><b>Docked, not floating.</b> A dock-left / dock-right / float control parks the panel at the edge so it stops covering the surface it previews. (Float stays available for spot checks.)</span></div>
+      <div class="note"><span class="note__n">2</span><span><b>Breadcrumb + search.</b> The existing <span class="mono tiny">getBreadcrumb()</span> helper is finally rendered as a real trail, and a search box jumps straight to any control — no returning Home to cross between siblings.</span></div>
+      <div class="note"><span class="note__n">3</span><span><b>Accordion, not drill-down.</b> Shallow sections expand in place; only genuinely deep areas (fine-tune, shader lab) push a level. Fewer taps, less disorientation.</span></div>
+      <div class="note"><span class="note__n">4</span><span><b>Review &amp; reset.</b> A change ledger with per-field revert replaces the all-or-nothing Reset. Same store, same injection path — no backend change.</span></div>
+    </div>
+  </section>
+  <section class="panel" id="p-b" role="tabpanel" aria-labelledby="t-b" hidden>
+    <style>
+    /* ===== Shared APP SHELL (Concepts B & C) ===== */
+    .app{border:1px solid var(--border); border-radius:var(--radius-xl); overflow:hidden; box-shadow:var(--shadow-xl); background:var(--surface);}
+    .app__titlebar{display:flex; align-items:center; gap:var(--s3); padding:var(--s2-5) var(--s4); background:var(--surface-2); border-bottom:1px solid var(--border);}
+    .app__dots{display:flex; gap:6px;}
+    .app__dots i{width:.6rem; height:.6rem; border-radius:var(--radius-full); background:var(--border-strong);}
+    .app__path{font-family:var(--font-mono); font-size:var(--text-xs); color:var(--text-3); background:var(--surface); padding:2px var(--s3); border-radius:var(--radius-full); border:1px solid var(--border);}
+    .app__badge{margin-left:auto; font-size:var(--text-xs); color:var(--text-3); display:flex; align-items:center; gap:var(--s2);}
+    .app__body{display:grid; min-height:560px;}
+    .app__body--b{grid-template-columns:296px 1fr;}
+    @media (max-width:860px){.app__body--b{grid-template-columns:1fr;} .rail{display:none;}}
+
+    /* rail */
+    .rail{display:flex; flex-direction:column; border-right:1px solid var(--border); background:var(--surface); min-width:0;}
+    .rail__top{padding:var(--s3) var(--s3) var(--s2);}
+    .rail__bc{display:flex; align-items:center; gap:var(--s1-5); font-size:var(--text-xs); color:var(--text-3); margin-bottom:var(--s2-5);}
+    .rail__bc b{color:var(--text);}
+    .rail__bc button{border:none; background:none; color:var(--text-3); padding:0; font-size:var(--text-xs);}
+    .rail__bc button:hover{color:var(--text);}
+    .rail__search{display:flex; align-items:center; gap:var(--s2); width:100%; padding:var(--s2) var(--s2-5); border:1px solid var(--border); border-radius:var(--radius-md); background:var(--surface-2); color:var(--text-3); font-size:var(--text-sm);}
+    .rail__search .kbd{margin-left:auto;}
+    .rail__scroll{flex:1; overflow-y:auto; padding:var(--s2) var(--s2) var(--s3);}
+    .rail__group{margin-top:var(--s3);}
+    .rail__glabel{font-family:var(--font-mono); font-size:.625rem; text-transform:uppercase; letter-spacing:var(--track-wider); color:var(--text-muted); padding:0 var(--s2) var(--s1-5);}
+    .rail__item{display:flex; align-items:center; gap:var(--s2-5); width:100%; padding:var(--s2) var(--s2-5); border-radius:var(--radius-md); border:1px solid transparent; background:none; color:var(--text-2); text-align:left; font-size:var(--text-sm); transition:var(--dur);}
+    .rail__item:hover{background:var(--surface-2); color:var(--text);}
+    .rail__item[aria-current="true"]{background:var(--interactive-subtle, var(--surface-2)); color:var(--text); border-color:color-mix(in oklab, var(--brand-color) 30%, var(--border));}
+    .rail__ico{flex:none; width:1.35rem; height:1.35rem; display:grid; place-items:center; border-radius:var(--radius-sm); background:var(--surface-2); font-size:.8rem;}
+    .rail__item[aria-current="true"] .rail__ico{background:var(--brand-color); color:#fff;}
+    .rail__label{flex:1; font-weight:var(--fw-medium); min-width:0;}
+    .rail__val{font-size:var(--text-xs); color:var(--text-3);}
+    .rail__sw{display:flex; gap:3px;}
+    .rail__sw i{width:.75rem; height:.75rem; border-radius:var(--radius-full); border:1px solid var(--border);}
+
+    /* active section controls inside rail */
+    .rail__section{padding:var(--s2) var(--s2-5) 0;}
+    .rail__sectionhead{display:flex; align-items:center; gap:var(--s2); margin:var(--s1) 0 var(--s3);}
+    .rail__sectionhead h4{font-size:var(--text-sm); font-weight:var(--fw-semibold);}
+    .fld{margin-bottom:var(--s4);}
+    .fld__l{display:flex; align-items:center; justify-content:space-between; font-size:var(--text-sm); font-weight:var(--fw-medium); margin-bottom:var(--s2);}
+    .fld__l .reset{border:none; background:none; color:var(--text-muted); font-size:var(--text-xs);}
+    .fld__l .reset:hover{color:var(--interactive);}
+    .fld__v{font-family:var(--font-mono); font-size:var(--text-xs); color:var(--text-3);}
+    .swrow{display:flex; align-items:center; gap:var(--s2-5); padding:var(--s2); border:1px solid var(--border); border-radius:var(--radius-md); background:var(--surface-2);}
+    .swrow__chip{width:1.6rem; height:1.6rem; border-radius:var(--radius-sm); border:1px solid var(--border-strong); flex:none;}
+    .swrow__name{font-size:var(--text-sm); font-weight:var(--fw-medium); flex:1;}
+    .swrow__hex{font-family:var(--font-mono); font-size:var(--text-xs); color:var(--text-3);}
+    .rng{-webkit-appearance:none; appearance:none; width:100%; height:4px; border-radius:2px; background:var(--surface-3); accent-color:var(--brand-color);}
+    .rng::-webkit-slider-thumb{-webkit-appearance:none; width:16px; height:16px; border-radius:50%; background:var(--brand-color); border:2px solid var(--surface); box-shadow:var(--shadow-sm); cursor:pointer;}
+    .seg{display:flex; padding:2px; gap:2px; background:var(--surface-2); border:1px solid var(--border); border-radius:var(--radius-md);}
+    .seg button{flex:1; padding:var(--s1-5) var(--s2); border:none; border-radius:calc(var(--radius-md) - 2px); background:none; color:var(--text-2); font-size:var(--text-xs); font-weight:var(--fw-medium);}
+    .seg button[aria-pressed="true"]{background:var(--surface); color:var(--text); box-shadow:var(--shadow-sm);}
+    .affects{display:flex; flex-wrap:wrap; gap:4px; margin-top:var(--s1);}
+    .affects .chip{font-size:.625rem; padding:1px var(--s1-5); border-radius:var(--radius-full); background:var(--surface-2); border:1px solid var(--border); color:var(--text-3);}
+
+    .rail__foot{border-top:1px solid var(--border); padding:var(--s3); background:var(--surface);}
+    .ledger{display:flex; align-items:center; gap:var(--s2); font-size:var(--text-xs); color:var(--text-2); margin-bottom:var(--s2-5);}
+    .ledger__dot{width:.5rem; height:.5rem; border-radius:var(--radius-full); background:var(--brand-accent);}
+    .btnrow{display:flex; gap:var(--s2);}
+    .btn{flex:1; padding:var(--s2) var(--s3); border-radius:var(--radius-md); font-size:var(--text-sm); font-weight:var(--fw-semibold); border:1px solid var(--border);}
+    .btn--ghost{background:none; color:var(--text-2);}
+    .btn--ghost:hover{color:var(--text); border-color:var(--border-strong);}
+    .btn--primary{background:var(--brand-color); color:#fff; border-color:transparent; flex:2;}
+    .btn--primary:hover{filter:brightness(.94);}
+
+    /* canvas — min-width:0 lets the 1fr grid track shrink below its content's
+       intrinsic width instead of overflowing (and being clipped by .app). */
+    .canvas{display:flex; flex-direction:column; min-width:0; overflow:hidden; background:
+      repeating-linear-gradient(45deg, transparent 0 11px, color-mix(in oklab, var(--text) 3%, transparent) 11px 12px), var(--bg);}
+    .cbar{display:flex; align-items:center; gap:var(--s2); padding:var(--s2-5) var(--s3); border-bottom:1px solid var(--border); background:var(--surface); flex-wrap:wrap;}
+    .routes{display:flex; gap:var(--s1); background:var(--surface-2); border:1px solid var(--border); border-radius:var(--radius-full); padding:2px;}
+    .routes button{padding:var(--s1) var(--s2-5); border:none; border-radius:var(--radius-full); background:none; color:var(--text-2); font-size:var(--text-xs); font-weight:var(--fw-medium);}
+    .routes button[aria-pressed="true"]{background:var(--text); color:var(--bg);}
+    .cbar__sp{flex:1;}
+    .cbar__grp{display:flex; gap:var(--s1); align-items:center; font-size:var(--text-xs); color:var(--text-3);}
+    .cbar__grp .seg{background:var(--surface-2);}
+    .cbar__grp .seg button{padding:var(--s1) var(--s2);}
+    .stage{flex:1; display:flex; align-items:flex-start; justify-content:center; padding:var(--s6); overflow:auto;}
+    .device{width:100%; max-width:720px; box-shadow:var(--shadow-xl); border-radius:var(--radius-lg); overflow:hidden;}
+    .device--split{display:grid; grid-template-columns:1fr 1fr; gap:var(--s4); max-width:900px; box-shadow:none;}
+    .device--split .preview{box-shadow:var(--shadow-lg);}
+    .device--phone{max-width:320px;}
+    .splitlabel{font-size:var(--text-xs); color:var(--text-3); text-align:center; margin-bottom:var(--s2); font-weight:var(--fw-semibold);}
+    </style>
+
+    <p class="eyebrow">Direction B · recommended near-term</p>
+    <h1 class="section-h">Studio Canvas — the preview <em style="font-style:normal;color:var(--doc-accent)">is</em> the workspace.</h1>
+    <p class="lede" style="margin-top:var(--s4)">
+      Promote the editor out of a floating box into a dedicated Studio workspace: a fixed control rail beside a large live canvas.
+      The canvas renders the org's <b>real</b> surfaces and you flip it between routes, devices, and themes — so you finally see your brand
+      where it actually lives, at full size, nothing occluded. Try the route and device switchers; the seed control still re-themes it live.
+    </p>
+
+    <div class="app" style="margin-top:var(--s6)">
+      <div class="app__titlebar">
+        <span class="app__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+        <span class="app__path">studio / brand</span>
+        <span class="app__badge"><span class="ledger__dot" style="background:var(--brand-accent)"></span> 3 unsaved changes</span>
+      </div>
+      <div class="app__body app__body--b">
+
+        <!-- CONTROL RAIL -->
+        <aside class="rail" aria-label="Brand controls">
+          <div class="rail__top">
+            <nav class="rail__bc" aria-label="Breadcrumb">
+              <button>Brand</button><span>›</span><b>Colours</b>
+            </nav>
+            <div class="rail__search"><span aria-hidden="true">⌕</span> Search settings <span class="kbd">/</span></div>
+          </div>
+
+          <div class="rail__scroll">
+            <!-- Active section: Colours, expanded in place -->
+            <div class="rail__section">
+              <div class="fld">
+                <div class="fld__l">Palette <button class="reset">Generate</button></div>
+                <div class="stack gap2">
+                  <div class="swrow"><span class="swrow__chip" style="background:var(--brand-color)"></span><span class="swrow__name">Primary</span><span class="swrow__hex" data-hex>#c24129</span></div>
+                  <div class="swrow"><span class="swrow__chip" style="background:var(--brand-secondary)"></span><span class="swrow__name">Secondary</span><span class="swrow__hex">#525252</span></div>
+                  <div class="swrow"><span class="swrow__chip" style="background:var(--brand-accent)"></span><span class="swrow__name">Accent</span><span class="swrow__hex">#f59e0b</span></div>
+                  <div class="swrow"><span class="swrow__chip" style="background:#fff"></span><span class="swrow__name">Background</span><span class="swrow__hex muted">auto</span></div>
+                </div>
+                <div class="affects"><span class="chip">buttons</span><span class="chip">links</span><span class="chip">focus rings</span><span class="chip">cards</span><span class="chip">player</span></div>
+              </div>
+
+              <div class="fld">
+                <div class="fld__l"><span>Editing theme</span></div>
+                <div class="seg" role="group" aria-label="Editing theme">
+                  <button aria-pressed="true">Light</button><button aria-pressed="false">Dark</button>
+                </div>
+                <p class="tiny muted" style="margin-top:var(--s2)">Dark values auto-derive from light until you override them.</p>
+              </div>
+
+              <div class="fld">
+                <div class="fld__l">Contrast check</div>
+                <div class="row gap2 tiny" style="color:var(--text-2)">
+                  <span class="pill pill--rec">AA ✓ text-on-brand</span>
+                  <span class="pill pill--rec">AA ✓ focus ring</span>
+                </div>
+                <p class="tiny muted" style="margin-top:var(--s2)">Auto-contrast picks black or white text for you at <span class="mono">l &lt; 0.62</span>.</p>
+              </div>
+            </div>
+
+            <!-- Other sections (collapsed nav) -->
+            <div class="rail__group">
+              <div class="rail__glabel">Foundations</div>
+              <button class="rail__item" aria-current="true"><span class="rail__ico">◑</span><span class="rail__label">Colours</span><span class="rail__sw"><i style="background:var(--brand-color)"></i><i style="background:var(--brand-secondary)"></i><i style="background:var(--brand-accent)"></i></span></button>
+              <button class="rail__item"><span class="rail__ico">Aa</span><span class="rail__label">Typography</span><span class="rail__val">Inter</span></button>
+              <button class="rail__item"><span class="rail__ico">⬡</span><span class="rail__label">Shape &amp; density</span><span class="rail__val">0.5rem</span></button>
+              <button class="rail__item"><span class="rail__ico">◐</span><span class="rail__label">Shadows</span><span class="rail__val">1×</span></button>
+            </div>
+            <div class="rail__group">
+              <div class="rail__glabel">Identity</div>
+              <button class="rail__item"><span class="rail__ico">◻</span><span class="rail__label">Logo</span><span class="rail__val muted">set</span></button>
+              <button class="rail__item"><span class="rail__ico">✦</span><span class="rail__label">Presets</span><span class="rail__val muted">12</span></button>
+            </div>
+            <div class="rail__group">
+              <div class="rail__glabel">Hero</div>
+              <button class="rail__item"><span class="rail__ico">⊞</span><span class="rail__label">Layout</span><span class="rail__val">Classic</span></button>
+              <button class="rail__item"><span class="rail__ico">◈</span><span class="rail__label">Effects</span><span class="rail__val muted">Pulse</span></button>
+              <button class="rail__item"><span class="rail__ico">▶</span><span class="rail__label">Intro video</span><span class="rail__val muted">—</span></button>
+            </div>
+          </div>
+
+          <div class="rail__foot">
+            <div class="ledger"><span class="ledger__dot"></span> 3 changes · <a style="color:var(--interactive); font-weight:var(--fw-semibold)">Review</a></div>
+            <div class="btnrow">
+              <button class="btn btn--ghost">Reset</button>
+              <button class="btn btn--primary">Save changes</button>
+            </div>
+          </div>
+        </aside>
+
+        <!-- LIVE CANVAS -->
+        <div class="canvas">
+          <div class="cbar">
+            <div class="routes" role="group" aria-label="Preview route">
+              <button aria-pressed="true">Landing</button>
+              <button aria-pressed="false">Grid</button>
+              <button aria-pressed="false">Detail</button>
+              <button aria-pressed="false">Player</button>
+            </div>
+            <span class="cbar__sp"></span>
+            <div class="cbar__grp" aria-label="Theme preview">
+              <div class="seg"><button aria-pressed="true" title="Light">☀</button><button aria-pressed="false" title="Dark">☾</button><button aria-pressed="false" title="Side by side">◧</button></div>
+            </div>
+            <div class="cbar__grp" aria-label="Device">
+              <div class="seg"><button aria-pressed="true" title="Desktop">▭</button><button aria-pressed="false" title="Phone">▯</button></div>
+            </div>
+          </div>
+          <div class="stage">
+            <div class="device">
+              <div class="preview" data-pv>
+                <div class="pv-nav">
+                  <span class="pv-logo"><span class="pv-logo__mk"></span> Northwind</span>
+                  <span class="pv-nav__links"><span>Watch</span><span>Series</span><span>Live</span></span>
+                  <span class="pv-nav__sp"></span>
+                  <button class="pv-nav__cta">Subscribe</button>
+                  <span class="pv-nav__avatar"></span>
+                </div>
+                <div class="pv-hero">
+                  <span class="pv-hero__eyebrow">Featured series</span>
+                  <h3 class="pv-hero__title">The Deep Field</h3>
+                  <p class="pv-hero__desc">Six episodes tracing the edge of the observable universe, scored live.</p>
+                  <div class="pv-hero__row">
+                    <button class="pv-btn pv-btn--solid">▶ Play</button>
+                    <button class="pv-btn pv-btn--glass">+ Watchlist</button>
+                  </div>
+                  <div class="pv-hero__stats">
+                    <span class="pv-stat"><b>6</b><span>Episodes</span></span>
+                    <span class="pv-stat"><b>4.9k</b><span>Members</span></span>
+                    <span class="pv-stat"><b>HDR</b><span>Quality</span></span>
+                  </div>
+                </div>
+                <div class="pv-body">
+                  <div class="pv-body__h"><h4>Continue watching</h4><a>See all</a></div>
+                  <div class="pv-cards">
+                    <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Ep 3</span></div><div class="pv-card__b"><div class="pv-card__t">Redshift</div><div class="pv-card__m">28 min left</div></div></div>
+                    <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">New</span></div><div class="pv-card__b"><div class="pv-card__t">Parallax</div><div class="pv-card__m">Series · 6 ep</div></div></div>
+                    <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Live</span></div><div class="pv-card__b"><div class="pv-card__t">Night Sky Q&amp;A</div><div class="pv-card__m">Starts 9pm</div></div></div>
+                  </div>
+                </div>
+                <div class="pv-player">
+                  <button class="pv-player__play">▶</button>
+                  <span class="pv-player__t">12:04</span>
+                  <span class="pv-player__bar"></span>
+                  <span class="pv-player__t">27:41</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid cols-3" style="margin-top:var(--s6)">
+      <div class="note"><span class="note__n">1</span><span><b>Nothing occludes the preview.</b> Rail and canvas are siblings, not overlapping layers. The canvas is the biggest thing on screen — as it should be.</span></div>
+      <div class="note"><span class="note__n">2</span><span><b>Preview spans the surface.</b> Route pills swap Landing / Grid / Detail / Player; the device and theme toggles (incl. a side-by-side light+dark) let you verify everywhere the brand reaches.</span></div>
+      <div class="note"><span class="note__n">3</span><span><b>The map is always visible.</b> Grouped rail (Foundations / Identity / Hero) with the active section expanded in place — no back-button maze, and search jumps anywhere.</span></div>
+      <div class="note"><span class="note__n">4</span><span><b>Changes have a ledger.</b> A running count with Review + per-field reset, so Save is deliberate. Editing-theme and live contrast checks sit next to the colours they judge.</span></div>
+      <div class="note"><span class="note__n">5</span><span><b>“Affects” chips make impact legible.</b> Each control shows which component families it touches — answering the v2 complaint that changes felt invisible.</span></div>
+      <div class="note"><span class="note__n">6</span><span><b>One home for identity.</b> Logo and hero-text fold into the rail, ending the split between the static settings page and the live editor.</span></div>
+    </div>
+  </section>
+  <section class="panel" id="p-c" role="tabpanel" aria-labelledby="t-c" hidden>
+    <style>
+    .app__body--c{grid-template-columns:236px 1fr 300px;}
+    @media (max-width:1040px){.app__body--c{grid-template-columns:1fr;} .tree,.inspector{display:none;}}
+    .tree{border-right:1px solid var(--border); background:var(--surface); overflow-y:auto; padding:var(--s3) var(--s2);}
+    .tree__glabel{font-family:var(--font-mono); font-size:.625rem; text-transform:uppercase; letter-spacing:var(--track-wider); color:var(--text-muted); padding:var(--s3) var(--s2) var(--s1-5);}
+    .tnode{display:flex; align-items:center; gap:var(--s2); width:100%; padding:var(--s1-5) var(--s2); border-radius:var(--radius-sm); border:none; background:none; color:var(--text-2); font-size:var(--text-sm); text-align:left;}
+    .tnode:hover{background:var(--surface-2); color:var(--text);}
+    .tnode[aria-current="true"]{background:var(--interactive-subtle, var(--surface-2)); color:var(--text); font-weight:var(--fw-medium);}
+    .tnode__tw{width:.8rem; flex:none; color:var(--text-muted); font-size:.6rem;}
+    .tnode__ico{flex:none; opacity:.8;}
+    .tnode--l2{padding-left:var(--s6);}
+    .tnode--l2 .tnode__tw{display:none;}
+    .tdot{width:.4rem; height:.4rem; border-radius:2px; flex:none;}
+
+    .inspector{border-left:1px solid var(--border); background:var(--surface); overflow-y:auto; display:flex; flex-direction:column;}
+    .insp__head{padding:var(--s3) var(--s3) var(--s2); border-bottom:1px solid var(--border-subtle); position:sticky; top:0; background:var(--surface); z-index:1;}
+    .insp__crumb{font-size:var(--text-xs); color:var(--text-3);}
+    .insp__title{display:flex; align-items:center; gap:var(--s2); font-size:var(--text-base); font-weight:var(--fw-semibold); margin-top:2px;}
+    .insp__title .dot{width:.5rem; height:.5rem; border-radius:2px; background:var(--brand-color);}
+    .insp__scope{margin-top:var(--s2); font-size:var(--text-xs); color:var(--text-3); display:flex; gap:var(--s2); align-items:center;}
+    .insp__body{padding:var(--s3);}
+    .insp__group{font-family:var(--font-mono); font-size:.625rem; text-transform:uppercase; letter-spacing:var(--track-wider); color:var(--text-muted); margin:var(--s3) 0 var(--s2);}
+    .tok{font-family:var(--font-mono); font-size:.625rem; color:var(--text-muted);}
+    .insp__foot{margin-top:auto; padding:var(--s3); border-top:1px solid var(--border);}
+
+    /* selection affordance on the canvas */
+    .canvas--c .stage{align-items:center;}
+    .sel{position:relative; outline:2px solid var(--brand-color); outline-offset:3px; border-radius:var(--pv-radius);}
+    .sel__tag{position:absolute; top:-1.4rem; left:-2px; font-size:.625rem; font-weight:var(--fw-bold); background:var(--brand-color); color:#fff; padding:1px 6px; border-radius:var(--radius-sm) var(--radius-sm) var(--radius-sm) 0;}
+    .selectable{cursor:pointer;}
+    .selectable:hover{outline:1.5px dashed color-mix(in oklab, var(--brand-color) 60%, transparent); outline-offset:2px;}
+    </style>
+
+    <p class="eyebrow">Direction C · the extensibility target</p>
+    <h1 class="section-h">Inspector — foundations today, components tomorrow.</h1>
+    <p class="lede" style="margin-top:var(--s4)">
+      The same rail-beside-canvas spine as B, with a third pane: a navigable <b>tree</b> on the left (Foundations → Surfaces → Components),
+      the live canvas in the middle, and a <b>contextual inspector</b> on the right. Select a token group <em style="font-style:normal">or a specific component</em>
+      — pick "Content card" in the tree, or click the highlighted card in the canvas — and the inspector shows exactly the properties that element honours.
+      Per-component theming isn't a rebuild: <b>the token layer already carries component-scoped keys</b> (<span class="mono tiny">card-*</span>, <span class="mono tiny">player-*</span>, <span class="mono tiny">glass-tint</span>, <span class="mono tiny">hero-*</span>). This is the UI that would surface them.
+    </p>
+
+    <div class="app" style="margin-top:var(--s6)">
+      <div class="app__titlebar">
+        <span class="app__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+        <span class="app__path">studio / brand / components / content-card</span>
+        <span class="app__badge"><span class="pill" style="font-size:.625rem">experimental</span></span>
+      </div>
+      <div class="app__body app__body--c">
+
+        <!-- TREE -->
+        <nav class="tree" aria-label="Design system tree">
+          <div class="tree__glabel">Foundations</div>
+          <button class="tnode"><span class="tnode__tw">▸</span><span class="tnode__ico">◑</span> Colours</button>
+          <button class="tnode"><span class="tnode__tw">▸</span><span class="tnode__ico">Aa</span> Typography</button>
+          <button class="tnode"><span class="tnode__tw">▸</span><span class="tnode__ico">⬡</span> Shape &amp; density</button>
+          <button class="tnode"><span class="tnode__tw">▸</span><span class="tnode__ico">◐</span> Shadows</button>
+
+          <div class="tree__glabel">Surfaces</div>
+          <button class="tnode"><span class="tnode__tw">▸</span><span class="tnode__ico">⊞</span> Hero</button>
+          <button class="tnode"><span class="tnode__tw">▾</span><span class="tnode__ico">▤</span> Components</button>
+          <button class="tnode tnode--l2"><span class="tdot" style="background:var(--brand-color)"></span> Button</button>
+          <button class="tnode tnode--l2" aria-current="true"><span class="tdot" style="background:var(--brand-accent)"></span> Content card</button>
+          <button class="tnode tnode--l2"><span class="tdot" style="background:var(--brand-secondary)"></span> Navigation</button>
+          <button class="tnode tnode--l2"><span class="tdot" style="background:#6b7280"></span> Player</button>
+          <button class="tnode tnode--l2"><span class="tdot" style="background:#6b7280"></span> Forms</button>
+        </nav>
+
+        <!-- CANVAS (with selection) -->
+        <div class="canvas canvas--c">
+          <div class="cbar">
+            <div class="routes" role="group" aria-label="Preview route">
+              <button aria-pressed="false">Landing</button>
+              <button aria-pressed="true">Grid</button>
+              <button aria-pressed="false">Detail</button>
+            </div>
+            <span class="cbar__sp"></span>
+            <span class="cbar__grp tiny"><span aria-hidden="true">⌖</span> Click any element to edit its tokens</span>
+          </div>
+          <div class="stage">
+            <div class="device" style="max-width:660px">
+              <div class="preview" data-pv>
+                <div class="pv-nav">
+                  <span class="pv-logo"><span class="pv-logo__mk"></span> Northwind</span>
+                  <span class="pv-nav__sp"></span>
+                  <button class="pv-nav__cta selectable">Subscribe</button>
+                  <span class="pv-nav__avatar"></span>
+                </div>
+                <div class="pv-body" style="padding-top:var(--s5)">
+                  <div class="pv-body__h"><h4>Browse the library</h4></div>
+                  <div class="pv-cards">
+                    <div class="pv-card sel"><span class="sel__tag">Content card</span><div class="pv-card__media"><span class="pv-card__badge">Ep 3</span></div><div class="pv-card__b"><div class="pv-card__t">Redshift</div><div class="pv-card__m">28 min left</div></div></div>
+                    <div class="pv-card selectable"><div class="pv-card__media"><span class="pv-card__badge">New</span></div><div class="pv-card__b"><div class="pv-card__t">Parallax</div><div class="pv-card__m">Series · 6 ep</div></div></div>
+                    <div class="pv-card selectable"><div class="pv-card__media"><span class="pv-card__badge">Live</span></div><div class="pv-card__b"><div class="pv-card__t">Night Sky</div><div class="pv-card__m">Starts 9pm</div></div></div>
+                    <div class="pv-card selectable"><div class="pv-card__media"></div><div class="pv-card__b"><div class="pv-card__t">Aphelion</div><div class="pv-card__m">Film · 98 min</div></div></div>
+                    <div class="pv-card selectable"><div class="pv-card__media"></div><div class="pv-card__b"><div class="pv-card__t">Perigee</div><div class="pv-card__m">Series · 4 ep</div></div></div>
+                    <div class="pv-card selectable"><div class="pv-card__media"></div><div class="pv-card__b"><div class="pv-card__t">Zenith</div><div class="pv-card__m">Film · 2h 10</div></div></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- INSPECTOR -->
+        <aside class="inspector" aria-label="Content card properties">
+          <div class="insp__head">
+            <div class="insp__crumb">Components ›</div>
+            <div class="insp__title"><span class="dot"></span> Content card</div>
+            <div class="insp__scope"><span class="pill" style="font-size:.625rem">scoped override</span> layers on the derived palette</div>
+          </div>
+          <div class="insp__body">
+            <div class="insp__group">Shape</div>
+            <div class="fld">
+              <div class="fld__l"><span>Corner radius</span><span class="fld__v">0.75rem</span></div>
+              <input class="rng" type="range" min="0" max="24" value="12" aria-label="Corner radius">
+              <div class="tok">→ inherits --radius-card</div>
+            </div>
+
+            <div class="insp__group">Interaction</div>
+            <div class="fld">
+              <div class="fld__l"><span>Hover lift</span><span class="fld__v">1.02×</span></div>
+              <input class="rng" type="range" min="100" max="110" value="102" aria-label="Hover scale">
+              <div class="tok">→ --brand-card-hover-scale</div>
+            </div>
+            <div class="fld">
+              <div class="fld__l"><span>Image zoom on hover</span><span class="fld__v">1.05×</span></div>
+              <input class="rng" type="range" min="100" max="115" value="105" aria-label="Image hover scale">
+              <div class="tok">→ --brand-card-image-hover-scale</div>
+            </div>
+
+            <div class="insp__group">Media cover</div>
+            <div class="fld">
+              <div class="fld__l"><span>Scrim depth</span><button class="reset">reset</button></div>
+              <input class="rng" type="range" min="40" max="80" value="60" aria-label="Scrim depth">
+              <div class="tok">→ --media-scrim (60% black + bg)</div>
+            </div>
+            <div class="fld">
+              <div class="fld__l"><span>Badge</span></div>
+              <div class="seg" role="group" aria-label="Badge style"><button aria-pressed="true">Solid</button><button aria-pressed="false">Glass</button><button aria-pressed="false">Off</button></div>
+            </div>
+          </div>
+          <div class="insp__foot">
+            <div class="btnrow"><button class="btn btn--ghost">Reset to derived</button></div>
+          </div>
+        </aside>
+      </div>
+    </div>
+
+    <div class="grid cols-3" style="margin-top:var(--s6)">
+      <div class="note"><span class="note__n">1</span><span><b>Two ways in.</b> Navigate the tree, or click an element in the canvas — both open the same inspector. Direct manipulation is how designers expect to work.</span></div>
+      <div class="note"><span class="note__n">2</span><span><b>Grounded in real tokens.</b> Every inspector row shows the CSS variable it writes — <span class="mono tiny">--brand-card-hover-scale</span>, <span class="mono tiny">--media-scrim</span> — keys the engine <em style="font-style:normal">already</em> honours. Adding a component is a "Path B" change: no migration.</span></div>
+      <div class="note"><span class="note__n">3</span><span><b>Overrides layer, never fork.</b> A component tweak sits on top of the derived palette and always carries "Reset to derived", so per-component edits can't strand an org off-brand.</span></div>
+    </div>
+
+    <div class="card" style="margin-top:var(--s6); border-color:color-mix(in oklab,var(--doc-accent) 30%, var(--border));">
+      <h3>What it would take to ship per-component editing (future, not now)</h3>
+      <div class="grid cols-2" style="margin-top:var(--s3); gap:var(--s3)">
+        <p><b>1. A component registry</b> — map each component (Button, Content card, Nav, Player, Hero, Form) to the override keys it honours, with safe ranges and sensible controls.</p>
+        <p><b>2. Tree/inspector IA</b> — the structure shown here, so "Components" is a first-class branch beside "Foundations".</p>
+        <p><b>3. Canvas selection</b> — a lightweight <span class="mono tiny">data-brand-component</span> annotation on component roots so a click maps to the registry.</p>
+        <p><b>4. Guardrails</b> — overrides layer on the derived palette (never replace it), each with a visible reset. Contrast checks travel with the component.</p>
+      </div>
+    </div>
+  </section>
+  <section class="panel" id="p-d" role="tabpanel" aria-labelledby="t-d" hidden>
+    <style>
+    .guided{display:grid; grid-template-columns:1fr 400px; gap:0; min-height:560px;}
+    @media (max-width:900px){.guided{grid-template-columns:1fr;}}
+    .guided__left{padding:var(--s6); border-right:1px solid var(--border); background:var(--surface);}
+    .guided__right{padding:var(--s6); background:
+      repeating-linear-gradient(45deg, transparent 0 11px, color-mix(in oklab, var(--text) 3%, transparent) 11px 12px), var(--bg);
+      display:flex; flex-direction:column; gap:var(--s3);}
+    .starttabs{display:flex; gap:var(--s1); background:var(--surface-2); border:1px solid var(--border); border-radius:var(--radius-md); padding:3px; margin:var(--s4) 0 var(--s5);}
+    .starttabs button{flex:1; padding:var(--s2) var(--s2-5); border:none; border-radius:calc(var(--radius-md) - 2px); background:none; color:var(--text-2); font-size:var(--text-sm); font-weight:var(--fw-medium);}
+    .starttabs button[aria-pressed="true"]{background:var(--surface); color:var(--text); box-shadow:var(--shadow-sm);}
+    .presetgrid{display:grid; grid-template-columns:1fr 1fr; gap:var(--s3);}
+    .preset{border:1px solid var(--border); border-radius:var(--radius-lg); overflow:hidden; background:var(--surface); text-align:left; padding:0; transition:var(--dur);}
+    .preset:hover{border-color:var(--border-strong); box-shadow:var(--shadow-md); transform:translateY(-2px);}
+    .preset[aria-pressed="true"]{border-color:var(--brand-color); box-shadow:0 0 0 2px color-mix(in oklab,var(--brand-color) 35%,transparent);}
+    .preset__bars{display:flex; height:3rem;}
+    .preset__bars i{flex:1;} .preset__bars i:first-child{flex:2.4;}
+    .preset__meta{padding:var(--s2-5) var(--s3); display:flex; flex-direction:column; gap:2px;}
+    .preset__name{display:block; font-size:var(--text-sm); font-weight:var(--fw-semibold);}
+    .preset__desc{display:block; font-size:var(--text-xs); color:var(--text-3);}
+    .seedwrap{display:flex; align-items:center; gap:var(--s3); padding:var(--s4); border:1px solid var(--border); border-radius:var(--radius-lg); background:var(--surface-2);}
+    .seedwrap__sw{width:3.5rem; height:3.5rem; border-radius:var(--radius-md); border:1px solid var(--border-strong); background:var(--brand-color); flex:none;}
+    .genrow{display:flex; gap:var(--s2); margin-top:var(--s4); flex-wrap:wrap;}
+    .genopt{border:1px solid var(--border); border-radius:var(--radius-md); overflow:hidden; background:var(--surface); flex:1; min-width:120px;}
+    .genopt__bars{display:flex; height:2rem;} .genopt__bars i{flex:1;} .genopt__bars i:first-child{flex:2;}
+    .genopt__n{font-size:var(--text-xs); color:var(--text-2); padding:var(--s1-5) var(--s2);}
+    .deeper{display:flex; align-items:center; justify-content:space-between; gap:var(--s3); margin-top:var(--s6); padding:var(--s3) var(--s4); border:1px dashed var(--border-strong); border-radius:var(--radius-lg); background:var(--surface-2);}
+    </style>
+
+    <p class="eyebrow">Direction D · the 60-second path</p>
+    <h1 class="section-h">Guided — good-looking before it's deep.</h1>
+    <p class="lede" style="margin-top:var(--s4)">
+      Most admins want their space to look on-brand fast, not to tune a shader. This entry mode leads with three fast starts — pick a
+      preset, drop a seed colour and get complete palettes, or pull colours from your logo — with a live preview the whole time.
+      "Go deeper" hands off to the full editor (B) only when they want it. It directly answers the v2 note: one click to a <b>complete</b> palette, not a field-by-field grind.
+    </p>
+
+    <div class="app" style="margin-top:var(--s6)">
+      <div class="app__titlebar">
+        <span class="app__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+        <span class="app__path">studio / brand · first run</span>
+      </div>
+      <div class="guided">
+        <div class="guided__left">
+          <h3 style="font-size:var(--text-xl); font-weight:var(--fw-bold)">Let's brand Northwind.</h3>
+          <p class="muted tiny" style="margin-top:var(--s1)">Start anywhere — you can refine every detail later.</p>
+
+          <div class="starttabs" role="group" aria-label="Start method">
+            <button aria-pressed="true">Presets</button>
+            <button aria-pressed="false">Seed colour</button>
+            <button aria-pressed="false">From logo</button>
+          </div>
+
+          <div class="presetgrid">
+            <button class="preset" aria-pressed="true">
+              <span class="preset__bars"><i style="background:#c24129"></i><i style="background:#525252"></i><i style="background:#f59e0b"></i></span>
+              <span class="preset__meta"><span class="preset__name">Ember</span><span class="preset__desc">Warm, editorial</span></span>
+            </button>
+            <button class="preset">
+              <span class="preset__bars"><i style="background:#1e3a8a"></i><i style="background:#0ea5e9"></i><i style="background:#f0f9ff"></i></span>
+              <span class="preset__meta"><span class="preset__name">Deep Field</span><span class="preset__desc">Cool, cinematic</span></span>
+            </button>
+            <button class="preset">
+              <span class="preset__bars"><i style="background:#14532d"></i><i style="background:#65a30d"></i><i style="background:#ecfccb"></i></span>
+              <span class="preset__meta"><span class="preset__name">Canopy</span><span class="preset__desc">Natural, calm</span></span>
+            </button>
+            <button class="preset">
+              <span class="preset__bars"><i style="background:#171717"></i><i style="background:#dc2626"></i><i style="background:#fafafa"></i></span>
+              <span class="preset__meta"><span class="preset__name">Monolith</span><span class="preset__desc">High-contrast, bold</span></span>
+            </button>
+          </div>
+
+          <div class="deeper">
+            <div><b style="font-size:var(--text-sm)">Want full control?</b><div class="tiny muted">Colours, type, shape, hero, per-component.</div></div>
+            <button class="btn btn--ghost" style="flex:none; padding:var(--s2) var(--s4)">Open full editor →</button>
+          </div>
+        </div>
+
+        <div class="guided__right">
+          <div class="splitlabel" style="text-align:left; color:var(--text-3)">Live preview · updates as you choose</div>
+          <div class="preview preview--mini" data-pv>
+            <div class="pv-hero">
+              <span class="pv-hero__eyebrow">Featured</span>
+              <h3 class="pv-hero__title">The Deep Field</h3>
+              <p class="pv-hero__desc">Scored live, in HDR.</p>
+              <div class="pv-hero__row">
+                <button class="pv-btn pv-btn--solid">▶ Play</button>
+                <button class="pv-btn pv-btn--glass">+ List</button>
+              </div>
+            </div>
+            <div class="pv-body">
+              <div class="pv-cards">
+                <div class="pv-card"><div class="pv-card__media"><span class="pv-card__badge">Ep 3</span></div><div class="pv-card__b"><div class="pv-card__t">Redshift</div></div></div>
+                <div class="pv-card"><div class="pv-card__media"></div><div class="pv-card__b"><div class="pv-card__t">Parallax</div></div></div>
+                <div class="pv-card"><div class="pv-card__media"></div><div class="pv-card__b"><div class="pv-card__t">Zenith</div></div></div>
+              </div>
+            </div>
+            <div class="pv-player">
+              <button class="pv-player__play">▶</button>
+              <span class="pv-player__t">12:04</span>
+              <span class="pv-player__bar"></span>
+            </div>
+          </div>
+          <p class="tiny muted">The preview uses your real content and the derived palette — what you approve is exactly what members see.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:var(--s6)">
+      <h3>Seed → complete palette (the v2 fix, shown)</h3>
+      <p style="margin:var(--s2) 0 var(--s3)">One seed colour generates several <b>complete</b> palettes via colour-theory strategies — primary + secondary + accent + background — as clickable options. No picking primary, then hunting for a secondary.</p>
+      <div class="seedwrap">
+        <span class="seedwrap__sw" data-seedsw></span>
+        <div class="stack" style="gap:2px"><b class="tiny">Seed colour</b><span class="mono tiny muted" data-hex>#c24129</span></div>
+        <div class="genrow" style="margin-top:0; flex:1">
+          <div class="genopt"><span class="genopt__bars" data-gen="comp"><i></i><i></i><i></i></span><span class="genopt__n">Complementary</span></div>
+          <div class="genopt"><span class="genopt__bars" data-gen="analog"><i></i><i></i><i></i></span><span class="genopt__n">Analogous</span></div>
+          <div class="genopt"><span class="genopt__bars" data-gen="triad"><i></i><i></i><i></i></span><span class="genopt__n">Triadic</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid cols-3" style="margin-top:var(--s6)">
+      <div class="note"><span class="note__n">1</span><span><b>Fast starts, not a form.</b> Preset, seed, or logo — each produces a full, coherent palette in one action.</span></div>
+      <div class="note"><span class="note__n">2</span><span><b>Progressive disclosure.</b> Depth is one click away via "Open full editor", never in the way of a quick, confident result.</span></div>
+      <div class="note"><span class="note__n">3</span><span><b>Preview from the first second.</b> The same live surface as every other concept — decisions are always seen, never guessed.</span></div>
+    </div>
+  </section>
+
+</main>
+
+<script>
+(function(){
+  var root=document.documentElement;
+  // theme toggle
+  var mq=window.matchMedia('(prefers-color-scheme: dark)');
+  function apply(t){
+    root.setAttribute('data-theme',t);
+    document.getElementById('themeIcon').textContent = t==='dark'?'☀':'☾';
+    document.getElementById('themeLbl').textContent = t==='dark'?'Light':'Dark';
+  }
+  apply(mq.matches?'dark':'light');
+  document.getElementById('themeBtn').addEventListener('click',function(){
+    apply(root.getAttribute('data-theme')==='dark'?'light':'dark');
+  });
+
+  // brand seed → re-theme all previews AND every var(--brand-color) consumer
+  var seed=document.getElementById('brandSeed');
+  function setBrand(hex){
+    // set on :root so rail swatches / icons using var(--brand-color) track too
+    root.style.setProperty('--brand-color',hex);
+    document.querySelectorAll('.preview').forEach(function(el){ el.style.setProperty('--brand-color',hex); });
+    // hex read-outs + seed swatch
+    document.querySelectorAll('[data-hex]').forEach(function(el){ el.textContent=hex; });
+    document.querySelectorAll('[data-seedsw]').forEach(function(el){ el.style.background=hex; });
+    // derived swatch strip(s)
+    document.querySelectorAll('[data-derive]').forEach(function(strip){
+      strip.querySelectorAll('i').forEach(function(i){
+        var t=i.getAttribute('data-t'); var v;
+        switch(t){
+          case 'p700': v='oklch(from '+hex+' calc(l - .15) c h)'; break;
+          case 'p600': v='oklch(from '+hex+' calc(l - .08) c h)'; break;
+          case 'p500': v=hex; break;
+          case 'p100': v='oklch(from '+hex+' .94 calc(c * .25) h)'; break;
+          case 'p50':  v='oklch(from '+hex+' .97 calc(c * .15) h)'; break;
+          case 'accent': v='var(--brand-accent)'; break;
+        }
+        i.style.background=v;
+      });
+    });
+    // Concept D — palette-generation strategies from the seed (hue rotations)
+    var strat={comp:[0,180,180],analog:[0,30,-30],triad:[0,120,240]};
+    document.querySelectorAll('[data-gen]').forEach(function(g){
+      var rot=strat[g.getAttribute('data-gen')]||[0,0,0];
+      var bars=g.querySelectorAll('i');
+      for(var j=0;j<bars.length;j++){
+        var lift=(j===2)?' calc(l + .12)':' l';
+        bars[j].style.background='oklch(from '+hex+lift+' c calc(h + '+rot[j]+'))';
+      }
+    });
+  }
+  seed.addEventListener('input',function(){ setBrand(seed.value); });
+  setBrand(seed.value);
+
+  // tabs
+  var tabs=Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function select(tab){
+    tabs.forEach(function(t){
+      var on=t===tab; t.setAttribute('aria-selected',on?'true':'false');
+      var panel=document.getElementById(t.getAttribute('aria-controls'));
+      panel.classList.toggle('is-active',on); panel.hidden=!on;
+    });
+    tab.focus({preventScroll:true});
+    window.scrollTo({top:0,behavior:'smooth'});
+  }
+  tabs.forEach(function(t){ t.addEventListener('click',function(){select(t);}); });
+  // number-key shortcuts
+  document.addEventListener('keydown',function(e){
+    if(e.target.matches('input,textarea')) return;
+    var i=parseInt(e.key,10);
+    if(i>=1 && i<=tabs.length){ select(tabs[i-1]); }
+  });
+})();
+</script>

--- a/docs/design/brand-editor-redesign-HANDOFF.md
+++ b/docs/design/brand-editor-redesign-HANDOFF.md
@@ -1,0 +1,46 @@
+# Brand Editor Redesign — implementation handoff
+
+> Zero-context continuation prompt for a **fresh session**. Paste the "Kickoff" block below into a new Claude Code session in this repo. Everything needed is already scoped, approved, and scaffolded.
+
+## Kickoff (paste this)
+
+> Run `codex-epic-implement` for epic **Codex-cijzb** ("Brand Editor Redesign — difficulty-dial workspace + token consumption"). The plan is approved at `~/.claude/plans/kind-painting-bird.md`; design research is in `docs/design/brand-editor-ux-investigation.md` + `docs/design/brand-editor-mockups.html` (view via LAN, never an artifact). Start Phase 0 — the two ready WPs `Codex-cijzb.1` (WP-0.1) and `Codex-cijzb.2` (WP-0.2). Base the epic branch `feat/Codex-cijzb-brand-editor-redesign` on **dev** (not main). Ship Phase 0 as its own PR, then Phase 1.
+
+## State at handoff (2026-07-19)
+
+- **Approved plan:** `~/.claude/plans/kind-painting-bird.md` (full context, data model, surfaces, WP table, verification).
+- **Beads:** epic `Codex-cijzb` + 10 WPs scaffolded with the dep chain wired. `.beads/` compacted (223 MB → 111 MB). Run `bd ready` — only `cijzb.1` + `cijzb.2` are unblocked.
+- **No code written yet.** This was scope + scaffold only.
+- **No DB migration** — Phase 0/1 add no columns; persistence (branding_settings + tokenOverrides/darkTokenOverrides/darkModeOverrides JSON) is reused unchanged.
+
+## WP map + dependency chain
+
+| WP | Bead | Ready? | Depends on |
+|---|---|---|---|
+| 0.1 Fix `--color-heading` reach + token cleanup | `cijzb.1` | ✅ ready | — |
+| 0.2 CI import-boundary guardrail | `cijzb.2` | ✅ ready | — |
+| 1.1 `/studio/brand` route + state | `cijzb.3` | blocked | 0.2 |
+| 1.2 CSP `frame-ancestors` relax (self) | `cijzb.4` | blocked | 1.1 |
+| 1.3 iframe live-preview canvas | `cijzb.5` | blocked | 1.2 |
+| 1.4 postMessage CSS-var bridge | `cijzb.6` | blocked | 1.3 |
+| 1.5 Control rail (difficulty-dial spine) | `cijzb.7` | blocked | 1.1 |
+| 1.6 Fold logo + hero-text into rail | `cijzb.8` | blocked | 1.5 |
+| 1.7 Guided (+ brand-from-logo) | `cijzb.9` | blocked | 1.5 |
+| 1.8 Verification | `cijzb.10` | blocked | 1.3–1.7 |
+
+## Locked decisions (do not re-litigate)
+
+- **One tool, difficulty dial:** Guided → Studio Canvas → per-component Inspector (**future, not this epic**).
+- **Live preview = real org routes in an iframe** on `/studio/brand`; edits applied via a **postMessage CSS-var bridge** (inert unless embedded same-origin). **Zero editor code in the customer bundle** — enforced by WP-0.2's CI grep gate.
+- **Full token-consumption pass**, but verified small: the ONLY genuine gap is `--color-heading` (a CSS **specificity** problem — class titles beat the `:is(h1..h6)` org-brand rule). Fix `.card-title` + `.cc__title` → `var(--color-heading, var(--color-text))`. Other knobs already wired; drop vestigial `--color-text-heading` + `--card-media-*`.
+- **Old UI retired:** `?brandEditor` overlay removed; old `studio/settings/branding` 301s to `/studio/brand`; logo + hero-text fold into the rail.
+- **Brand-from-logo** colour extraction is in Phase 1 (WP-1.7), client-side.
+- **CSP:** `svelte.config.js` `frame-ancestors 'none' → 'self'` (WP-1.2, security-reviewed). Same-origin confirmed — public + studio both on `{slug}.revelations.studio`.
+- **Brand editing stays admin/owner** (studio SPA admits creator+; add a page-level admin/owner guard on `/studio/brand`).
+
+## Gotchas
+
+- Base on **dev**, not main (main is a stale release pointer). `git fetch` + verify base before branching.
+- Reuse existing components: OKLCH picker, `FontPicker`, `BrandSliderField`, `LogoUpload`, `palette-generator`, and the 12 existing presets — don't rebuild.
+- Repo static analysis is **biome only** (no eslint/dep-cruiser); WP-0.2 is a CI grep step in `.github/workflows/static_analysis.yml`, not a lint rule.
+- Serve any preview to the user over LAN (`python3 -m http.server --bind 0.0.0.0`), never publish an artifact.

--- a/docs/design/brand-editor-ux-investigation.md
+++ b/docs/design/brand-editor-ux-investigation.md
@@ -1,0 +1,325 @@
+# Brand Editor — UX Investigation & Redesign Directions
+
+> Investigation date: 2026-07-18 · Scope: full chain (DB → service → validation → remote → SvelteKit layout → CSS derivation → editor UI → design system)
+> **Companion mockups:** [`brand-editor-mockups.html`](./brand-editor-mockups.html) — a self-contained, interactive file (4 concepts + a live OKLCH-derived preview). Published copy: <https://claude.ai/code/artifact/c8a5eda7-7899-4948-bbc8-57e7ead9c59a>
+
+## 0. TL;DR
+
+The brand editor sits on top of a **genuinely powerful derivation engine** — 7 raw inputs fan out into ~50 semantic design tokens via OKLCH relative color, with per-theme (light/dark) support and component-scoped tokens (player, cards, glass, hero) already wired. **The engine is not the problem. The UI that drives it is.**
+
+The current UI is a 360px floating glass panel with a modal-stack (back-button-only) drill-down across ~12 levels — one of which (Hero Effects) is a whole shader sub-application with dozens of presets × 5–8 sliders each. The three biggest UX failures:
+
+1. **The panel occludes the preview it exists to show**, and the preview is only ever the org *landing page* — you can't see your brand on grids, detail pages, the player, nav, or forms without navigating away (which trips the discard-guard).
+2. **Navigation is a stack with no map** — no breadcrumb trail, no overview, no search, no jump. Across 12 levels it is easy to lose your place.
+3. **The surface is enormous and undifferentiated** — foundational choices (colors, type, shape) sit in the same flat list as a 300-parameter shader lab, so the tool feels equally heavy for "just make it match my logo" and "tune the caustics refraction."
+
+This document maps the system end-to-end, catalogs the full editable surface, names the pain points with evidence, and proposes four UI directions (with working mockups). It also analyzes **per-component editing** as an extensibility target — which the token layer already supports, meaning it is a *UI-surface* problem, not an engine rebuild.
+
+---
+
+## 1. System architecture
+
+### 1.1 The four-layer CSS cascade
+
+Brand theming is a pure-CSS-variable cascade. Nothing re-renders; the browser re-resolves `var()`:
+
+```
+Layer 1  Token foundation      :root, 13 files in styles/tokens/     (--space-*, --radius-*, --text-*, --color-primary-*, …)
+   ↓ overridden by
+Layer 2  Theme                 [data-theme="light|dark"]             (semantic: --color-surface, --color-text, …)
+   ↓ overridden by
+Layer 3  Org branding          [data-org-brand] / [data-org-bg]      (OKLCH derivation from --brand-* inputs)
+   ↓ overridden by
+Layer 4  Inline JS injection   .org-layout style + el.setProperty()  (SSR bindings + live editor injection)
+```
+
+The engine lives in **`apps/web/src/lib/styles/tokens/org-brand.css`** (367 lines). It takes 7 raw inputs and derives the palette with CSS relative color:
+
+```css
+--color-interactive:        var(--brand-color, var(--color-primary-500));
+--color-interactive-hover:  oklch(from var(--brand-color) calc(l - 0.08) c h);
+--color-text-on-brand:      oklch(from var(--brand-color) clamp(0, (0.62 - l) * 1000, 1) 0 0); /* auto-contrast */
+```
+
+**Two activation gates**, so an unbranded org is untouched:
+- `[data-org-brand]` — color, shape (radius), density, fonts, and the component-scoped tokens. Active whenever the org has *any* branding.
+- `[data-org-bg]` — surface/text/border re-derivation. Active *only* when a background color is explicitly set (so most orgs keep the neutral theme surfaces).
+
+**Per-theme dark** (`Codex-wwedk`): dark values ride `--brand-*-dark` keys, read under `.dark [data-org-brand]`, `[data-theme=dark] [data-org-brand]`, and `[data-editing-theme=dark][data-org-brand]`. The last selector lets the **editor preview dark without mutating `<html data-theme>`** — a nice touch. Each dark token uses `var(--brand-x-dark, var(--brand-x))` so an unset dark value transparently inherits light.
+
+> **Engine caveat worth knowing (already documented):** ShaderHero reads `--brand-shader-*` via `getComputedStyle`, and the light values are injected *inline* on `.org-layout` (inline beats stylesheet). You cannot rebind `--brand-shader-x` in the dark gate (self-referential `var(--x-dark, var(--x))` cycle). The fix is a stylesheet-only sentinel `--brand-shader-is-dark: 1` that the JS reader honors. (`Codex-d0cr2`, PR #391.)
+
+### 1.2 The backend save/load chain
+
+*(Detail confirmed against the `/design-system` skill reference `references/10-brand-editor.md`, which documents 6 change-paths and the full file matrix.)*
+
+```
+SAVE:  editor store.pending ──$effect──▶ injectBrandVars()            (live preview, browser only)
+       Save click ─▶ updateBrandingCommand() (remote)
+                   ─▶ org-api PUT /settings/branding
+                   ─▶ BrandingSettingsService.update() (upsert branding_settings)
+                   ─▶ waitUntil: invalidate brand KV cache
+
+LOAD:  +layout.server.ts ─▶ api.org.getPublicInfo(slug)  [VersionedCache KV]
+                          ─▶ fetchPublicOrgInfo() (DB row → API shape)
+                          ─▶ +layout.svelte derives brandPrimary, heroHideFlags, fine-tune JSON…
+                          ─▶ inline style:--brand-* on .org-layout  +  injectTokenOverrides() ($effect)
+                          ─▶ org-brand.css [data-org-brand] rules activate → palette derived
+                          ─▶ components read var(--color-*) — no component code runs
+```
+
+Persistence is a single **`branding_settings`** row per org. Base fields (primary/secondary/accent/background hex, fontBody, fontHeading, radius, density, logoUrl) have dedicated columns; everything else (fine-tune tokens, shader params, hero flags, hero text colors) is serialized into two JSON columns: **`tokenOverrides`** (light) and **`darkTokenOverrides`** (dark), plus **`darkModeOverrides`** for the dark base *colors*.
+
+The full field-by-field contract, exact validation constraints, DB column table, and verified backend gaps are in §9.5. (Confirmed: the entire chain is **organization-api**, despite CLAUDE.md files attributing branding to identity-api.)
+
+### 1.3 How the editor mounts
+
+- Entry: **Studio → Settings → Branding** page renders a read-only brand summary + logo upload + hero-text form, and an **"Edit Brand Live"** button that does `goto('/?brandEditor=true')` — navigating to the org's **public landing page** with a URL param.
+- The org layout sees `?brandEditor`, reconstructs saved state from the server JSON, and **dynamically imports `BrandEditorMount.svelte`** (so normal visitors never download the editor JS — good perf hygiene).
+- Access is **admin/owner only** (role guard redirects otherwise).
+- The panel renders **outside `.org-layout`**, so its own chrome uses *system* tokens while the page behind it live-updates with *brand* tokens. Genuinely clever — but see §4.1.
+
+---
+
+## 2. The editable surface (full inventory)
+
+The state object (`BrandEditorState`) plus the token-override system expose an unusually large surface:
+
+| Group | What's editable | Storage |
+|---|---|---|
+| **Colors** | primary, secondary, accent, background (+ independent dark variants) | columns + `darkModeOverrides` |
+| **Typography** | body font, heading font (+ per-theme), text scale, heading weight, body weight, label text-transform | columns + `tokenOverrides` |
+| **Shape** | radius (drives the whole radius scale), density (drives the whole spacing scale) | columns |
+| **Shadows** | shadow scale (intensity), shadow color/tint (+ dark) | `tokenOverrides` |
+| **Logo** | upload/preview (R2), used in header + hero + shader logo texture | column |
+| **Header layout** | 10 hero layout variants + 5 element-visibility flags + hero logo scale | column (`heroLayout`) + `tokenOverrides` |
+| **Hero colors (fine-tune)** | hero text/muted/title color + blend mode, CTA bg/text, glass tint/text, border tint | `tokenOverrides` |
+| **Hero effects (shaders)** | preset selection + per-preset params — **40 presets, ~215 tunable controls** (3 shared + ~5–6 per preset; `hero-fx-presets.ts` is 2,961 lines) | `tokenOverrides` (`shader-*`) |
+| **Intro video** | upload a hero background video | (media) |
+| **Player chrome** | player text/surface/border/overlay tokens (+ dark) — *component-scoped* | `tokenOverrides` (`player-*`) |
+| **Cards** | hover scale, image hover scale, media scrim/glyph — *component-scoped* | `tokenOverrides` (`card-*`) |
+| **Glass** | glass tint (+ dark) | `tokenOverrides` (`glass-tint`) |
+| **Presets** | apply a full bundled design system (colors + tokens + hero layout) | — |
+
+**Key structural fact:** the override system already splits into two prefix families in `css-injection.ts`:
+- `BRAND_PREFIX_KEYS` → emitted as `--brand-{key}` (consumed by `org-brand.css` rules or `getComputedStyle`).
+- everything else → `--color-{key}` (direct semantic-token replacement).
+
+This is the mechanism that makes **per-component theming already possible** (player, cards, glass, hero are all component-scoped token groups). See §7.
+
+---
+
+## 3. Information architecture (current)
+
+`levels.ts` defines a 3-depth tree, surfaced by `BrandEditorHome.svelte` grouped into labeled sections:
+
+```
+Home (depth 0)  "Brand Editor"
+├─ Colors ▸  (+ Fine-tune Colors, depth 2)         [primary row + swatches]
+├─ Generate Palette  (inline expander → palette swatch grid)
+├─ Hero:        Header Layout ▸ · Hero Effects ▸ · Intro Video ▸
+├─ Customize:   Typography ▸ (+ Fine-tune Typography) · Shape & Spacing ▸
+├─ Advanced:    Shadows ▸ · Logo ▸
+└─ Browse Presets ▸
+```
+
+Navigation is a **stack**: `navigateTo(level)` pushes, `navigateBack()` pops to `parent`. The header shows only a back-arrow + the current level's label. There is **no breadcrumb trail, no overview, no search, no direct jump** between sibling levels — to go Colors → Typography you must go back to Home first.
+
+Control vocabulary is consistent and clean:
+- **Row buttons** (icon + name + description + chevron) for navigation.
+- **`ControlField`** — a manifest-driven dispatcher rendering a slider / native color input / toggle switch (this replaced 41 hand-written per-preset blocks — good refactor).
+- **`BrandSliderField`** — label + mono value read-out + range + min/max hint labels.
+- **OKLCH color picker** (custom, no dependency) for the color levels.
+- **`FontPicker`** for typography.
+
+Footer is global: **Reset** (discards *all* pending) + an "Unsaved" dot + **Save**. Minimized state collapses to a compact bottom-right pill with a Save shortcut.
+
+---
+
+## 4. UX pain points (evidence-based)
+
+### 4.1 The panel occludes the preview — and the preview is only the landing page
+The panel is `position: fixed; bottom/right; width: min(360px, …)` over `.org-layout`. On a laptop it covers ~25–30% of the viewport — exactly the region you're trying to evaluate. Worse, "Edit Brand Live" only ever lands you on `/` (the landing). Brand tokens theme the **entire** org surface — content grids, detail pages, the video player (`--color-player-*`), nav, forms — but there is **no way to preview those** without navigating away, and navigating away while dirty triggers the discard-confirmation. So the tool asks you to commit to changes you can only partially see.
+
+### 4.2 Navigation is a stack with no map
+Back-button-only across 12 levels. No breadcrumb, no "where am I," no search, no sibling-jump. The `getBreadcrumb()` helper *exists* in `levels.ts` but the header renders only parent-back + title. Deep spots (Fine-tune Colors, a specific shader's params) are 2–3 pops from anywhere else.
+
+### 4.3 One panel, wildly different task weights
+Choosing a brand colour and tuning `shader-caustic-refraction` are the same 360px column. The **Hero Effects** level alone is a shader lab: **40 presets and ~215 tunable controls** (`hero-fx-presets.ts` is 2,961 lines), presented as a **text-only 2-column grid of 40 tiny cards** — no thumbnails, no search/filter — with a generic `ControlField` slider/colour/toggle stack appended below the active preset. It shares an information hierarchy with "upload your logo." There is no separation between **"make it look right in 60 seconds"** and **"tune every parameter"** — and the shader grid, the single densest surface, has no visual preview on the tiles themselves.
+
+### 4.4 Weak visual payoff (user-reported, v2 testing)
+Direct user feedback from v2 testing (captured in project memory): *"changes don't make enough of a visual difference … branding tokens aren't consumed broadly enough across components."* The engine has since grown "blind-spot fix" derivations and forces `.content-card` shadows + heading colors, but the breadth of brand-token consumption across product components is the gating factor for perceived impact.
+
+The measured census (§9.3) makes this concrete: the *spine* is broadly wired (`--color-text*` 233 files, `--radius-*` 223, `--color-interactive` 129), but the editor's fine-tune knobs are near-dead — **`--color-heading` has 0 consumers**, `--card-hover-scale` 1, `--media-scrim` 3, `--font-body` 8. The editor exposes more knobs than the component layer reads; that gap *is* the weak-payoff bug.
+
+### 4.5 All-or-nothing save; no change summary; no history
+Reset discards everything; there's no per-field revert affordance in the footer, no "here's what you changed" summary before saving, and no undo/redo. For a tool where one slider can shift the whole page, the absence of a change ledger is a confidence problem.
+
+### 4.6 Editing is split across two surfaces
+Logo upload and hero-text (org name + description) live on the **static settings page**; everything else lives in the **live editor**. So a first-time admin edits brand identity in two disconnected places with two mental models.
+
+### 4.7 Discoverability of depth
+Fine-tune panels, per-component tokens (player/cards/glass), and the 10 hero layouts are real power, but they're buried behind generic rows ("Advanced", "Fine-tune"). Nothing communicates the *range* of what's possible, so most admins likely never find it.
+
+---
+
+## 5. Design principles for a redesign
+
+1. **The preview is the product.** The live org surface should be the largest thing on screen; controls serve it, never cover it.
+2. **Preview must span the surface.** Let the admin flip the preview between Landing / Grid / Detail / Player / Nav, across light+dark, at desktop/tablet/mobile — because the brand touches all of them.
+3. **Always show the map.** A persistent, navigable structure (breadcrumb or tree) so you always know where you are and can jump anywhere.
+4. **Separate "fast" from "deep."** A 60-second happy path (preset or seed-color → full palette → done) distinct from progressive-disclosure power controls.
+5. **Make impact obvious.** Surface the component families that respond to each control ("this affects: buttons, cards, player, focus rings") so changes feel consequential.
+6. **Give changes a ledger.** A visible summary of pending edits with per-field revert; save is deliberate, not a leap.
+7. **Design for per-component editing now, even if you build it later.** The token model already supports it; the IA should have a natural home for it (see §7).
+
+---
+
+## 6. Four UI directions (see mockups)
+
+| # | Direction | Core move | Best for | Risk |
+|---|---|---|---|---|
+| **A** | **Refined Panel** | Keep the floating panel; add breadcrumb, search, section overview, per-field reset, side-dock to reduce occlusion, change-summary drawer | Shipping an improvement fast without re-architecting | Low |
+| **B** | **Studio Canvas** ⭐ | A dedicated workspace: left control rail + **large live-preview canvas** with route / device / theme switchers | The primary near-term target — fixes occlusion + preview-scope + navigation together | Medium |
+| **C** | **Inspector** ⭐ | Three-pane Figma/Framer model: navigable **tree** (Foundations → Surfaces → Components) → canvas → **contextual inspector**; click any element in the canvas to edit its tokens | The per-component-editing future, grounded in existing tokens | Higher |
+| **D** | **Guided / Presets-first** | Progressive disclosure: preset gallery + seed-color→full-palette + "brand from logo", then "go deeper" reveals | First-run and non-designer admins | Low |
+
+Recommendation: **B for the next iteration, evolving toward C.** A and D are patterns that can fold into either. B and C share the same spine (rail/tree + canvas), so B can be built such that C is an additive step, not a rewrite.
+
+---
+
+## 7. Per-component editing — extensibility analysis
+
+The user asked to *consider* per-component editing "at one point but not now." The important finding: **the hard part is already done.**
+
+- The override system already carries **component-scoped token groups**: `player-*`, `card-*` (hover scales), `glass-tint`, `media-scrim/glyph`, `heading-color`, and the full `hero-*` family. These are honored by `org-brand.css` today.
+- Adding a new component-scoped group is a **Path B** change in the skill's taxonomy: add the key's prefix in `css-injection.ts`, add a `var(--brand-x, fallback)` rule in `org-brand.css`, add a control. **No DB migration, no service change.**
+- So per-component editing is fundamentally a **UI-surface + IA problem**, not an engine rebuild. The blocker is that the flat level list has nowhere to express "Components → ContentCard → these tokens."
+
+What it would take (future, not now):
+1. **A component registry** mapping a component (Button, ContentCard, Nav, Player, Hero, Form) → the set of override keys it honors → sensible controls + safe ranges.
+2. **A tree/inspector IA** (Concept C) so "Components" is a first-class branch alongside "Foundations."
+3. **Canvas element selection** — click a card in the preview to open its inspector (needs a lightweight `data-brand-component` annotation on component roots).
+4. Guardrails: per-component overrides should *layer on* the derived palette (never fork it), and every override needs a visible reset-to-derived.
+
+Concept C's mockup shows this end-state so the near-term IA can be built toward it.
+
+---
+
+## 8. Tech-debt observed during the investigation
+
+Not blockers for a UX redesign, but worth logging. (Verified against current code — several claims in the older `/design-system` skill doc have since been resolved, noted below.)
+
+- **`--color-heading` has zero consumers** (§9.3) — the highest-value, lowest-effort fix: the editor writes a heading colour the page never reads. Wire it.
+- **Doc drift (attribution):** `apps/web/CLAUDE.md` and `packages/platform-settings/CLAUDE.md` say identity-api owns branding; it's entirely **organization-api** (§9.5).
+- **Skill doc path drift** — `references/10-brand-editor.md` cites `apps/web/src/lib/theme/tokens/org-brand.css`; the file is at `apps/web/src/lib/styles/tokens/org-brand.css`.
+- **Stringly-typed fine-tune** — all fine-tune keys live in `text` JSON columns, contract enforced only by the client injector (§9.5). *(Note: the earlier "base fields double-written to columns + JSON" debt is largely resolved — the 6 broken-out fine-tune columns were backfilled in migration `0059` and dropped in `0060`; JSON is now the single source of truth.)*
+- **`heroLayout` now has a single source** — `HERO_LAYOUTS` in `@codex/validation`, consumed by both the validation and remote command schemas, so the old "triplication" (`Codex-a4zc`) is substantially resolved; verify whether the inline union cast in `BrandEditorMount.svelte` still lingers. But the **read** path types it as free `z.string()` (§9.5) — worth tightening.
+- **`applyPreset` merge semantics** — already fixed to spread-merge (`Codex-oqv3r`); any redesigned preset flow must preserve it.
+- **Settings/editor split** (§4.6) — logo + hero-text on the settings page vs. the live editor; consolidating is partly a data-ownership decision, not just UI.
+
+See §9.5 for the full verified gap list (strings-for-numbers, `pricingFaq` public-path gap, redundant schema pipe).
+
+---
+
+## 9. Backend contract & consumption coverage
+
+### 9.1 Save contract — `updateBrandingCommand`
+
+The editor's Save calls `updateBrandingCommand` (`apps/web/src/lib/remote/branding.remote.ts`) with these fields (confirmed against `BrandEditorMount.svelte` `handleSave()`):
+
+| Field | Type | Source in editor | Persistence |
+|---|---|---|---|
+| `orgId` | string | store.orgId | scope key |
+| `primaryColorHex` | hex string | colours | column |
+| `secondaryColorHex` | hex / `''` | colours (`''` clears) | column |
+| `accentColorHex` | hex / `''` | colours | column |
+| `backgroundColorHex` | hex / `''` | colours | column |
+| `fontBody` | string / `''` | typography | column |
+| `fontHeading` | string / `''` | typography | column |
+| `radiusValue` | number | shape | column |
+| `densityValue` | number | shape | column |
+| `tokenOverrides` | JSON string / `''` | all fine-tune + hero + shader + component keys (light) | `tokenOverrides` JSON column |
+| `darkModeOverrides` | JSON string / `''` | dark base *colours* | `darkModeOverrides` column |
+| `darkTokenOverrides` | JSON string / `''` | dark fine-tune/token keys | `darkTokenOverrides` JSON column |
+| `heroLayout` | enum | header-layout | column |
+
+Empty string is the explicit "clear this" signal (the worker nulls the column); an absent/empty JSON map clears the override column. After save, `invalidate('cache:org-versions')` re-runs the org layout load so the change appears without a manual reload (`Codex-7afgp` + synchronous KV invalidation `Codex-ja9zp`).
+
+### 9.2 The chain, by file (per `/design-system` skill `references/10-brand-editor.md`)
+
+```
+validation   packages/validation/src/schemas/settings.ts   → updateBrandingSchema, DEFAULT_BRANDING, heroLayout enum
+service      packages/platform-settings/.../branding-settings-service.ts → fieldMap, mapRow, upsert
+worker       workers/organization-api/src/routes/organizations.ts → fetchPublicOrgInfo() (DB row → public API shape)
+db           packages/database/src/schema/settings.ts       → brandingSettings table
+types        packages/shared-types/src/api-responses.ts      → BrandingSettingsResponse, PublicBrandingResponse
+load         apps/web/.../_org/[slug]/+layout.server.ts → +layout.svelte  → inline style:--brand-* + injectTokenOverrides()
+```
+
+`branding_settings` is one row per org: dedicated columns for the base fields above, plus JSON columns `tokenOverrides` / `darkTokenOverrides` / `darkModeOverrides`. Migrations of note: `0059_backfill_branding_token_overrides.sql` (backfilled dropped fine-tune columns into the JSON — the JSON is now the sole source of truth per `Codex-g49b4`), and `0061`.
+
+Auth: the settings page and update endpoint are **admin/owner-gated**; the public read path (`fetchPublicOrgInfo`) is unauthenticated and KV-cached (`VersionedCache`), which is why a save must invalidate the org-versions cache to surface immediately.
+
+### 9.3 Brand-token consumption coverage — measured census
+
+*This is the crux of the "changes don't make enough visual difference" complaint (§4.4). Grep census over `lib/components` + `routes` (`.svelte`/`.css`/`.ts`), file counts:*
+
+**Well-wired — the brand spine works:**
+
+| Token | Files | |
+|---|---:|---|
+| `--color-text*` | 233 | body/heading text |
+| `--radius-*` | 223 | shape scale (from `--brand-radius`) |
+| `--color-surface*` | 196 | surfaces |
+| `--color-interactive` | 129 | buttons, links, active, focus |
+| `--font-heading` | 74 | heading *family* |
+| `--shadow-*` | 66 | elevation |
+| `--color-brand-*` | 46 | brand accents |
+
+**Thin — brand knobs barely reach the page:**
+
+| Token | Files | |
+|---|---:|---|
+| `--color-player-*` | 15 | player chrome |
+| `--font-body` | **8** | body *family* |
+| `--material-*` | 4 | glass |
+| `--media-scrim` | 3 | card media cover |
+| `--card-hover-scale` | **1** | card hover |
+
+**Defined by the editor, read by NOTHING (dead knobs):** `--color-heading` → **0** · `--color-text-heading` → 0 · `--card-media-*` → 0.
+
+**The smoking gun.** `org-brand.css` defines `--color-heading` (a heading-*colour* override the editor writes) but **nothing reads it** — headings resolve their colour from `--color-text` (233 files) and use `--font-heading` only for the *family* (74 files). So **editing heading colour in the editor is literally invisible.** Body-font changes reach only 8 files; card hover-scale 1; media-scrim 3. The derivation engine (and the editor UI) *over-produce knobs relative to what the component layer consumes* — that gap is the concrete mechanism behind "changes don't show." (Note: `--brand-*` at 0 consumers is expected — those are OKLCH *inputs*; product reads the *derived* `--color-interactive` / `--color-brand-*`.)
+
+This corroborates the open beads found in the docs (§9.4): `Codex-g49b4` (6 write-orphaned columns — since backfilled into JSON and dropped), `Codex-mdg94` (audit whether fine-tune values actually route to `tokenOverrides`), and `Codex-wcwpw` (token-override FOUC — shader/CSS-var keys arrive post-hydration).
+
+**Family wiring (qualitative):** Button — well-wired (`--color-interactive`). ContentCard — reads brand + media-cover tokens, but those are the *narrow* ones. Hero/Shader — the richest brand surface. Forms (~11 files), Player (6), Footer — wired. Nav (~4 files) — partial.
+
+**Implication for the redesign:** the "Affects: buttons · cards · player · focus rings" chips in Concepts B/C are not decoration — they set honest expectations about which surfaces a control actually moves, *and* double as a punch-list for closing the consumption gap. Two of the highest-leverage fixes are trivial: **wire `--color-heading`** (make headings read it) and either **encourage a background colour** or derive a subtle brand-tinted surface even without one (today, with no explicit bg, the `[data-org-bg]` gate stays off and the largest surfaces keep the neutral theme).
+
+### 9.4 Remaining level components (control inventory)
+
+From `levels/`: **Colours** (an `OklchColorPicker` per role — primary/secondary/accent/background — with add/remove/clear) → **Fine-tune Colours** (568 lines, the largest level — per-token pickers in collapsible accordion groups, incl. a segmented "Adaptive | Light | Custom" blend-mode control for hero-title colour). **Typography** (body/heading `FontPicker` — 492-line searchable dropdown with `IntersectionObserver` lazy font-loading) → **Fine-tune Typography** (text-scale slider; weight sliders historically no-op — see below). **Shape** (radius + density sliders). **Shadows** (intensity slider + tint `ColorInput`). **Logo** (upload/preview). **Header Layout** (10 layout variants + per-element visibility toggles + logo-scale slider). **Hero Effects** — see §4.3, the dominant surface. **Intro Video** (multi-phase upload→transcode→preview). **Presets** (gallery grouped by category; `applyPreset` spread-merges so user fine-tunes survive — `Codex-oqv3r`).
+
+The colour picker is a custom OKLCH stack (no dependency): `OklchColorArea` (2D L/C canvas), `HueSlider`, `ColorInput` (hex), `SwatchRow`, composed by `OklchColorPicker`.
+
+### 9.5 Exact save contract, constraints & verified backend gaps
+
+*From a full trace of the save/load chain. The entire chain is **organization-api** — not identity-api.*
+
+**Route & auth:** `PUT /api/organizations/:id/settings/branding` (`workers/organization-api/src/routes/settings.ts`), `policy:{ auth:'required', requireOrgManagement:true }` (owner/admin). Server-of-record schema: `updateBrandingSchema` (`packages/validation/src/schemas/settings.ts`).
+
+**Constraints:** hex `#RRGGBB` (uppercased); font names ≤50 chars; `radiusValue` 0–2; `densityValue` 0.75–1.25; `heroLayout` ∈ `HERO_LAYOUTS` (a single exported const — `default, centered, logo-hero, minimal, split, magazine, asymmetric, portrait, gallery, stacked`); `DEFAULT_BRANDING` primary `#3B82F6`, radius 0.5, density 1. Primary colour is **NOT NULL**; empty-string on any other field clears it.
+
+**Service:** `BrandingSettingsService.update()` (`packages/platform-settings`) does a **partial upsert** — only fields `!== undefined` are written, spread into *both* `values()` and the `onConflictDoUpdate` set, so omitted fields are never nulled. Cache invalidation is deliberately dual: the slug-keyed `ORG_CONFIG:{slug}` content cache is invalidated **inline/awaited** (fixes a save→reload race, `Codex-ja9zp`); the `orgId` version is bumped fire-and-forget for client staleness.
+
+**Load:** the page reads branding via the **public, unauthenticated** endpoint `GET /public/:slug/info` (`fetchPublicOrgInfo`), wrapped in a 30-min slug-keyed `VersionedCache` (`CacheType.ORG_CONFIG`). All three JSON blobs (`tokenOverrides`, `darkModeOverrides`, `darkTokenOverrides`) confirmed to propagate through this path into `data.org.brandFineTune`.
+
+**Verified gaps / tech-debt (fresh, not from the skill doc):**
+1. **Doc drift — branding is organization-api, but `apps/web/CLAUDE.md` and `packages/platform-settings/CLAUDE.md` attribute it to identity-api.** identity-api has no branding code. Actionable one-line doc fix.
+2. **`radius_value` / `density_value` are stored as `varchar(10)` strings** — no DB numeric/range guarantee; ranges enforced only by Zod at the edge, then coerced back to number on read.
+3. **`heroLayout` is read unvalidated** — the response types it as free `z.string()`, not the `HERO_LAYOUTS` enum, so a stored garbage value passes straight to the client.
+4. **`pricingFaq` is validated + persisted but absent from the public read path** and not settable from the brand-editor command schema — a silent split between the two "branding" shapes (also `introVideoMediaItemId` is in the authed shape but dropped from public).
+5. **Fine-tune is a stringly-typed JSON bag** — since `Codex-g49b4`, all fine-tune keys live in `token_overrides` / `dark_token_overrides` `text` columns; the key contract (heading-color, shadow-scale, text-scale, weights, shader preset, hero-hide flags) is enforced only by the client injector + a migration comment, not by validation or the DB.
+6. **Redundant `brandingSettingsSchema` `.pipe()`** — the 16-field object is declared twice with no meaningful transform.
+


### PR DESCRIPTION
## Summary
Phase 0 (foundation) of the **Brand Editor Redesign** epic (`Codex-cijzb`). Lands the token-consumption fix + isolation guardrail that the UI redesign (Phase 1) depends on: no UI redesign has payoff until the product actually *reads* the brand tokens, and no new route may leak editor code into the customer bundle.

- **Base:** `dev`. **Draft** — full human review at the end of the epic on desktop.
- **Phase 1** (the `/studio/brand` workspace) stacks on this branch.
- Also includes the epic's design research (investigation + interactive mockups + zero-context handoff) as a docs baseline commit.

### WP-0.1 — `--color-heading` reach + token-consumer guard
"Heading Color" was invisible: class-based titles (`.cc__title`, `.card-title`) outrank the `[data-org-brand] :is(h1..h6)` rule — a **specificity** problem, not a broken chain. Now those titles consume `var(--color-heading, var(--color-text))`, plus a scoped class-based backstop in `org-brand.css` for future title classes. The `--media-glyph` title-in-cover override at (0,3,0) still wins, so titles over cover art keep their ink. New guard test derives the editor-writable token set from `css-injection` config and asserts every derived token has ≥1 consumer (proven can-fail).

### WP-0.2 — CI import-boundary guardrail
New dependency-free `apps/web/scripts/check-brand-editor-boundary.mjs` fails CI if any public (non-`studio`) route **statically** imports `$lib/components/brand-editor/*` — which would bundle the heavy editor into the customer chunk. Allows the dynamic `import()` lazy-chunk pattern and the `$lib/brand-editor` store/helpers. Wired into `static_analysis.yml`.

## Test Plan
- `pnpm --filter web typecheck` — green.
- Guard test `writable-token-consumers.test.ts` — 4/4 (proven it fails if a token loses its consumer).
- Boundary gate — exit 0 clean (107 public files); exit 1 on a planted public violation; an identical studio-route import correctly **not** flagged.
- brand-editor suite 43/43; Card/ContentCard/TopicCard component tests 43/43.
- `svelte-autofixer` clean on changed `.svelte`.

## Notes
- No DB migration (Phase 0/1 add no columns).
- Token cleanup (`--color-text-heading`, `--card-media-*`) was a verified no-op — those tokens don't exist on `dev` (phantoms from an unrelated in-flight card branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
