### PR TITLE
refactor(constants): consolidate drifted access enums to one source of truth (Codex-2pryk.1.2)

### DIFF
--- a/packages/constants/src/content.ts
+++ b/packages/constants/src/content.ts
@@ -34,28 +34,27 @@ export const VISIBILITY = {
   PURCHASED_ONLY: 'purchased_only',
 } as const;
 
-export const ACCESS_TYPES = {
-  FREE: 'free',
-  PURCHASED: 'purchased',
-  SUBSCRIPTION: 'subscription',
-  COMPLIMENTARY: 'complimentary',
-  MEMBERS_ONLY: 'members_only',
-} as const;
-
 /**
- * Content access model — defines HOW content is gated.
+ * Content access model — defines HOW a piece of content is gated
+ * (`content.access_type`).
+ *
+ * Single source of truth for the `content.access_type` column: mirrors its
+ * CHECK constraint (`database/schema/content.ts` `check_content_access_type`)
+ * and the `contentAccessTypeEnum` Zod schema (`@codex/validation`).
  *
  * Hierarchy (each level includes the ones above):
  *   free < followers < subscribers < team
  *
- * - free: Anyone can access (price must be null/0, no tier)
- * - paid: One-time purchase required (price > 0, no tier)
- * - followers: Must follow the org (free opt-in) — subscribers + team also qualify
+ * - free:        Anyone can access (price must be null/0, no tier)
+ * - paid:        One-time purchase required (price > 0, no tier)
+ * - followers:   Must follow the org (free opt-in) — subscribers + team also qualify
  * - subscribers: Subscription tier required (tier set, optional price for buy-bypass)
- * - team: Owner/admin/creator only (org management roles)
- * - members: @deprecated — alias for 'team', kept for backward compat during migration
+ * - team:        Owner/admin/creator only (org management roles)
  *
- * @see ACCESS_TYPES for per-user grant records (how a user *obtained* access)
+ * NB: 'members' was a legacy alias for 'team'; it has been fully removed and
+ * 'team' is the canonical value.
+ *
+ * @see ACCESS_TYPES for per-user grant records (how a user *obtained* access).
  */
 export const CONTENT_ACCESS_TYPE = {
   FREE: 'free',
@@ -67,3 +66,31 @@ export const CONTENT_ACCESS_TYPE = {
 
 export type ContentAccessType =
   (typeof CONTENT_ACCESS_TYPE)[keyof typeof CONTENT_ACCESS_TYPE];
+
+/**
+ * Content-access GRANT records — how a user *obtained* access to a piece of
+ * content. One row per (user, content) in the `content_access` table
+ * (`database/schema/ecommerce.ts`).
+ *
+ * Single source of truth for the `content_access.access_type` column: mirrors
+ * its CHECK constraint (`database/schema/ecommerce.ts` `check_access_type`).
+ *
+ * - purchased:     one-time purchase (completed or pending-webhook)
+ * - subscription:  granted via an active subscription
+ * - complimentary: manually granted by an org admin (no charge)
+ * - preview:       time-boxed / partial preview grant
+ *
+ * NB: distinct from CONTENT_ACCESS_TYPE, which gates the content itself
+ * (`content.access_type`) rather than recording how a user got in.
+ *
+ * @see CONTENT_ACCESS_TYPE for the content-gating model.
+ */
+export const ACCESS_TYPES = {
+  PURCHASED: 'purchased',
+  SUBSCRIPTION: 'subscription',
+  COMPLIMENTARY: 'complimentary',
+  PREVIEW: 'preview',
+} as const;
+
+export type ContentAccessGrantType =
+  (typeof ACCESS_TYPES)[keyof typeof ACCESS_TYPES];

--- a/packages/database/src/schema/content.ts
+++ b/packages/database/src/schema/content.ts
@@ -259,8 +259,10 @@ export const content = pgTable(
     shaderConfig:
       jsonb('shader_config').$type<Record<string, number | boolean>>(),
 
-    // Access model — defines how content is gated
-    // 'free' | 'paid' | 'subscribers' | 'members'
+    // Access model — defines how content is gated.
+    // Values: 'free' | 'paid' | 'followers' | 'subscribers' | 'team'.
+    // Single source of truth: CONTENT_ACCESS_TYPE (@codex/constants);
+    // enforced by check_content_access_type below.
     accessType: varchar('access_type', { length: 50 })
       .default('free')
       .notNull(),

--- a/packages/database/src/schema/ecommerce.ts
+++ b/packages/database/src/schema/ecommerce.ts
@@ -40,10 +40,11 @@ export const contentAccess = pgTable(
       onDelete: 'cascade',
     }),
 
-    // Access type with CHECK constraint enforcement
+    // Access type — how the user obtained access to this content.
+    // Values: 'purchased' | 'subscription' | 'complimentary' | 'preview'.
+    // Single source of truth: ACCESS_TYPES (@codex/constants);
+    // enforced by check_access_type below.
     accessType: varchar('access_type', { length: 50 }).notNull(),
-    // Phase 1: 'purchased', 'complimentary'
-    // Phase 2: 'subscription', 'preview'
 
     // Access window
     expiresAt: timestamp('expires_at', { withTimezone: true }),

--- a/packages/test-utils/src/purchase-helpers.ts
+++ b/packages/test-utils/src/purchase-helpers.ts
@@ -15,7 +15,12 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { ACCESS_TYPES, FEES, PURCHASE_STATUS } from '@codex/constants';
+import {
+  ACCESS_TYPES,
+  type ContentAccessGrantType,
+  FEES,
+  PURCHASE_STATUS,
+} from '@codex/constants';
 import type { Purchase } from '@codex/database/schema';
 import { contentAccess, purchases } from '@codex/database/schema';
 import type { Database } from './database';
@@ -32,7 +37,7 @@ export interface SeedPurchaseWithAccessInput {
   /** Stripe intent ID. Auto-generated unique value if omitted. */
   stripePaymentIntentId?: string;
   /** Access type granted. Default: `'purchased'`. */
-  accessType?: string;
+  accessType?: ContentAccessGrantType;
 }
 
 /**


### PR DESCRIPTION
## Summary

CE-2 (`Codex-2pryk.1.2`) — Journeys Epic 0 Cleanup. **Behavior-preserving** consolidation of the three drifted content-access enums to one canonical source of truth per domain (HARDENING §C). **No model change**: schema CHECK SQL is byte-identical, no migration.

Two genuinely distinct domains were tangled (HARDENING §C Axis A vs B). Each now has exactly one authoritative TS constant, documented against its schema CHECK, with stale comments removed:

| Domain | Column | Canonical constant | CHECK (unchanged) |
|---|---|---|---|
| Content gate (Axis A) | `content.access_type` | `CONTENT_ACCESS_TYPE` | `free\|paid\|followers\|subscribers\|team` |
| Grant record (Axis B) | `content_access.access_type` | `ACCESS_TYPES` | `purchased\|subscription\|complimentary\|preview` |

### Changes
- **`CONTENT_ACCESS_TYPE`** — values unchanged (already matched its CHECK + the Zod `contentAccessTypeEnum`). Documented as the single source of truth; dropped the misleading `members @deprecated` doc line (never a member of this const).
- **`ACCESS_TYPES`** — realigned to mirror the deployed grant CHECK: removed the unused + invalid `FREE`/`MEMBERS_ONLY` drift, added the valid-but-missing `PREVIEW`. Added the derived `ContentAccessGrantType`.
- Fixed the **stale `content.access_type` column comment** (`schema/content.ts`, was `free|paid|subscribers|members`) and the **grant column comment** (`schema/ecommerce.ts`) to match the CHECKs and point at the constants.
- Narrowed the `@codex/test-utils` grant helper param from loose `string` to `ContentAccessGrantType`.

### Why zero caller edits
Every live caller uses only surviving members (`ACCESS_TYPES.PURCHASED`/`.COMPLIMENTARY`; all `CONTENT_ACCESS_TYPE.*`). Verified by exhaustive grep across all workspaces (incl. `e2e/`), with **no `Object.keys/values/entries` shape-iteration** over either constant — so removing the dead members changes no behavior. This is the behavior-preservation proof.

### Out of scope (reported, not touched)
- `apps/web/src/lib/server/content-detail.ts:92` re-declares `ContentAccessType` locally (duplicate of the canonical type) — **CE-3's lane**.
- Grant-column magic-string writers (`database/scripts/seed/commerce.ts`, etc.) and the separate library-reason union (`'purchased'|'membership'|'subscription'` in `access/src/types.ts` / `library-access.ts`) — a distinct concept, left alone.

## Test Plan
- `pnpm typecheck` — **57/57 green**.
- `biome check` on the 4 changed files — clean.
- `pnpm turbo run test --concurrency=1` across the 8 affected packages (shared local Neon) — **1239 passed / 16 pre-existing skips, 0 failed**: constants 23, database 60, validation 441, test-utils 1, content 196, purchase 247, admin 86 (incl. complimentary-grant), access 185 (incl. gating + `seedPurchaseWithAccess`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
