### PR TITLE
refactor(web): version-branch libraryCollection hydration (Codex-2pryk.1.6)

### DIFF
--- a/apps/web/src/lib/collections/library.ts
+++ b/apps/web/src/lib/collections/library.ts
@@ -14,6 +14,10 @@ import type { UserLibraryResponse } from '@codex/access';
 import { VIDEO_PROGRESS } from '@codex/constants';
 import { createCollection, localStorageCollectionOptions } from '@tanstack/db';
 import { browser } from '$app/environment';
+import {
+  LIBRARY_STORAGE_KEY,
+  reconcileLibrarySchemaVersion,
+} from '$lib/library/schema-version';
 import { logger } from '$lib/observability';
 import { getUserLibrary } from '$lib/remote/library.remote';
 
@@ -49,10 +53,21 @@ type LibraryProgress = NonNullable<LibraryItem['progress']>;
  * </script>
  * ```
  */
+// Reconcile the persisted payload's schema version BEFORE the collection is
+// created. TanStack DB reads localStorage the first time the collection syncs,
+// so an incompatible payload must be migrated or discarded first — otherwise a
+// future course-grouping schema change strands old rows (risk R-B). This is a
+// no-op at the current version; see $lib/library/schema-version.ts.
+if (browser) {
+  reconcileLibrarySchemaVersion(
+    typeof localStorage !== 'undefined' ? localStorage : undefined
+  );
+}
+
 export const libraryCollection = browser
   ? createCollection<LibraryItem, string>(
       localStorageCollectionOptions({
-        storageKey: 'codex-library',
+        storageKey: LIBRARY_STORAGE_KEY,
         getKey: (item) => item.content.id,
       })
     )

--- a/apps/web/src/lib/library/filter-by-org.ts
+++ b/apps/web/src/lib/library/filter-by-org.ts
@@ -1,18 +1,34 @@
 /**
- * Library Filter by Org — pure predicate + helper for scoping a user's
- * multi-org library collection to a single organization on org-subdomain
- * library views (e.g. `acme.codex.app/library`, `acme.codex.app/`).
+ * Library Filter by Org — the single cross-org boundary for the library
+ * collection. Pure predicate + helper for scoping a user's multi-org library
+ * to one organization on org-subdomain library views (e.g.
+ * `acme.codex.app/library`, `acme.codex.app/`).
  *
- * The library collection is stored in a single localStorage key spanning
- * every org the user has joined, keyed by content.id. When rendered on an
- * org subdomain we must filter to that org ONLY — otherwise cross-org
- * content bleeds through. The original bug (Codex-q3zuf) filtered by
- * `organizationSlug` which was nullable; legacy entries with null slugs
- * slipped through.
+ * ## Why one shared boundary
  *
- * Extracted here so the predicate is unit-testable and its contract is
- * enforced by a test suite — making it hard to silently regress back to
- * the slug-based filter.
+ * The library collection (`$lib/collections/library.ts`) is stored in a single
+ * localStorage key spanning every org the user has joined, keyed by
+ * content.id. Two surfaces read that one cross-org collection:
+ *   - the platform library (`(platform)/library`) shows the FULL set (no org
+ *     filter — it is the "everything you own" view), and
+ *   - the org library (`_org/[slug]/(space)/library`) must scope to the
+ *     current org ONLY, via `filterLibraryItemsByOrg`, or cross-org content
+ *     bleeds through.
+ * Keeping the org-scoping predicate here (rather than inline in the org page)
+ * means the one place both surfaces disagree — "all orgs" vs "this org" — is
+ * expressed once and locked by tests.
+ *
+ * The original bug (Codex-q3zuf) filtered by `organizationSlug`, which was
+ * nullable; legacy entries with null slugs slipped through. This predicate
+ * filters strictly by the non-null `organizationId` instead.
+ *
+ * ## Relationship to schema versioning
+ *
+ * This predicate trusts that every entry carries the current `LibraryItem`
+ * shape (`content.organizationId`). That invariant is upheld by
+ * `$lib/library/schema-version.ts`, which discards/migrates any stale-shape
+ * localStorage payload BEFORE the collection hydrates. When the course-grouping
+ * change lands it will extend both this filter and the schema version together.
  */
 
 interface LibraryItemLike {

--- a/apps/web/src/lib/library/schema-version.test.ts
+++ b/apps/web/src/lib/library/schema-version.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Library schema-version reconcile tests.
+ *
+ * Locks the R-B mitigation (HARDENING §E): a course-grouping schema change
+ * must NOT strand old localStorage payloads. The reconcile pass runs before
+ * the collection is created and:
+ *   - hydrates a current-version payload unchanged (fast path),
+ *   - adopts an unstamped payload at the introduction version WITHOUT
+ *     discarding (behaviour-preserving for existing users), and
+ *   - discards/migrates an incompatible older payload (never hydrated as-is).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  LIBRARY_SCHEMA_STORAGE_KEY,
+  LIBRARY_SCHEMA_VERSION,
+  LIBRARY_STORAGE_KEY,
+  type LibrarySchemaMigrations,
+  reconcileLibrarySchemaVersion,
+} from './schema-version';
+
+/** Minimal in-memory Storage stand-in (independent of jsdom global state). */
+function memoryStorage(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    // test helpers
+    has: (k: string) => map.has(k),
+    peek: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+  };
+}
+
+// A realistic TanStack-DB localStorage blob: { [id]: { versionKey, data } }.
+const PAYLOAD = JSON.stringify({
+  'content-1': { versionKey: 'v-uuid', data: { content: { id: 'content-1' } } },
+});
+
+describe('reconcileLibrarySchemaVersion', () => {
+  describe('current-version data hydrates unchanged', () => {
+    it('is a no-op when the stamp already matches the current version', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: String(LIBRARY_SCHEMA_VERSION),
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+
+      const outcome = reconcileLibrarySchemaVersion(storage);
+
+      expect(outcome).toBe('current');
+      // Payload untouched — this is the "hydrate as-is" guarantee.
+      expect(storage.peek(LIBRARY_STORAGE_KEY)).toBe(PAYLOAD);
+      expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe(
+        String(LIBRARY_SCHEMA_VERSION)
+      );
+    });
+
+    it('injected current version matches an injected stamp (fast path)', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: '3',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+
+      expect(
+        reconcileLibrarySchemaVersion(storage, { currentVersion: 3 })
+      ).toBe('current');
+      expect(storage.peek(LIBRARY_STORAGE_KEY)).toBe(PAYLOAD);
+    });
+  });
+
+  describe('old-version data is discarded, never stranded (R-B)', () => {
+    it('discards a payload stamped with an older version when no migration exists', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+
+      // Simulate the future course-grouping bump: current is now v2.
+      const outcome = reconcileLibrarySchemaVersion(storage, {
+        currentVersion: 2,
+        introductionVersion: 1,
+      });
+
+      expect(outcome).toBe('discarded');
+      // The stale payload is GONE (self-heals via loadLibraryFromServer on
+      // mount) rather than hydrated with a shape the new code can't read.
+      expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+      // Stamp advanced so the discard happens exactly once.
+      expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe('2');
+    });
+
+    it('discards an UNSTAMPED payload once past the introduction version', () => {
+      // No stamp, but we are already at v2 — the payload predates stamping and
+      // its shape cannot be trusted against v2.
+      const storage = memoryStorage({ [LIBRARY_STORAGE_KEY]: PAYLOAD });
+
+      const outcome = reconcileLibrarySchemaVersion(storage, {
+        currentVersion: 2,
+        introductionVersion: 1,
+      });
+
+      expect(outcome).toBe('discarded');
+      expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+      expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe('2');
+    });
+
+    it('treats a corrupt stamp as incompatible when past the introduction version', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: 'not-a-number',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+
+      expect(
+        reconcileLibrarySchemaVersion(storage, {
+          currentVersion: 2,
+          introductionVersion: 1,
+        })
+      ).toBe('discarded');
+      expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+    });
+  });
+
+  describe('migration seam', () => {
+    it('migrates an older payload in place when a migration is registered', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+      const MIGRATED = JSON.stringify({ migrated: true });
+      const migrations: LibrarySchemaMigrations = {
+        1: vi.fn(() => MIGRATED),
+      };
+
+      const outcome = reconcileLibrarySchemaVersion(storage, {
+        currentVersion: 2,
+        introductionVersion: 1,
+        migrations,
+      });
+
+      expect(outcome).toBe('migrated');
+      expect(migrations[1]).toHaveBeenCalledWith(PAYLOAD);
+      expect(storage.peek(LIBRARY_STORAGE_KEY)).toBe(MIGRATED);
+      expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe('2');
+    });
+
+    it('falls back to discard when the migration returns null', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+      const migrations: LibrarySchemaMigrations = { 1: () => null };
+
+      expect(
+        reconcileLibrarySchemaVersion(storage, {
+          currentVersion: 2,
+          introductionVersion: 1,
+          migrations,
+        })
+      ).toBe('discarded');
+      expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+    });
+
+    it('falls back to discard when the migration throws', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+      const migrations: LibrarySchemaMigrations = {
+        1: () => {
+          throw new Error('bad migration');
+        },
+      };
+
+      expect(
+        reconcileLibrarySchemaVersion(storage, {
+          currentVersion: 2,
+          introductionVersion: 1,
+          migrations,
+        })
+      ).toBe('discarded');
+      expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+    });
+  });
+
+  describe('introduction bootstrap is behaviour-preserving', () => {
+    it('adopts an unstamped payload at the introduction version WITHOUT discarding', () => {
+      const storage = memoryStorage({ [LIBRARY_STORAGE_KEY]: PAYLOAD });
+
+      const outcome = reconcileLibrarySchemaVersion(storage, {
+        currentVersion: 1,
+        introductionVersion: 1,
+      });
+
+      expect(outcome).toBe('initialized');
+      // Existing data is kept — no empty-library flash for current users.
+      expect(storage.peek(LIBRARY_STORAGE_KEY)).toBe(PAYLOAD);
+      expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe('1');
+    });
+
+    it('adopts an unstamped corrupt-stamp payload at the introduction version', () => {
+      const storage = memoryStorage({
+        [LIBRARY_SCHEMA_STORAGE_KEY]: 'garbage',
+        [LIBRARY_STORAGE_KEY]: PAYLOAD,
+      });
+
+      expect(
+        reconcileLibrarySchemaVersion(storage, {
+          currentVersion: 1,
+          introductionVersion: 1,
+        })
+      ).toBe('initialized');
+      expect(storage.peek(LIBRARY_STORAGE_KEY)).toBe(PAYLOAD);
+    });
+
+    it('records the stamp on a fresh (empty) store', () => {
+      const storage = memoryStorage();
+
+      expect(reconcileLibrarySchemaVersion(storage)).toBe('initialized');
+      expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe(
+        String(LIBRARY_SCHEMA_VERSION)
+      );
+      expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+    });
+  });
+
+  describe('storage safety', () => {
+    it('is a no-op when storage is null/undefined (SSR)', () => {
+      expect(reconcileLibrarySchemaVersion(null)).toBe('unavailable');
+      expect(reconcileLibrarySchemaVersion(undefined)).toBe('unavailable');
+    });
+
+    it('never throws when localStorage access throws (blocked storage)', () => {
+      const throwing: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = {
+        getItem: () => {
+          throw new Error('SecurityError');
+        },
+        setItem: () => {
+          throw new Error('SecurityError');
+        },
+        removeItem: () => {
+          throw new Error('SecurityError');
+        },
+      };
+
+      expect(reconcileLibrarySchemaVersion(throwing)).toBe('unavailable');
+    });
+  });
+});

--- a/apps/web/src/lib/library/schema-version.ts
+++ b/apps/web/src/lib/library/schema-version.ts
@@ -1,0 +1,201 @@
+/**
+ * Library Collection — localStorage schema versioning
+ *
+ * The library collection (`$lib/collections/library.ts`) persists a user's
+ * cross-org content library into a single localStorage key. TanStack DB's
+ * `localStorageCollectionOptions` stores each row as
+ * `{ [contentId]: { versionKey, data } }`, where `versionKey` is a per-row
+ * conflict UUID for cross-tab reconciliation — it is NOT a schema version.
+ * Nothing today records the *shape* of the persisted `data`.
+ *
+ * That is fine until the shape changes. When the course-grouping work lands
+ * (SPEC §11, HARDENING risk R-B) `LibraryItem` gains course-entitlement fields
+ * and the library page groups by course. On the first load after that ships,
+ * the collection would hydrate OLD-shape rows straight out of localStorage;
+ * the new grouping/filter code reads fields those rows never had, so items
+ * drop out of view — an empty library that stays empty until a server refetch
+ * happens to overwrite every row. That is R-B: "schema change strands stale
+ * localStorage".
+ *
+ * This module scaffolds a schema-version stamp plus a branch that runs BEFORE
+ * the collection is created, so an incompatible payload is migrated or
+ * discarded (discard is self-healing: the collection loads empty, then
+ * `loadLibraryFromServer()` on mount refetches current-shape rows) instead of
+ * hydrated as garbage.
+ *
+ * IMPORTANT — behaviour today is unchanged. At the introduction version (v1)
+ * there is no schema change yet, so:
+ *   - a payload already stamped v1 hydrates untouched (the fast path), and
+ *   - an UNSTAMPED payload is, by definition, current-shape (it was written by
+ *     this same code), so it is adopted (stamped, kept) — no discard, no
+ *     empty-library flash for existing users.
+ * The discard/migrate branch only fires once `LIBRARY_SCHEMA_VERSION` is
+ * bumped for a real shape change.
+ *
+ * @see $lib/collections/library.ts — the collection this guards.
+ * @see $lib/library/filter-by-org.ts — the cross-org filter that trusts the
+ *   entries this guard keeps current-shape.
+ */
+
+/**
+ * localStorage key the library collection persists into. Single source of
+ * truth — imported by `library.ts` for the collection's `storageKey`.
+ *
+ * NOTE: `version-manifest.ts` keeps its own copy of this literal in
+ * `CODEX_STORAGE_KEYS` (for logout-clear). That module is being reworked in
+ * parallel (CE-5); once it settles it should import this constant too.
+ */
+export const LIBRARY_STORAGE_KEY = 'codex-library';
+
+/** localStorage key holding the library payload's schema-version stamp. */
+export const LIBRARY_SCHEMA_STORAGE_KEY = 'codex-library-schema';
+
+/**
+ * Current schema version of the library localStorage payload.
+ *
+ * BUMP THIS whenever the persisted `LibraryItem` shape changes in a way old
+ * rows can't satisfy (e.g. the course-grouping change). Bumping it activates
+ * the discard/migrate branch for every older payload. If the new shape can be
+ * derived from the old one, register a migration in `librarySchemaMigrations`
+ * instead of relying on discard.
+ */
+export const LIBRARY_SCHEMA_VERSION = 1;
+
+/**
+ * The version at which schema-stamping was introduced. Used to distinguish
+ * "unstamped because stamping did not exist yet" (safe to adopt as current at
+ * introduction) from "unstamped at a later version" (unknown provenance →
+ * discard). Do not change this when bumping `LIBRARY_SCHEMA_VERSION`.
+ */
+const INTRODUCTION_VERSION = 1;
+
+/**
+ * Transforms a raw stored payload string (the TanStack DB
+ * `{ [key]: { versionKey, data } }` JSON blob) from the version it is keyed
+ * under towards the current shape, or returns `null` to signal "cannot
+ * migrate — discard instead". Migrations are keyed by the version being
+ * migrated FROM.
+ *
+ * Empty today (the scaffold discards on any mismatch). The course-grouping
+ * change can register `{ 1: (raw) => addCourseFields(raw) }` here to preserve
+ * a user's local library across the bump instead of forcing a refetch.
+ */
+export type LibrarySchemaMigration = (rawPayload: string) => string | null;
+export type LibrarySchemaMigrations = Readonly<
+  Record<number, LibrarySchemaMigration>
+>;
+
+export const librarySchemaMigrations: LibrarySchemaMigrations = {};
+
+/**
+ * Outcome of a reconcile pass, surfaced for observability/tests.
+ * - `current`     — stamp already matches; payload hydrates as-is.
+ * - `initialized` — no stamp at the introduction version (or no payload); the
+ *                   current stamp was recorded and any payload was kept.
+ * - `migrated`    — an older payload was transformed in place by a migration.
+ * - `discarded`   — an incompatible payload was cleared (self-heals on next
+ *                   server fetch).
+ * - `unavailable` — no usable storage (SSR, blocked localStorage); no-op.
+ */
+export type LibrarySchemaReconcileOutcome =
+  | 'current'
+  | 'initialized'
+  | 'migrated'
+  | 'discarded'
+  | 'unavailable';
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+/**
+ * Reconcile the persisted library payload's schema version.
+ *
+ * Call this synchronously BEFORE the collection is created — TanStack DB reads
+ * localStorage the first time the collection syncs, so the payload must be
+ * made compatible first.
+ *
+ * `currentVersion`, `introductionVersion` and `migrations` are injectable so
+ * the branch is unit-testable without mutating the real module constants or
+ * touching real localStorage.
+ */
+export function reconcileLibrarySchemaVersion(
+  storage: StorageLike | null | undefined,
+  options: {
+    currentVersion?: number;
+    introductionVersion?: number;
+    migrations?: LibrarySchemaMigrations;
+  } = {}
+): LibrarySchemaReconcileOutcome {
+  if (!storage) return 'unavailable';
+
+  const current = options.currentVersion ?? LIBRARY_SCHEMA_VERSION;
+  const introduction = options.introductionVersion ?? INTRODUCTION_VERSION;
+  const migrations = options.migrations ?? librarySchemaMigrations;
+
+  try {
+    const stored = readStamp(storage);
+
+    // Fast path: the stamp already matches — the payload is current-shape, so
+    // hydrate it untouched.
+    if (stored === current) return 'current';
+
+    // Bootstrap at the introduction version: an unstamped payload was written
+    // by this same code, so it is current-shape. Adopt it (record the stamp,
+    // keep the data). This is the behaviour-preserving path for users who
+    // predate stamping — no discard, no empty-library flash.
+    if (stored === null && current === introduction) {
+      writeStamp(storage, current);
+      return 'initialized';
+    }
+
+    // Otherwise the stored payload predates the current shape (older/unknown
+    // stamp, or unstamped once we are past the introduction version). Migrate
+    // it if a migration is registered for its version, else discard so the
+    // collection reloads clean from the server on next mount.
+    const rawPayload = storage.getItem(LIBRARY_STORAGE_KEY);
+    if (rawPayload === null) {
+      // Nothing persisted to strand; just record the current stamp.
+      writeStamp(storage, current);
+      return 'initialized';
+    }
+
+    const migration = stored === null ? undefined : migrations[stored];
+    const migrated = migration ? safeMigrate(migration, rawPayload) : null;
+
+    if (migrated !== null) {
+      storage.setItem(LIBRARY_STORAGE_KEY, migrated);
+      writeStamp(storage, current);
+      return 'migrated';
+    }
+
+    storage.removeItem(LIBRARY_STORAGE_KEY);
+    writeStamp(storage, current);
+    return 'discarded';
+  } catch {
+    // localStorage blocked/unavailable — never block collection creation.
+    return 'unavailable';
+  }
+}
+
+/** Read the stamp as an integer, or `null` when absent or corrupt. */
+function readStamp(storage: StorageLike): number | null {
+  const raw = storage.getItem(LIBRARY_SCHEMA_STORAGE_KEY);
+  if (raw === null) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function writeStamp(storage: StorageLike, version: number): void {
+  storage.setItem(LIBRARY_SCHEMA_STORAGE_KEY, String(version));
+}
+
+/** Run a migration, treating a thrown error as "unmigratable" (→ discard). */
+function safeMigrate(
+  migration: LibrarySchemaMigration,
+  rawPayload: string
+): string | null {
+  try {
+    return migration(rawPayload);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## CE-6 — libraryCollection hydration version-branch (Codex-2pryk.1.6)

Epic 0 (Journeys Cleanup) work package. Behaviour-preserving scaffold + tidy that de-risks the later course-grouping schema change.

### Problem (HARDENING risk R-B)
The library collection persists to a single `codex-library` localStorage key via TanStack DB's `localStorageCollectionOptions`, which stores each row as `{ [contentId]: { versionKey, data } }`. `versionKey` is a **per-row cross-tab conflict UUID — not a schema version**. Nothing records the *shape* of the persisted `LibraryItem`.

When the course-grouping work lands (SPEC §11) and `LibraryItem` gains course-entitlement fields, old-shape rows would hydrate straight out of localStorage on the first load after deploy; the new grouping/filter code reads fields those rows never had, so items silently drop out of view — an empty library that stays empty until a server refetch happens to overwrite every row.

The existing `version-manifest.ts` does **not** cover this — it tracks *server data* versions (KV bump → refetch), an axis orthogonal to *client-code schema drift* of the persisted payload.

### Change
- **New `$lib/library/schema-version.ts`** — a `LIBRARY_SCHEMA_VERSION` stamp plus `reconcileLibrarySchemaVersion()`, run **before** the collection is created (TanStack reads localStorage on first sync). Branch:
  - stamp `===` current → `current` (hydrate as-is, fast path)
  - unstamped at the introduction version → `initialized` (**adopt, no discard** — existing rows are current-shape by definition)
  - older/unknown/corrupt stamp (or unstamped past introduction) → **migrate** (via a registered migration) or **discard** so the collection self-heals from the server on next mount
  - null/blocked storage → `unavailable` (never blocks collection creation)
  - `librarySchemaMigrations` registry is the seam the future change registers a migrator in; empty today (discard is the default). Version/introduction/migrations are injectable for unit-testability.
- **`collections/library.ts`** — browser-guarded reconcile call before `createCollection`; `storageKey` now uses the shared `LIBRARY_STORAGE_KEY` constant.
- **`library/filter-by-org.ts`** (the cross-org filter shared with platform `/library`) — tidied docs to document it as the single cross-org boundary for both the platform (full set) and org (scoped) library surfaces, and its reliance on the schema-version guarantee. **Predicate byte-identical** (its 8 regression tests pass unchanged).

### Behaviour today is unchanged
At the current version the discard/migrate branch never fires: stamped-current rows hydrate untouched and unstamped rows are adopted (no empty-library flash). The branch only activates once `LIBRARY_SCHEMA_VERSION` is bumped for a real shape change.

### Tests / gates
- New `schema-version.test.ts` (13 tests) proves the gate: current-version hydrates unchanged; OLD/unstamped-past-introduction/corrupt stamps are discarded (payload removed, not stranded); registered migration is honoured; introduction bootstrap adopts without discard; SSR/blocked storage is a safe no-op.
- `pnpm --filter web exec vitest run` on the 5 affected files = **51/51 pass**.
- biome clean on all changed files. svelte-check: **0 errors in changed files** (the repo's pre-existing dev-branch drift in `revenue-share`/`unsubscribe` is untouched).

### Note for CE-5 (parallel)
`version-manifest.ts` keeps its own `'codex-library'` literal and its logout-clear list. Once CE-5 settles, it should import `LIBRARY_STORAGE_KEY` and add `LIBRARY_SCHEMA_STORAGE_KEY` to `CODEX_STORAGE_KEYS` so logout also clears the stamp. Left untouched here to avoid collision with CE-5's `+layout.svelte`/staleness-dispatch work. (A leftover stamp after logout is benign — the payload is cleared, so re-hydration is empty either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)