### PR TITLE
feat(page-builder): freeze shared journey contracts + buildJourneyUrl (Codex-2pryk.2.1)

### DIFF
--- a/apps/web/src/lib/page-builder/brand-overrides-guard.ts
+++ b/apps/web/src/lib/page-builder/brand-overrides-guard.ts
@@ -1,0 +1,62 @@
+/**
+ * Compile-time drift guard: `BrandTokenOverrides` ↔ `BrandEditorState`
+ * (Codex-2pryk.2.1 · WP-0).
+ *
+ * `BrandTokenOverrides` (`@codex/shared-types`) is the per-page brand-override
+ * contract (D6). It is a STANDALONE structural mirror of the brand editor's
+ * editable state (`BrandEditorState`, `$lib/brand-editor`) — every field made
+ * optional — because a cross-worker package cannot import an apps/web `$lib` type.
+ *
+ * This module is the ONE place both types are importable, so it enforces that
+ * mirror at COMPILE TIME rather than by convention. If a future edit to EITHER
+ * type diverges on a shared key — a value type changes, or a shared field is
+ * added or dropped — the `Assert<… extends true>` applications below stop
+ * compiling and `pnpm typecheck` FAILS. The brand editor is actively evolving
+ * (Codex-cijzb), so a doc-note "keep in sync" is too weak; this is the gate.
+ *
+ * TYPE-ONLY: it imports only the brand-editor *types*, never its components, so
+ * the CE-4 public-bundle import-boundary gate stays green. It emits no runtime.
+ *
+ * WHEN THIS GUARD FAILS: re-align `BrandTokenOverrides`
+ * (`packages/shared-types/src/journeys.ts`) with `BrandEditorState`
+ * (`apps/web/src/lib/brand-editor/types.ts`) so the shared keys match again — do
+ * NOT weaken the guard.
+ */
+
+import type { BrandTokenOverrides } from '@codex/shared-types';
+import type { BrandEditorState } from '$lib/brand-editor';
+
+/** Mutual assignability — structural equality for our purposes. */
+type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/**
+ * Compiles only when `T` is exactly `true`. Catches both `false` (all keys
+ * diverge) and the mixed `boolean` (some keys diverge) — a plain
+ * `const x: T = true` would accept `boolean` and miss the partial-divergence case.
+ */
+type Assert<T extends true> = T;
+
+/** Keys the override mirror and the editor state share. */
+type SharedKey = keyof BrandTokenOverrides & keyof BrandEditorState;
+
+/**
+ * (1) The mirror declares EXACTLY the editor's editable keys. Adding or dropping
+ * a shared field makes the key sets diverge and fails compilation here.
+ */
+export type _AssertBrandOverrideKeysMirrorEditor = Assert<
+  Equal<keyof BrandTokenOverrides, keyof BrandEditorState>
+>;
+
+/**
+ * (2) Every shared key's value type matches the editor's (optionality stripped
+ * via `Required`, since the mirror makes each field optional). A value-type
+ * change on either side fails compilation here.
+ */
+export type _AssertBrandOverrideValuesMirrorEditor = Assert<
+  {
+    [K in SharedKey]: Equal<
+      Required<BrandTokenOverrides>[K],
+      BrandEditorState[K]
+    >;
+  }[SharedKey]
+>;

--- a/apps/web/src/lib/page-builder/index.ts
+++ b/apps/web/src/lib/page-builder/index.ts
@@ -1,0 +1,73 @@
+/**
+ * `$lib/page-builder` — the FE public/inert contract surface for the
+ * Landing-Page-Builder & Guided-Journeys build (Codex-2pryk · WP-0).
+ *
+ * INERT by design: types + pure helpers only. It re-exports the cross-worker
+ * journey contracts from `@codex/shared-types` (so the FE has ONE import surface,
+ * the same pattern as `$lib/utils/subdomain` re-exporting `@codex/urls`) and adds
+ * the FE-only inert helpers (section catalogue, preview protocol, remote-function
+ * contracts).
+ *
+ * IMPORT BOUNDARY (CE-4 gate): this module is a scanned PUBLIC_LIB_ROOT — it must
+ * NEVER statically import the heavy editor UI (`$lib/components/page-builder`).
+ * The WP-3 public section renderer will live alongside this module; the WP-5
+ * editor UI stays in `$lib/components/page-builder`.
+ */
+
+// Cross-worker journey model (page model + entitlements + resolver signature),
+// re-exported from @codex/shared-types so FE code imports one surface.
+export type {
+  BrandTokenOverrides,
+  ContentAccessPolicy,
+  CourseSectionType,
+  Entitlement,
+  EntitlementResolver,
+  EntitlementSource,
+  PageBuilderState,
+  PageSection,
+  PageStatus,
+  ResourceType,
+  SectionProps,
+  StoredEntitlementSource,
+} from '@codex/shared-types';
+// Remote-function contracts — signatures + read-model return types.
+export type {
+  GetCourseDashboardQuery,
+  GetCoursePageQuery,
+  GetJourneyForBuilderQuery,
+  GetJourneyLibraryQuery,
+  JourneyContentType,
+  JourneyCoursePage,
+  JourneyCourseView,
+  JourneyDashboardData,
+  JourneyLibrary,
+  JourneyLibraryContentItem,
+  JourneyLibraryCourse,
+  JourneyListItem,
+  JourneyPageRecord,
+  JourneyPracticeView,
+  JourneyProgress,
+  JourneyStageView,
+  JourneyTestimonialView,
+  LibraryAccessSource,
+  ListJourneysQuery,
+} from './journey-queries';
+
+// Live-preview protocol — `codex:page-preview:v1` message + guard + sender contract.
+export {
+  isPagePreviewMessage,
+  PAGE_PREVIEW_MESSAGE_TYPE,
+  type PagePreviewMessage,
+  type PagePreviewSender,
+} from './preview-protocol';
+// Section model — the catalogue + ordering + search + default-template factory.
+export {
+  createDefaultSections,
+  defaultSectionOrder,
+  findSectionDefinition,
+  firstSectionMatch,
+  listSectionDefinitions,
+  SECTION_CATALOG,
+  type SectionDefinition,
+  sectionMatchesQuery,
+} from './section-catalog';

