### PR TITLE
fix(web): homogenise landing cards + clamp title-in-cover overflow

### DIFF
--- a/apps/web/src/lib/components/browse/BrowseModule.svelte
+++ b/apps/web/src/lib/components/browse/BrowseModule.svelte
@@ -133,6 +133,7 @@
   <ContentCard
     variant="grid"
     {shape}
+    titleInCover
     chrome="transparent"
     id={item.id}
     title={item.title}

--- a/apps/web/src/lib/components/browse/BrowseModule.svelte.test.ts
+++ b/apps/web/src/lib/components/browse/BrowseModule.svelte.test.ts
@@ -143,6 +143,31 @@ describe('BrowseModule — unfiltered (grid)', () => {
     }
   });
 
+  test('every browse card opts into title-in-cover so all types share the cover treatment (Codex-p7wc8)', () => {
+    render();
+    const cards = Array.from(
+      document.querySelectorAll<HTMLElement>('.content-grid .cc')
+    );
+    expect(cards.length).toBe(items.length);
+    // The homogenised catalogue passes `titleInCover` for EVERY type — not just
+    // articles (which auto-enable it at 1:1/3:4). Before this opt-in, video and
+    // audio tiles stayed plain and clashed with the flipped article tiles in the
+    // same grid (and the flipped article tile overflowed its cell to the right).
+    for (const card of cards) {
+      expect(card.classList.contains('cc--title-in-cover')).toBe(true);
+    }
+    // Guard the non-article types explicitly — this is exactly what the opt-in
+    // adds over the article-only auto-enable.
+    const byType = (t: string) =>
+      cards.find((c) => c.getAttribute('data-content-type') === t);
+    expect(byType('video')?.classList.contains('cc--title-in-cover')).toBe(
+      true
+    );
+    expect(byType('audio')?.classList.contains('cc--title-in-cover')).toBe(
+      true
+    );
+  });
+
   test('the active tab is "All" and marked aria-selected', () => {
     render();
     expect(tabByLabel('All')?.getAttribute('aria-selected')).toBe('true');

--- a/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
+++ b/apps/web/src/lib/components/ui/ContentCard/ContentCard.svelte
@@ -1968,6 +1968,11 @@
        the image edge instead of floating over blank card in a mixed row that
        is taller than the media's natural aspect. */
     grid-template-rows: 1fr auto;
+    /* Single column clamped to the card box: `minmax(0, 1fr)` (not the implicit
+       `auto` track) keeps the overlaid body's min-content title from growing the
+       column past the card and — with `overflow: visible` below — spilling the
+       tile out to the right inside a fixed-width carousel/grid cell. (Codex-p7wc8) */
+    grid-template-columns: minmax(0, 1fr);
     padding: 0;
     /* Floating-media card: the cover fills edge-to-edge, so the card surface
        itself is always transparent (no frame) regardless of the `chrome`
@@ -1998,6 +2003,8 @@
   .cc--title-in-cover .cc__thumb {
     grid-row: 1;
     grid-column: 1;
+    /* Shrink to the clamped column rather than the image's intrinsic width. */
+    min-width: 0;
     /* Fill the media row even when the card is stretched past the media's
        natural aspect (mixed rows). `stretch` grows the tile beyond its aspect
        floor so the cover image + scrimmed title reach down to the caption. */
@@ -2009,6 +2016,8 @@
   .cc--title-in-cover .cc__body {
     grid-row: 1;
     grid-column: 1;
+    /* Shrink to the clamped column so a long title can't widen the grid. */
+    min-width: 0;
     align-self: end;
     z-index: 2;
     padding: var(--space-4);

--- a/apps/web/src/routes/_org/[slug]/(space)/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/+page.svelte
@@ -594,6 +594,7 @@
     <ContentCard
       variant="grid"
       {shape}
+      titleInCover
       chrome="transparent"
       id={c.id}
       title={c.title}


### PR DESCRIPTION
## Summary
Follow-up to #399. The homogenised title-in-cover treatment only reached explore/library/discover, so on the **org landing** (New this week + Browse everything) only articles auto-flipped to it while video/audio stayed plain — and the wider flipped article tile spilled out of its carousel/grid cell to the right.

- **ContentCard** — clamp `.cc--title-in-cover` to a `minmax(0, 1fr)` grid column + `min-width: 0` on thumb/body, so the overlaid title can't grow the tile past its cell (`overflow: visible` was letting the oversized column bleed right).
- **Landing `gridCard`** (New this week) + **`BrowseModule` `browseCard`** (Browse everything) — opt every type into `titleInCover`, per the chosen 'catalogue surfaces' scope. Curated surfaces without a shape (RelatedContent, continue-watching, creators, AudioWall) untouched.
- Regression test in BrowseModule locking the non-article opt-in.

## Test plan
- `ContentCard` 21/21, `BrowseModule` 21/21 (incl. new opt-in guard) green.
- `svelte-check`: 0 errors in touched files (the 93 are the known cold `svelte-kit sync` remote-type cascade in unrelated files; CI resolves).
- **Live (chrome-devtools, of-blood-and-bones):** New this week + Browse everything now render video/audio/article all title-in-cover with per-type flair, uniform width, zero cell bleed (article thumb 427→382 / 458→393, bleed −1). Explore unregressed (uniform 366px, no bleed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)