### PR TITLE
refactor(web): clarify shared content-detail access seam for WP-2 rewire (Codex-2pryk.1.3)

### DIFF
--- a/apps/web/src/lib/server/content-detail.test.ts
+++ b/apps/web/src/lib/server/content-detail.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Content-detail shared access seam (Codex-2pryk.1.3 · CE-3).
+ *
+ * These helpers are the SINGLE access seam feeding both content-detail routes
+ * (org `_org/[slug]/(space)/content/[contentSlug]` + creator
+ * `_creators/[username]/content/[contentSlug]`). The suite pins the
+ * behaviour-preserving contract so the WP-2 `@codex/access` rewire, which
+ * replaces `resolveAccessGranted`, has a regression net:
+ *   - `isPublicAccessType` — only `free` is publicly readable;
+ *   - `resolveAccessGranted` — a resolved `/stream` response grants access,
+ *     INCLUDING a written article whose `streamingUrl` is null; a thrown call
+ *     (null result) denies. This is the historical "getStreamingUrl-throws"
+ *     gate that must survive the swap;
+ *   - the shared fallback constants keep a stable field set so drift is caught
+ *     in one place.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  DENIED_ACCESS_RESULT,
+  EMPTY_SUB_CONTEXT,
+  isPublicAccessType,
+  loadSubscriptionContext,
+  resolveAccessGranted,
+} from './content-detail';
+
+/** A non-null `/stream` payload — only its presence matters to the seam. */
+type StreamResult = NonNullable<Parameters<typeof resolveAccessGranted>[0]>;
+
+describe('isPublicAccessType', () => {
+  it('treats only "free" content as publicly readable', () => {
+    expect(isPublicAccessType('free')).toBe(true);
+  });
+
+  it.each([
+    'paid',
+    'followers',
+    'subscribers',
+    'team',
+  ])('gates "%s" content behind the access check', (accessType) => {
+    expect(isPublicAccessType(accessType)).toBe(false);
+  });
+
+  it('is not public for null / undefined / empty accessType', () => {
+    expect(isPublicAccessType(null)).toBe(false);
+    expect(isPublicAccessType(undefined)).toBe(false);
+    expect(isPublicAccessType('')).toBe(false);
+  });
+});
+
+describe('resolveAccessGranted (WP-2 swap point)', () => {
+  it('denies when the /stream call threw (null result)', () => {
+    // A thrown getStreamingUrl (403 / network / 5xx) is captured as null.
+    expect(resolveAccessGranted(null)).toBe(false);
+  });
+
+  it('grants when /stream resolved with a signed streaming URL', () => {
+    const withMedia = {
+      streamingUrl: 'https://cdn.example/x.m3u8',
+    } as unknown as StreamResult;
+    expect(resolveAccessGranted(withMedia)).toBe(true);
+  });
+
+  it('grants when /stream resolved with a null URL (written article)', () => {
+    // HARDENING-critical: a successful access check with no media to sign
+    // (written content) still means the user may view. Must not regress.
+    const writtenArticle = {
+      streamingUrl: null,
+    } as unknown as StreamResult;
+    expect(resolveAccessGranted(writtenArticle)).toBe(true);
+  });
+
+  it('matches the DENIED_ACCESS_RESULT fallback on the denied branch', () => {
+    // The routes fall back to DENIED_ACCESS_RESULT when the await rejects;
+    // its hasAccess must agree with the seam's null (denied) verdict.
+    expect(resolveAccessGranted(null)).toBe(DENIED_ACCESS_RESULT.hasAccess);
+  });
+});
+
+describe('shared fallback shapes', () => {
+  it('DENIED_ACCESS_RESULT is fully absent/denied', () => {
+    expect(DENIED_ACCESS_RESULT).toEqual({
+      hasAccess: false,
+      streamingUrl: null,
+      waveformUrl: null,
+      readyVariants: null,
+      expiresAt: null,
+      revocationReason: null,
+      progress: null,
+    });
+  });
+
+  it('EMPTY_SUB_CONTEXT requires no subscription', () => {
+    expect(EMPTY_SUB_CONTEXT).toEqual({
+      requiresSubscription: false,
+      hasSubscription: false,
+      subscriptionCoversContent: false,
+      currentSubscription: null,
+      tiers: [],
+    });
+  });
+});
+
+describe('loadSubscriptionContext (non-subscriber early return)', () => {
+  type Cookies = Parameters<typeof loadSubscriptionContext>[3];
+  const unusedCookies = {} as unknown as Cookies;
+
+  it('returns the empty context for free content with no minimum tier', async () => {
+    // No accessType === "subscribers" and no minimumTierId → the function
+    // short-circuits before ever touching the API, and the inline literal it
+    // returns must stay identical to EMPTY_SUB_CONTEXT.
+    const ctx = await loadSubscriptionContext(
+      'org-1',
+      null,
+      undefined,
+      unusedCookies,
+      'free'
+    );
+    expect(ctx).toEqual(EMPTY_SUB_CONTEXT);
+  });
+});