--- a/apps/web/src/lib/page-builder/journey-queries.ts
+++ b/apps/web/src/lib/page-builder/journey-queries.ts
@@ -1,0 +1,186 @@
+/**
+ * Journey remote-function CONTRACTS (Codex-2pryk.2.1 · WP-0).
+ *
+ * The frozen signatures + return types for the SvelteKit remote functions that
+ * feed the journey surfaces (HARDENING §G item d). WP-3/4/5/7 IMPLEMENT these as
+ * `query()` / `command()` in apps/web `*.remote.ts` files (mirroring
+ * `$lib/remote/library.remote.ts`); until then FE surfaces mock against these
+ * shapes and BE knows what to produce.
+ *
+ * These are READ-MODEL ENVELOPES. The load-bearing, frozen parts are the
+ * function names, their params, the top-level return shape, and the access
+ * fields (`canView`/`canEnterCourse`, `via`). The nested presentational fields
+ * are grounded in the prototype (`docs/design/course-journeys/prototype/`) +
+ * FRONTEND-MAP §E and MAY be extended by WP-3/WP-4 as surfaces are built —
+ * additive only.
+ *
+ * INERT + public-bundle safe: types only, no component imports — lives under
+ * `$lib/page-builder` (CE-4 boundary gate scanned root).
+ */
+import type { PageBuilderState, PageStatus } from '@codex/shared-types';
+
+// ── Shared read-model atoms ──────────────────────────────────────────────────
+
+/**
+ * The canonical access-source lexicon (pins the drift HARDENING §A flagged:
+ * "members"/"via membership"/"subscribers"/"Included" collapse to ONE set mapped
+ * to SPEC §6.1). This is the library's "why can I see this" signal.
+ */
+export type LibraryAccessSource =
+  | 'free'
+  | 'purchased'
+  | 'included_in_tier'
+  | 'part_of_course';
+
+/** Practice/content kinds (`content.contentType`), presented per-type by surfaces. */
+export type JourneyContentType = 'video' | 'audio' | 'written';
+
+export interface JourneyPracticeView {
+  contentId: string;
+  slug: string | null;
+  title: string;
+  contentType: JourneyContentType;
+  /** Flat practice index within the course (`stage.sortOrder` ⋈ `practice.sortOrder`). */
+  sortOrder: number;
+  /** Completion — dashboard / in-course only; omitted on the public sales page. */
+  completed?: boolean;
+}
+
+export interface JourneyStageView {
+  id: string;
+  name: string;
+  gloss: string | null;
+  sortOrder: number;
+  practices: JourneyPracticeView[];
+}
+
+export interface JourneyCourseView {
+  id: string;
+  slug: string;
+  title: string;
+  kicker: string | null;
+  lede: string | null;
+  status: PageStatus;
+  /** One-off purchase price; null = not sold standalone (§5). */
+  priceCents: number | null;
+  stageCount: number;
+  practiceCount: number;
+}
+
+export interface JourneyTestimonialView {
+  id: string;
+  quote: string;
+  authorName: string;
+  authorContext: string | null;
+  sortOrder: number;
+}
+
+/** A persisted landing page = the editable {@link PageBuilderState} + its row identity. */
+export interface JourneyPageRecord extends PageBuilderState {
+  id: string;
+  organizationId: string;
+  publishedAt: string | null;
+}
+
+/** Progress rollup = `practice_completions ⋈ stage_practices`, scoped to the enrollment (§11). */
+export interface JourneyProgress {
+  completed: number;
+  total: number;
+  /** 0–100, integer. */
+  pct: number;
+}
+
+// ── Return shapes, per surface ───────────────────────────────────────────────
+
+/** Public sales/landing page (SSR shell+stream). No `canView` on the shell. */
+export interface JourneyCoursePage {
+  page: JourneyPageRecord;
+  course: JourneyCourseView;
+  stages: JourneyStageView[];
+  testimonials: JourneyTestimonialView[];
+}
+
+/** Studio home / index row, with `live` reporting rollups. */
+export interface JourneyListItem {
+  id: string;
+  pageType: string;
+  subjectType: string | null;
+  slug: string;
+  title: string;
+  status: PageStatus;
+  tagline: string | null;
+  /** Course-only rollups — null for a plain landing page. */
+  stageCount: number | null;
+  practiceCount: number | null;
+  enrolledCount: number | null;
+  /** `live` provenance (purchases + subscriptions). */
+  revenueCents: number | null;
+  updatedAt: string;
+}
+
+/**
+ * Member journey portal (non-SSR; the route's `+page.server.ts` runs the
+ * `canEnterCourse` gate before this resolves — §6.4 / HARDENING §E).
+ */
+export interface JourneyDashboardData {
+  course: JourneyCourseView;
+  stages: JourneyStageView[];
+  canEnterCourse: boolean;
+  enrolledAt: string | null;
+  lastActivityAt: string | null;
+  progress: JourneyProgress;
+}
+
+/** One owned journey shelf entry (library grouped by course — §8.4 / §14.6). */
+export interface JourneyLibraryCourse {
+  course: JourneyCourseView;
+  via: LibraryAccessSource;
+  progress: JourneyProgress;
+  canEnterCourse: boolean;
+}
+
+/** One owned standalone content item in the library. */
+export interface JourneyLibraryContentItem {
+  contentId: string;
+  slug: string | null;
+  title: string;
+  contentType: JourneyContentType;
+  via: LibraryAccessSource;
+  /** Set for `part_of_course` items → the standalone page can offer "open in course". */
+  courseSlug: string | null;
+}
+
+/** The user's journeys shelf + owned content, grouped by source. */
+export interface JourneyLibrary {
+  journeys: JourneyLibraryCourse[];
+  content: JourneyLibraryContentItem[];
+}
+
+// ── Remote-function signature aliases ────────────────────────────────────────
+// WP-3/4/5/7 implement these as query()/command() in apps/web `*.remote.ts`.
+// The alias names the CONTRACT (params → resolved value); the wire wrapper
+// (query/command) and Zod input schema are the implementer's concern.
+
+/** Public sales page read (WP-3). Returns null when no published page matches. */
+export type GetCoursePageQuery = (input: {
+  slug: string;
+}) => Promise<JourneyCoursePage | null>;
+
+/** Member dashboard read (WP-4). Returns null when the course does not exist. */
+export type GetCourseDashboardQuery = (input: {
+  slug: string;
+}) => Promise<JourneyDashboardData | null>;
+
+/** Library shelf read (WP-4). Self-scoped to the session user; empty for guests. */
+export type GetJourneyLibraryQuery = () => Promise<JourneyLibrary>;
+
+/** Studio home list (WP-5), reactive off the org + a status filter. */
+export type ListJourneysQuery = (input: {
+  organizationId: string;
+  status?: PageStatus;
+}) => Promise<JourneyListItem[]>;
+
+/** Load a page draft into the studio builder (WP-5). Null when not found. */
+export type GetJourneyForBuilderQuery = (input: {
+  id: string;
+}) => Promise<JourneyPageRecord | null>;

