### PR TITLE
Homogenise browse-grid cards (Codex-p7wc8): 3:4 title-in-cover + per-type flair

### DIFF
--- a/apps/web/src/lib/components/library/LibraryPageView.svelte
+++ b/apps/web/src/lib/components/library/LibraryPageView.svelte
@@ -224,6 +224,7 @@
           <ContentCard
             variant={viewMode === 'list' ? 'list' : 'grid'}
             shape={viewMode === 'list' ? undefined : '3:4'}
+            titleInCover={viewMode === 'list' ? undefined : true}
             chrome="transparent"
             id={item.content.id}
             title={item.content.title}

--- a/apps/web/src/lib/components/library/LibraryPageView.svelte
+++ b/apps/web/src/lib/components/library/LibraryPageView.svelte
@@ -223,7 +223,7 @@
           {@const access = stateForItem(item)}
           <ContentCard
             variant={viewMode === 'list' ? 'list' : 'grid'}
-            shape={viewMode === 'list' ? undefined : '1:1'}
+            shape={viewMode === 'list' ? undefined : '3:4'}
             chrome="transparent"
             id={item.content.id}
             title={item.content.title}

--- a/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
+++ b/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
@@ -262,18 +262,33 @@
   const isArticle = $derived(contentType === 'article');
 
   // Resolved media shape. `normalizeRatio` is a deprecated alias for
-  // `shape='16:9'`; an explicit `shape` always wins.
+  // `shape='16:9'`; an explicit `shape` always wins. Homogenised browse grid
+  // (Codex-p7wc8): every grid tile defaults to a 3:4 portrait cover so
+  // audio/video/article share one shape and one editorial treatment.
+  // list/compact/resume/featured and audio-row keep their own ratios.
   const resolvedShape = $derived<'16:9' | '1:1' | '3:4' | '3:2' | undefined>(
-    shape ?? (normalizeRatio ? '16:9' : undefined),
+    shape ??
+      (normalizeRatio
+        ? '16:9'
+        : variant === 'grid' && !isAudioRow
+          ? '3:4'
+          : undefined),
   );
 
-  // Article title-in-cover overlay. Explicit `titleInCover` wins; otherwise
-  // AUTO — on for article cards in a portrait/square shape (matches the
-  // approved mockup, where shaped article sections render title-in-cover).
+  // Title-in-cover is now the shared treatment for EVERY portrait/square grid
+  // tile, not just articles: the eyebrow + title sit over the cover on a
+  // scrim, each type carrying its own flair (audio waveform, video play-ring,
+  // article dropcap). Explicit `titleInCover` wins; audio-row keeps its
+  // playlist layout. (Codex-p7wc8)
   const showTitleInCover = $derived(
     titleInCover ??
-      (isArticle && (resolvedShape === '1:1' || resolvedShape === '3:4')),
+      (!isAudioRow &&
+        (resolvedShape === '1:1' || resolvedShape === '3:4')),
   );
+
+  // First letter of the title — the imageless cover renders it as a ghosted
+  // serif dropcap flair for articles (the type's signature). (Codex-p7wc8)
+  const coverInitial = $derived((title ?? '').trim().charAt(0).toUpperCase());
 
   // Audio grid/featured tiles ALWAYS read as audio: the cover image (or a
   // brand-gradient fallback) sits BEHIND a decorative waveform + a centred
@@ -281,9 +296,14 @@
   // compact `cc--audio-row` playlist layout keeps its own treatment, so
   // this is gated to the vertical grid/featured tiles only. Decorative /
   // navigational only — the whole card is already a link.
+  // Audio's old grid overlay (waveform + play glyph with metadata BELOW) is
+  // now superseded by the title-in-cover flair on grid tiles — so it only
+  // remains for the `featured` hero variant, which isn't title-in-cover yet.
+  // (Codex-p7wc8)
   const showAudioMedia = $derived(
     contentType === 'audio' &&
       !isAudioRow &&
+      !showTitleInCover &&
       (variant === 'grid' || variant === 'featured'),
   );
 
@@ -296,8 +316,14 @@
   // stacked creator row/avatar is suppressed to avoid duplication. Articles
   // render a compact text byline in the meta row, so we suppress the avatar
   // row there too.
+  // In-body creator row (avatar + name under the title). Suppressed for
+  // title-in-cover tiles — those carry the byline in the below-cover caption
+  // instead, so it isn't duplicated. (Codex-p7wc8)
   const showCreator = $derived(
-    (variant === 'grid' || variant === 'featured') && !isAudioRow && !isArticle
+    (variant === 'grid' || variant === 'featured') &&
+      !isAudioRow &&
+      !isArticle &&
+      !showTitleInCover
   );
   // Description lives under the title in vertical tiles. For audio-row the
   // waveform + meta already fill that slot. Articles are text-led and
@@ -307,6 +333,21 @@
     !!description && !isAudioRow && !showTitleInCover &&
     (variant === 'featured' || variant === 'grid' || isArticle)
   );