--- a/apps/web/src/lib/server/content-detail.ts
+++ b/apps/web/src/lib/server/content-detail.ts
@@ -1,13 +1,33 @@
 /**
  * Shared helpers for content detail server loads and actions.
  *
- * Both the org content detail (`_org/[slug]/(space)/content/[contentSlug]`)
- * and the creator content detail (`_creators/[username]/content/[contentSlug]`)
- * perform the same authenticated-user access check and purchase checkout flow.
+ * # Single shared access seam — two routes, one source of truth
  *
- * This module extracts that duplicated logic:
+ * TWO content-detail routes call these helpers with identical arguments and
+ * MUST stay in lockstep. They form ONE access seam — access logic lives here,
+ * never per-route:
+ *
+ *   1. org content     — `routes/_org/[slug]/(space)/content/[contentSlug]/+page.server.ts`
+ *   2. creator content — `routes/_creators/[username]/content/[contentSlug]/+page.server.ts`
+ *
+ * Each route calls `loadAccessAndProgress(content.id, platform, cookies,
+ * content.accessType)` in both of its branches — streamed on the free
+ * fast-path, awaited on the gated path — so there are four call sites but a
+ * single signature. Neither `+page.server.ts` may add its own grant/deny
+ * logic; keeping the decision here is what stops the two routes diverging.
+ *
+ * ## WP-2 swap point (Codex-2pryk journeys)
+ *
+ * The `@codex/access` rewire (canView / canEnterCourse) replaces exactly ONE
+ * function — {@link resolveAccessGranted} — with an explicit entitlement
+ * resolver. Because both routes reach the grant decision only through that
+ * function, the swap rewires both at once and cannot diverge by route. See
+ * its doc block for the behaviour that must be preserved through the swap.
+ *
+ * This module extracts the shared logic:
  * - `loadAccessAndProgress` — parallel fetch of streaming URL + playback progress
- * - `handlePurchaseAction` — Stripe checkout session creation with error handling
+ * - `resolveAccessGranted`  — THE access-grant seam (WP-2 swap point)
+ * - `handlePurchaseAction`  — Stripe checkout session creation with error handling
  */
 import type { Cookies } from '@sveltejs/kit';
 import { fail } from '@sveltejs/kit';
@@ -103,8 +123,8 @@ type ContentAccessType = 'free' | 'paid' | 'followers' | 'subscribers' | 'team';
  * `requiresSubscription` from content state, so it stays inline rather than
  * sharing this constant.
  *