--- a/apps/web/src/lib/page-builder/preview-protocol.test.ts
+++ b/apps/web/src/lib/page-builder/preview-protocol.test.ts
@@ -1,0 +1,62 @@
+import type { PageBuilderState } from '@codex/shared-types';
+import { describe, expect, it } from 'vitest';
+import {
+  isPagePreviewMessage,
+  PAGE_PREVIEW_MESSAGE_TYPE,
+  type PagePreviewMessage,
+} from './preview-protocol';
+
+const draft: PageBuilderState = {
+  pageType: 'course',
+  slug: 'rootwork',
+  title: 'Rootwork',
+  status: 'draft',
+  subjectType: 'course',
+  subjectId: 'course-1',
+  brandOverrides: null,
+  sections: [{ id: 's1', type: 'hero', enabled: true, props: {} }],
+};
+
+describe('PAGE_PREVIEW_MESSAGE_TYPE', () => {
+  it('is the versioned page-preview channel tag', () => {
+    expect(PAGE_PREVIEW_MESSAGE_TYPE).toBe('codex:page-preview:v1');
+  });
+});
+
+describe('isPagePreviewMessage', () => {
+  it('accepts a well-formed message', () => {
+    const msg: PagePreviewMessage = {
+      type: PAGE_PREVIEW_MESSAGE_TYPE,
+      page: draft,
+    };
+    expect(isPagePreviewMessage(msg)).toBe(true);
+  });
+
+  it('rejects a wrong / unversioned type tag', () => {
+    expect(
+      isPagePreviewMessage({ type: 'codex:brand-preview:v1', page: draft })
+    ).toBe(false);
+    expect(
+      isPagePreviewMessage({ type: 'codex:page-preview:v2', page: draft })
+    ).toBe(false);
+  });
+
+  it('rejects a missing or non-object page payload', () => {
+    expect(isPagePreviewMessage({ type: PAGE_PREVIEW_MESSAGE_TYPE })).toBe(
+      false
+    );
+    expect(
+      isPagePreviewMessage({ type: PAGE_PREVIEW_MESSAGE_TYPE, page: null })
+    ).toBe(false);
+    expect(
+      isPagePreviewMessage({ type: PAGE_PREVIEW_MESSAGE_TYPE, page: 'nope' })
+    ).toBe(false);
+  });
+
+  it('rejects non-object / null inbound data', () => {
+    expect(isPagePreviewMessage(null)).toBe(false);
+    expect(isPagePreviewMessage(undefined)).toBe(false);
+    expect(isPagePreviewMessage('codex:page-preview:v1')).toBe(false);
+    expect(isPagePreviewMessage(42)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/page-builder/preview-protocol.ts
+++ b/apps/web/src/lib/page-builder/preview-protocol.ts
@@ -1,0 +1,81 @@
+/**
+ * Page-builder live-preview PROTOCOL (Codex-2pryk.2.1 · WP-0).
+ *
+ * The frozen postMessage contract between the studio page builder (the SENDER,
+ * in the studio document) and the org's real journey page loaded same-origin in
+ * the preview `<iframe>` (the APPLIER, in the framed document). Mirrors
+ * `$lib/brand-editor/brand-preview-bridge.ts` — the same versioned-type + guard
+ * shape — but carries the pending PAGE DRAFT instead of brand vars (SPEC §9).
+ *
+ * WP-0 freezes the PROTOCOL only: the versioned message type, the message shape,
+ * the inbound type-guard, and the SENDER interface. The sender/applier RUNTIME
+ * (the `createPagePreviewSender` clone + the framed-page applier) is WP-5 — it
+ * implements {@link PagePreviewSender} and drives a page-builder store's pending
+ * state, exactly as `createBrandPreviewSender` / `initBrandPreviewBridge` do.
+ *
+ * INERT + public-bundle safe: types + a pure guard only, no component imports —
+ * lives under `$lib/page-builder` (CE-4 boundary gate scanned root).
+ *
+ * Security (WP-5 must preserve): same-origin ONLY. The sender always targets an
+ * explicit origin (NEVER `'*'`); the applier is inert unless embedded and accepts
+ * a message only when source + origin + type all match. Treat as a security
+ * boundary.
+ */
+import type { PageBuilderState } from '@codex/shared-types';
+
+/**
+ * Versioned message type — bump the `:vN` suffix on any breaking payload change
+ * (mirrors `BRAND_PREVIEW_MESSAGE_TYPE = 'codex:brand-preview:v1'`).
+ */
+export const PAGE_PREVIEW_MESSAGE_TYPE = 'codex:page-preview:v1';
+
+/**
+ * Studio → iframe preview message.
+ *
+ * `page` is the builder's PENDING {@link PageBuilderState} — the page draft being
+ * previewed (sections + brandOverrides + meta). The framed page re-derives its
+ * render from this, so copy / order / toggle / theme edits go live with NO reload
+ * (SPEC §9). It is the full pending draft, not a pre-derived DOM patch, so the
+ * framed page reuses its own render + branding-injection machinery.
+ */
+export interface PagePreviewMessage {
+  readonly type: typeof PAGE_PREVIEW_MESSAGE_TYPE;
+  readonly page: PageBuilderState;
+}
+
+/**
+ * Shallow, runtime type-tag check for an inbound message. This is a trusted
+ * same-origin admin channel (both ends are our own code on the same subdomain),
+ * so it verifies the discriminating tag + that `page` is a non-null object,
+ * rather than deep-validating every {@link PageBuilderState} field. Mirrors
+ * `brand-preview-bridge.ts` `isBrandPreviewMessage`.
+ */
+export function isPagePreviewMessage(
+  data: unknown
+): data is PagePreviewMessage {
+  if (typeof data !== 'object' || data === null) return false;
+  const msg = data as { type?: unknown; page?: unknown };
+  return (
+    msg.type === PAGE_PREVIEW_MESSAGE_TYPE &&
+    typeof msg.page === 'object' &&
+    msg.page !== null
+  );
+}
+
+/**
+ * Parent-side sender contract — WP-5 implements this (clone of
+ * `BrandPreviewSender`). Frozen here so the studio builder and the framed applier
+ * compose against one shape.
+ */
+export interface PagePreviewSender {
+  /**
+   * Track a preview frame and immediately sync it to the latest pending draft.
+   * Call from `onframeload` on every (re)load — a route change or reload swaps
+   * the framed document, which must re-reflect in-progress edits at once.
+   */
+  register(element: HTMLIFrameElement, targetOrigin: string): void;
+  /** Debounced broadcast of the latest pending draft to every tracked frame. */
+  send(page: PageBuilderState): void;
+  /** Stop the debounce timer and forget all tracked frames. */
+  destroy(): void;
+}

--- a/apps/web/src/lib/page-builder/section-catalog.test.ts
+++ b/apps/web/src/lib/page-builder/section-catalog.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultSections,
+  defaultSectionOrder,
+  findSectionDefinition,
+  firstSectionMatch,
+  listSectionDefinitions,
+  SECTION_CATALOG,
+  sectionMatchesQuery,
+} from './section-catalog';
+
+const EXPECTED_ORDER = [
+  'hero',
+  'introVideo',
+  'ache',
+  'turn',
+  'reel',
+  'map',
+  'feel',
+  'proof',
+  'guide',
+  'faq',
+  'invite',
+];
+
+describe('SECTION_CATALOG', () => {
+  it('ships the course template section set in order (SPEC §4.1)', () => {
+    expect(SECTION_CATALOG.map((d) => d.type)).toEqual(EXPECTED_ORDER);
+  });
+
+  it('has a unique type per definition', () => {
+    const types = SECTION_CATALOG.map((d) => d.type);
+    expect(new Set(types).size).toBe(types.length);
+  });
+
+  it('every definition carries a label, summary, icon and keywords', () => {
+    for (const def of SECTION_CATALOG) {
+      expect(def.label.length).toBeGreaterThan(0);
+      expect(def.summary.length).toBeGreaterThan(0);
+      expect(def.icon.length).toBeGreaterThan(0);
+      expect(def.keywords.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('listSectionDefinitions / defaultSectionOrder', () => {
+  it('lists every definition in ship order', () => {
+    expect(listSectionDefinitions()).toBe(SECTION_CATALOG);
+  });
+
+  it('defaultSectionOrder mirrors the catalogue order', () => {
+    expect(defaultSectionOrder()).toEqual(EXPECTED_ORDER);
+  });
+});
+
+describe('findSectionDefinition', () => {
+  it('finds a known section type', () => {
+    expect(findSectionDefinition('invite')?.label).toBe('The invite');
+  });
+
+  it('returns null for an unknown / widened type', () => {
+    expect(findSectionDefinition('retreat-schedule')).toBeNull();
+  });
+});
+
+describe('sectionMatchesQuery', () => {
+  const hero = SECTION_CATALOG[0];
+
+  it('matches every section on an empty / whitespace query', () => {
+    expect(sectionMatchesQuery(hero, '')).toBe(true);
+    expect(sectionMatchesQuery(hero, '   ')).toBe(true);
+  });
+
+  it('matches on the label (case-insensitive substring)', () => {
+    expect(sectionMatchesQuery(hero, 'HER')).toBe(true);
+  });
+
+  it('matches on a keyword synonym', () => {
+    // 'invite' carries the 'pricing' keyword.
+    const invite = findSectionDefinition('invite');
+    expect(invite && sectionMatchesQuery(invite, 'pricing')).toBe(true);
+  });
+
+  it('does not match an unrelated query', () => {
+    expect(sectionMatchesQuery(hero, 'zzzznope')).toBe(false);
+  });
+});
+
+describe('firstSectionMatch', () => {
+  it('returns null for an empty query', () => {
+    expect(firstSectionMatch('')).toBeNull();
+  });
+
+  it('returns the first matching section in ship order', () => {
+    // Both 'hero' and 'invite' carry the 'cta' keyword; hero is first.
+    expect(firstSectionMatch('cta')?.type).toBe('hero');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(firstSectionMatch('zzzznope')).toBeNull();
+  });
+});
+
+describe('createDefaultSections', () => {
+  it('builds one enabled section per catalogue entry, in order, with empty props', () => {
+    let n = 0;
+    const sections = createDefaultSections(() => `sec-${n++}`);
+    expect(sections.map((s) => s.type)).toEqual(EXPECTED_ORDER);
+    expect(sections.every((s) => s.enabled)).toBe(true);
+    expect(sections.every((s) => Object.keys(s.props).length === 0)).toBe(true);
+  });
+
+  it('uses the injected id factory', () => {
+    let n = 0;
+    const sections = createDefaultSections(() => `sec-${n++}`);
+    expect(sections[0].id).toBe('sec-0');
+    expect(sections.at(-1)?.id).toBe(`sec-${EXPECTED_ORDER.length - 1}`);
+  });
+
+  it('mints unique ids by default (crypto.randomUUID)', () => {
+    const ids = createDefaultSections().map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/apps/web/src/lib/page-builder/section-catalog.ts
+++ b/apps/web/src/lib/page-builder/section-catalog.ts
@@ -1,0 +1,192 @@
+/**
+ * Page-builder SECTION MODEL — the section catalogue (Codex-2pryk.2.1 · WP-0).
+ *
+ * The "section-model" half of the WP-0 page-builder document model (HARDENING §G
+ * item a): the analogue of the brand studio's `rail/rail-model.ts` (catalogue,
+ * ordering, search). This is the pure, framework-free spine — section-type
+ * metadata + the search matcher + the default-template factory. The WP-5 editor
+ * rail renders FROM it; the WP-3 public renderer maps each {@link PageSection}'s
+ * `type` → a Svelte component.
+ *
+ * INERT + public-bundle safe: types + pure helpers only, no component imports —
+ * so it lives under `$lib/page-builder` (scanned by the CE-4 import-boundary gate)
+ * and never pulls the heavy editor UI (`$lib/components/page-builder`) into the
+ * public chunk.
+ *
+ * The catalogue is the DEFAULT course-page template's section set (SPEC §4.1). A
+ * future page type registers its own catalogue; the union {@link CourseSectionType}
+ * constrains only what THIS template ships — the renderer skips unknown types.
+ *
+ * Icons/labels here are advisory stand-ins; the WP-5 editor rebinds them to real
+ * design-system icons (see the design-system skill).
+ */
+import type { CourseSectionType, PageSection } from '@codex/shared-types';
+
+// ── Section definition ───────────────────────────────────────────────────────
+
+export interface SectionDefinition {
+  readonly type: CourseSectionType;
+  readonly label: string;
+  /** One-line description shown in the add-section picker. */
+  readonly summary: string;
+  /** Advisory glyph for the rail header (WP-5 rebinds to a DS icon). */
+  readonly icon: string;
+  /** Extra search terms beyond the label (synonyms). */
+  readonly keywords: readonly string[];
+}
+
+/**
+ * The default course-page template catalogue, in the template's ship order
+ * (SPEC §4.1): hero → introVideo → ache → turn → reel → map → feel → proof →
+ * guide → faq → invite.
+ */
+export const SECTION_CATALOG: readonly SectionDefinition[] = [
+  {
+    type: 'hero',
+    label: 'Hero',
+    summary: 'The opening headline, kicker and primary call-to-action.',
+    icon: '◇',
+    keywords: ['hero', 'headline', 'title', 'opening', 'banner', 'cta'],
+  },
+  {
+    type: 'introVideo',
+    label: 'Intro video',
+    summary: 'A short sell/intro video that sets the tone.',
+    icon: '▷',
+    keywords: ['intro', 'video', 'trailer', 'preview', 'media', 'sell'],
+  },
+  {
+    type: 'ache',
+    label: 'The ache',
+    summary: 'Name the problem or longing the journey speaks to.',
+    icon: '◍',
+    keywords: ['ache', 'problem', 'pain', 'longing', 'why', 'struggle'],
+  },
+  {
+    type: 'turn',
+    label: 'The turn',
+    summary: 'The shift on offer — from where they are to where they could be.',
+    icon: '↺',
+    keywords: ['turn', 'shift', 'change', 'promise', 'transformation'],
+  },
+  {
+    type: 'reel',
+    label: 'Reel',
+    summary: 'A montage of moments / practices from inside the journey.',
+    icon: '▤',
+    keywords: ['reel', 'montage', 'gallery', 'highlights', 'moments'],
+  },
+  {
+    type: 'map',
+    label: 'The map',
+    summary: 'The descent map — the journey stages laid out (no progress).',
+    icon: '⊞',
+    keywords: ['map', 'stages', 'curriculum', 'path', 'descent', 'outline'],
+  },
+  {
+    type: 'feel',
+    label: 'How it feels',
+    summary: 'The felt-sense of the work — and the free-taste door.',
+    icon: '≈',
+    keywords: ['feel', 'taste', 'free', 'sample', 'experience', 'sense'],
+  },
+  {
+    type: 'proof',
+    label: 'Proof',
+    summary: 'Testimonials and social proof from past members.',
+    icon: '❝',
+    keywords: ['proof', 'testimonial', 'reviews', 'quotes', 'social proof'],
+  },
+  {
+    type: 'guide',
+    label: 'Your guide',
+    summary: 'The guide bio, portrait and guide video.',
+    icon: '☺',
+    keywords: ['guide', 'teacher', 'about', 'bio', 'host', 'facilitator'],
+  },
+  {
+    type: 'faq',
+    label: 'FAQ',
+    summary: 'Common questions, answered.',
+    icon: '?',
+    keywords: ['faq', 'questions', 'answers', 'help', 'objections'],
+  },
+  {
+    type: 'invite',
+    label: 'The invite',
+    summary: 'The offer and pricing — the primary conversion moment.',
+    icon: '✦',
+    keywords: ['invite', 'offer', 'pricing', 'join', 'buy', 'checkout', 'cta'],
+  },
+];
+
+// ── Lookups ──────────────────────────────────────────────────────────────────
+
+/** Every section definition, in template ship order. */
+export function listSectionDefinitions(): readonly SectionDefinition[] {
+  return SECTION_CATALOG;
+}
+
+/**
+ * The definition for a section type, or null when the type is not in this
+ * template's catalogue (a widened/unknown {@link PageSection.type}).
+ */
+export function findSectionDefinition(type: string): SectionDefinition | null {
+  return SECTION_CATALOG.find((def) => def.type === type) ?? null;
+}
+
+/** Section types in template ship order (the default arrangement). */
+export function defaultSectionOrder(): readonly CourseSectionType[] {
+  return SECTION_CATALOG.map((def) => def.type);
+}
+
+// ── Search ─────────────────────────────────────────────────────────────────
+
+function normalise(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+/**
+ * Does a section match the search query? An empty/whitespace query matches every
+ * section (search inactive). Matches the label or any keyword — substring,
+ * case-insensitive. Mirrors `rail-model.ts` `controlMatchesQuery`.
+ */
+export function sectionMatchesQuery(
+  def: SectionDefinition,
+  query: string
+): boolean {
+  const q = normalise(query);
+  if (q === '') return true;
+  const haystack = [def.label, ...def.keywords].map(normalise);
+  return haystack.some((entry) => entry.includes(q));
+}
+
+/**
+ * The first section (in ship order) matching a non-empty query — the jump target
+ * for the add-picker. Returns null when the query is empty or nothing matches.
+ */
+export function firstSectionMatch(query: string): SectionDefinition | null {
+  if (normalise(query) === '') return null;
+  return SECTION_CATALOG.find((def) => sectionMatchesQuery(def, query)) ?? null;
+}
+
+// ── Default template factory ─────────────────────────────────────────────────
+
+/**
+ * Build the default set of enabled {@link PageSection}s for a new course page
+ * (SPEC §4.1 — "the course template ships a default set"). Sections are in
+ * template ship order, enabled, with empty props (the WP-5 editor fills copy).
+ *
+ * `makeId` is injectable so tests get deterministic ids; it defaults to
+ * `crypto.randomUUID` (available in the SvelteKit + Node runtimes).
+ */
+export function createDefaultSections(
+  makeId: () => string = () => crypto.randomUUID()
+): PageSection[] {
+  return SECTION_CATALOG.map((def) => ({
+    id: makeId(),
+    type: def.type,
+    enabled: true,
+    props: {},
+  }));
+}

--- a/apps/web/src/lib/utils/subdomain.ts
+++ b/apps/web/src/lib/utils/subdomain.ts
@@ -12,6 +12,7 @@
 import {
   buildContentUrl as buildContentUrlInner,
   buildCreatorsUrl as buildCreatorsUrlInner,
+  buildJourneyUrl as buildJourneyUrlInner,
   buildOrgUrl as buildOrgUrlInner,
   buildPlatformUrl as buildPlatformUrlInner,
   parseHost,
@@ -52,6 +53,8 @@ export const buildOrgUrl = buildOrgUrlInner;
 export const buildCreatorsUrl = buildCreatorsUrlInner;
 export const buildPlatformUrl = buildPlatformUrlInner;
 export const buildContentUrl = buildContentUrlInner;
+/** Journeys build (Codex-2pryk · WP-0) — sibling of buildContentUrl for course pages. */
+export const buildJourneyUrl = buildJourneyUrlInner;
 
 /**
  * Determine the context type from a hostname.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -34,6 +34,25 @@ export type {
 // Financial types (revenue splits, fees, payouts)
 export type { RevenueSplit } from './financial';
 
+// Journeys / Landing-Page-Builder contracts (Codex-2pryk · WP-0 freeze).
+// Page model (D1/§4), content access policy + entitlements + the resolver
+// signature (D2/§6). Consumed by @codex/database (schema jsonb $type),
+// @codex/access (resolver impl), and apps/web via $lib/page-builder.
+export type {
+  BrandTokenOverrides,
+  ContentAccessPolicy,
+  CourseSectionType,
+  Entitlement,
+  EntitlementResolver,
+  EntitlementSource,
+  PageBuilderState,
+  PageSection,
+  PageStatus,
+  ResourceType,
+  SectionProps,
+  StoredEntitlementSource,
+} from './journeys';
+
 // Organization and Member types
 export type { OrgMemberContext, OrgMemberRole } from './member-types';
 

--- a/packages/shared-types/src/journeys.ts
+++ b/packages/shared-types/src/journeys.ts
@@ -1,0 +1,242 @@
+/**
+ * Journeys / Landing-Page-Builder shared contracts (Codex-2pryk.2.1 · WP-0).
+ *
+ * The CONTRACT BARRIER for the Landing-Page-Builder & Guided-Journeys build.
+ * Everything downstream composes on the shapes frozen here:
+ *   - WP-1 SCHEMA         — `landing_pages.sections` / `.brandOverrides` jsonb
+ *                           `$type<>()`, the §6.1 content access policy columns,
+ *                           and the `entitlements` grant row.
+ *   - WP-2 RESOLVER       — implements {@link EntitlementResolver} in @codex/access.
+ *   - WP-3/4/5/7 SURFACES — the FE renderer, dashboard, studio builder + reporting
+ *                           mock against these + the FE aggregation in
+ *                           `apps/web/src/lib/page-builder`.
+ *
+ * Placement: this is a CROSS-WORKER contract module. It lives in
+ * `@codex/shared-types` (zero runtime deps) rather than `$lib/page-builder`
+ * because BE packages — the Drizzle schema (`@codex/database`) and the resolver
+ * (`@codex/access`) — cannot import an apps/web `$lib` module. `$lib/page-builder`
+ * re-exports everything here so the FE still imports one inert surface (the same
+ * shape as `$lib/utils/subdomain` re-exporting `@codex/urls`).
+ *
+ * TYPES ONLY — no runtime, no DB, no resolver implementation. Grounded in
+ * `docs/design/course-journeys/SPEC.md` §4/§6 + `HARDENING.md` §G, verified against
+ * the live brand-editor precedents this build clones.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page model (D1 — SPEC §4 + §4.1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Lifecycle status shared by `landing_pages` and `courses` (SPEC §4 / §5). */
+export type PageStatus = 'draft' | 'published' | 'archived';
+
+/**
+ * Section types shipped by the course-page template (SPEC §4.1 — the prototype's
+ * section set). The renderer maps a KNOWN type → Svelte component and SKIPS
+ * unknown types (forward-compatible), so the stored {@link PageSection.type} is a
+ * widenable `string`, not this union — this catalogue constrains only what the
+ * BUILDER may add and what the default template ships. A future page type
+ * (retreat, …) registers its own section-type set.
+ */
+export type CourseSectionType =
+  | 'hero'
+  | 'introVideo'
+  | 'ache'
+  | 'turn'
+  | 'reel'
+  | 'map'
+  | 'feel'
+  | 'proof'
+  | 'guide'
+  | 'faq'
+  | 'invite';
+
+/**
+ * Per-section config bag — section-type-specific copy/props (headline, mediaId,
+ * testimonial ids, …). The exact PER-TYPE prop schema is owned by the WP-3
+ * renderer + WP-5 editor; the frozen contract fixes only the envelope.
+ */
+export type SectionProps = Record<string, unknown>;
+
+/**
+ * One composable section INSTANCE (SPEC §4.1). Order is array position;
+ * on/off is {@link PageSection.enabled}; copy/config is {@link PageSection.props}.
+ * `type` is a widenable `string` (not {@link CourseSectionType}) so the renderer
+ * can skip an unknown section type without a decode error (forward-compatible).
+ */
+export interface PageSection {
+  readonly id: string;
+  type: string;
+  enabled: boolean;
+  props: SectionProps;
+}
+
+/**
+ * Per-page brand overrides (D6 — "inherit by default, override per-page").
+ * Structurally MIRRORS the brand-editor's editable state
+ * (`apps/web/src/lib/brand-editor/types.ts` `BrandEditorState`) so the page
+ * builder reuses the same colour/token controls; every field is optional — an
+ * unset field inherits the org brand.
+ *
+ * Kept a STANDALONE structural type (deliberately NOT `Partial<BrandEditorState>`)
+ * so this cross-worker contract carries no apps/web `$lib` dependency. Keep in
+ * sync with `BrandEditorState` (D6). Backs `landing_pages.brandOverrides`
+ * jsonb `$type<BrandTokenOverrides>()`.
+ */
+export interface BrandTokenOverrides {
+  primaryColor?: string;
+  secondaryColor?: string | null;
+  accentColor?: string | null;
+  backgroundColor?: string | null;
+  fontBody?: string | null;
+  fontHeading?: string | null;
+  radius?: number;
+  density?: number;
+  logoUrl?: string | null;
+  /** Per-token fine-tune overrides. null value = auto-derive from primary. */
+  tokenOverrides?: Record<string, string | null>;
+  /** Dark-theme colour overrides. null = auto-derive from light values. */
+  darkOverrides?: Record<string, string | null> | null;
+  /** Dark-theme fine-tune overrides (parallel to tokenOverrides). */
+  darkTokenOverrides?: Record<string, string | null> | null;
+  heroLayout?: string;
+}
+
+/**
+ * The page-builder DOCUMENT MODEL — the editable draft a builder session mutates
+ * and the {@link PagePreviewMessage} preview payload streams to the framed page
+ * (SPEC §4 / §9). Analogue of the brand editor's `BrandEditorState`: it holds the
+ * EDITABLE page fields only — the persisted row's `id` / `organizationId` /
+ * `creatorId` / timestamps live on the row, not the draft. The builder store
+ * (WP-5) wraps this in a `saved` / `pending` runes spine cloned from
+ * `brand-editor-store.svelte.ts`.
+ */
+export interface PageBuilderState {
+  /** 'course' now; 'retreat' etc. later (D1). */
+  pageType: string;
+  slug: string;
+  title: string;
+  status: PageStatus;
+  /** 'course' → the domain object this page presents (polymorphic; §4). */
+  subjectType: string | null;
+  /** → `courses.id` (validated in the service layer; §4). */
+  subjectId: string | null;
+  brandOverrides: BrandTokenOverrides | null;
+  /** Ordered, typed, toggleable (§4.1). */
+  sections: PageSection[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Access & entitlements (D2 — SPEC §6, the greenfield core)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** What an entitlement grants a right OVER (SPEC §6.2). Extensible: 'page' | 'bundle'. */
+export type ResourceType = 'content' | 'course';
+
+/**
+ * The source of a STORED entitlement grant row (SPEC §6.2). These are the only
+ * values ever inserted; use this union for the DB write-path CHECK.
+ */
+export type StoredEntitlementSource =
+  | 'content_purchase'
+  | 'course_purchase'
+  | 'course_subscription'
+  | 'grant';
+
+/**
+ * Every source the RESOLVER may report, including the derived one.
+ *
+ * `tier_subscription` is RESOLVER-OUTPUT-ONLY (SPEC §6.2 [H]): tier access is
+ * DERIVED live from the user's active `subscriptions` row + the tier→resource
+ * mappings, never materialised as a row — so tier changes take effect instantly
+ * and can't strand a stale grant. Keep `tier_subscription` OUT of any DB
+ * write-path CHECK; it appears only in resolver output. Persisted rows are typed
+ * {@link StoredEntitlementSource}.
+ */
+export type EntitlementSource = StoredEntitlementSource | 'tier_subscription';
+
+/**
+ * Per-content access POLICY (SPEC §6.1) — separable, non-exclusive flags that
+ * REPLACE the single `content.accessType` enum. Stored on `content` (WP-1),
+ * read by the resolver (WP-2).
+ *
+ * `courseOnly=true` suppresses EVERY standalone path regardless of the other
+ * flags — the content is reachable ONLY via a course entitlement.
+ * `isFree` / `isPurchasable` / `includedInTierId` may combine freely.
+ *
+ * The legacy `accessType` CHECK maps (HARDENING §H2): `free`→`isFree`,
+ * `paid`→`isPurchasable`, `subscribers`→`includedInTierId`,
+ * `followers`→`isFollowerGated`, `team`→`isTeamOnly`.
+ */
+export interface ContentAccessPolicy {
+  isFree: boolean;
+  /** Paired with {@link ContentAccessPolicy.priceCents} for a one-off content purchase. */
+  isPurchasable: boolean;
+  priceCents: number | null;
+  /** Included in this org tier AND ABOVE (by `subscription_tiers.sortOrder`). */
+  includedInTierId: string | null;
+  courseOnly: boolean;
+  /** [H2] Free to org followers / opt-in (was accessType 'followers'). */
+  isFollowerGated: boolean;
+  /** [H2] Management/staff-only (was accessType 'team'); also covered by the resolver role-bypass. */
+  isTeamOnly: boolean;
+}
+
+/**
+ * A granted right (SPEC §6.2 — the `entitlements` grant record).
+ *
+ * `userId` is TEXT, not uuid ([H] — `users.id` is `text('id')`). A STORED row
+ * carries a {@link StoredEntitlementSource}; the resolver may synthesise a
+ * DERIVED `tier_subscription` grant that is never persisted (see
+ * {@link EntitlementSource}).
+ */
+export interface Entitlement {
+  id: string;
+  /** TEXT — `users.id` is `text('id')`, not uuid ([H]). */
+  userId: string;
+  organizationId: string;
+  resourceType: ResourceType;
+  resourceId: string;
+  source: EntitlementSource;
+  /** purchase id / subscription id / course_subscription id. */
+  sourceRef: string | null;
+  /** ISO-8601 timestamp. */
+  grantedAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+}
+
+/**
+ * The two-question access resolver (SPEC §6.3). WP-2 IMPLEMENTS this interface in
+ * `@codex/access` (co-located with `getStreamingUrl`, which gates on `canView`);
+ * WP-0 freezes only the SIGNATURE. The implementation folds in the arms the SPEC
+ * pseudocode omits but live code requires (HARDENING §B.6): the management-role
+ * bypass (owner/admin/creator see all org content) and the orgless-content-with-
+ * tier fail-closed deny.
+ *
+ * `userId` is `null` for anonymous visitors (public sales pages / free content).
+ * Both questions are DB-backed and authorization-sensitive → async, per-request,
+ * and NEVER cross-user cached (SPEC §12 / `cache/CLAUDE.md`).
+ *
+ *   - {@link EntitlementResolver.canView} — may the user open this content
+ *     ANYWHERE? Gates `getStreamingUrl`.
+ *   - {@link EntitlementResolver.canEnterCourse} — may the user open this course's
+ *     DASHBOARD / journey? Course-scoped, so shared content never leaks course
+ *     access.
+ *
+ * The `?notenrolled` surface state (SPEC §6.3 / §14.2) is
+ * `canView && !canEnterCourse` — computed by the caller from the two answers, so
+ * no third method is needed.
+ *
+ * {@link EntitlementResolver.canEnterCoursesBatch} resolves MANY courses in ONE
+ * query — REQUIRED for a dashboard/library grid to avoid N+1 on Neon HTTP
+ * (HARDENING §D / §E / §12).
+ */
+export interface EntitlementResolver {
+  canView(userId: string | null, contentId: string): Promise<boolean>;
+  canEnterCourse(userId: string | null, courseId: string): Promise<boolean>;
+  canEnterCoursesBatch(
+    userId: string | null,
+    courseIds: readonly string[]
+  ): Promise<ReadonlyMap<string, boolean>>;
+}

--- a/packages/shared-types/src/journeys.ts
+++ b/packages/shared-types/src/journeys.ts
@@ -79,9 +79,13 @@ export interface PageSection {
  * unset field inherits the org brand.
  *
  * Kept a STANDALONE structural type (deliberately NOT `Partial<BrandEditorState>`)
- * so this cross-worker contract carries no apps/web `$lib` dependency. Keep in
- * sync with `BrandEditorState` (D6). Backs `landing_pages.brandOverrides`
- * jsonb `$type<BrandTokenOverrides>()`.
+ * so this cross-worker contract carries no apps/web `$lib` dependency. It is an
+ * EXACT structural mirror of the brand editor's editable state, every field made
+ * optional (D6). The mirror is enforced at COMPILE TIME, not by convention: see
+ * the drift guard in `apps/web/src/lib/page-builder/brand-overrides-guard.ts`,
+ * which fails `pnpm typecheck` if this type and `BrandEditorState` diverge on any
+ * shared key. **A future edit to either type must keep them structurally equal.**
+ * Backs `landing_pages.brandOverrides` jsonb `$type<BrandTokenOverrides>()`.
  */
 export interface BrandTokenOverrides {
   primaryColor?: string;
@@ -95,8 +99,16 @@ export interface BrandTokenOverrides {
   logoUrl?: string | null;
   /** Per-token fine-tune overrides. null value = auto-derive from primary. */
   tokenOverrides?: Record<string, string | null>;
-  /** Dark-theme colour overrides. null = auto-derive from light values. */
-  darkOverrides?: Record<string, string | null> | null;
+  /**
+   * Dark-theme colour overrides. null = auto-derive from light values.
+   * Structural mirror of the brand editor's `Partial<ThemeColors> | null`.
+   */
+  darkOverrides?: {
+    primaryColor?: string;
+    secondaryColor?: string | null;
+    accentColor?: string | null;
+    backgroundColor?: string | null;
+  } | null;
   /** Dark-theme fine-tune overrides (parallel to tokenOverrides). */
   darkTokenOverrides?: Record<string, string | null> | null;
   heroLayout?: string;

--- a/packages/urls/src/__tests__/build-url-builders.test.ts
+++ b/packages/urls/src/__tests__/build-url-builders.test.ts
@@ -5,6 +5,7 @@
  *   - buildPlatformUrl(currentUrl, path?)
  *   - buildCreatorsUrl(currentUrl, path?)
  *   - buildContentUrl(currentUrl, content)
+ *   - buildJourneyUrl(currentUrl, journey, options?)  ← NEW (Codex-2pryk · WP-0)
  *
  * Test contract: must produce identical output to the historical
  * apps/web/src/lib/utils/subdomain.ts builders. Existing 35-test
@@ -17,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildContentUrl,
   buildCreatorsUrl,
+  buildJourneyUrl,
   buildOrgUrl,
   buildOrgUrlFromEnv,
   buildPlatformUrl,
@@ -263,5 +265,129 @@ describe('buildContentUrl (cross-org-aware)', () => {
         organizationSlug: 'studio-beta',
       })
     ).toBe('https://studio-beta.dev.revelations.studio/content/first-video');
+  });
+});
+
+describe('buildJourneyUrl (cross-org-aware, surface-aware)', () => {
+  // ── Cross-org routing + slug/id fallback (mirrors buildContentUrl) ──
+  it('returns root-relative path when the journey is on the current org subdomain', () => {
+    expect(
+      buildJourneyUrl(new URL('http://acme.lvh.me:3000/'), {
+        id: 'course-123',
+        slug: 'rootwork',
+        organizationSlug: 'acme',
+      })
+    ).toBe('/journeys/rootwork');
+  });
+
+  it('returns a full cross-org URL when the journey is on another org', () => {
+    expect(
+      buildJourneyUrl(new URL('http://acme.lvh.me:3000/'), {
+        id: 'course-456',
+        slug: 'grief-and-the-body',
+        organizationSlug: 'other-studio',
+      })
+    ).toBe('http://other-studio.lvh.me:3000/journeys/grief-and-the-body');
+  });
+
+  it('returns a full URL when the current page is on the platform apex', () => {
+    expect(
+      buildJourneyUrl(new URL('http://lvh.me:3000/discover'), {
+        id: 'course-789',
+        slug: 'sleep',
+        organizationSlug: 'rest-studio',
+      })
+    ).toBe('http://rest-studio.lvh.me:3000/journeys/sleep');
+  });
+
+  it('falls back to the journey id when slug is null', () => {
+    expect(
+      buildJourneyUrl(new URL('http://acme.lvh.me:3000/'), {
+        id: 'course-abc',
+        slug: null,
+        organizationSlug: 'acme',
+      })
+    ).toBe('/journeys/course-abc');
+  });
+
+  it('falls back to the journey id when slug is missing', () => {
+    expect(
+      buildJourneyUrl(new URL('http://acme.lvh.me:3000/'), {
+        id: 'course-def',
+        organizationSlug: 'acme',
+      })
+    ).toBe('/journeys/course-def');
+  });
+
+  it('returns root-relative path when organizationSlug is missing', () => {
+    expect(
+      buildJourneyUrl(new URL('http://lvh.me:3000/'), {
+        id: 'course-xyz',
+        slug: 'standalone-journey',
+      })
+    ).toBe('/journeys/standalone-journey');
+  });
+
+  it('handles deployed dev cross-org navigation', () => {
+    expect(
+      buildJourneyUrl(new URL('https://studio-alpha.dev.revelations.studio/'), {
+        id: 'course-1',
+        slug: 'rootwork',
+        organizationSlug: 'studio-beta',
+      })
+    ).toBe('https://studio-beta.dev.revelations.studio/journeys/rootwork');
+  });
+
+  // ── Surface variants (all sub-paths of /journeys/{slug}) ──
+  it('defaults to the sales surface (no options == { surface: "sales" })', () => {
+    const journey = {
+      id: 'course-1',
+      slug: 'rootwork',
+      organizationSlug: 'acme',
+    };
+    const currentUrl = new URL('http://acme.lvh.me:3000/');
+    expect(buildJourneyUrl(currentUrl, journey)).toBe(
+      buildJourneyUrl(currentUrl, journey, { surface: 'sales' })
+    );
+  });
+
+  it('appends /dashboard for the dashboard surface (same org → root-relative)', () => {
+    expect(
+      buildJourneyUrl(
+        new URL('http://acme.lvh.me:3000/'),
+        { id: 'course-1', slug: 'rootwork', organizationSlug: 'acme' },
+        { surface: 'dashboard' }
+      )
+    ).toBe('/journeys/rootwork/dashboard');
+  });
+
+  it('appends /checkout for the checkout surface', () => {
+    expect(
+      buildJourneyUrl(
+        new URL('http://acme.lvh.me:3000/'),
+        { id: 'course-1', slug: 'rootwork', organizationSlug: 'acme' },
+        { surface: 'checkout' }
+      )
+    ).toBe('/journeys/rootwork/checkout');
+  });
+
+  it('applies the surface suffix on a cross-org full URL', () => {
+    expect(
+      buildJourneyUrl(
+        new URL('http://lvh.me:3000/'),
+        { id: 'course-1', slug: 'rootwork', organizationSlug: 'acme' },
+        { surface: 'dashboard' }
+      )
+    ).toBe('http://acme.lvh.me:3000/journeys/rootwork/dashboard');
+  });
+
+  it('combines the id fallback with a surface suffix', () => {
+    expect(
+      buildJourneyUrl(
+        new URL('http://acme.lvh.me:3000/'),
+        { id: 'course-2', organizationSlug: 'acme' },
+        { surface: 'dashboard' }
+      )
+    ).toBe('/journeys/course-2/dashboard');
   });
 });

--- a/packages/urls/src/build-url.ts
+++ b/packages/urls/src/build-url.ts
@@ -237,3 +237,83 @@ export function buildContentUrl(
 
   return contentPath;
 }
+
+/**
+ * A journey (course landing page) URL target. Mirrors {@link buildContentUrl}'s
+ * `content` shape: prefer the slug, fall back to the id, and carry the owning
+ * org's slug so a cross-org link resolves to a full URL.
+ */
+export interface JourneyUrlTarget {
+  slug?: string | null;
+  id: string;
+  organizationSlug?: string | null;
+}
+
+/**
+ * Which journey surface to link to. All are sub-paths of `/journeys/{slug}` on
+ * the org subdomain (SPEC confirms the URL segment `journeys`; HARDENING §E route
+ * table). `sales` is the public landing/sell page; `checkout` the offer/pay step;
+ * `dashboard` the authed member journey portal.
+ *
+ * The deep in-course `practice/[contentSlug]` surface is intentionally NOT here:
+ * it is always reached same-origin from inside the course and takes a second
+ * (content) slug, so WP-4 builds it from its own route with
+ * {@link buildContentUrl}-style handling.
+ */
+export type JourneySurface = 'sales' | 'checkout' | 'dashboard';
+
+export interface BuildJourneyUrlOptions {
+  /** The journey surface to target. Defaults to `'sales'`. */
+  surface?: JourneySurface;
+}
+
+const JOURNEY_SURFACE_SUFFIX: Record<JourneySurface, string> = {
+  sales: '',
+  checkout: '/checkout',
+  dashboard: '/dashboard',
+};
+
+/**
+ * Build a URL to a guided-journey (course) page, handling cross-org subdomain
+ * routing. Net-new sibling of {@link buildContentUrl} for the Journeys build
+ * (Codex-2pryk); same rules:
+ *
+ * - On the journey's own org subdomain → root-relative `/journeys/{slug}[/…]`
+ *   (the slug lives in the hostname, never the path).
+ * - On a different origin (platform, another org) → a full URL via
+ *   {@link buildOrgUrl} (a different origin needs an absolute URL, not a path).
+ * - Falls back to the journey id when `slug` is missing.
+ * - `options.surface` selects the sub-path (default `'sales'`).
+ *
+ * Slugs are URL-safe by construction (validated on write), so — like
+ * {@link buildContentUrl} — the path segment is not re-encoded.
+ *
+ * @example
+ * buildJourneyUrl(new URL('https://acme.revelations.studio/explore'), { slug: 'rootwork', id: 'c1' })
+ * // → '/journeys/rootwork'  (same org → root-relative)
+ *
+ * @example
+ * buildJourneyUrl(new URL('https://revelations.studio/'), { slug: 'rootwork', id: 'c1', organizationSlug: 'acme' })
+ * // → 'https://acme.revelations.studio/journeys/rootwork'  (cross-org → full URL)
+ *
+ * @example
+ * buildJourneyUrl(new URL('http://acme.lvh.me:3000/'), { id: 'c1' }, { surface: 'dashboard' })
+ * // → '/journeys/c1/dashboard'  (no slug → id fallback)
+ */
+export function buildJourneyUrl(
+  currentUrl: URL,
+  journey: JourneyUrlTarget,
+  options: BuildJourneyUrlOptions = {}
+): string {
+  const surface = options.surface ?? 'sales';
+  const journeyPath = `/journeys/${journey.slug ?? journey.id}${JOURNEY_SURFACE_SUFFIX[surface]}`;
+
+  if (journey.organizationSlug) {
+    const { subdomain } = parseHost(currentUrl.hostname);
+    if (subdomain !== journey.organizationSlug) {
+      return buildOrgUrl(currentUrl, journey.organizationSlug, journeyPath);
+    }
+  }
+
+  return journeyPath;
+}

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -1,12 +1,16 @@
 // Stubs for WP-3 (buildServiceUrl) and WP-4 (URL builders).
 // Each throws an explicit "not implemented (WP-N)" error on call.
 export {
+  type BuildJourneyUrlOptions,
   buildContentUrl,
   buildCreatorsUrl,
+  buildJourneyUrl,
   buildOrgUrl,
   buildOrgUrlFromEnv,
   buildPlatformUrl,
   buildServiceUrl,
+  type JourneySurface,
+  type JourneyUrlTarget,
 } from './build-url';
 export { getCookieConfig } from './cookie-config';
 export { cookieDomainFor } from './cookie-domain';


### PR DESCRIPTION
## WP-0 — the contract barrier (Codex-2pryk.2.1)

Freezes the shared contracts every downstream WP of the Landing-Page-Builder & Guided-Journeys build composes on (HARDENING §G). Types + one pure URL helper — **no DB, no components, no resolver implementation, no feature runtime.**

### What's frozen

**`@codex/shared-types/src/journeys.ts`** (cross-worker, zero-dep leaf package):
- **Page model** (D1 / SPEC §4): `PageBuilderState`, `PageSection`, `SectionProps`, `BrandTokenOverrides`, `CourseSectionType`, `PageStatus`.
- **Access model** (D2 / SPEC §6): `ContentAccessPolicy` (the §6.1 flags replacing `accessType`), `Entitlement`, `ResourceType`, `StoredEntitlementSource` / `EntitlementSource` (with `tier_subscription` documented resolver-output-only).
- **`EntitlementResolver`** — the `canView` / `canEnterCourse` (+ batched) signatures WP-2 implements in `@codex/access`. **Types only.**

**`@codex/urls` `buildJourneyUrl`** — net-new sibling of `buildContentUrl` (`build-url.ts`): same cross-org subdomain routing + `slug ?? id` fallback, plus a `surface` param (`sales` / `checkout` / `dashboard`). Re-exported via `$lib/utils/subdomain`, mirroring `buildContentUrl`. **Real runtime + 12 unit tests.**

**`$lib/page-builder`** (FE inert aggregation surface; a CE-4 boundary-gate scanned root):
- re-exports the shared-types journey model (single FE import surface, like `$lib/utils/subdomain` re-exports `@codex/urls`);
- `section-catalog.ts` — the **SectionModel**: catalogue + ordering + search + default-template factory (analogue of `rail/rail-model.ts`);
- `preview-protocol.ts` — the **`codex:page-preview:v1`** message + type-guard + `PagePreviewSender` interface (analogue of `brand-preview-bridge.ts` — **protocol only**; the sender/applier runtime is WP-5);
- `journey-queries.ts` — remote-function signatures + read-model return types (`getJourneyLibrary`, `listJourneys`, course/page/dashboard reads).

### Placement rationale
Cross-worker atoms live in `@codex/shared-types` (not `$lib/page-builder`) because the WP-1 Drizzle `jsonb().$type<>()` and the WP-2 `@codex/access` resolver are BE packages that cannot import an apps/web `$lib` module. `$lib/page-builder` re-exports them so the FE still imports one inert surface — the exact pattern `$lib/utils/subdomain` uses for `@codex/urls`.

### Gates (local — GitHub CI is down for billing)
- `@codex/urls` **204 tests** green (42 builder-family incl. 12 `buildJourneyUrl`); typecheck clean.
- `@codex/shared-types` typecheck clean.
- `$lib/page-builder` **22 tests** green (section-catalog 17 + preview-protocol 5).
- Import-boundary gate green (135 files scanned, `$lib/page-builder` now armed) + its suite (11).
- biome clean.
- apps/web `svelte-check`: **0 errors in WP-0 files** (the 93 pre-existing errors are unrelated dev-branch static-analysis drift — `feedback_main_needs_static_analysis_gate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)