+
+  // Cover excerpt — a short preview under the title INSIDE the scrim, for any
+  // title-in-cover tile (generalises the old article-only cover excerpt so
+  // audio/video tiles read as content too). (Codex-p7wc8)
+  const coverExcerpt = $derived.by(() => {
+    if (!showTitleInCover || !description) return '';
+    const plain = extractPlainText(description);
+    return plain.length > 120 ? plain.slice(0, 117).trimEnd() + '…' : plain;
+  });
+
+  // Below-cover caption (avatar + creator name) for every title-in-cover
+  // tile, giving audio/video the same media-plus-byline baseline articles
+  // already had. (Codex-p7wc8)
+  const captionName = $derived(creator?.displayName ?? creator?.username ?? '');
+  const showCaption = $derived(showTitleInCover && !!captionName);
   const showPriceBadge = $derived(
     variant !== 'compact' && variant !== 'resume' &&
     (price != null || purchased || included || contentAccessType != null)
@@ -360,9 +401,6 @@
   //                         as video/audio tiles and aligns in mixed rows.
   const showArticleMeta = $derived(
     isArticle && !showTitleInCover && (!!articleByline || !!articleReadTime)
-  );
-  const showArticleCaption = $derived(
-    isArticle && showTitleInCover && (!!articleByline || !!articleReadTime)
   );
 
   // ── Media-type kind-line ─────────────────────────────────────────────
@@ -426,7 +464,7 @@
   class:cc--access-dimmed={isDimmed}
   class:cc--audio-row={isAudioRow}
   class:cc--title-in-cover={showTitleInCover}
-  class:cc--article-captioned={showArticleCaption}
+  class:cc--article-captioned={showCaption}
   class:cc--featured-item={showFeaturedTreatment}
   data-variant={variant}
   data-layout={resolvedLayout !== 'default' ? resolvedLayout : undefined}
@@ -453,7 +491,39 @@
       class:cc__thumb--featured={showFeaturedTreatment}
       class:cc__thumb--audio-media={showAudioMedia}
     >
-      {#if showAudioMedia}
+      {#if showTitleInCover}
+        <!-- Title-in-cover (all types): the cover is the uploaded image or a
+             shared brand-gradient fallback, with a per-type FLAIR layer
+             (audio → waveform + play disc, video → play-ring, article →
+             ghosted serif dropcap) sitting behind the scrimmed title. The
+             flair is decorative/navigational — the whole card is the link.
+             (Codex-p7wc8) -->
+        {#if thumbnail}
+          <img
+            src={thumbnail}
+            srcset={getThumbnailSrcset(thumbnail)}
+            sizes={DEFAULT_SIZES}
+            alt={m.content_thumbnail_alt({ title })}
+            loading="lazy"
+            decoding="async"
+            class="cc__image"
+            onerror={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; (e.currentTarget as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }}
+          />
+          <div class="cc__cover cc__cover--brand hidden"></div>
+        {:else}
+          <div class="cc__cover cc__cover--brand"></div>
+        {/if}
+        <div class="cc__flair" aria-hidden="true">
+          {#if contentType === 'audio'}
+            <AudioWaveform {id} bars={40} class="cc__flair-wave" />
+            <span class="cc__flair-disc"><PlayIcon size={26} /></span>
+          {:else if contentType === 'video'}
+            <span class="cc__flair-ring"><PlayIcon size={26} /></span>
+          {:else if contentType === 'article' && !thumbnail}
+            <span class="cc__flair-dropcap">{coverInitial}</span>
+          {/if}
+        </div>
+      {:else if showAudioMedia}
         <!-- Audio grid/featured tile: cover image (or brand-gradient
              fallback) BEHIND a decorative waveform + centred play glyph, so
              audio never masquerades as a silent video tile. The waveform
@@ -510,11 +580,6 @@
             <FileTextIcon size={32} />
           {/if}
         </div>
-      {:else if showTitleInCover}
-        <!-- Title-in-cover with no image: a brand-tinted gradient cover
-             stands in for the photograph. The eyebrow + title render over
-             it via the scrimmed overlay body — no placeholder icon needed. -->
-        <div class="cc__cover cc__cover--article"></div>
       {:else}
         <div class="cc__placeholder">
           {#if contentType === 'video'}
@@ -624,11 +689,11 @@
         <a href={href}>{title}</a>
       </h3>
 
-      {#if showTitleInCover && articleExcerpt}
-        <!-- Cover excerpt — a short preview inside the scrim, under the title.
-             Only for title-in-cover articles; the regular excerpt (below) is
-             suppressed when the title lives in the cover. -->
-        <p class="cc__cover-excerpt">{articleExcerpt}</p>
+      {#if coverExcerpt}
+        <!-- Cover excerpt — a short preview inside the scrim, under the title,
+             for any title-in-cover tile. The regular excerpt (below) is
+             suppressed when the title lives in the cover. (Codex-p7wc8) -->
+        <p class="cc__cover-excerpt">{coverExcerpt}</p>
       {/if}
 
       {#if isAudioRow}
@@ -708,26 +773,21 @@
       {/if}
     </div>
 
-    {#if showArticleCaption}
-      <!-- Below-media caption for title-in-cover articles. The title lives
-           INSIDE the cover; this row carries the author avatar/name +
-           read-time UNDER the media, giving article cards the same
-           media-plus-caption baseline as video/audio tiles so mixed rows
-           align. Title is NOT repeated here. -->
+    {#if showCaption}
+      <!-- Below-cover caption for every title-in-cover tile: author avatar +
+           name (+ read-time for articles) UNDER the media, so audio/video get
+           the same media-plus-byline baseline articles already had. The title
+           lives INSIDE the cover and is NOT repeated here. (Codex-p7wc8) -->
       <div class="cc__article-caption">
-        {#if articleByline}
-          <a href={profileHref} class="cc__creator-link">
-            <Avatar src={creator?.avatar} class="cc__creator-avatar">
-              <AvatarImage src={creator?.avatar} alt={articleByline} />
-              <AvatarFallback>{articleByline.charAt(0).toUpperCase()}</AvatarFallback>
-            </Avatar>
-            <span class="cc__creator-name">{articleByline}</span>
-          </a>
-        {/if}
-        {#if articleByline && articleReadTime}
+        <a href={profileHref} class="cc__creator-link">
+          <Avatar src={creator?.avatar} class="cc__creator-avatar">
+            <AvatarImage src={creator?.avatar} alt={captionName} />
+            <AvatarFallback>{captionName.charAt(0).toUpperCase()}</AvatarFallback>
+          </Avatar>
+          <span class="cc__creator-name">{captionName}</span>
+        </a>
+        {#if isArticle && articleReadTime}
           <span class="cc__article-sep" aria-hidden="true">·</span>
-        {/if}
-        {#if articleReadTime}
           <span class="cc__article-read-time">{articleReadTime}</span>
         {/if}
       </div>
@@ -1908,6 +1968,30 @@
        is taller than the media's natural aspect. */
     grid-template-rows: 1fr auto;
     padding: 0;
+    /* Floating-media card: the cover fills edge-to-edge, so the card surface
+       itself is always transparent (no frame) regardless of the `chrome`
+       prop, and overflow is visible so the media tile's own shadow escapes
+       the card bounds. The media + its shadow ARE the card. (Codex-p7wc8) */
+    background: transparent;
+    border-color: transparent;
+    overflow: visible;
+    row-gap: var(--space-2);
+  }
+
+  /* Media tile carries its own shadow (the card is transparent). */
+  .cc--title-in-cover .cc__thumb {
+    box-shadow: var(--shadow-md);
+  }
+  .cc--title-in-cover:hover .cc__thumb,
+  .cc--title-in-cover:focus-within:has(:focus-visible) .cc__thumb {
+    box-shadow: var(--shadow-lg);
+  }
+  /* Card-level hover surface/shadow is redundant with the tile shadow here. */
+  .cc--title-in-cover:hover,
+  .cc--title-in-cover:focus-within:has(:focus-visible) {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
   }
 
   .cc--title-in-cover .cc__thumb {
@@ -1968,7 +2052,7 @@
      selector mirrors the article-title rule's specificity (0,6,0) and is
      declared later so it wins; scoped to article so a non-article caller that
      opts into title-in-cover keeps the neutral size. */
-  .cc--title-in-cover[data-content-type='article']:not([data-variant='compact']):not([data-variant='resume']):not([data-variant='featured']) .cc__title {
+  .cc--title-in-cover[data-content-type]:not([data-variant='compact']):not([data-variant='resume']):not([data-variant='featured']) .cc__title {
     font-size: var(--text-3xl);
     line-height: var(--leading-tight);
   }
@@ -1976,7 +2060,7 @@
   /* Two-line clamp for the overlaid headline — the excerpt below needs room,
      and a 3xl title rarely needs three lines. Mirrors the article-title rule's
      (0,3,0) specificity and is declared later so it wins over the 3-line clamp. */
-  .cc--title-in-cover[data-content-type='article'] .cc__title {
+  .cc--title-in-cover[data-content-type] .cc__title {
     -webkit-line-clamp: 2;
     line-clamp: 2;
   }
@@ -2027,12 +2111,110 @@
     inset: 0;
   }
 
-  .cc__cover--article {
+  /* The brand cover is the imageless fallback: rendered (hidden) behind a real
+     thumbnail so `onerror` can reveal it if the image 404s. This codebase has
+     no global `.hidden`, only scoped ones — so scope the hide to `.cc__cover`
+     or the absolutely-positioned cover paints OVER the photo. (Codex-p7wc8) */
+  .cc__cover.hidden {
+    display: none;
+  }
+
+  /* Shared imageless cover — a brand-tinted gradient standing in for a
+     photograph on ANY title-in-cover tile (audio/video/article). Warm brand
+     tint at the top fades to the scrim anchor at the bottom so the near-white
+     title always reads; the flair layer draws the type signature on top.
+     Re-themes per org via the brand + scrim tokens. (Codex-p7wc8) */
+  .cc__cover--brand {
     background: linear-gradient(
-      155deg,
-      color-mix(in oklab, var(--color-brand-primary) 20%, var(--color-surface-card)),
-      var(--color-surface-card)
+      158deg,
+      color-mix(in oklab, var(--color-brand-primary) 26%, var(--color-surface-card)) 0%,
+      color-mix(in oklab, var(--color-brand-primary) 12%, var(--color-surface-card)) 34%,
+      color-mix(in oklab, var(--media-scrim) 40%, var(--color-surface-card)) 66%,
+      var(--media-scrim) 100%
     );
+  }
+  /* Soft off-centre accent glow so the cover reads as lit, not a flat ramp. */
+  .cc__cover--brand::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      90% 60% at 78% 8%,
+      color-mix(in srgb, var(--color-brand-accent) 26%, transparent),
+      transparent 60%
+    );
+  }
+
+  /* ═══════════════════════════════════════════
+     FLAIR LAYER (Codex-p7wc8)
+     The type's own signature, drawn over the cover but BEHIND the scrimmed
+     title (z-index 1 vs the body's 2). Decorative — aria-hidden + no pointer
+     events, so the whole-card title link still wins every click.
+     ═══════════════════════════════════════════ */
+  .cc__flair {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    overflow: hidden;
+    border-radius: inherit;
+  }
+
+  /* AUDIO — a waveform field with a centred play disc over it. */
+  :global(.cc__flair-wave) {
+    position: absolute;
+    left: 50%;
+    top: 38%;
+    transform: translate(-50%, -50%);
+    width: 78%;
+    height: 34%;
+    color: color-mix(in srgb, var(--color-brand-primary) 55%, var(--media-glyph));
+    opacity: var(--opacity-80, 0.82);
+  }
+  .cc__flair-disc,
+  .cc__flair-ring {
+    position: absolute;
+    left: 50%;
+    top: 38%;
+    transform: translate(-50%, -50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-full);
+    color: var(--media-glyph);
+    background: color-mix(in srgb, var(--media-scrim) 46%, transparent);
+    border: var(--border-width) var(--border-style)
+      color-mix(in srgb, var(--media-glyph) 55%, transparent);
+    backdrop-filter: blur(var(--blur-sm));
+    -webkit-backdrop-filter: blur(var(--blur-sm));
+  }
+  .cc__flair-disc {
+    width: var(--space-12);
+    height: var(--space-12);
+  }
+  /* VIDEO — a larger play-ring, no waveform behind it. */
+  .cc__flair-ring {
+    width: calc(var(--space-12) + var(--space-4));
+    height: calc(var(--space-12) + var(--space-4));
+  }
+  .cc__flair-disc :global(svg),
+  .cc__flair-ring :global(svg) {
+    fill: currentColor;
+    /* optical centring of the play triangle inside the disc/ring */
+    margin-left: 0.12em;
+  }
+
+  /* ARTICLE — an oversized serif dropcap ghosted top-left of the cover. */
+  .cc__flair-dropcap {
+    position: absolute;
+    left: -0.04em;
+    top: -0.12em;
+    font-family: var(--font-heading);
+    font-weight: var(--font-bold);
+    font-size: calc(var(--text-display) * 1.7);
+    line-height: 1;
+    color: color-mix(in srgb, var(--media-glyph) 26%, transparent);
+    user-select: none;
   }
 
   /* Below-media caption row for title-in-cover articles. Auto-placed into
@@ -2064,6 +2246,20 @@
 
   .cc--article-captioned .cc__body {
     border-radius: 0;
+  }
+
+  /* Floating-media cards keep ALL corners rounded — the caption sits on the
+     page background BELOW the tile (not on a contiguous card surface), so the
+     media reads as a self-contained rounded tile. Overrides the square-bottom
+     rule above for title-in-cover. (Codex-p7wc8) */
+  .cc--title-in-cover.cc--article-captioned .cc__thumb {
+    border-radius: var(--radius-xl);
+  }
+  /* Caption aligns with the tile's left edge (no card inset) and gets a small
+     top gap from the media. */
+  .cc--title-in-cover .cc__article-caption {
+    padding: var(--space-1) var(--space-1) 0;
+    color: var(--color-text-secondary);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
+++ b/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
@@ -262,28 +262,26 @@
   const isArticle = $derived(contentType === 'article');
 
   // Resolved media shape. `normalizeRatio` is a deprecated alias for
-  // `shape='16:9'`; an explicit `shape` always wins. Homogenised browse grid
-  // (Codex-p7wc8): every grid tile defaults to a 3:4 portrait cover so
-  // audio/video/article share one shape and one editorial treatment.
-  // list/compact/resume/featured and audio-row keep their own ratios.
+  // `shape='16:9'`; an explicit `shape` always wins, otherwise no `data-shape`
+  // is emitted and the CSS default cascade applies. The homogenised browse grid
+  // (Codex-p7wc8) opts in PER CALL-SITE via shape="3:4" + titleInCover
+  // (explore/library/discover) rather than changing this default — so curated
+  // surfaces (RelatedContent, creator pages, org landing, BrowseModule) keep
+  // their own treatment and nothing flips unasked.
   const resolvedShape = $derived<'16:9' | '1:1' | '3:4' | '3:2' | undefined>(
-    shape ??
-      (normalizeRatio
-        ? '16:9'
-        : variant === 'grid' && !isAudioRow
-          ? '3:4'
-          : undefined),
+    shape ?? (normalizeRatio ? '16:9' : undefined),
   );
 
-  // Title-in-cover is now the shared treatment for EVERY portrait/square grid
-  // tile, not just articles: the eyebrow + title sit over the cover on a
-  // scrim, each type carrying its own flair (audio waveform, video play-ring,
-  // article dropcap). Explicit `titleInCover` wins; audio-row keeps its
-  // playlist layout. (Codex-p7wc8)
+  // Title-in-cover: eyebrow + title over the cover on a scrim, each type
+  // carrying its own flair (audio waveform, video play-ring, article dropcap).
+  // AUTO for shaped articles (the long-standing editorial default); every other
+  // type opts in EXPLICITLY via `titleInCover`. The homogenised browse grids
+  // (explore/library/discover) pass it so audio/video tiles join the treatment;
+  // curated surfaces don't, so it never leaks into a caller that didn't ask.
+  // (Codex-p7wc8)
   const showTitleInCover = $derived(
     titleInCover ??
-      (!isAudioRow &&
-        (resolvedShape === '1:1' || resolvedShape === '3:4')),
+      (isArticle && (resolvedShape === '1:1' || resolvedShape === '3:4')),
   );
 
   // First letter of the title — the imageless cover renders it as a ghosted
@@ -498,6 +496,12 @@
              ghosted serif dropcap) sitting behind the scrimmed title. The
              flair is decorative/navigational — the whole card is the link.
              (Codex-p7wc8) -->
+        <!-- Brand cover is ALWAYS painted behind — a 404, or a no-JS /
+             pre-hydration load error (before the onerror listener attaches),
+             reveals the gradient with no handler required. The image is
+             promoted above it (`.cc--title-in-cover .cc__image`); onerror is a
+             progressive enhancement that hides the broken <img>. (Codex-p7wc8) -->
+        <div class="cc__cover cc__cover--brand"></div>
         {#if thumbnail}
           <img
             src={thumbnail}
@@ -507,11 +511,8 @@
             loading="lazy"
             decoding="async"
             class="cc__image"
-            onerror={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; (e.currentTarget as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }}
+            onerror={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
           />
-          <div class="cc__cover cc__cover--brand hidden"></div>
-        {:else}
-          <div class="cc__cover cc__cover--brand"></div>
         {/if}
         <div class="cc__flair" aria-hidden="true">
           {#if contentType === 'audio'}
@@ -519,7 +520,7 @@
             <span class="cc__flair-disc"><PlayIcon size={26} /></span>
           {:else if contentType === 'video'}
             <span class="cc__flair-ring"><PlayIcon size={26} /></span>
-          {:else if contentType === 'article' && !thumbnail}
+          {:else if contentType === 'article' && !thumbnail && coverInitial}
             <span class="cc__flair-dropcap">{coverInitial}</span>
           {/if}
         </div>
@@ -2111,12 +2112,12 @@
     inset: 0;
   }
 
-  /* The brand cover is the imageless fallback: rendered (hidden) behind a real
-     thumbnail so `onerror` can reveal it if the image 404s. This codebase has
-     no global `.hidden`, only scoped ones — so scope the hide to `.cc__cover`
-     or the absolutely-positioned cover paints OVER the photo. (Codex-p7wc8) */
-  .cc__cover.hidden {
-    display: none;
+  /* Title-in-cover promotes the image above the always-present brand cover
+     (mirrors the audio-media pattern) so the photo paints on top and a load
+     error — even pre-hydration / no-JS — falls back to the gradient with no
+     handler. (Codex-p7wc8) */
+  .cc--title-in-cover .cc__image {
+    position: relative;
   }
 
   /* Shared imageless cover — a brand-tinted gradient standing in for a
@@ -2169,7 +2170,7 @@
     width: 78%;
     height: 34%;
     color: color-mix(in srgb, var(--color-brand-primary) 55%, var(--media-glyph));
-    opacity: var(--opacity-80, 0.82);
+    opacity: var(--opacity-80, 0.8);
   }
   .cc__flair-disc,
   .cc__flair-ring {
@@ -2212,7 +2213,7 @@
     font-family: var(--font-heading);
     font-weight: var(--font-bold);
     font-size: calc(var(--text-display) * 1.7);
-    line-height: 1;
+    line-height: var(--leading-none);
     color: color-mix(in srgb, var(--media-glyph) 26%, transparent);
     user-select: none;
   }

--- a/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte.test.ts
+++ b/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte.test.ts
@@ -45,13 +45,8 @@ describe('ContentCard — shape prop', () => {
     expect(card()?.getAttribute('data-shape')).toBe(shape);
   });
 
-  test('grid tile with no explicit shape defaults to 3:4 (homogenised browse grid)', () => {
+  test('no shape and no normalizeRatio emits no data-shape (default cascade)', () => {
     component = render({ contentType: 'video' });
-    expect(card()?.getAttribute('data-shape')).toBe('3:4');
-  });
-
-  test('non-grid variant with no shape emits no data-shape (default cascade preserved)', () => {
-    component = render({ contentType: 'video', variant: 'list' });
     expect(card()?.hasAttribute('data-shape')).toBe(false);
   });
 
@@ -131,29 +126,31 @@ describe('ContentCard — article title-in-cover', () => {
     expect(document.querySelector('.cc__placeholder')).toBeNull();
   });
 
-  test('article + shape="3:4" WITH an image uses the image; brand cover stays hidden', () => {
+  test('article + shape="3:4" WITH an image renders the image over an always-present brand cover', () => {
     component = render({
       contentType: 'article',
       shape: '3:4',
       thumbnail: 'https://cdn.example/img.jpg',
     });
     expect(document.querySelector('img.cc__image')).toBeTruthy();
-    // The brand fallback is rendered but hidden behind the image (revealed via
-    // onerror only) — so there is no VISIBLE gradient cover.
+    // The brand cover is ALWAYS painted behind the (promoted) image — not
+    // hidden — so a load error, even pre-hydration / no-JS, falls back to the
+    // gradient with no onerror handler required.
     const brandCover = document.querySelector('.cc__cover--brand');
     expect(brandCover).toBeTruthy();
-    expect(brandCover?.classList.contains('hidden')).toBe(true);
+    expect(brandCover?.classList.contains('hidden')).toBe(false);
   });
 
-  test('article in the default grid auto-enables title-in-cover (homogenised)', () => {
+  test('article without a shape does NOT enable title-in-cover (default cascade)', () => {
     component = render({
       contentType: 'article',
-      description: 'This excerpt now surfaces inside the cover, not the body.',
+      description: 'This excerpt should still render in the body.',
     });
     const el = card();
-    expect(el?.classList.contains('cc--title-in-cover')).toBe(true);
-    // The plain body excerpt is suppressed — it moves into the scrimmed cover.
-    expect(document.querySelector('.cc__description')).toBeNull();
+    expect(el?.classList.contains('cc--title-in-cover')).toBe(false);
+    expect(document.querySelector('.cc__description')?.textContent).toContain(
+      'This excerpt should still render'
+    );
   });
 
   test('list variant does NOT enable title-in-cover; body description renders', () => {
@@ -185,5 +182,54 @@ describe('ContentCard — article title-in-cover', () => {
       titleInCover: true,
     });
     expect(card()?.classList.contains('cc--title-in-cover')).toBe(true);
+  });
+
+  // ── Browse-grid opt-in (explore/library/discover pass shape="3:4" +
+  //    titleInCover): every type joins the title-in-cover treatment with its
+  //    own per-type flair. This is the homogenisation feature. ──
+  test('opt-in video tile → title-in-cover with the play-ring flair (no audio disc)', () => {
+    component = render({
+      contentType: 'video',
+      shape: '3:4',
+      titleInCover: true,
+    });
+    expect(card()?.classList.contains('cc--title-in-cover')).toBe(true);
+    expect(document.querySelector('.cc__flair-ring')).toBeTruthy();
+    expect(document.querySelector('.cc__flair-disc')).toBeNull();
+  });
+
+  test('opt-in audio tile → play disc flair, and the below-cover audio overlay is suppressed', () => {
+    component = render({
+      contentType: 'audio',
+      shape: '3:4',
+      titleInCover: true,
+    });
+    expect(card()?.classList.contains('cc--title-in-cover')).toBe(true);
+    expect(document.querySelector('.cc__flair-disc')).toBeTruthy();
+    // Superseded by the flair — the old audio-media overlay must not render.
+    expect(document.querySelector('.cc__audio-overlay')).toBeNull();
+  });
+
+  test('imageless article tile → dropcap flair with the uppercased initial', () => {
+    component = render({
+      contentType: 'article',
+      shape: '3:4',
+      title: 'deep work',
+      thumbnail: null,
+    });
+    const dropcap = document.querySelector('.cc__flair-dropcap');
+    expect(dropcap).toBeTruthy();
+    expect(dropcap?.textContent).toBe('D');
+  });
+
+  test('title-in-cover always paints a brand cover behind the image (JS-free fallback)', () => {
+    component = render({
+      contentType: 'video',
+      shape: '3:4',
+      titleInCover: true,
+      thumbnail: 'https://cdn.example/v.jpg',
+    });
+    expect(document.querySelector('.cc__cover--brand')).toBeTruthy();
+    expect(document.querySelector('img.cc__image')).toBeTruthy();
   });
 });

--- a/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte.test.ts
+++ b/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte.test.ts
@@ -45,8 +45,13 @@ describe('ContentCard — shape prop', () => {
     expect(card()?.getAttribute('data-shape')).toBe(shape);
   });
 
-  test('no shape and no normalizeRatio emits no data-shape (default cascade)', () => {
+  test('grid tile with no explicit shape defaults to 3:4 (homogenised browse grid)', () => {
     component = render({ contentType: 'video' });
+    expect(card()?.getAttribute('data-shape')).toBe('3:4');
+  });
+
+  test('non-grid variant with no shape emits no data-shape (default cascade preserved)', () => {
+    component = render({ contentType: 'video', variant: 'list' });
     expect(card()?.hasAttribute('data-shape')).toBe(false);
   });
 
@@ -121,26 +126,40 @@ describe('ContentCard — article title-in-cover', () => {
       shape: '3:4',
       thumbnail: null,
     });
-    expect(
-      document.querySelector('.cc__thumb .cc__cover--article')
-    ).toBeTruthy();
+    expect(document.querySelector('.cc__thumb .cc__cover--brand')).toBeTruthy();
     // No file-text placeholder icon — the cover stands in for the image.
     expect(document.querySelector('.cc__placeholder')).toBeNull();
   });
 
-  test('article + shape="3:4" WITH an image uses the image, not the gradient cover', () => {
+  test('article + shape="3:4" WITH an image uses the image; brand cover stays hidden', () => {
     component = render({
       contentType: 'article',
       shape: '3:4',
       thumbnail: 'https://cdn.example/img.jpg',
     });
     expect(document.querySelector('img.cc__image')).toBeTruthy();
-    expect(document.querySelector('.cc__cover--article')).toBeNull();
+    // The brand fallback is rendered but hidden behind the image (revealed via
+    // onerror only) — so there is no VISIBLE gradient cover.
+    const brandCover = document.querySelector('.cc__cover--brand');
+    expect(brandCover).toBeTruthy();
+    expect(brandCover?.classList.contains('hidden')).toBe(true);
   });
 
-  test('article without a shape does NOT enable title-in-cover (backward compatible)', () => {
+  test('article in the default grid auto-enables title-in-cover (homogenised)', () => {
     component = render({
       contentType: 'article',
+      description: 'This excerpt now surfaces inside the cover, not the body.',
+    });
+    const el = card();
+    expect(el?.classList.contains('cc--title-in-cover')).toBe(true);
+    // The plain body excerpt is suppressed — it moves into the scrimmed cover.
+    expect(document.querySelector('.cc__description')).toBeNull();
+  });
+
+  test('list variant does NOT enable title-in-cover; body description renders', () => {
+    component = render({
+      contentType: 'article',
+      variant: 'list',
       description: 'This excerpt should still render in the body.',
     });
     const el = card();

--- a/apps/web/src/routes/(platform)/discover/+page.svelte
+++ b/apps/web/src/routes/(platform)/discover/+page.svelte
@@ -77,7 +77,6 @@
     {#if data.content.items && data.content.items.length > 0}
       {#each data.content.items as item (item.id)}
         <ContentCard
-          autoPromoteAudio
           id={item.id}
           title={item.title}
           thumbnail={item.mediaItem?.thumbnailUrl ?? null}

--- a/apps/web/src/routes/(platform)/discover/+page.svelte
+++ b/apps/web/src/routes/(platform)/discover/+page.svelte
@@ -77,6 +77,8 @@
     {#if data.content.items && data.content.items.length > 0}
       {#each data.content.items as item (item.id)}
         <ContentCard
+          shape="3:4"
+          titleInCover
           id={item.id}
           title={item.title}
           thumbnail={item.mediaItem?.thumbnailUrl ?? null}

--- a/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
@@ -477,7 +477,7 @@
       {#each displayItems as item (item.id)}
         <ContentCard
           variant={viewMode === 'list' ? 'list' : 'grid'}
-          shape={viewMode === 'list' ? undefined : '1:1'}
+          shape={viewMode === 'list' ? undefined : '3:4'}
           chrome="transparent"
           id={item.id}
           title={item.title}

--- a/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
@@ -478,6 +478,7 @@
         <ContentCard
           variant={viewMode === 'list' ? 'list' : 'grid'}
           shape={viewMode === 'list' ? undefined : '3:4'}
+          titleInCover={viewMode === 'list' ? undefined : true}
           chrome="transparent"
           id={item.id}
           title={item.title}

--- a/docs/design/card-system-mockup.html
+++ b/docs/design/card-system-mockup.html
@@ -1,0 +1,573 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Content cards — one language, three voices</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<style>
+/* =========================================================================
+   TOKENS — mirror of tokens/org-brand.css for "of blood and bones".
+   Components paint ONLY with semantic tokens, so swapping the --brand-*
+   inputs re-themes the whole card family. Two themes: light parchment
+   (default, matches the screenshot) + dark oxblood.
+   ========================================================================= */
+:root{
+  --font-heading:'Libre Baskerville', Georgia, 'Times New Roman', serif;
+  --font-body:'Libre Baskerville', Georgia, 'Times New Roman', serif;
+  --font-ui:'Libre Baskerville', Georgia, serif;
+
+  --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem;
+  --space-5:1.25rem; --space-6:1.5rem; --space-8:2rem; --space-10:2.5rem;
+  --space-12:3rem; --space-16:4rem; --space-20:5rem;
+  --radius-card:.7rem; --radius-full:9999px;
+
+  /* ---- LIGHT: parchment ---- */
+  --ground:#F0E7D8;
+  --ground-2:#E9DECB;
+  --surface-card:#FBF6EC;
+  --ink:#2B221C;
+  --ink-2:#6C5E53;
+  --ink-3:#9A8B7E;
+  --border:#E3D6C1;
+  --border-strong:#D3C2A6;
+
+  --brand:#B0462B;            /* terracotta primary */
+  --brand-hover:#9C3B22;
+  --accent:#C0762C;           /* ochre accent */
+
+  /* on-media tokens — read over any cover */
+  --media-scrim:#1C1510;      /* the dark anchor mixed into cover gradients */
+  --media-glyph:#EEC488;      /* warm gold: eyebrows + glyphs over scrim */
+  --on-media:#F7EEE3;         /* near-white title over scrim */
+  --on-media-2:#D8C7B7;       /* excerpt over scrim */
+
+  --shadow-card:0 1px 2px rgba(40,20,12,.10), 0 10px 26px -8px rgba(40,20,12,.20);
+  --shadow-lift:0 2px 6px rgba(40,20,12,.14), 0 22px 44px -14px rgba(40,20,12,.34);
+  --dur:.22s; --ease:cubic-bezier(.2,.7,.2,1);
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --ground:#251110; --ground-2:#2E1513; --surface-card:#3A1A16;
+    --ink:#F4E7DD; --ink-2:#CBB4A8; --ink-3:#9E8578; --border:#4C2823; --border-strong:#623128;
+    --brand:#E06A46; --brand-hover:#EC7A56; --accent:#E0913F;
+    --media-scrim:#140C09; --media-glyph:#F2CB92; --on-media:#F8EFE5; --on-media-2:#D9C7B7;
+    --shadow-card:0 1px 2px rgba(0,0,0,.4), 0 12px 30px -10px rgba(0,0,0,.6);
+    --shadow-lift:0 2px 6px rgba(0,0,0,.5), 0 26px 50px -14px rgba(0,0,0,.7);
+  }
+}
+:root[data-theme="light"]{
+  --ground:#F0E7D8; --ground-2:#E9DECB; --surface-card:#FBF6EC;
+  --ink:#2B221C; --ink-2:#6C5E53; --ink-3:#9A8B7E; --border:#E3D6C1; --border-strong:#D3C2A6;
+  --brand:#B0462B; --brand-hover:#9C3B22; --accent:#C0762C;
+  --media-scrim:#1C1510; --media-glyph:#EEC488; --on-media:#F7EEE3; --on-media-2:#D8C7B7;
+  --shadow-card:0 1px 2px rgba(40,20,12,.10), 0 10px 26px -8px rgba(40,20,12,.20);
+  --shadow-lift:0 2px 6px rgba(40,20,12,.14), 0 22px 44px -14px rgba(40,20,12,.34);
+}
+:root[data-theme="dark"]{
+  --ground:#251110; --ground-2:#2E1513; --surface-card:#3A1A16;
+  --ink:#F4E7DD; --ink-2:#CBB4A8; --ink-3:#9E8578; --border:#4C2823; --border-strong:#623128;
+  --brand:#E06A46; --brand-hover:#EC7A56; --accent:#E0913F;
+  --media-scrim:#140C09; --media-glyph:#F2CB92; --on-media:#F8EFE5; --on-media-2:#D9C7B7;
+  --shadow-card:0 1px 2px rgba(0,0,0,.4), 0 12px 30px -10px rgba(0,0,0,.6);
+  --shadow-lift:0 2px 6px rgba(0,0,0,.5), 0 26px 50px -14px rgba(0,0,0,.7);
+}
+
+*{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{
+  font-family:var(--font-body);
+  background:
+    radial-gradient(120% 90% at 100% -10%, color-mix(in oklab, var(--brand) 12%, var(--ground)) 0%, transparent 46%),
+    var(--ground);
+  color:var(--ink);
+  line-height:1.5;
+  -webkit-font-smoothing:antialiased;
+  min-height:100vh;
+  padding-bottom:var(--space-20);
+}
+.wrap{max-width:76rem;margin-inline:auto;padding-inline:clamp(var(--space-4),4vw,var(--space-12));}
+h1,h2,h3{font-family:var(--font-heading);font-weight:700;line-height:1.15;text-wrap:balance;}
+:focus-visible{outline:2px solid var(--brand);outline-offset:2px;border-radius:3px;}
+
+/* ---- page header ---- */
+.masthead{padding-block:var(--space-12) var(--space-8);}
+.eyebrow-lead{
+  font-size:.72rem;letter-spacing:.22em;text-transform:uppercase;
+  color:var(--brand);font-weight:700;margin-bottom:var(--space-4);
+}
+.masthead h1{font-size:clamp(2rem,1.4rem + 2.6vw,3.2rem);letter-spacing:-.01em;max-width:18ch;}
+.masthead p{
+  margin-top:var(--space-5);max-width:60ch;color:var(--ink-2);
+  font-size:1.05rem;line-height:1.7;
+}
+.masthead .principle{
+  margin-top:var(--space-6);padding-left:var(--space-5);
+  border-left:3px solid color-mix(in oklab, var(--brand) 60%, transparent);
+  color:var(--ink);font-style:italic;max-width:56ch;
+}
+
+.topbar{position:sticky;top:0;z-index:20;
+  background:color-mix(in oklab, var(--ground) 82%, transparent);
+  backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);
+  border-bottom:1px solid var(--border);}
+.topbar__in{max-width:76rem;margin-inline:auto;display:flex;align-items:center;gap:var(--space-4);
+  padding:var(--space-3) clamp(var(--space-4),4vw,var(--space-12));}
+.topbar__mark{font-family:var(--font-heading);font-weight:700;display:flex;align-items:center;gap:.5em;font-size:1rem;}
+.topbar__mark .dot{width:.6em;height:.6em;border-radius:var(--radius-full);background:var(--brand);}
+.topbar__mark small{font-family:var(--font-ui);font-weight:400;color:var(--ink-3);font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;}
+.toggle{margin-left:auto;font:inherit;font-size:.8rem;cursor:pointer;
+  border:1px solid var(--border-strong);background:var(--surface-card);color:var(--ink);
+  border-radius:var(--radius-full);padding:.4em 1em;display:inline-flex;gap:.5em;align-items:center;}
+.toggle:hover{border-color:var(--brand);}
+
+/* ---- section scaffolding ---- */
+section{margin-top:var(--space-16);}
+.sec-head{display:flex;align-items:baseline;gap:var(--space-4);flex-wrap:wrap;margin-bottom:var(--space-6);}
+.sec-head h2{font-size:clamp(1.4rem,1.1rem + 1vw,1.9rem);}
+.sec-head .n{font-family:var(--font-ui);font-size:.8rem;color:var(--ink-3);letter-spacing:.14em;text-transform:uppercase;
+  border:1px solid var(--border);border-radius:var(--radius-full);padding:.25em .8em;}
+.sec-head p{flex-basis:100%;color:var(--ink-2);max-width:64ch;margin-top:var(--space-1);line-height:1.7;}
+
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(248px,1fr));gap:var(--space-8) var(--space-6);}
+
+/* =========================================================================
+   CARD — the shared language. `.cc--cover` = title-in-cover (the article
+   treatment applied to every type). `.cc__thumb` is the media frame; the
+   cover-body (eyebrow/title/excerpt) is absolutely positioned over the scrim.
+   ========================================================================= */
+.cc{display:flex;flex-direction:column;gap:var(--space-3);}
+.cc__link{display:block;border-radius:var(--radius-card);}
+.cc__thumb{
+  position:relative;aspect-ratio:3/4;border-radius:var(--radius-card);overflow:hidden;
+  background:var(--ground-2);
+  box-shadow:var(--shadow-card);
+  transition:transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+  isolation:isolate;
+}
+.cc__link:hover .cc__thumb{transform:translateY(-4px);box-shadow:var(--shadow-lift);}
+.cc__media{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:0;}
+.cc__media--faux{background-size:cover;background-position:center;}
+.grain{position:absolute;inset:0;z-index:1;pointer-events:none;opacity:.5;mix-blend-mode:overlay;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.5'/%3E%3C/svg%3E");}
+
+/* Scrim — the reusable dark gradient that guarantees text legibility over
+   ANY cover (photo or generated). Painted from --media-scrim. */
+.cc__scrim{position:absolute;inset:0;z-index:2;pointer-events:none;
+  background:linear-gradient(to top,
+    color-mix(in oklab, var(--media-scrim) 92%, transparent) 0%,
+    color-mix(in oklab, var(--media-scrim) 74%, transparent) 22%,
+    color-mix(in oklab, var(--media-scrim) 30%, transparent) 48%,
+    transparent 72%);}
+
+/* Cover body — eyebrow + title + excerpt, bottom-aligned over the scrim */
+.cc__body{position:absolute;z-index:3;left:0;right:0;bottom:0;
+  padding:var(--space-4) var(--space-4) var(--space-5);display:flex;flex-direction:column;gap:var(--space-2);}
+.cc__kind{display:inline-flex;align-items:center;gap:.5em;
+  font-family:var(--font-ui);font-size:.7rem;font-weight:700;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--media-glyph);}
+.cc__kind svg{width:.95em;height:.95em;flex:none;}
+.cc__title{color:var(--on-media);font-size:1.5rem;line-height:1.12;letter-spacing:-.01em;
+  display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;}
+.cc__excerpt{color:var(--on-media-2);font-size:.86rem;line-height:1.55;
+  display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;
+  text-shadow:0 1px 8px rgba(0,0,0,.4);}
+
+/* Corner chrome */
+.cc__pill{position:absolute;z-index:4;top:var(--space-3);border-radius:var(--radius-full);
+  font-family:var(--font-ui);font-size:.72rem;font-weight:700;padding:.35em .8em;display:inline-flex;align-items:center;gap:.4em;}
+.cc__pill--featured{left:var(--space-3);background:var(--brand);color:#fff;}
+.cc__pill--free{right:var(--space-3);background:color-mix(in oklab, var(--media-scrim) 66%, transparent);color:var(--on-media);
+  backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);}
+.cc__dur{position:absolute;z-index:4;right:var(--space-3);bottom:var(--space-3);
+  font-family:var(--font-ui);font-size:.72rem;font-weight:700;color:var(--on-media);
+  background:color-mix(in oklab, var(--media-scrim) 60%, transparent);
+  border-radius:var(--radius-full);padding:.28em .7em;backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);}
+/* when duration would collide with the excerpt, we float it top-right instead */
+.cc__dur--top{top:var(--space-3);bottom:auto;}
+
+/* Author row (below the cover) — unchanged from today */
+.cc__author{display:flex;align-items:center;gap:var(--space-2);padding-inline:var(--space-1);}
+.cc__avatar{width:1.85rem;height:1.85rem;border-radius:var(--radius-full);flex:none;
+  background:color-mix(in oklab, var(--brand) 22%, var(--surface-card));
+  color:var(--brand);display:grid;place-items:center;font-family:var(--font-heading);font-weight:700;font-size:.85rem;
+  border:1px solid var(--border);}
+.cc__author span{font-size:.86rem;color:var(--ink-2);}
+
+/* =========================================================================
+   FLAIR ZONE — each type's own signature, painted mid-cover so it never
+   fights the title. Present on ALL covers (photo covers get a lighter touch).
+   ========================================================================= */
+.cc__flair{position:absolute;z-index:1;inset:0;pointer-events:none;}
+
+/* VIDEO — play affordance in a ring, + faint frame ticks */
+.play-ring{position:absolute;left:50%;top:42%;transform:translate(-50%,-50%);
+  width:64px;height:64px;border-radius:var(--radius-full);display:grid;place-items:center;
+  background:color-mix(in oklab, var(--media-scrim) 42%, transparent);
+  border:1.5px solid color-mix(in oklab, var(--on-media) 60%, transparent);
+  backdrop-filter:blur(3px);-webkit-backdrop-filter:blur(3px);}
+.play-ring::after{content:"";width:0;height:0;margin-left:5px;
+  border-left:19px solid var(--on-media);border-top:12px solid transparent;border-bottom:12px solid transparent;}
+
+/* AUDIO — a full waveform field (bars injected by JS), + play disc */
+.wavefield{position:absolute;left:0;right:0;top:34%;transform:translateY(-50%);
+  height:38%;display:flex;align-items:center;justify-content:center;gap:2.5px;padding-inline:12%;}
+.wavefield .bar{width:3px;border-radius:2px;background:var(--media-glyph);opacity:.85;}
+.audio-disc{position:absolute;left:50%;top:34%;transform:translate(-50%,-50%);
+  width:52px;height:52px;border-radius:var(--radius-full);display:grid;place-items:center;
+  background:color-mix(in oklab, var(--media-scrim) 46%, transparent);
+  border:1.5px solid color-mix(in oklab, var(--on-media) 55%, transparent);
+  backdrop-filter:blur(3px);-webkit-backdrop-filter:blur(3px);}
+.audio-disc::after{content:"";width:0;height:0;margin-left:4px;
+  border-left:15px solid var(--on-media);border-top:9px solid transparent;border-bottom:9px solid transparent;}
+
+/* ARTICLE — an oversized serif dropcap ghosted top-left */
+.dropcap{position:absolute;left:-.06em;top:-.14em;font-family:var(--font-heading);font-weight:700;
+  font-size:15rem;line-height:1;color:color-mix(in oklab, var(--media-glyph) 30%, transparent);
+  user-select:none;}
+
+/* =========================================================================
+   IMAGELESS COVER FILLS — the brand gradient that stands in for a photo.
+   All three types share ONE gradient family (homogeneity); the flair zone
+   carries the difference. This is `.cc__cover--article` generalised.
+   ========================================================================= */
+.cover-brand{position:absolute;inset:0;z-index:0;
+  background:linear-gradient(158deg,
+    color-mix(in oklab, var(--brand) 26%, var(--surface-card)) 0%,
+    color-mix(in oklab, var(--brand) 12%, var(--surface-card)) 34%,
+    color-mix(in oklab, var(--media-scrim) 40%, var(--surface-card)) 66%,
+    var(--media-scrim) 100%);}
+/* subtle radial glow so it isn't a flat ramp */
+.cover-brand::after{content:"";position:absolute;inset:0;
+  background:radial-gradient(90% 60% at 78% 8%, color-mix(in oklab, var(--accent) 26%, transparent), transparent 60%);}
+
+/* alt imageless directions for the options strip */
+.cover-glyph{position:absolute;inset:0;z-index:0;
+  background:linear-gradient(158deg, color-mix(in oklab, var(--brand) 20%, var(--surface-card)), var(--media-scrim));}
+.cover-glyph .big{position:absolute;right:-.12em;bottom:-.22em;opacity:.16;color:var(--on-media);}
+.cover-glyph .big svg{width:12rem;height:12rem;}
+.cover-flat{position:absolute;inset:0;z-index:0;
+  background:linear-gradient(160deg, color-mix(in oklab, var(--brand) 30%, var(--surface-card)), color-mix(in oklab, var(--media-scrim) 88%, var(--brand)));}
+
+/* faux photographic covers (stand-ins — real thumbnails replace these) */
+.faux-canyon{background:
+  linear-gradient(to bottom, #9DB9CE 0%, #C9B08A 46%, #A9603C 74%, #7C3F27 100%);}
+.faux-textile{background:
+  repeating-linear-gradient(96deg, #7C2A2A 0 10px, #C4703A 10px 20px, #2E5A55 20px 30px, #C9A24B 30px 42px, #6B3A63 42px 52px);}
+.faux-dusk{background:
+  linear-gradient(to bottom, #2B3A55 0%, #6A4A63 44%, #B26A45 78%, #8A3F2E 100%);}
+
+/* ---- options strip ---- */
+.options{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:var(--space-6);align-items:start;}
+.opt h3{font-size:1.05rem;margin-bottom:var(--space-1);}
+.opt .rec{color:var(--brand);font-size:.72rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;}
+.opt p{color:var(--ink-2);font-size:.86rem;line-height:1.6;margin-top:var(--space-2);}
+.opt .cc__thumb{aspect-ratio:3/4;margin-bottom:var(--space-3);}
+
+/* ---- anatomy callouts ---- */
+.anatomy{display:grid;grid-template-columns:minmax(220px,300px) 1fr;gap:var(--space-8);align-items:center;}
+.anatomy ul{list-style:none;display:flex;flex-direction:column;gap:var(--space-4);}
+.anatomy li{padding-left:var(--space-5);position:relative;color:var(--ink-2);line-height:1.6;}
+.anatomy li::before{content:"";position:absolute;left:0;top:.55em;width:9px;height:9px;border-radius:2px;background:var(--brand);}
+.anatomy li b{color:var(--ink);font-family:var(--font-ui);}
+@media (max-width:640px){.anatomy{grid-template-columns:1fr;}}
+
+/* ---- map / footer ---- */
+.map{margin-top:var(--space-16);border-top:1px solid var(--border);padding-top:var(--space-8);}
+.map h2{font-size:1.3rem;margin-bottom:var(--space-4);}
+.map dl{display:grid;grid-template-columns:auto 1fr;gap:var(--space-3) var(--space-5);max-width:60rem;}
+.map dt{font-family:var(--font-ui);color:var(--brand);font-weight:700;white-space:nowrap;}
+.map dd{color:var(--ink-2);line-height:1.6;}
+.map code{font-family:ui-monospace,monospace;font-size:.85em;
+  background:color-mix(in oklab, var(--brand) 10%, var(--surface-card));padding:.1em .45em;border-radius:4px;color:var(--ink);}
+@media (max-width:560px){.map dl{grid-template-columns:1fr;gap:var(--space-1) 0;} .map dt{margin-top:var(--space-3);}}
+
+@media (prefers-reduced-motion:reduce){*{transition:none !important;}}
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <div class="topbar__in">
+    <span class="topbar__mark"><span class="dot"></span>of blood &amp; bones <small>card system — mockup</small></span>
+    <button class="toggle" id="themeBtn" type="button" aria-label="Toggle light and dark theme">
+      <span id="themeIcon">☾</span><span id="themeLabel">Dark</span>
+    </button>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <header class="masthead">
+    <p class="eyebrow-lead">Browse cards · homogenised</p>
+    <h1>One language, three voices.</h1>
+    <p>
+      Today the article card reads as an editorial object — a type eyebrow, a big serif headline, and a
+      short excerpt laid straight over the artwork. The audio and video cards don't; they hang their
+      metadata underneath a plain tile. This mockup gives all three the article's <em>title-in-cover</em>
+      treatment, then hands each type its own signature so a card still says what it is at a glance.
+    </p>
+    <p class="principle">
+      Same frame, same headline, same scrim — the flair is the difference. Audio brings a waveform,
+      video a play affordance, an article its opening letter.
+    </p>
+  </header>
+
+  <!-- ===================== ANATOMY ===================== -->
+  <section>
+    <div class="sec-head">
+      <span class="n">The shared frame</span>
+      <h2>What every card now has in common</h2>
+      <p>The parts below are identical across types. Only the <b>flair zone</b> and the imageless cover fill change per type.</p>
+    </div>
+    <div class="anatomy">
+      <div class="cc">
+        <a class="cc__link" href="#" aria-label="Anatomy example">
+          <div class="cc__thumb">
+            <div class="cover-brand"></div>
+            <div class="cc__flair"><span class="dropcap">T</span></div>
+            <div class="cc__scrim"></div>
+            <span class="cc__pill cc__pill--featured">✦ Featured</span>
+            <div class="cc__body">
+              <span class="cc__kind">📄 Article · Healing</span>
+              <h3 class="cc__title">The anatomy of a card</h3>
+              <p class="cc__excerpt">Eyebrow, headline and excerpt, all sitting over the scrim.</p>
+            </div>
+          </div>
+        </a>
+      </div>
+      <ul>
+        <li><b>Type eyebrow</b> — small-caps <code>--media-glyph</code> gold, with the type icon. Always the type + category.</li>
+        <li><b>Serif headline</b> — the card's anchor, in <code>--on-media</code> near-white, up to three lines.</li>
+        <li><b>Excerpt</b> — one or two lines of preview, quiet <code>--on-media-2</code>.</li>
+        <li><b>Scrim</b> — one reusable gradient from <code>--media-scrim</code>; keeps text legible over any cover.</li>
+        <li><b>Flair zone</b> — the type's signature, painted mid-cover behind the text.</li>
+        <li><b>Corner chrome</b> — Featured / Free pills and duration, unchanged.</li>
+        <li><b>Author row</b> — stays below the cover exactly as it does now.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ===================== WITH IMAGE ===================== -->
+  <section>
+    <div class="sec-head">
+      <span class="n">With a thumbnail</span>
+      <h2>When the creator uploaded artwork</h2>
+      <p>The photo fills the frame; the scrim carries the same headline block. Video keeps a play ring, audio keeps its waveform + play disc — their signatures ride lightly over the image.</p>
+    </div>
+    <div class="grid">
+
+      <!-- VIDEO with image -->
+      <div class="cc"><a class="cc__link" href="#">
+        <div class="cc__thumb">
+          <div class="cc__media cc__media--faux faux-dusk"></div>
+          <div class="grain"></div>
+          <div class="cc__flair"><span class="play-ring"></span></div>
+          <div class="cc__scrim"></div>
+          <span class="cc__dur">48m</span>
+          <div class="cc__body">
+            <span class="cc__kind">▶ Video · Somatic practice</span>
+            <h3 class="cc__title">Somatic Release — Full Session</h3>
+            <p class="cc__excerpt">A slow, guided descent into the body. Ninety minutes of held space.</p>
+          </div>
+        </div></a>
+        <div class="cc__author"><span class="cc__avatar">L</span><span>Luzura Peralta</span></div>
+      </div>
+
+      <!-- AUDIO with image -->
+      <div class="cc"><a class="cc__link" href="#">
+        <div class="cc__thumb">
+          <div class="cc__media cc__media--faux faux-canyon"></div>
+          <div class="grain"></div>
+          <div class="cc__flair"><div class="wavefield" data-bars="34"></div><span class="audio-disc"></span></div>
+          <div class="cc__scrim"></div>
+          <span class="cc__pill cc__pill--free">Free</span>
+          <span class="cc__dur">35m</span>
+          <div class="cc__body">
+            <span class="cc__kind">♫ Audio · Sound &amp; vibration</span>
+            <h3 class="cc__title">Sound Therapy</h3>
+            <p class="cc__excerpt">Singing bowls and low drones tuned for the parasympathetic drop.</p>
+          </div>
+        </div></a>
+        <div class="cc__author"><span class="cc__avatar">L</span><span>Luzura Peralta</span></div>
+      </div>
+
+      <!-- ARTICLE with image -->
+      <div class="cc"><a class="cc__link" href="#">
+        <div class="cc__thumb">
+          <div class="cc__media cc__media--faux faux-textile"></div>
+          <div class="grain"></div>
+          <div class="cc__scrim"></div>
+          <div class="cc__body">
+            <span class="cc__kind">📄 Article · Healing</span>
+            <h3 class="cc__title">Closing the Bones</h3>
+            <p class="cc__excerpt">A postpartum and grief ritual rooted in Latin American tradition.</p>
+          </div>
+        </div></a>
+        <div class="cc__author"><span class="cc__avatar">L</span><span>Luzura Peralta</span></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ===================== WITHOUT IMAGE ===================== -->
+  <section>
+    <div class="sec-head">
+      <span class="n">Without a thumbnail</span>
+      <h2>The imageless cover — where the flair earns its keep</h2>
+      <p>No photo, no collapse, no lonely icon. Each card gets the same brand gradient (so a row stays even) and its type's signature drawn large behind the text. This is the recommended direction — the generated cover <em>is</em> the identity.</p>
+    </div>
+    <div class="grid">
+
+      <!-- VIDEO imageless -->
+      <div class="cc"><a class="cc__link" href="#">
+        <div class="cc__thumb">
+          <div class="cover-brand"></div>
+          <div class="cc__flair"><span class="play-ring"></span></div>
+          <div class="cc__scrim"></div>
+          <span class="cc__dur cc__dur--top">22m</span>
+          <div class="cc__body">
+            <span class="cc__kind">▶ Video · Breathwork</span>
+            <h3 class="cc__title">The Physiology of Letting Go</h3>
+            <p class="cc__excerpt">Why the exhale is where release actually happens.</p>
+          </div>
+        </div></a>
+        <div class="cc__author"><span class="cc__avatar">L</span><span>Luzura Peralta</span></div>
+      </div>
+
+      <!-- AUDIO imageless -->
+      <div class="cc"><a class="cc__link" href="#">
+        <div class="cc__thumb">
+          <div class="cover-brand"></div>
+          <div class="cc__flair"><div class="wavefield" data-bars="40"></div><span class="audio-disc"></span></div>
+          <div class="cc__scrim"></div>
+          <span class="cc__pill cc__pill--free">Free</span>
+          <span class="cc__dur cc__dur--top">12m</span>
+          <div class="cc__body">
+            <span class="cc__kind">♫ Audio · Meditation</span>
+            <h3 class="cc__title">A Grounding for Grief</h3>
+            <p class="cc__excerpt">Twelve minutes to come back into the body when it hurts.</p>
+          </div>
+        </div></a>
+        <div class="cc__author"><span class="cc__avatar">L</span><span>Luzura Peralta</span></div>
+      </div>
+
+      <!-- ARTICLE imageless -->
+      <div class="cc"><a class="cc__link" href="#">
+        <div class="cc__thumb">
+          <div class="cover-brand"></div>
+          <div class="cc__flair"><span class="dropcap">M</span></div>
+          <div class="cc__scrim"></div>
+          <span class="cc__pill cc__pill--featured">✦ Featured</span>
+          <div class="cc__body">
+            <span class="cc__kind">📄 Article · Healing</span>
+            <h3 class="cc__title">The Medicine of Grief</h3>
+            <p class="cc__excerpt">A written meditation on grief as sacred medicine. How loss cracks us open.</p>
+          </div>
+        </div></a>
+        <div class="cc__author"><span class="cc__avatar">L</span><span>Luzura Peralta</span></div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ===================== OPTIONS FOR IMAGELESS ===================== -->
+  <section>
+    <div class="sec-head">
+      <span class="n">Pick one</span>
+      <h2>Three ways to treat the imageless cover</h2>
+      <p>All use the brand gradient. They differ in what sits on top. Tell me which reads best on your orgs and I'll build that one (the others stay easy to switch to — it's one token/branch).</p>
+    </div>
+    <div class="options">
+
+      <div class="opt">
+        <div class="cc__thumb">
+          <div class="cover-brand"></div>
+          <div class="cc__flair"><div class="wavefield" data-bars="36"></div><span class="audio-disc"></span></div>
+          <div class="cc__scrim"></div>
+          <div class="cc__body"><span class="cc__kind">♫ Audio · Meditation</span><h3 class="cc__title">A Grounding for Grief</h3></div>
+        </div>
+        <span class="rec">Recommended</span>
+        <h3>A · Type-native cover</h3>
+        <p>The signature is drawn full-size — a waveform field, a play ring, a serif dropcap. Most distinctive; the cover itself tells you the type before you read a word.</p>
+      </div>
+
+      <div class="opt">
+        <div class="cc__thumb">
+          <div class="cover-glyph"><span class="big" aria-hidden="true"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg></span></div>
+          <div class="cc__scrim"></div>
+          <div class="cc__body"><span class="cc__kind">♫ Audio · Meditation</span><h3 class="cc__title">A Grounding for Grief</h3></div>
+        </div>
+        <h3>B · Watermark glyph</h3>
+        <p>A single oversized type icon bleeding off the corner, low opacity. Calmer and more uniform; less playful than the type-native covers.</p>
+      </div>
+
+      <div class="opt">
+        <div class="cc__thumb">
+          <div class="cover-flat"></div>
+          <div class="cc__scrim"></div>
+          <div class="cc__body"><span class="cc__kind">♫ Audio · Meditation</span><h3 class="cc__title">A Grounding for Grief</h3></div>
+        </div>
+        <h3>C · Gradient only</h3>
+        <p>Just the brand gradient and the headline — the current article look, applied everywhere. Cleanest and quietest; leans entirely on the eyebrow to signal type.</p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ===================== MAP TO CODE ===================== -->
+  <div class="map wrap" style="padding-inline:0;">
+    <h2>How this maps onto <code>ContentCard.svelte</code></h2>
+    <dl>
+      <dt>Title-in-cover</dt>
+      <dd>Extend the existing <code>showTitleInCover</code> so it's the default for <code>variant="grid"</code> across <em>all</em> types, not just articles — reusing <code>.cc--title-in-cover</code>, <code>.cc__scrim</code>, and the cover body already in the file.</dd>
+      <dt>Flair zone</dt>
+      <dd>A new <code>.cc__flair</code> layer: reuse <code>&lt;AudioWaveform&gt;</code> for audio (already imported), the existing <code>PlayIcon</code> ring for video, and a dropcap from the title's first letter for articles.</dd>
+      <dt>Imageless cover</dt>
+      <dd>Generalise <code>.cc__cover--article</code> into one <code>.cc__cover--brand</code> gradient used by every type when there's no thumbnail — this also removes the <code>display:none</code> collapse that started this.</dd>
+      <dt>Tokens</dt>
+      <dd>No new tokens needed — <code>--media-scrim</code>, <code>--media-glyph</code>, <code>--on-media</code> already exist and re-theme per org.</dd>
+      <dt>Shape</dt>
+      <dd>Shown at <code>3:4</code> portrait (what makes the article cards feel premium). Swappable to <code>1:1</code> per surface via the existing <code>shape</code> prop.</dd>
+    </dl>
+  </div>
+
+</div>
+
+<script>
+// Waveform fields — deterministic per element (no Math.random so it's stable).
+document.querySelectorAll('.wavefield').forEach((el, idx) => {
+  const n = parseInt(el.dataset.bars || '36', 10);
+  let seed = 2166136261 ^ idx;
+  const rnd = () => { seed = Math.imul(seed ^ (seed >>> 15), 2246822507); seed ^= seed >>> 13; return ((seed >>> 0) % 1000) / 1000; };
+  for (let i = 0; i < n; i++) {
+    const b = document.createElement('span');
+    b.className = 'bar';
+    const t = i / (n - 1);
+    // envelope: taller in the middle, tapered at the edges
+    const env = 0.35 + 0.65 * Math.sin(Math.PI * t);
+    const h = Math.round((0.25 + 0.75 * rnd()) * env * 100);
+    b.style.height = Math.max(8, h) + '%';
+    el.appendChild(b);
+  }
+});
+
+// Theme toggle — flips data-theme and mirrors OS default on first paint.
+const root = document.documentElement;
+const btn = document.getElementById('themeBtn');
+const icon = document.getElementById('themeIcon');
+const label = document.getElementById('themeLabel');
+function apply(theme){
+  root.setAttribute('data-theme', theme);
+  const dark = theme === 'dark';
+  icon.textContent = dark ? '☀' : '☾';
+  label.textContent = dark ? 'Light' : 'Dark';
+}
+const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+apply(prefersDark ? 'dark' : 'light');
+btn.addEventListener('click', () => apply(root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Homogenises the **browse-grid** content cards (Codex-p7wc8): explore / library / discover render every tile — audio, video, article — with one **3:4 portrait title-in-cover** treatment, differentiated only by a decorative per-type **flair**:

- **audio** → waveform field + centred play disc
- **video** → play-ring
- **article** → ghosted serif dropcap (imageless)

The card surface goes transparent (the media + its shadow *are* the card); imageless tiles get a shared brand-gradient cover. Titles stay light (`--media-glyph`) over the scrim, preserving Phase 0's `--color-heading` base rule for non-cover titles.

Recovered from a stash (WIP preserved 2026-07-19) and taken through the full review cycle.

## Scope (important)

The treatment is **opt-in per call-site**, not a global default. `explore`/`library`/`discover` pass `shape="3:4"` + `titleInCover`; **every other `ContentCard` caller keeps its current look**. This was a deliberate fix — an earlier revision changed ContentCard's default, which `codex-review` caught as leaking 3:4 title-in-cover into curated surfaces (RelatedContent, creator pages, org landing, BrowseModule) that ContentCard's own prop doc marks "restrained".

## Review (codex-review swarm — all findings addressed)

- **HIGH / MED — blast-radius over-reach** (both reviewers): resolved by scoping to explicit opt-in; global default reverted.
- **MED — onerror fallback** (silent-failure): the imageless fallback relied on a hydration-attached `onerror`, so a 404 pre-hydration / no-JS showed a broken image. Now the brand cover is **always painted behind** the (promoted) image — JS-free fallback, mirroring the existing audio-media pattern.
- **LOW — test coverage**: added per-type flair assertions (video ring, audio disc + suppressed overlay, article dropcap) + the JS-free fallback.
- **NITs**: guarded empty dropcap; `line-height` → `var(--leading-none)`; `opacity` fallback `0.8`.

## Test plan

- `ContentCard.svelte.test.ts` — **21 pass** (scoped contract + opt-in per-type flair + JS-free brand-cover fallback)
- svelte-autofixer clean on `ContentCard.svelte`
- No other component/e2e specs reference the changed selectors (`cc__cover--*`, `cc__flair*`, `cc--title-in-cover`)
- **Visual verification is partial** — confirmed live (Storybook, computed-style probe): 3:4 shape, transparent card, light title over scrim, brand cover + video play-ring flair. The audio/article flair and multi-surface layout were verified via the DOM tests + code, not live, because the local workers were down and the Storybook instance wouldn't switch stories. A Playwright visual pass on discover/explore/library is recommended before merge (CI + reviewer eyeball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