- * Iter-027 F3 — see proof test
- * `apps/web/src/__denoise_proofs__/iter-027/F3-content-detail-loader-dup.test.ts`.
+ * Shape pinned by `content-detail.test.ts` so the field set can only drift in
+ * one place (originally the removed iter-027 F3 denoise proof).
  */
 export const EMPTY_SUB_CONTEXT: SubscriptionContext = {
   requiresSubscription: false,
@@ -124,8 +144,8 @@ export const EMPTY_SUB_CONTEXT: SubscriptionContext = {
  * literal but with `hasAccess: isPublic` rather than `false`, so it can't
  * share this constant directly without a wrapper.
  *
- * Iter-027 F3 — see proof test
- * `apps/web/src/__denoise_proofs__/iter-027/F3-content-detail-loader-dup.test.ts`.
+ * Shape pinned by `content-detail.test.ts` so the field set can only drift in
+ * one place (originally the removed iter-027 F3 denoise proof).
  */
 export const DENIED_ACCESS_RESULT: AccessAndProgress = {
   hasAccess: false,
@@ -154,11 +174,54 @@ export function isPublicAccessType(
   return accessType === 'free';
 }
 
+/** The server-side API surface returned by `createServerApi`. */
+type ServerApi = ReturnType<typeof createServerApi>;
+
+/**
+ * Resolved payload of the access worker's `/stream` endpoint
+ * (`api.access.getStreamingUrl`). Threaded through {@link resolveAccessGranted}
+ * as `StreamResult | null`, where `null` means the call threw — a 403
+ * `AccessDeniedError`, a network error, or a 5xx — i.e. the backend did not
+ * grant access.
+ */
+type StreamResult = Awaited<ReturnType<ServerApi['access']['getStreamingUrl']>>;
+
+/**
+ * ── ACCESS-GRANT SEAM · single WP-2 swap point ───────────────────────────
+ *
+ * Decides whether the authenticated user may view this content. This is the
+ * ONE place both content-detail routes resolve "granted?" — see the module
+ * header for the two routes and the lockstep contract.
+ *
+ * BEHAVIOUR TODAY (must be preserved): access is inferred from the `/stream`
+ * response. A resolved response — *even one whose `streamingUrl` is null*
+ * (written articles have no media to sign) — means the backend access check
+ * passed. A thrown call (captured by the caller as `streamResult === null`)
+ * means denied. This is the historical "getStreamingUrl-throws" gate; the
+ * null-streamingUrl-but-granted case must not regress.
+ *
+ * WP-2 (Codex-2pryk · `@codex/access` rewire) replaces the BODY of this
+ * function with an explicit `canView` entitlement resolver. The signature may
+ * widen (e.g. to take contentId / accessType / platform / cookies) — keep that
+ * change inside this function so both routes inherit it in one swap and cannot
+ * diverge by route.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+export function resolveAccessGranted(
+  streamResult: StreamResult | null
+): boolean {
+  return streamResult !== null;
+}
+
 /**
  * Fetch streaming URL and playback progress for an authenticated user.
  *
  * Returns `{ hasAccess, streamingUrl, progress }`.
  * Gracefully handles 403 / network errors by returning hasAccess=false.
+ *
+ * Shared verbatim by both content-detail routes (see module header). The
+ * access-grant decision is isolated in {@link resolveAccessGranted} — the
+ * single WP-2 swap point; everything else here is response assembly.
  *
  * `accessType` short-circuits the result for free content: `hasAccess` is
  * forced to `true` even if the stream fetch fails, so the body stays visible
@@ -177,7 +240,6 @@ export async function loadAccessAndProgress(
   // revocation `reason` from AccessDeniedError without bubbling the error
   // out of the server load. `.catch(() => null)` would swallow the detail
   // — we need the ApiError instance.
-  type StreamResult = Awaited<ReturnType<typeof api.access.getStreamingUrl>>;
   let streamResult: StreamResult | null = null;
   let streamError: unknown = null;
 
@@ -196,7 +258,9 @@ export async function loadAccessAndProgress(
   // A successful response from /stream means the access check passed,
   // even when streamingUrl is null (written articles — no media to sign).
   // Only a thrown error (403 denied, network failure) means no access.
-  const accessGranted = streamResult !== null;
+  // Single access-grant seam — WP-2 swaps `resolveAccessGranted` for an
+  // explicit `@codex/access` canView resolver (see its doc block).
+  const accessGranted = resolveAccessGranted(streamResult);
   const hasAccess = isPublicAccessType(accessType) || accessGranted;
   const streamingUrl =
     (streamResult as StreamResult | null)?.streamingUrl ?? null;


### PR DESCRIPTION
## CE-3 · Codex-2pryk.1.3 — Clarify shared content-detail access seam

Behaviour-preserving clarity/structure/documentation pass on
`apps/web/src/lib/server/content-detail.ts` so the later **WP-2** `@codex/access`
rewire (`canView` / `canEnterCourse`) is **one clean swap point that cannot
diverge by route**. No access-logic change; no `accessType` rework (that's CE-2).

### The two-route sharing (now documented + enforced by structure)
`loadAccessAndProgress` feeds **both** content-detail routes with an identical
signature (four call sites — streamed on the free fast-path, awaited on the
gated path):
- org content — `routes/_org/[slug]/(space)/content/[contentSlug]/+page.server.ts`
- creator content — `routes/_creators/[username]/content/[contentSlug]/+page.server.ts`

The module header now states they **must stay in lockstep** — access logic lives
in this module, never per-route.

### What changed vs documented
- **Structure:** extracted the access-grant decision (previously the inline
  `streamResult !== null` gate) into a single exported, documented
  `resolveAccessGranted()` — **THE WP-2 swap point**. Both routes reach the
  grant decision only through it, so the future `canView` rewire rewires both
  at once and cannot diverge. `StreamResult` hoisted to module scope to support
  it.
- **Preserved (security-critical):** a resolved `/stream` response with a null
  `streamingUrl` (written articles) still grants access — pinned by a test so
  it can't regress through the swap.
- **Docs:** module header + `loadAccessAndProgress`/`resolveAccessGranted` doc
  blocks describe the seam and the swap plan.
- **Test:** new `content-detail.test.ts` (regression net for WP-2) covering the
  seam grant/deny incl. the null-URL written-article case, `isPublicAccessType`,
  and the shared fallback-shape constants.
- **Cleanup:** fixed two stale comment pointers to the removed iter-027 denoise
  proof.

### Local gate (GitHub CI down for billing)
- `pnpm --filter web test` on `content-detail.test.ts` — **13 passed**
- `pnpm --filter web typecheck` — **exit 0, 0 errors**
- `biome check` on both files — **exit 0** (the pre-existing `noUnusedVariables`
  warning on the dead `ContentAccessType` mirror is on HEAD baseline and in
  CE-2's enum lane — left untouched)

Depends on CE-1 (merged to `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)