### PR TITLE
feat(web): studio journey builder (clone brand-studio) on frozen contracts (Codex-2pryk.3.3)

### DIFF
--- a/apps/web/src/lib/components/page-builder/AddSectionPicker.svelte
+++ b/apps/web/src/lib/components/page-builder/AddSectionPicker.svelte
@@ -1,0 +1,184 @@
+<!--
+  @component AddSectionPicker
+
+  The add-section picker (Codex-2pryk.3.3 · WP-5): a search field over the
+  course-template section catalogue (`$lib/page-builder` `SECTION_CATALOG`) with
+  a filtered, keyboard-reachable list. Picking a section calls `onadd(type)`;
+  the store appends it. Pure catalogue search — reuses the frozen inert
+  `sectionMatchesQuery` matcher so the editor and any future consumer rank the
+  same way.
+-->
+<script lang="ts">
+  import {
+    listSectionDefinitions,
+    sectionMatchesQuery,
+    type SectionDefinition,
+  } from '$lib/page-builder';
+  import { SearchIcon } from '$lib/components/ui/Icon';
+
+  interface Props {
+    /** Add a section of this type to the page. */
+    onadd: (type: string) => void;
+    /** Close the picker without adding. */
+    onclose?: () => void;
+  }
+
+  const { onadd, onclose }: Props = $props();
+
+  let query = $state('');
+
+  const matches = $derived<readonly SectionDefinition[]>(
+    listSectionDefinitions().filter((def) => sectionMatchesQuery(def, query))
+  );
+
+  function onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onclose?.();
+    }
+  }
+</script>
+
+<div class="add-picker" role="group" aria-label="Add a section">
+  <div class="add-picker__search">
+    <SearchIcon size={15} />
+    <input
+      type="text"
+      class="add-picker__input"
+      placeholder="Search sections…"
+      aria-label="Search sections"
+      bind:value={query}
+      onkeydown={onKeydown}
+    />
+  </div>
+
+  {#if matches.length > 0}
+    <ul class="add-picker__list" role="list">
+      {#each matches as def (def.type)}
+        <li>
+          <button type="button" class="add-picker__item" onclick={() => onadd(def.type)}>
+            <span class="add-picker__glyph" aria-hidden="true">{def.icon}</span>
+            <span class="add-picker__text">
+              <span class="add-picker__label">{def.label}</span>
+              <span class="add-picker__summary">{def.summary}</span>
+            </span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <p class="add-picker__empty">No sections match “{query}”.</p>
+  {/if}
+</div>
+
+<style>
+  .add-picker {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+  }
+
+  .add-picker__search {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1-5) var(--space-2-5);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+  }
+
+  .add-picker__input {
+    flex: 1;
+    min-width: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+  }
+
+  .add-picker__input:focus {
+    outline: none;
+  }
+
+  .add-picker__input::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  .add-picker__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    max-height: var(--space-64, 20rem);
+    overflow-y: auto;
+  }
+
+  .add-picker__item {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    width: 100%;
+    padding: var(--space-2);
+    border: 0;
+    border-radius: var(--radius-md);
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .add-picker__item:hover {
+    background-color: var(--color-surface-secondary);
+  }
+
+  .add-picker__item:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .add-picker__glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+  }
+
+  .add-picker__text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    min-width: 0;
+  }
+
+  .add-picker__label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text);
+  }
+
+  .add-picker__summary {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    line-height: var(--leading-snug);
+  }
+
+  .add-picker__empty {
+    margin: 0;
+    padding: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/JourneyBuilderCanvas.svelte
+++ b/apps/web/src/lib/components/page-builder/JourneyBuilderCanvas.svelte
@@ -1,0 +1,165 @@
+<!--
+  @component JourneyBuilderCanvas
+
+  Live-preview canvas for the journey sales-page builder (Codex-2pryk.3.3 · WP-5).
+  Cloned from `brand-studio/BrandStudioCanvas.svelte` — embeds the org's REAL
+  public journey page in a same-origin <iframe> and lets a builder flip device
+  width and light/dark (plus a side-by-side compare). The canvas IS the workspace.
+
+  STABLE IFRAME: `src` derives ONLY from the page slug — never from the builder's
+  pending draft — so copy/section edits never reload or re-create it. They stream
+  in over the `codex:page-preview:v1` postMessage bridge (attached via the
+  `onframeload` seam below). A device change only resizes this viewport; a theme
+  flip re-stamps the framed document in place. Only toggling side-by-side
+  mounts/unmounts the SECOND (dark) frame; the primary frame stays put.
+
+  Unlike the brand canvas, the theme is LOCAL preview state (the page store edits
+  sections, not brand tokens — there is no shared `editingTheme`).
+-->
+<script lang="ts">
+  import JourneyCanvasToolbar from './JourneyCanvasToolbar.svelte';
+  import JourneyPreviewFrame from './JourneyPreviewFrame.svelte';
+  import {
+    resolveJourneyPreviewPath,
+    type JourneyPreviewDeviceId,
+    type JourneyPreviewFrameLoad,
+    type JourneyPreviewThemeMode,
+  } from './journey-preview-canvas';
+
+  interface Props {
+    /**
+     * Same-origin origin of the org subdomain (e.g. `page.url.origin`). Surfaced
+     * to the preview seam as the postMessage targetOrigin. The iframe `src` is
+     * root-relative, so this is only needed for the bridge, not for loading.
+     */
+    previewOrigin: string;
+    /** The page's slug — resolves the root-relative public journey path. */
+    slug: string;
+    /**
+     * WP-5 SEAM — invoked every time a preview iframe finishes loading, with a
+     * live handle to the framed window, its origin and theme. The preview wiring
+     * registers the frame with the sender here, then posts the pending draft.
+     */
+    onframeload?: (detail: JourneyPreviewFrameLoad) => void;
+    /**
+     * Full-screen preview state, owned by the route (the toggle lives in this
+     * canvas' toolbar, but the position:fixed effect applies to the sibling
+     * layout, so the page owns the state).
+     */
+    fullscreen?: boolean;
+    onToggleFullscreen?: () => void;
+  }
+
+  const {
+    previewOrigin,
+    slug,
+    onframeload,
+    fullscreen = false,
+    onToggleFullscreen,
+  }: Props = $props();
+
+  // Canvas view state — all local (the page builder has no shared editing theme).
+  let device = $state<JourneyPreviewDeviceId>('desktop');
+  let theme = $state<'light' | 'dark'>('light');
+  let split = $state(false);
+
+  const isSplit = $derived(split);
+  // What the toolbar's theme segment shows as active: the compare view, else the
+  // single-frame theme.
+  const themeMode = $derived<JourneyPreviewThemeMode>(split ? 'split' : theme);
+
+  function onThemeModeChange(mode: JourneyPreviewThemeMode): void {
+    if (mode === 'split') {
+      split = true;
+      return;
+    }
+    split = false;
+    theme = mode;
+  }
+
+  // Root-relative path for the sales page. `src` derives ONLY from slug so a
+  // pending edit can never reload the frame (WP-5 stable-iframe invariant).
+  const previewSrc = $derived(resolveJourneyPreviewPath(slug));
+</script>
+
+<div class="journey-canvas">
+  <JourneyCanvasToolbar
+    {device}
+    {themeMode}
+    {fullscreen}
+    ondevicechange={(id) => (device = id)}
+    onthememodechange={onThemeModeChange}
+    ontogglefullscreen={onToggleFullscreen}
+  />
+
+  <div
+    class="journey-canvas__viewport"
+    data-device={device}
+    data-mode={isSplit ? 'split' : 'single'}
+  >
+    <JourneyPreviewFrame
+      src={previewSrc}
+      title={isSplit ? 'Journey preview (light)' : 'Journey preview'}
+      theme={isSplit ? 'light' : theme}
+      origin={previewOrigin}
+      {onframeload}
+    />
+    {#if isSplit}
+      <JourneyPreviewFrame
+        src={previewSrc}
+        title="Journey preview (dark)"
+        theme="dark"
+        origin={previewOrigin}
+        {onframeload}
+      />
+    {/if}
+  </div>
+</div>
+
+<style>
+  .journey-canvas {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .journey-canvas__viewport {
+    flex: 1;
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    min-width: 0;
+    min-height: 0;
+    padding: var(--space-4);
+    overflow: auto;
+  }
+
+  /* Single-frame device widths — desktop is fluid; tablet/mobile cap the frame
+     to the shared brand-studio viewport tokens and centre it. */
+  .journey-canvas__viewport[data-mode='single'][data-device='tablet']
+    :global(.preview-frame) {
+    max-width: var(--brand-studio-preview-tablet);
+  }
+
+  .journey-canvas__viewport[data-mode='single'][data-device='mobile']
+    :global(.preview-frame) {
+    max-width: var(--brand-studio-preview-mobile);
+  }
+
+  /* Side-by-side: two equal columns filling the viewport. Device caps do not
+     apply — the split IS the comparison view. */
+  .journey-canvas__viewport[data-mode='split'] {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4);
+    align-items: stretch;
+  }
+
+  @media (--below-md) {
+    .journey-canvas__viewport[data-mode='split'] {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/JourneyBuilderRail.svelte
+++ b/apps/web/src/lib/components/page-builder/JourneyBuilderRail.svelte
@@ -1,0 +1,217 @@
+<!--
+  @component JourneyBuilderRail
+
+  The control rail for the journey sales-page builder (Codex-2pryk.3.3 · WP-5) —
+  the page-builder analog of `BrandStudioRail`. Composes:
+    · page-meta head  — title + lifecycle status (writes `pending` meta)
+    · SectionList     — ordered add / toggle / reorder / remove
+    · SectionEditor   — copy fields for the selected section
+    · a save/discard footer (mirrors the brand rail's dirty-gated actions)
+
+  All edits flow through the module-singleton `pageBuilder` store, so they stream
+  to the live preview. `saving` + `onsave` are owned by the route (it runs the
+  persist command + `markSaved`); `discard` is handled here via the store.
+-->
+<script lang="ts">
+  import type { PageStatus } from '@codex/shared-types';
+  import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
+  import SectionList from './SectionList.svelte';
+  import SectionEditor from './SectionEditor.svelte';
+
+  interface Props {
+    /** Persist in flight — disables the Save button + shows a saving label. */
+    saving?: boolean;
+    /** Persist the pending draft (route maps → command() + markSaved). */
+    onsave: () => void;
+  }
+
+  const { saving = false, onsave }: Props = $props();
+
+  const pending = $derived(pageBuilder.pending);
+  const selected = $derived(pageBuilder.selectedSection);
+  const isDirty = $derived(pageBuilder.isDirty);
+
+  const STATUSES: readonly { id: PageStatus; label: string }[] = [
+    { id: 'draft', label: 'Draft' },
+    { id: 'published', label: 'Published' },
+    { id: 'archived', label: 'Archived' },
+  ];
+
+  function onTitleInput(event: Event): void {
+    pageBuilder.updateMeta('title', (event.target as HTMLInputElement).value);
+  }
+
+  function onStatusChange(event: Event): void {
+    pageBuilder.updateMeta('status', (event.target as HTMLSelectElement).value as PageStatus);
+  }
+</script>
+
+<div class="rail">
+  {#if pending}
+    <header class="rail__meta">
+      <label class="rail__field">
+        <span class="rail__field-label">Page title</span>
+        <input
+          type="text"
+          class="rail__title-input"
+          value={pending.title}
+          oninput={onTitleInput}
+          placeholder="Untitled page"
+        />
+      </label>
+      <label class="rail__field rail__field--status">
+        <span class="rail__field-label">Status</span>
+        <select class="rail__status" value={pending.status} onchange={onStatusChange}>
+          {#each STATUSES as s (s.id)}
+            <option value={s.id}>{s.label}</option>
+          {/each}
+        </select>
+      </label>
+    </header>
+
+    <div class="rail__body">
+      <SectionList />
+      {#if selected}
+        <div class="rail__editor">
+          <SectionEditor section={selected} />
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rail__footer">
+      <button
+        type="button"
+        class="rail__btn rail__btn--ghost"
+        disabled={!isDirty || saving}
+        onclick={() => pageBuilder.discard()}
+      >
+        Discard
+      </button>
+      <button
+        type="button"
+        class="rail__btn rail__btn--primary"
+        disabled={!isDirty || saving}
+        onclick={onsave}
+      >
+        {saving ? 'Saving…' : 'Save'}
+      </button>
+    </footer>
+  {/if}
+</div>
+
+<style>
+  .rail {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .rail__meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-3);
+    border-bottom: var(--border-width) var(--border-style) var(--color-border-subtle);
+  }
+
+  .rail__field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .rail__field--status {
+    max-width: var(--space-40, 12rem);
+  }
+
+  .rail__field-label {
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    color: var(--color-text-secondary);
+  }
+
+  .rail__title-input,
+  .rail__status {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    transition: var(--transition-colors);
+  }
+
+  .rail__title-input:focus-visible,
+  .rail__status:focus-visible {
+    outline: none;
+    border-color: var(--color-interactive);
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  /* Scrolling middle — the list + selected editor scroll while head + footer pin. */
+  .rail__body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding-bottom: var(--space-4);
+  }
+
+  .rail__editor {
+    border-top: var(--border-width) var(--border-style) var(--color-border-subtle);
+    margin-top: var(--space-2);
+  }
+
+  .rail__footer {
+    display: flex;
+    gap: var(--space-2);
+    flex-shrink: 0;
+    padding: var(--space-3);
+    border-top: var(--border-width) var(--border-style) var(--color-border);
+    background-color: var(--color-surface);
+  }
+
+  .rail__btn {
+    flex: 1;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .rail__btn:disabled {
+    opacity: var(--opacity-40);
+    cursor: not-allowed;
+  }
+
+  .rail__btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .rail__btn--ghost {
+    border: var(--border-width) var(--border-style) var(--color-border);
+    background: none;
+    color: var(--color-text-secondary);
+  }
+
+  .rail__btn--ghost:hover:not(:disabled) {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .rail__btn--primary {
+    border: var(--border-width) var(--border-style) transparent;
+    background-color: var(--color-interactive);
+    color: var(--color-text-on-brand, var(--color-background));
+  }
+
+  .rail__btn--primary:hover:not(:disabled) {
+    background-color: var(--color-interactive-hover);
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/JourneyCanvasToolbar.svelte
+++ b/apps/web/src/lib/components/page-builder/JourneyCanvasToolbar.svelte
@@ -1,0 +1,215 @@
+<!--
+  @component JourneyCanvasToolbar
+
+  The journey builder canvas toolbar (Codex-2pryk.3.3 · WP-5): a device switcher
+  (Desktop / Tablet / Mobile) with the current width read-out, a theme control
+  (Light / Dark / Side by side), and a full-screen toggle. Cloned + trimmed from
+  `brand-studio/CanvasToolbar.svelte` — the journey builder previews a single
+  surface (the sales page), so the brand toolbar's route switcher is dropped.
+
+  Pure + presentational — it holds no state; the parent owns the selected values
+  and receives changes via callbacks.
+-->
+<script lang="ts">
+  import { MaximizeIcon, XIcon } from '$lib/components/ui/Icon';
+  import {
+    JOURNEY_PREVIEW_DEVICES,
+    type JourneyPreviewDeviceId,
+    type JourneyPreviewThemeMode,
+  } from './journey-preview-canvas';
+
+  interface Props {
+    device: JourneyPreviewDeviceId;
+    themeMode: JourneyPreviewThemeMode;
+    /** Whether the workspace is full-screen (drives the toggle glyph). */
+    fullscreen?: boolean;
+    ondevicechange: (id: JourneyPreviewDeviceId) => void;
+    onthememodechange: (mode: JourneyPreviewThemeMode) => void;
+    /** Toggle full-screen preview. Absent → the button hides. */
+    ontogglefullscreen?: () => void;
+  }
+
+  const {
+    device,
+    themeMode,
+    fullscreen = false,
+    ondevicechange,
+    onthememodechange,
+    ontogglefullscreen,
+  }: Props = $props();
+
+  const THEME_MODES: readonly { id: JourneyPreviewThemeMode; label: string }[] = [
+    { id: 'light', label: 'Light' },
+    { id: 'dark', label: 'Dark' },
+    { id: 'split', label: 'Side by side' },
+  ];
+
+  const currentDevice = $derived(
+    JOURNEY_PREVIEW_DEVICES.find((d) => d.id === device) ?? JOURNEY_PREVIEW_DEVICES[0]
+  );
+</script>
+
+<div class="canvas-toolbar">
+  <div class="canvas-toolbar__device">
+    <div class="canvas-toolbar__group" role="group" aria-label="Preview device">
+      {#each JOURNEY_PREVIEW_DEVICES as d (d.id)}
+        <button
+          type="button"
+          class="canvas-toolbar__seg"
+          aria-pressed={device === d.id}
+          onclick={() => ondevicechange(d.id)}
+        >
+          {d.label}
+        </button>
+      {/each}
+    </div>
+    <span class="canvas-toolbar__width" aria-live="polite">
+      {currentDevice.widthLabel}
+    </span>
+  </div>
+
+  <div class="canvas-toolbar__spacer"></div>
+
+  <div class="canvas-toolbar__group" role="group" aria-label="Preview theme">
+    {#each THEME_MODES as t (t.id)}
+      <button
+        type="button"
+        class="canvas-toolbar__seg"
+        aria-pressed={themeMode === t.id}
+        onclick={() => onthememodechange(t.id)}
+      >
+        {t.label}
+      </button>
+    {/each}
+  </div>
+
+  {#if ontogglefullscreen}
+    <div class="canvas-toolbar__actions" role="group" aria-label="Preview size">
+      <button
+        type="button"
+        class="canvas-toolbar__icon"
+        aria-pressed={fullscreen}
+        aria-label={fullscreen ? 'Exit full screen' : 'Full screen'}
+        title={fullscreen ? 'Exit full screen' : 'Full screen'}
+        onclick={ontogglefullscreen}
+      >
+        {#if fullscreen}
+          <XIcon size={16} />
+        {:else}
+          <MaximizeIcon size={16} />
+        {/if}
+      </button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .canvas-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: var(--border-width) var(--border-style) var(--color-border);
+  }
+
+  .canvas-toolbar__spacer {
+    flex: 1 1 var(--space-4);
+  }
+
+  .canvas-toolbar__device {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  /* Segmented pill group — mirrors the brand-studio toolbar's rounded segments. */
+  .canvas-toolbar__group {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    background-color: var(--color-surface-secondary);
+    border-radius: var(--radius-full);
+  }
+
+  .canvas-toolbar__seg {
+    padding: var(--space-1) var(--space-3);
+    border: 0;
+    border-radius: var(--radius-full);
+    background: none;
+    color: var(--color-text-secondary);
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-default),
+      color var(--duration-fast) var(--ease-default);
+  }
+
+  .canvas-toolbar__seg:hover {
+    color: var(--color-text);
+    background-color: color-mix(in oklch, var(--color-interactive) 12%, transparent);
+  }
+
+  .canvas-toolbar__seg[aria-pressed='true'] {
+    background-color: var(--color-text);
+    color: var(--color-background);
+  }
+
+  .canvas-toolbar__seg:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .canvas-toolbar__width {
+    min-width: var(--space-12);
+    font-size: var(--text-xs);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted);
+  }
+
+  .canvas-toolbar__actions {
+    display: flex;
+    gap: var(--space-1);
+  }
+
+  .canvas-toolbar__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-7);
+    height: var(--space-7);
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius-full);
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-default),
+      color var(--duration-fast) var(--ease-default);
+  }
+
+  .canvas-toolbar__icon:hover {
+    color: var(--color-text);
+    background-color: color-mix(in oklch, var(--color-interactive) 12%, transparent);
+  }
+
+  .canvas-toolbar__icon[aria-pressed='true'] {
+    background-color: var(--color-text);
+    color: var(--color-background);
+  }
+
+  .canvas-toolbar__icon:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  @media (--below-md) {
+    .canvas-toolbar__spacer {
+      display: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/JourneyPreviewFrame.svelte
+++ b/apps/web/src/lib/components/page-builder/JourneyPreviewFrame.svelte
@@ -1,0 +1,143 @@
+<!--
+  @component JourneyPreviewFrame
+
+  ONE live-preview iframe for the journey builder canvas (Codex-2pryk.3.3 · WP-5).
+  Cloned from `brand-studio/PreviewFrame.svelte`. Loads the org's REAL public
+  journey page same-origin (root-relative `src`) and shows a token-driven skeleton
+  until it finishes loading.
+
+  STABLE ELEMENT — the `<iframe>` is never re-created on parent re-renders. Its
+  `src` derives ONLY from the page slug (passed in), never from the builder's
+  pending draft, so a copy/section edit cannot reload it — those stream in over
+  the `codex:page-preview:v1` postMessage bridge with no reload. Theme changes
+  re-stamp the loaded document in place (below), also no reload.
+
+  WP-5 SEAM — `onframeload` fires after every load with a live handle to the
+  framed window + its origin; the preview wiring registers it with the sender.
+  This component never sends or receives postMessage.
+-->
+<script lang="ts">
+  import type {
+    JourneyPreviewFrameLoad,
+    JourneyPreviewFrameTheme,
+  } from './journey-preview-canvas';
+
+  interface Props {
+    /** Root-relative path to load (e.g. `/journeys/<slug>`). */
+    src: string;
+    /** Accessible iframe title. */
+    title: string;
+    /** Theme to paint the framed document in. */
+    theme: JourneyPreviewFrameTheme;
+    /** Same-origin origin for the postMessage targetOrigin. */
+    origin: string;
+    /** WP-5 SEAM — fires on every load with a handle to the framed window. */
+    onframeload?: (detail: JourneyPreviewFrameLoad) => void;
+  }
+
+  const { src, title, theme, origin, onframeload }: Props = $props();
+
+  let frameEl: HTMLIFrameElement | null = $state(null);
+  // The `src` that has finished loading. `loaded` derives from comparing it to
+  // the current `src`, so a new `src` implicitly clears the loaded state — no
+  // state-mutating effect needed to reset the skeleton.
+  let loadedSrc = $state<string | null>(null);
+  const loaded = $derived(loadedSrc === src);
+
+  /**
+   * Reach into the same-origin framed document and stamp the theme, mirroring
+   * theme.svelte.ts setTheme() (data-theme attribute + light/dark class).
+   * Guarded: a not-yet-loaded / cross-origin frame has no reachable
+   * documentElement, so we no-op rather than throw.
+   */
+  function applyPreviewTheme(): void {
+    const root = frameEl?.contentDocument?.documentElement;
+    if (!root) return;
+    root.setAttribute('data-theme', theme);
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+  }
+
+  function handleLoad(): void {
+    loadedSrc = src;
+    applyPreviewTheme();
+    const win = frameEl?.contentWindow;
+    if (win && frameEl) {
+      onframeload?.({ window: win, element: frameEl, origin, theme });
+    }
+  }
+
+  // Re-stamp the theme in place when it flips on an already-loaded frame — a
+  // mode change, not a per-edit update, so no reload. This is a same-origin DOM
+  // side-effect on the framed document (not reactive state), so an $effect is
+  // the correct tool; it never assigns a stateful variable.
+  $effect(() => {
+    void theme;
+    if (loaded) applyPreviewTheme();
+  });
+</script>
+
+<div class="preview-frame" data-preview-theme={theme}>
+  <iframe
+    bind:this={frameEl}
+    class="preview-frame__doc"
+    {src}
+    {title}
+    onload={handleLoad}
+  ></iframe>
+
+  {#if !loaded}
+    <div class="preview-frame__skeleton" aria-hidden="true"></div>
+  {/if}
+</div>
+
+<style>
+  .preview-frame {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    background-color: var(--color-surface);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-lg);
+  }
+
+  .preview-frame__doc {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background-color: var(--color-surface);
+  }
+
+  /* Skeleton overlay — token-driven shimmer while the real page loads. */
+  .preview-frame__skeleton {
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(
+      100deg,
+      var(--color-surface-secondary) 30%,
+      var(--color-surface) 50%,
+      var(--color-surface-secondary) 70%
+    );
+    background-size: 200% 100%;
+    animation: journey-preview-shimmer var(--duration-slower) var(--ease-default)
+      infinite;
+  }
+
+  @keyframes journey-preview-shimmer {
+    from {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .preview-frame__skeleton {
+      animation: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/SectionEditor.svelte
+++ b/apps/web/src/lib/components/page-builder/SectionEditor.svelte
@@ -1,0 +1,214 @@
+<!--
+  @component SectionEditor
+
+  The config editor for the rail's currently-selected section (Codex-2pryk.3.3 ·
+  WP-5). The analog of a brand-editor `levels/*` panel: it renders the copy
+  fields declared for the section's type (`section-fields.ts`) and writes each
+  edit straight into the page-builder store's pending draft, so every keystroke
+  streams to the live preview over the postMessage bridge.
+
+  Reads/writes the module-singleton `pageBuilder` store — no props needed beyond
+  the section. A per-section "Reset" reverts just this section to its saved value.
+-->
+<script lang="ts">
+  import type { PageSection } from '@codex/shared-types';
+  import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
+  import { findSectionDefinition } from '$lib/page-builder';
+  import { fieldsForSectionType } from './section-fields';
+
+  interface Props {
+    section: PageSection;
+  }
+
+  const { section }: Props = $props();
+
+  const definition = $derived(findSectionDefinition(section.type));
+  const fields = $derived(fieldsForSectionType(section.type));
+
+  /** Read a prop as a string for an input `value` (non-strings coerce to ''). */
+  function valueOf(key: string): string {
+    const v = section.props[key];
+    return typeof v === 'string' ? v : '';
+  }
+
+  function onInput(key: string, event: Event): void {
+    const target = event.target as HTMLInputElement | HTMLTextAreaElement;
+    pageBuilder.setSectionProp(section.id, key, target.value);
+  }
+
+  // A section is resettable only when it exists in the saved baseline (a newly
+  // added section has no saved value to revert to).
+  const canReset = $derived(
+    !!pageBuilder.saved?.sections.some((s) => s.id === section.id)
+  );
+</script>
+
+<div class="section-editor">
+  <header class="section-editor__head">
+    <div class="section-editor__title">
+      <span class="section-editor__glyph" aria-hidden="true">{definition?.icon ?? '◌'}</span>
+      <div>
+        <p class="section-editor__label">{definition?.label ?? section.type}</p>
+        {#if definition?.summary}
+          <p class="section-editor__summary">{definition.summary}</p>
+        {/if}
+      </div>
+    </div>
+    {#if canReset}
+      <button
+        type="button"
+        class="section-editor__reset"
+        onclick={() => pageBuilder.resetSection(section.id)}
+        title="Reset this section to its saved values"
+      >
+        Reset
+      </button>
+    {/if}
+  </header>
+
+  <div class="section-editor__fields">
+    {#each fields as field (field.key)}
+      <label class="section-editor__field">
+        <span class="section-editor__field-label">{field.label}</span>
+        {#if field.control === 'textarea'}
+          <textarea
+            class="section-editor__input section-editor__input--area"
+            rows="3"
+            placeholder={field.placeholder}
+            value={valueOf(field.key)}
+            oninput={(e) => onInput(field.key, e)}
+          ></textarea>
+        {:else}
+          <input
+            type="text"
+            class="section-editor__input"
+            placeholder={field.placeholder}
+            value={valueOf(field.key)}
+            oninput={(e) => onInput(field.key, e)}
+          />
+        {/if}
+      </label>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .section-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-4);
+  }
+
+  .section-editor__head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .section-editor__title {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .section-editor__glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-7);
+    height: var(--space-7);
+    flex-shrink: 0;
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+  }
+
+  .section-editor__label {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .section-editor__summary {
+    margin: var(--space-0-5) 0 0;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    line-height: var(--leading-snug);
+  }
+
+  .section-editor__reset {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex-shrink: 0;
+    padding: var(--space-1) var(--space-2);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: var(--text-xs);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .section-editor__reset:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .section-editor__reset:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .section-editor__fields {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .section-editor__field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .section-editor__field-label {
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    color: var(--color-text-secondary);
+  }
+
+  .section-editor__input {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    transition: var(--transition-colors);
+  }
+
+  .section-editor__input--area {
+    resize: vertical;
+    line-height: var(--leading-normal);
+  }
+
+  .section-editor__input::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  .section-editor__input:focus-visible {
+    outline: none;
+    border-color: var(--color-interactive);
+    box-shadow: var(--shadow-focus-ring);
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/SectionList.svelte
+++ b/apps/web/src/lib/components/page-builder/SectionList.svelte
@@ -1,0 +1,314 @@
+<!--
+  @component SectionList
+
+  The ordered section list for the journey builder rail (Codex-2pryk.3.3 · WP-5).
+  Each row selects a section for editing, toggles it on/off (§4.1), reorders it
+  up/down, or removes it. An "Add section" control reveals the catalogue picker.
+  Reorder uses accessible up/down buttons (not pointer-only drag) so it works
+  with a keyboard and screen reader.
+
+  Drives the module-singleton `pageBuilder` store directly — every mutation
+  flows to the live preview via the store's pending draft.
+-->
+<script lang="ts">
+  import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
+  import { findSectionDefinition } from '$lib/page-builder';
+  import {
+    ChevronUpIcon,
+    ChevronDownIcon,
+    EyeIcon,
+    EyeOffIcon,
+    PlusIcon,
+    TrashIcon,
+  } from '$lib/components/ui/Icon';
+  import AddSectionPicker from './AddSectionPicker.svelte';
+
+  const sections = $derived(pageBuilder.sections);
+  let picking = $state(false);
+
+  function labelFor(type: string): string {
+    return findSectionDefinition(type)?.label ?? type;
+  }
+
+  function glyphFor(type: string): string {
+    return findSectionDefinition(type)?.icon ?? '◌';
+  }
+
+  function onAdd(type: string): void {
+    pageBuilder.addSection(type);
+    picking = false;
+  }
+</script>
+
+<div class="section-list">
+  <div class="section-list__head">
+    <h2 class="section-list__title">Sections</h2>
+    <button
+      type="button"
+      class="section-list__add"
+      aria-expanded={picking}
+      onclick={() => (picking = !picking)}
+    >
+      <PlusIcon size={15} />
+      Add
+    </button>
+  </div>
+
+  {#if picking}
+    <div class="section-list__picker">
+      <AddSectionPicker onadd={onAdd} onclose={() => (picking = false)} />
+    </div>
+  {/if}
+
+  {#if sections.length > 0}
+    <ol class="section-list__rows" role="list">
+      {#each sections as section, i (section.id)}
+        {@const selected = pageBuilder.selectedSectionId === section.id}
+        <li class="section-list__row" class:section-list__row--selected={selected}>
+          <div class="section-list__reorder">
+            <button
+              type="button"
+              class="section-list__icon-btn"
+              aria-label="Move {labelFor(section.type)} up"
+              disabled={i === 0}
+              onclick={() => pageBuilder.moveSection(section.id, -1)}
+            >
+              <ChevronUpIcon size={14} />
+            </button>
+            <button
+              type="button"
+              class="section-list__icon-btn"
+              aria-label="Move {labelFor(section.type)} down"
+              disabled={i === sections.length - 1}
+              onclick={() => pageBuilder.moveSection(section.id, 1)}
+            >
+              <ChevronDownIcon size={14} />
+            </button>
+          </div>
+
+          <button
+            type="button"
+            class="section-list__select"
+            class:section-list__select--disabled={!section.enabled}
+            aria-pressed={selected}
+            onclick={() => pageBuilder.selectSection(section.id)}
+          >
+            <span class="section-list__glyph" aria-hidden="true">{glyphFor(section.type)}</span>
+            <span class="section-list__label">{labelFor(section.type)}</span>
+          </button>
+
+          <div class="section-list__actions">
+            <button
+              type="button"
+              class="section-list__icon-btn"
+              aria-pressed={section.enabled}
+              aria-label={section.enabled
+                ? `Hide ${labelFor(section.type)}`
+                : `Show ${labelFor(section.type)}`}
+              title={section.enabled ? 'Hide section' : 'Show section'}
+              onclick={() => pageBuilder.toggleSection(section.id)}
+            >
+              {#if section.enabled}
+                <EyeIcon size={15} />
+              {:else}
+                <EyeOffIcon size={15} />
+              {/if}
+            </button>
+            <button
+              type="button"
+              class="section-list__icon-btn section-list__icon-btn--danger"
+              aria-label="Remove {labelFor(section.type)}"
+              title="Remove section"
+              onclick={() => pageBuilder.removeSection(section.id)}
+            >
+              <TrashIcon size={15} />
+            </button>
+          </div>
+        </li>
+      {/each}
+    </ol>
+  {:else}
+    <p class="section-list__empty">No sections yet. Add one to begin building the page.</p>
+  {/if}
+</div>
+
+<style>
+  .section-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-3) 0;
+  }
+
+  .section-list__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .section-list__title {
+    margin: 0;
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+  }
+
+  .section-list__add {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .section-list__add:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .section-list__add:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .section-list__picker {
+    padding-bottom: var(--space-1);
+  }
+
+  .section-list__rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+  }
+
+  .section-list__row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    border-radius: var(--radius-md);
+    transition: var(--transition-colors);
+  }
+
+  .section-list__row:hover {
+    background-color: var(--color-surface-secondary);
+  }
+
+  .section-list__row--selected {
+    background-color: var(--color-surface-secondary);
+    box-shadow: inset var(--space-0-5) 0 0 0 var(--color-interactive);
+  }
+
+  .section-list__reorder {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .section-list__select {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex: 1;
+    min-width: 0;
+    padding: var(--space-1) var(--space-2);
+    border: 0;
+    border-radius: var(--radius-md);
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .section-list__select:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .section-list__select--disabled {
+    color: var(--color-text-muted);
+  }
+
+  .section-list__glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+  }
+
+  .section-list__label {
+    flex: 1;
+    min-width: 0;
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .section-list__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-0-5);
+    flex-shrink: 0;
+  }
+
+  .section-list__icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .section-list__icon-btn:hover:not(:disabled) {
+    color: var(--color-text);
+    background-color: color-mix(in oklch, var(--color-interactive) 12%, transparent);
+  }
+
+  .section-list__icon-btn--danger:hover:not(:disabled) {
+    color: var(--color-danger, var(--color-text));
+    background-color: color-mix(in oklch, var(--color-danger, red) 12%, transparent);
+  }
+
+  .section-list__icon-btn:disabled {
+    opacity: var(--opacity-40);
+    cursor: not-allowed;
+  }
+
+  .section-list__icon-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .section-list__empty {
+    margin: 0;
+    padding: var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    line-height: var(--leading-normal);
+  }
+</style>

--- a/apps/web/src/lib/components/page-builder/index.ts
+++ b/apps/web/src/lib/components/page-builder/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Page-builder EDITOR UI — the heavy studio-only journey/page builder
+ * (Codex-2pryk.3.3 · WP-5).
+ *
+ * IMPORT BOUNDARY (CE-4 gate): this tree is admin-only editor UI. It must NEVER
+ * be statically imported by public-bundle code — only `studio/journeys/*` routes
+ * (the `ssr = false` studio SPA chunk) may import it. Public journey pages import
+ * only the inert `$lib/page-builder`. The `check:brand-boundary` gate enforces
+ * this. Conversely, this tree freely imports the public-safe `$lib/page-builder`
+ * (store, bridge, section catalogue) — the allowed direction.
+ */
+
+export { default as AddSectionPicker } from './AddSectionPicker.svelte';
+// Canvas (stable same-origin iframe of the real journey page + preview bridge seam).
+export { default as JourneyBuilderCanvas } from './JourneyBuilderCanvas.svelte';
+// Rail (section list + add-picker + per-section config editor).
+export { default as JourneyBuilderRail } from './JourneyBuilderRail.svelte';
+export { default as JourneyCanvasToolbar } from './JourneyCanvasToolbar.svelte';
+export { default as JourneyPreviewFrame } from './JourneyPreviewFrame.svelte';
+export {
+  JOURNEY_PREVIEW_DEVICES,
+  type JourneyPreviewDevice,
+  type JourneyPreviewDeviceId,
+  type JourneyPreviewFrameLoad,
+  type JourneyPreviewFrameTheme,
+  type JourneyPreviewThemeMode,
+  resolveJourneyPreviewPath,
+} from './journey-preview-canvas';
+export {
+  createJourneyPreviewWiring,
+  type JourneyPreviewWiring,
+} from './preview-wiring';
+export { default as SectionEditor } from './SectionEditor.svelte';
+export { default as SectionList } from './SectionList.svelte';
+export {
+  fieldsForSectionType,
+  SECTION_FIELDS,
+  type SectionFieldControl,
+  type SectionFieldDef,
+} from './section-fields';

--- a/apps/web/src/lib/components/page-builder/journey-preview-canvas.ts
+++ b/apps/web/src/lib/components/page-builder/journey-preview-canvas.ts
@@ -1,0 +1,76 @@
+/**
+ * Journey builder live-preview canvas — shared types + device/theme model
+ * (Codex-2pryk.3.3 · WP-5).
+ *
+ * Cloned from `brand-studio/preview-canvas.ts` (NOT reused — HARDENING §B18[H]:
+ * `BrandStudioCanvas` binds the brand-editor store + a fixed 4-member brand
+ * preview-route catalogue, so the stable-iframe pattern is cloned, not the
+ * component). The journey builder previews ONE surface — the org's real public
+ * journey sales page — so there is no route switcher; the model keeps only the
+ * device + theme presets and the `onframeload` seam the WP-5 preview bridge
+ * attaches to.
+ *
+ * EDITOR-TREE placement: lives under `$lib/components/page-builder`, behind the
+ * CE-4 import boundary — never pulled into the public chunk. Co-located in a
+ * `.ts` (not a `<script module>`) so the exported types cross the Svelte/tsc
+ * boundary cleanly.
+ */
+
+/** A device-width preset the canvas constrains the iframe to. */
+export type JourneyPreviewDeviceId = 'desktop' | 'tablet' | 'mobile';
+
+/** Theme control: a single frame in light/dark, or two frames side-by-side. */
+export type JourneyPreviewThemeMode = 'light' | 'dark' | 'split';
+
+/** The concrete theme a single rendered frame paints in (`split` resolves per-frame). */
+export type JourneyPreviewFrameTheme = 'light' | 'dark';
+
+export interface JourneyPreviewDevice {
+  readonly id: JourneyPreviewDeviceId;
+  readonly label: string;
+  /** Human-readable width shown in the toolbar (the CSS width lives in tokens). */
+  readonly widthLabel: string;
+}
+
+/**
+ * Device presets. The actual widths come from the same brand-studio tokens
+ * (`--brand-studio-preview-mobile` / `--brand-studio-preview-tablet`) applied via
+ * the viewport's `data-device` attribute; `widthLabel` here is display text only.
+ */
+export const JOURNEY_PREVIEW_DEVICES: readonly JourneyPreviewDevice[] = [
+  { id: 'desktop', label: 'Desktop', widthLabel: 'Fluid' },
+  { id: 'tablet', label: 'Tablet', widthLabel: '768px' },
+  { id: 'mobile', label: 'Mobile', widthLabel: '375px' },
+];
+
+/**
+ * Resolve the ROOT-RELATIVE public path for a journey's sales page.
+ *
+ * The builder is served from `studio/journeys/[id]/page` on the org subdomain,
+ * so the org's real public journey page is reached with a root-relative path
+ * (the org slug lives in the hostname, never the path). The framed page mounts
+ * the {@link ../../page-builder/page-preview-bridge} applier and re-renders the
+ * builder's pending draft — so an unpublished draft still previews live.
+ *
+ * @param slug the page's slug (`PageBuilderState.slug`).
+ */
+export function resolveJourneyPreviewPath(slug: string): string {
+  return `/journeys/${encodeURIComponent(slug)}`;
+}
+
+/**
+ * WP-5 PREVIEW SEAM — payload handed to the parent each time a preview iframe
+ * loads. The preview wiring (`preview-wiring.ts`) captures `element` + `origin`
+ * and registers the frame with the {@link PagePreviewSender}, which posts the
+ * builder's pending draft to `origin` (an explicit targetOrigin, never `'*'`).
+ */
+export interface JourneyPreviewFrameLoad {
+  /** The framed page's window (the postMessage target). */
+  readonly window: Window;
+  /** The iframe element itself (stable across pending-edit re-renders). */
+  readonly element: HTMLIFrameElement;
+  /** Exact origin for postMessage `targetOrigin` (same-origin as the studio). */
+  readonly origin: string;
+  /** Which theme this frame is rendering. */
+  readonly theme: JourneyPreviewFrameTheme;
+}

--- a/apps/web/src/lib/components/page-builder/journey-queries.mock.svelte.ts
+++ b/apps/web/src/lib/components/page-builder/journey-queries.mock.svelte.ts
@@ -1,0 +1,199 @@
+/**
+ * Journey studio MOCK data + query layer (Codex-2pryk.3.3 · WP-5).
+ *
+ * ┌─ INTEGRATION SEAM ─────────────────────────────────────────────────────────┐
+ * │ AGGRESSIVE-MODE MOCKS. This module stands in for the real SvelteKit remote  │
+ * │ functions until WP-2 lands. The conductor swaps it for `*.remote.ts`        │
+ * │ implementations of the FROZEN contract aliases in `$lib/page-builder`       │
+ * │ (`ListJourneysQuery`, `GetJourneyForBuilderQuery`, + the create/save        │
+ * │ commands). The reactive `query()` shape below (`.current` / `.loading`) is  │
+ * │ chosen to MATCH SvelteKit remote `query()` so integration is a one-line     │
+ * │ import swap at each call site — see `apps/web/src/lib/remote/content.remote`│
+ * │ (`listContent(...).current` / `.loading`) for the real shape.               │
+ * └────────────────────────────────────────────────────────────────────────────┘
+ *
+ * All money is pence, GBP (§ grounding). All returned shapes conform to the
+ * frozen read-model types re-exported from `$lib/page-builder`.
+ */
+import { browser } from '$app/environment';
+import type {
+  JourneyListItem,
+  JourneyPageRecord,
+  PageStatus,
+} from '$lib/page-builder';
+import { createDefaultSections } from '$lib/page-builder';
+
+// ── Reactive resource (mirrors SvelteKit remote query().current/.loading) ─────
+
+export interface MockResource<T> {
+  readonly current: T | undefined;
+  readonly loading: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Resolve `loader` and expose it as a reactive resource. A microtask delay keeps
+ * `loading` briefly true so the surfaces exercise their skeleton/empty branches
+ * exactly as they will against the real (network-backed) query.
+ */
+function createMockResource<T>(loader: () => Promise<T>): MockResource<T> {
+  let current = $state<T | undefined>(undefined);
+  let loading = $state(true);
+  let error = $state<Error | null>(null);
+
+  if (browser) {
+    loader()
+      .then((value) => {
+        current = value;
+      })
+      .catch((err: unknown) => {
+        error = err instanceof Error ? err : new Error(String(err));
+      })
+      .finally(() => {
+        loading = false;
+      });
+  } else {
+    loading = false;
+  }
+
+  return {
+    get current() {
+      return current;
+    },
+    get loading() {
+      return loading;
+    },
+    get error() {
+      return error;
+    },
+  };
+}
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const MOCK_JOURNEYS: readonly JourneyListItem[] = [
+  {
+    id: 'jny-stillness',
+    pageType: 'course',
+    subjectType: 'course',
+    slug: 'stillness',
+    title: 'Stillness — a 6-week descent',
+    status: 'published',
+    tagline: 'Come home to the quiet underneath the noise.',
+    stageCount: 6,
+    practiceCount: 24,
+    enrolledCount: 148,
+    revenueCents: 512_400,
+    updatedAt: '2026-07-20T09:12:00.000Z',
+  },
+  {
+    id: 'jny-first-light',
+    pageType: 'course',
+    subjectType: 'course',
+    slug: 'first-light',
+    title: 'First Light',
+    status: 'draft',
+    tagline: 'A morning practice for beginning again.',
+    stageCount: 3,
+    practiceCount: 9,
+    enrolledCount: 0,
+    revenueCents: 0,
+    updatedAt: '2026-07-22T16:40:00.000Z',
+  },
+  {
+    id: 'jny-welcome',
+    pageType: 'landing',
+    subjectType: null,
+    slug: 'welcome',
+    title: 'Welcome landing page',
+    status: 'published',
+    tagline: null,
+    stageCount: null,
+    practiceCount: null,
+    enrolledCount: null,
+    revenueCents: null,
+    updatedAt: '2026-07-11T11:05:00.000Z',
+  },
+];
+
+/** Build a fresh course-page draft record (a new page or a mock existing one). */
+function makePageRecord(
+  overrides: Partial<JourneyPageRecord> = {}
+): JourneyPageRecord {
+  return {
+    id: overrides.id ?? 'jny-stillness',
+    organizationId: overrides.organizationId ?? 'org-mock',
+    publishedAt: overrides.publishedAt ?? null,
+    pageType: 'course',
+    slug: overrides.slug ?? 'stillness',
+    title: overrides.title ?? 'Stillness — a 6-week descent',
+    status: overrides.status ?? 'draft',
+    subjectType: 'course',
+    subjectId: overrides.subjectId ?? 'course-stillness',
+    brandOverrides: overrides.brandOverrides ?? null,
+    sections:
+      overrides.sections ??
+      createDefaultSections().map((s, i) =>
+        i === 0
+          ? {
+              ...s,
+              props: {
+                kicker: 'A 6-week descent',
+                headline: 'Come home to stillness',
+                subhead:
+                  'A guided journey back to the quiet underneath the noise.',
+                ctaLabel: 'Begin the journey',
+              },
+            }
+          : s
+      ),
+  };
+}
+
+// ── Query mocks (frozen `ListJourneysQuery` / `GetJourneyForBuilderQuery`) ─────
+
+/** {@link ListJourneysQuery} mock — reactive off org + status filter. */
+export function listJourneysMock(input: {
+  organizationId: string;
+  status?: PageStatus;
+}): MockResource<JourneyListItem[]> {
+  return createMockResource(async () =>
+    MOCK_JOURNEYS.filter((j) => !input.status || j.status === input.status)
+  );
+}
+
+/** {@link GetJourneyForBuilderQuery} mock — load a draft into the builder. */
+export function getJourneyForBuilderMock(input: {
+  id: string;
+}): MockResource<JourneyPageRecord | null> {
+  return createMockResource(async () =>
+    makePageRecord({
+      id: input.id,
+      slug: input.id.replace(/^jny-/, '') || 'draft',
+    })
+  );
+}
+
+// ── Command mocks (the real ones are command()/form() — WP-5 BE) ──────────────
+
+/** Persist the builder's draft. Real impl: `command()` + cache invalidation. */
+export async function saveJourneyPageMock(
+  _payload: JourneyPageRecord
+): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+/** Create a new journey/page. Real impl: `command()`/`form()`; returns the new id. */
+export async function createJourneyMock(input: {
+  title: string;
+  pageType: string;
+}): Promise<{ id: string; slug: string }> {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const slug =
+    input.title
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'untitled';
+  return { id: `jny-${slug}`, slug };
+}

--- a/apps/web/src/lib/components/page-builder/preview-wiring.test.ts
+++ b/apps/web/src/lib/components/page-builder/preview-wiring.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Journey preview wiring tests (Codex-2pryk.3.3 · WP-5).
+ *
+ * Proves the seam forwards to the sender with the frozen protocol's arguments:
+ * `registerFrame` passes the frame element + its explicit origin (never '*'),
+ * and `pushSnapshot` forwards the page draft to `send`.
+ */
+
+import type { PageBuilderState } from '@codex/shared-types';
+import { describe, expect, it, vi } from 'vitest';
+import type { PagePreviewSender } from '$lib/page-builder';
+import type { JourneyPreviewFrameLoad } from './journey-preview-canvas';
+import { createJourneyPreviewWiring } from './preview-wiring';
+
+function makeSender() {
+  return {
+    register: vi.fn(),
+    send: vi.fn(),
+    destroy: vi.fn(),
+  } satisfies PagePreviewSender;
+}
+
+const PAGE: PageBuilderState = {
+  pageType: 'course',
+  slug: 'stillness',
+  title: 'Stillness',
+  status: 'draft',
+  subjectType: 'course',
+  subjectId: null,
+  brandOverrides: null,
+  sections: [],
+};
+
+describe('createJourneyPreviewWiring', () => {
+  it('registerFrame passes the element + explicit origin to the sender', () => {
+    const sender = makeSender();
+    const wiring = createJourneyPreviewWiring(sender);
+    const element = {} as HTMLIFrameElement;
+    const detail: JourneyPreviewFrameLoad = {
+      window: {} as Window,
+      element,
+      origin: 'https://acme.example',
+      theme: 'light',
+    };
+
+    wiring.registerFrame(detail);
+
+    expect(sender.register).toHaveBeenCalledWith(
+      element,
+      'https://acme.example'
+    );
+    expect(sender.register).not.toHaveBeenCalledWith(element, '*');
+  });
+
+  it('pushSnapshot forwards the page draft to send', () => {
+    const sender = makeSender();
+    const wiring = createJourneyPreviewWiring(sender);
+
+    wiring.pushSnapshot(PAGE);
+
+    expect(sender.send).toHaveBeenCalledWith(PAGE);
+  });
+});

--- a/apps/web/src/lib/components/page-builder/preview-wiring.ts
+++ b/apps/web/src/lib/components/page-builder/preview-wiring.ts
@@ -1,0 +1,39 @@
+/**
+ * Journey preview wiring (Codex-2pryk.3.3 · WP-5).
+ *
+ * The seam between the page-builder store and the live-preview sender, lifted
+ * out of the `studio/journeys/[id]/page` route so it can be unit-tested in
+ * isolation — cloned from `brand-studio/preview-wiring.ts`. When wiring lives
+ * only inside a `.svelte` `$effect`, a dropped `register` / `send` ships green;
+ * this names + tests it. Pure + framework-free, so the route stays a thin caller.
+ */
+import type { PageBuilderState } from '@codex/shared-types';
+import type { PagePreviewSender } from '$lib/page-builder';
+import type { JourneyPreviewFrameLoad } from './journey-preview-canvas';
+
+export interface JourneyPreviewWiring {
+  /** Register a (re)loaded preview frame so it receives pending-draft updates. */
+  registerFrame(detail: JourneyPreviewFrameLoad): void;
+  /** Broadcast the builder's pending page draft to every tracked frame. */
+  pushSnapshot(page: PageBuilderState): void;
+}
+
+/**
+ * Bind a {@link PagePreviewSender} to the two operations the route drives:
+ * registering each framed preview on load, and pushing the pending draft on
+ * every edit. Preserves the frozen protocol's security semantics — the sender
+ * posts to each frame's explicit `origin` (never `'*'`) and debounces; this only
+ * names + tests the seam.
+ */
+export function createJourneyPreviewWiring(
+  sender: PagePreviewSender
+): JourneyPreviewWiring {
+  return {
+    registerFrame(detail) {
+      sender.register(detail.element, detail.origin);
+    },
+    pushSnapshot(page) {
+      sender.send(page);
+    },
+  };
+}

--- a/apps/web/src/lib/components/page-builder/section-fields.test.ts
+++ b/apps/web/src/lib/components/page-builder/section-fields.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Section-fields model tests (Codex-2pryk.3.3 · WP-5).
+ *
+ * Guards the editor↔renderer contract: every catalogue section type has a field
+ * set, each field names a `PageSection.props` key + a valid control, and an
+ * unknown type degrades to the generic body field rather than throwing.
+ */
+import { describe, expect, it } from 'vitest';
+import { SECTION_CATALOG } from '$lib/page-builder';
+import { fieldsForSectionType, SECTION_FIELDS } from './section-fields';
+
+describe('section-fields', () => {
+  it('declares a field set for every catalogue section type', () => {
+    for (const def of SECTION_CATALOG) {
+      const fields = SECTION_FIELDS[def.type];
+      expect(fields, `missing fields for ${def.type}`).toBeDefined();
+      expect(fields.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every field names a prop key and a supported control', () => {
+    for (const fields of Object.values(SECTION_FIELDS)) {
+      for (const field of fields) {
+        expect(field.key).toMatch(/^[a-zA-Z][a-zA-Z0-9]*$/);
+        expect(['text', 'textarea']).toContain(field.control);
+      }
+    }
+  });
+
+  it('falls back to a generic body field for an unknown type', () => {
+    const fields = fieldsForSectionType('retreat-only-widget');
+    expect(fields).toHaveLength(1);
+    expect(fields[0].key).toBe('body');
+  });
+});

--- a/apps/web/src/lib/components/page-builder/section-fields.ts
+++ b/apps/web/src/lib/components/page-builder/section-fields.ts
@@ -1,0 +1,160 @@
+/**
+ * Per-section editable-field model (Codex-2pryk.3.3 · WP-5).
+ *
+ * The pragmatic analog of `brand-editor/levels/*`: it declares which copy fields
+ * the rail's config editor renders for each {@link CourseSectionType}. The exact
+ * per-type prop schema is deliberately NOT frozen (SPEC §4.1 / `journey-queries`
+ * comment: the WP-3 renderer + WP-5 editor co-own it), so this is EXTENSIBLE —
+ * add fields here and the public renderer reads the same `PageSection.props`
+ * keys. Unknown/absent types fall back to a generic body field.
+ *
+ * Pure + framework-free — no component imports — so it stays cheap to unit-test
+ * and cheap to bundle in the editor chunk.
+ */
+import type { CourseSectionType } from '@codex/shared-types';
+
+/** The control a field renders as in the config editor. */
+export type SectionFieldControl = 'text' | 'textarea';
+
+export interface SectionFieldDef {
+  /** The `PageSection.props` key this field reads/writes. */
+  readonly key: string;
+  readonly label: string;
+  readonly control: SectionFieldControl;
+  readonly placeholder?: string;
+}
+
+const GENERIC_FIELDS: readonly SectionFieldDef[] = [
+  {
+    key: 'body',
+    label: 'Body',
+    control: 'textarea',
+    placeholder: 'Section copy…',
+  },
+];
+
+/**
+ * Field sets per course-section type, grounded in the prototype's section copy
+ * (`docs/design/course-journeys/prototype/`). Keys are additive: extend a set
+ * without breaking stored drafts (an unknown key is simply ignored on render).
+ */
+export const SECTION_FIELDS: Readonly<
+  Record<CourseSectionType, readonly SectionFieldDef[]>
+> = {
+  hero: [
+    {
+      key: 'kicker',
+      label: 'Kicker',
+      control: 'text',
+      placeholder: 'A 6-week descent',
+    },
+    {
+      key: 'headline',
+      label: 'Headline',
+      control: 'text',
+      placeholder: 'Come home to stillness',
+    },
+    { key: 'subhead', label: 'Subhead', control: 'textarea' },
+    {
+      key: 'ctaLabel',
+      label: 'Primary CTA label',
+      control: 'text',
+      placeholder: 'Begin the journey',
+    },
+  ],
+  introVideo: [
+    { key: 'headline', label: 'Headline', control: 'text' },
+    {
+      key: 'mediaId',
+      label: 'Media id',
+      control: 'text',
+      placeholder: 'Sell/intro video id',
+    },
+    { key: 'caption', label: 'Caption', control: 'textarea' },
+  ],
+  ache: [
+    { key: 'headline', label: 'Headline', control: 'text' },
+    {
+      key: 'body',
+      label: 'Body',
+      control: 'textarea',
+      placeholder: 'Name the ache…',
+    },
+  ],
+  turn: [
+    { key: 'headline', label: 'Headline', control: 'text' },
+    {
+      key: 'body',
+      label: 'Body',
+      control: 'textarea',
+      placeholder: 'The shift on offer…',
+    },
+  ],
+  reel: [
+    { key: 'headline', label: 'Headline', control: 'text' },
+    { key: 'caption', label: 'Caption', control: 'textarea' },
+  ],
+  map: [
+    {
+      key: 'headline',
+      label: 'Headline',
+      control: 'text',
+      placeholder: 'The descent',
+    },
+    { key: 'intro', label: 'Intro', control: 'textarea' },
+  ],
+  feel: [
+    { key: 'headline', label: 'Headline', control: 'text' },
+    { key: 'body', label: 'Body', control: 'textarea' },
+    {
+      key: 'freeTasteLabel',
+      label: 'Free-taste label',
+      control: 'text',
+      placeholder: 'Take a free breath',
+    },
+  ],
+  proof: [
+    {
+      key: 'headline',
+      label: 'Headline',
+      control: 'text',
+      placeholder: 'What members say',
+    },
+  ],
+  guide: [
+    { key: 'name', label: 'Guide name', control: 'text' },
+    { key: 'bio', label: 'Bio', control: 'textarea' },
+    { key: 'mediaId', label: 'Guide video id', control: 'text' },
+  ],
+  faq: [
+    {
+      key: 'headline',
+      label: 'Headline',
+      control: 'text',
+      placeholder: 'Questions',
+    },
+  ],
+  invite: [
+    {
+      key: 'headline',
+      label: 'Headline',
+      control: 'text',
+      placeholder: 'Join the journey',
+    },
+    { key: 'body', label: 'Body', control: 'textarea' },
+    {
+      key: 'ctaLabel',
+      label: 'CTA label',
+      control: 'text',
+      placeholder: 'Enrol now',
+    },
+  ],
+};
+
+/** The editable fields for a section type; a generic body field for unknown types. */
+export function fieldsForSectionType(type: string): readonly SectionFieldDef[] {
+  return (
+    (SECTION_FIELDS as Record<string, readonly SectionFieldDef[]>)[type] ??
+    GENERIC_FIELDS
+  );
+}

--- a/apps/web/src/lib/page-builder/page-builder-store.svelte.ts
+++ b/apps/web/src/lib/page-builder/page-builder-store.svelte.ts
@@ -1,0 +1,363 @@
+/**
+ * Page-builder store (Svelte 5 runes) — Codex-2pryk.3.3 · WP-5.
+ *
+ * The `saved` / `pending` runes spine for the journey/page builder, cloned from
+ * `$lib/brand-editor/brand-editor-store.svelte.ts`. The studio builder mutates
+ * `pending` (add / reorder / toggle a {@link PageSection}, edit its props, edit
+ * page meta + brand overrides); a route `$effect` streams the pending draft to
+ * the live-preview iframe over the `codex:page-preview:v1` bridge
+ * ({@link ../page-builder/page-preview-bridge}). Inside the framed public page
+ * the applier drives THIS store's `pending` (a SEPARATE realm's module
+ * instance), so copy / order / toggle edits go live with NO reload — exactly as
+ * `brandEditor.applyPreviewVars` does for brand tokens (SPEC §9).
+ *
+ * PUBLIC-SAFE PLACEMENT: this lives under `$lib/page-builder` (a CE-4
+ * public-lib scan root, `apps/web/scripts/check-brand-editor-boundary.mjs`) so
+ * the framed public journey page (WP-3) can import the applier + read `pending`
+ * without pulling heavy editor UI into the public chunk. It therefore uses only
+ * runes + sessionStorage and imports NO `$lib/components/*` — mirroring why the
+ * brand store lives in `$lib/brand-editor`, not `$lib/components/brand-editor`.
+ *
+ * Uses $state/$derived/$effect — NOT svelte/store. Module-level $effect needs an
+ * explicit `$effect.root()`, wired lazily on first `open`/`applyPreviewState`.
+ */
+
+import type {
+  PageBuilderState,
+  PageSection,
+  SectionProps,
+} from '@codex/shared-types';
+import { browser } from '$app/environment';
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'codex:page-builder';
+
+// ── ID factory (injectable for tests) ───────────────────────────────────────
+// Defaults to crypto.randomUUID (present in the SvelteKit + Node runtimes).
+let makeId: () => string = () => crypto.randomUUID();
+
+/** Override the section-id factory (tests inject a deterministic sequence). */
+function setIdFactory(fn: () => string): void {
+  makeId = fn;
+}
+
+// ── Internal State ────────────────────────────────────────────────────────
+
+const state = $state<{
+  /** The persisted draft last loaded/saved — the diff baseline for `isDirty`. */
+  saved: PageBuilderState | null;
+  /** The editable draft the rail mutates and the preview bridge streams. */
+  pending: PageBuilderState | null;
+  /** Persisted page row id — the crash-recovery scope. null in a preview frame. */
+  pageId: string | null;
+  /** Which section the rail's config editor is focused on. */
+  selectedSectionId: string | null;
+  /** Whether a builder/preview session is active (mirrors brandEditor.isOpen). */
+  isOpen: boolean;
+}>({
+  saved: null,
+  pending: null,
+  pageId: null,
+  selectedSectionId: null,
+  isOpen: false,
+});
+
+// ── Derived State ─────────────────────────────────────────────────────────
+
+const isDirty = $derived.by(() => {
+  if (!state.saved || !state.pending) return false;
+  return JSON.stringify(state.saved) !== JSON.stringify(state.pending);
+});
+
+const sections = $derived<PageSection[]>(state.pending?.sections ?? []);
+
+const selectedSection = $derived.by<PageSection | null>(
+  () => sections.find((s) => s.id === state.selectedSectionId) ?? null
+);
+
+// ── Effects ───────────────────────────────────────────────────────────────
+// Wrapped in $effect.root() because module-level $effect needs an explicit
+// root — it runs at import time, outside any component lifecycle.
+
+let effectsInitialized = false;
+
+function initEffects(): void {
+  if (effectsInitialized) return;
+  effectsInitialized = true;
+
+  $effect.root(() => {
+    // sessionStorage crash-recovery. Guarded on `pageId`, so a PREVIEW-frame
+    // session (applyPreviewState sets no pageId) never writes — the framed page
+    // and a real editor share this origin's sessionStorage.
+    $effect(() => {
+      if (!browser || !state.pageId || !state.pending) return;
+      try {
+        sessionStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            pageId: state.pageId,
+            pending: state.pending,
+            selectedSectionId: state.selectedSectionId,
+          })
+        );
+      } catch {
+        // sessionStorage full/unavailable — crash recovery is best-effort.
+      }
+    });
+  });
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Structural deep-clone that survives `$state` proxies (via snapshot). */
+function clone<T>(value: T): T {
+  return structuredClone($state.snapshot(value)) as T;
+}
+
+/** Index of a section by id in the pending draft, or -1. */
+function indexOf(id: string): number {
+  return state.pending?.sections.findIndex((s) => s.id === id) ?? -1;
+}
+
+// ── Actions ───────────────────────────────────────────────────────────────
+
+/**
+ * Begin a builder session for a persisted page. Seeds `saved`/`pending` from the
+ * loaded draft, restoring an in-flight `pending` from sessionStorage when it
+ * matches this page (crash recovery), and focuses the first section.
+ */
+function open(pageId: string, saved: PageBuilderState): void {
+  initEffects();
+  state.pageId = pageId;
+  state.saved = clone(saved);
+
+  if (browser) {
+    try {
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const restored = JSON.parse(raw) as {
+          pageId?: string;
+          pending?: PageBuilderState;
+          selectedSectionId?: string | null;
+        };
+        if (restored.pageId === pageId && restored.pending) {
+          state.pending = restored.pending;
+          state.selectedSectionId =
+            restored.selectedSectionId ?? firstSectionId(restored.pending);
+          state.isOpen = true;
+          return;
+        }
+      }
+    } catch {
+      // Corrupt persisted state — fall through to a clean clone.
+    }
+  }
+
+  state.pending = clone(saved);
+  state.selectedSectionId = firstSectionId(state.pending);
+  state.isOpen = true;
+}
+
+function firstSectionId(page: PageBuilderState): string | null {
+  return page.sections[0]?.id ?? null;
+}
+
+/** End the session and clear crash-recovery state. */
+function close(): void {
+  clearStorage();
+  state.saved = null;
+  state.pending = null;
+  state.pageId = null;
+  state.selectedSectionId = null;
+  state.isOpen = false;
+}
+
+/** Focus a section in the rail's config editor (null clears the selection). */
+function selectSection(id: string | null): void {
+  state.selectedSectionId = id;
+}
+
+/** Set a top-level page-meta field (title / slug / status / subjectId / …). */
+function updateMeta<K extends keyof PageBuilderState>(
+  field: K,
+  value: PageBuilderState[K]
+): void {
+  if (!state.pending) return;
+  state.pending[field] = value;
+}
+
+/** Replace one section's props wholesale (merge is the caller's choice). */
+function setSectionProps(id: string, props: SectionProps): void {
+  const i = indexOf(id);
+  if (i < 0 || !state.pending) return;
+  state.pending.sections[i].props = props;
+}
+
+/** Set a single key within a section's props bag (the config editor's per-field write). */
+function setSectionProp(id: string, key: string, value: unknown): void {
+  const i = indexOf(id);
+  if (i < 0 || !state.pending) return;
+  state.pending.sections[i].props = {
+    ...state.pending.sections[i].props,
+    [key]: value,
+  };
+}
+
+/** Flip a section on/off (§4.1 toggleable). */
+function toggleSection(id: string): void {
+  const i = indexOf(id);
+  if (i < 0 || !state.pending) return;
+  state.pending.sections[i].enabled = !state.pending.sections[i].enabled;
+}
+
+/**
+ * Append a new section of `type` (empty props, enabled) and focus it. Returns
+ * the new section's id so the caller can scroll/focus it. The WP-3 renderer
+ * skips unknown types, so `type` is a plain string (matches the contract).
+ */
+function addSection(type: string): string {
+  if (!state.pending) return '';
+  const section: PageSection = { id: makeId(), type, enabled: true, props: {} };
+  state.pending.sections.push(section);
+  state.selectedSectionId = section.id;
+  return section.id;
+}
+
+/** Remove a section; re-focus a neighbour so the editor never points at nothing. */
+function removeSection(id: string): void {
+  const i = indexOf(id);
+  if (i < 0 || !state.pending) return;
+  state.pending.sections.splice(i, 1);
+  if (state.selectedSectionId === id) {
+    const next = state.pending.sections[i] ?? state.pending.sections[i - 1];
+    state.selectedSectionId = next?.id ?? null;
+  }
+}
+
+/** Reorder a section one slot up (-1) or down (+1); a no-op at the ends. */
+function moveSection(id: string, direction: -1 | 1): void {
+  const i = indexOf(id);
+  if (i < 0 || !state.pending) return;
+  const target = i + direction;
+  if (target < 0 || target >= state.pending.sections.length) return;
+  const list = state.pending.sections;
+  [list[i], list[target]] = [list[target], list[i]];
+}
+
+/** Merge a partial brand-override patch into `pending.brandOverrides`. */
+function updateBrandOverrides(
+  patch: NonNullable<PageBuilderState['brandOverrides']>
+): void {
+  if (!state.pending) return;
+  state.pending.brandOverrides = {
+    ...(state.pending.brandOverrides ?? {}),
+    ...patch,
+  };
+}
+
+/** Revert every pending edit to the last saved draft. */
+function discard(): void {
+  if (!state.saved) return;
+  state.pending = clone(state.saved);
+  state.selectedSectionId = firstSectionId(state.pending);
+  clearStorage();
+}
+
+/**
+ * Revert ONE section to its saved value, leaving other pending edits intact
+ * (mirrors `brandEditor.resetField`). No-op when the section is new (absent from
+ * `saved`) or already equal to saved.
+ */
+function resetSection(id: string): void {
+  if (!state.pending || !state.saved) return;
+  const savedSection = state.saved.sections.find((s) => s.id === id);
+  const i = indexOf(id);
+  if (!savedSection || i < 0) return;
+  state.pending.sections[i] = clone(savedSection);
+}
+
+/**
+ * Apply an inbound preview snapshot inside the framed public page (driven by the
+ * postMessage bridge). Sets `pending` + opens so the framed renderer re-derives
+ * its output. Deliberately sets NO `pageId`, so the sessionStorage effect stays
+ * inert in a preview frame (mirrors `brandEditor.applyPreviewVars`). Pure applier
+ * — it never posts a message, so it cannot echo back to the sender.
+ */
+function applyPreviewState(page: PageBuilderState): void {
+  initEffects();
+  state.pending = page;
+  state.isOpen = true;
+}
+
+/** The payload to persist — a plain (non-proxy) deep snapshot of `pending`. */
+function getSavePayload(): PageBuilderState | null {
+  return state.pending ? clone(state.pending) : null;
+}
+
+/** Mark the current pending draft as the new saved baseline (post-persist). */
+function markSaved(): void {
+  if (!state.pending) return;
+  state.saved = clone(state.pending);
+  clearStorage();
+}
+
+function clearStorage(): void {
+  if (!browser) return;
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore
+  }
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────
+
+export const pageBuilder = {
+  // Reactive getters
+  get isOpen() {
+    return state.isOpen;
+  },
+  get isDirty() {
+    return isDirty;
+  },
+  get pageId() {
+    return state.pageId;
+  },
+  get saved() {
+    return state.saved;
+  },
+  get pending() {
+    return state.pending;
+  },
+  get sections() {
+    return sections;
+  },
+  get selectedSectionId() {
+    return state.selectedSectionId;
+  },
+  get selectedSection() {
+    return selectedSection;
+  },
+
+  // Actions
+  open,
+  close,
+  selectSection,
+  updateMeta,
+  setSectionProps,
+  setSectionProp,
+  toggleSection,
+  addSection,
+  removeSection,
+  moveSection,
+  updateBrandOverrides,
+  discard,
+  resetSection,
+  applyPreviewState,
+  getSavePayload,
+  markSaved,
+
+  // Test seam — deterministic section ids.
+  setIdFactory,
+};

--- a/apps/web/src/lib/page-builder/page-builder-store.test.ts
+++ b/apps/web/src/lib/page-builder/page-builder-store.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Page-builder store tests (Codex-2pryk.3.3 · WP-5).
+ *
+ * The `saved`/`pending` spine drives the whole builder + the live preview, so
+ * the section mutations (add / remove / reorder / toggle / prop edits), the
+ * dirty diff, per-section reset, discard, and the preview-applier entry point
+ * are each proven. The store is a Svelte 5 module-level `$state` singleton, so
+ * every test resets via `close()` then re-opens with a known saved draft.
+ */
+
+import type { PageBuilderState, PageSection } from '@codex/shared-types';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { pageBuilder } from './page-builder-store.svelte';
+
+const PAGE_ID = '00000000-0000-4000-8000-000000000000';
+
+function makeSection(overrides: Partial<PageSection> = {}): PageSection {
+  return {
+    id: 'sec-hero',
+    type: 'hero',
+    enabled: true,
+    props: {},
+    ...overrides,
+  };
+}
+
+function makeSaved(
+  overrides: Partial<PageBuilderState> = {}
+): PageBuilderState {
+  return {
+    pageType: 'course',
+    slug: 'stillness',
+    title: 'Stillness',
+    status: 'draft',
+    subjectType: 'course',
+    subjectId: 'course-1',
+    brandOverrides: null,
+    sections: [
+      makeSection({ id: 'sec-hero', type: 'hero' }),
+      makeSection({ id: 'sec-ache', type: 'ache' }),
+      makeSection({ id: 'sec-invite', type: 'invite' }),
+    ],
+    ...overrides,
+  };
+}
+
+describe('pageBuilder — session lifecycle', () => {
+  beforeEach(() => {
+    pageBuilder.close();
+    // Deterministic ids for addSection assertions.
+    let n = 0;
+    pageBuilder.setIdFactory(() => `new-${++n}`);
+  });
+
+  it('open() seeds pending from a clone of saved and focuses the first section', () => {
+    pageBuilder.open(PAGE_ID, makeSaved());
+
+    expect(pageBuilder.isOpen).toBe(true);
+    expect(pageBuilder.pageId).toBe(PAGE_ID);
+    expect(pageBuilder.pending?.title).toBe('Stillness');
+    expect(pageBuilder.selectedSectionId).toBe('sec-hero');
+    // pending is a distinct object graph — mutating it must not touch saved.
+    expect(pageBuilder.pending).not.toBe(pageBuilder.saved);
+    expect(pageBuilder.isDirty).toBe(false);
+  });
+
+  it('close() clears the session', () => {
+    pageBuilder.open(PAGE_ID, makeSaved());
+    pageBuilder.close();
+
+    expect(pageBuilder.isOpen).toBe(false);
+    expect(pageBuilder.pending).toBeNull();
+    expect(pageBuilder.saved).toBeNull();
+    expect(pageBuilder.pageId).toBeNull();
+    expect(pageBuilder.selectedSectionId).toBeNull();
+  });
+});
+
+describe('pageBuilder — section mutations', () => {
+  beforeEach(() => {
+    pageBuilder.close();
+    let n = 0;
+    pageBuilder.setIdFactory(() => `new-${++n}`);
+    pageBuilder.open(PAGE_ID, makeSaved());
+  });
+
+  it('toggleSection flips enabled and marks dirty', () => {
+    pageBuilder.toggleSection('sec-ache');
+    expect(pageBuilder.sections.find((s) => s.id === 'sec-ache')?.enabled).toBe(
+      false
+    );
+    expect(pageBuilder.isDirty).toBe(true);
+  });
+
+  it('addSection appends an enabled section with the injected id and focuses it', () => {
+    const id = pageBuilder.addSection('faq');
+    expect(id).toBe('new-1');
+    const added = pageBuilder.sections.at(-1);
+    expect(added).toMatchObject({
+      id: 'new-1',
+      type: 'faq',
+      enabled: true,
+      props: {},
+    });
+    expect(pageBuilder.selectedSectionId).toBe('new-1');
+  });
+
+  it('removeSection drops the section and re-focuses a neighbour', () => {
+    pageBuilder.selectSection('sec-ache');
+    pageBuilder.removeSection('sec-ache');
+    expect(pageBuilder.sections.map((s) => s.id)).toEqual([
+      'sec-hero',
+      'sec-invite',
+    ]);
+    // Focus moves to the section that slid into the removed slot.
+    expect(pageBuilder.selectedSectionId).toBe('sec-invite');
+  });
+
+  it('moveSection reorders up and down and clamps at the ends', () => {
+    pageBuilder.moveSection('sec-ache', -1);
+    expect(pageBuilder.sections.map((s) => s.id)).toEqual([
+      'sec-ache',
+      'sec-hero',
+      'sec-invite',
+    ]);
+    // Already first — moving up again is a no-op.
+    pageBuilder.moveSection('sec-ache', -1);
+    expect(pageBuilder.sections[0].id).toBe('sec-ache');
+
+    pageBuilder.moveSection('sec-invite', 1); // already last — no-op
+    expect(pageBuilder.sections.at(-1)?.id).toBe('sec-invite');
+  });
+
+  it('setSectionProp merges one key without clobbering the rest', () => {
+    pageBuilder.setSectionProp(
+      'sec-hero',
+      'headline',
+      'Come home to stillness'
+    );
+    pageBuilder.setSectionProp('sec-hero', 'kicker', 'A 6-week descent');
+    const hero = pageBuilder.sections.find((s) => s.id === 'sec-hero');
+    expect(hero?.props).toEqual({
+      headline: 'Come home to stillness',
+      kicker: 'A 6-week descent',
+    });
+  });
+});
+
+describe('pageBuilder — revert paths', () => {
+  beforeEach(() => {
+    pageBuilder.close();
+    pageBuilder.open(PAGE_ID, makeSaved());
+  });
+
+  it('discard restores pending to the saved baseline', () => {
+    pageBuilder.setSectionProp('sec-hero', 'headline', 'edited');
+    pageBuilder.addSection('proof');
+    expect(pageBuilder.isDirty).toBe(true);
+
+    pageBuilder.discard();
+    expect(pageBuilder.isDirty).toBe(false);
+    expect(pageBuilder.sections.map((s) => s.id)).toEqual([
+      'sec-hero',
+      'sec-ache',
+      'sec-invite',
+    ]);
+  });
+
+  it('resetSection reverts one section, keeping other pending edits', () => {
+    pageBuilder.setSectionProp('sec-hero', 'headline', 'edited hero');
+    pageBuilder.setSectionProp('sec-ache', 'body', 'edited ache');
+
+    pageBuilder.resetSection('sec-hero');
+
+    expect(
+      pageBuilder.sections.find((s) => s.id === 'sec-hero')?.props
+    ).toEqual({});
+    // The ache edit survives.
+    expect(
+      pageBuilder.sections.find((s) => s.id === 'sec-ache')?.props
+    ).toEqual({
+      body: 'edited ache',
+    });
+  });
+
+  it('resetSection is a no-op for a section absent from saved (a newly added one)', () => {
+    let n = 0;
+    pageBuilder.setIdFactory(() => `new-${++n}`);
+    const id = pageBuilder.addSection('faq');
+    pageBuilder.setSectionProp(id, 'q', 'How long?');
+
+    pageBuilder.resetSection(id);
+    // Still present, still carries the edit — reset can't invent a saved value.
+    expect(pageBuilder.sections.find((s) => s.id === id)?.props).toEqual({
+      q: 'How long?',
+    });
+  });
+});
+
+describe('pageBuilder — save + preview applier', () => {
+  beforeEach(() => {
+    pageBuilder.close();
+  });
+
+  it('markSaved advances the baseline so isDirty resets', () => {
+    pageBuilder.open(PAGE_ID, makeSaved());
+    pageBuilder.setSectionProp('sec-hero', 'headline', 'edited');
+    expect(pageBuilder.isDirty).toBe(true);
+
+    pageBuilder.markSaved();
+    expect(pageBuilder.isDirty).toBe(false);
+    // getSavePayload returns a plain (non-proxy) deep snapshot.
+    const payload = pageBuilder.getSavePayload();
+    expect(payload?.sections.find((s) => s.id === 'sec-hero')?.props).toEqual({
+      headline: 'edited',
+    });
+  });
+
+  it('applyPreviewState sets pending + opens WITHOUT a pageId (inert crash-recovery)', () => {
+    const incoming = makeSaved({ title: 'Live preview draft' });
+    pageBuilder.applyPreviewState(incoming);
+
+    expect(pageBuilder.isOpen).toBe(true);
+    expect(pageBuilder.pending?.title).toBe('Live preview draft');
+    // A preview frame must never own a persisted pageId (would pollute storage).
+    expect(pageBuilder.pageId).toBeNull();
+  });
+});

--- a/apps/web/src/lib/page-builder/page-preview-bridge.test.ts
+++ b/apps/web/src/lib/page-builder/page-preview-bridge.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Page-builder preview bridge tests (Codex-2pryk.3.3 · WP-5).
+ *
+ * This is a security + correctness boundary (the `codex:page-preview:v1`
+ * protocol), so it is tested as one, mirroring the brand-bridge suite:
+ *   - SENDER: a pending edit posts a debounced, versioned message carrying the
+ *     PageBuilderState with an EXPLICIT targetOrigin (never '*'); rapid edits
+ *     coalesce (latest wins); a (re)loaded frame is re-synced; a copy edit never
+ *     reloads or swaps src; a disconnected split frame is pruned.
+ *   - APPLIER: a well-formed same-origin message from the parent frame applies
+ *     the draft (store pending); every ill-formed / cross-origin / non-parent /
+ *     wrong-type / standalone case is a proven no-op.
+ */
+
+import type { PageBuilderState } from '@codex/shared-types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pageBuilder } from './page-builder-store.svelte';
+import {
+  createPagePreviewSender,
+  initPagePreviewBridge,
+} from './page-preview-bridge';
+import {
+  PAGE_PREVIEW_MESSAGE_TYPE,
+  type PagePreviewMessage,
+} from './preview-protocol';
+
+const ORIGIN = 'https://acme.example';
+
+function makePage(overrides: Partial<PageBuilderState> = {}): PageBuilderState {
+  return {
+    pageType: 'course',
+    slug: 'stillness',
+    title: 'Stillness',
+    status: 'draft',
+    subjectType: 'course',
+    subjectId: 'course-1',
+    brandOverrides: null,
+    sections: [{ id: 'sec-hero', type: 'hero', enabled: true, props: {} }],
+    ...overrides,
+  };
+}
+
+// ── Fake preview frame ───────────────────────────────────────────────────────
+interface FakeFrame {
+  element: HTMLIFrameElement;
+  posts: Array<{ message: unknown; targetOrigin: string }>;
+  reload: ReturnType<typeof vi.fn>;
+  setConnected(connected: boolean): void;
+  readonly src: string;
+}
+
+function makeFrame(): FakeFrame {
+  const posts: Array<{ message: unknown; targetOrigin: string }> = [];
+  const reload = vi.fn();
+  let connected = true;
+  let src = '/';
+  const contentWindow = {
+    postMessage: (message: unknown, targetOrigin: string) => {
+      posts.push({ message, targetOrigin });
+    },
+    location: { reload },
+  } as unknown as Window;
+  const element = {
+    get isConnected() {
+      return connected;
+    },
+    get contentWindow() {
+      return contentWindow;
+    },
+    get src() {
+      return src;
+    },
+    set src(value: string) {
+      src = value;
+    },
+  } as unknown as HTMLIFrameElement;
+  return {
+    element,
+    posts,
+    reload,
+    setConnected(value) {
+      connected = value;
+    },
+    get src() {
+      return src;
+    },
+  };
+}
+
+// ── Fake target window (for the applier) ─────────────────────────────────────
+function makeTarget(origin = ORIGIN) {
+  const messageListeners = new Set<(event: MessageEvent) => void>();
+  const target = {
+    location: { origin } as Location,
+    addEventListener: (type: string, cb: (event: MessageEvent) => void) => {
+      if (type === 'message') messageListeners.add(cb);
+    },
+    removeEventListener: (type: string, cb: (event: MessageEvent) => void) => {
+      if (type === 'message') messageListeners.delete(cb);
+    },
+  } as unknown as Window & { parent: Window };
+  const parent = {} as Window;
+  target.parent = parent;
+  return {
+    target,
+    parent,
+    /** Force standalone: parent === target (a real visitor's top window). */
+    makeStandalone() {
+      target.parent = target;
+    },
+    dispatch(event: Partial<MessageEvent>) {
+      for (const cb of messageListeners) cb(event as MessageEvent);
+    },
+    listenerCount() {
+      return messageListeners.size;
+    },
+  };
+}
+
+describe('createPagePreviewSender (studio → iframe)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('posts a versioned message with the page draft and an explicit targetOrigin after debounce', () => {
+    const sender = createPagePreviewSender({ debounceMs: 50 });
+    const frame = makeFrame();
+    sender.register(frame.element, ORIGIN); // latest is null → no immediate post
+    expect(frame.posts).toHaveLength(0);
+
+    sender.send(makePage({ title: 'Edited' }));
+    expect(frame.posts).toHaveLength(0); // debounced — not yet
+    vi.advanceTimersByTime(50);
+
+    expect(frame.posts).toHaveLength(1);
+    const { message, targetOrigin } = frame.posts[0];
+    expect(targetOrigin).toBe(ORIGIN);
+    expect(targetOrigin).not.toBe('*'); // NEVER wildcard
+    const msg = message as PagePreviewMessage;
+    expect(msg.type).toBe(PAGE_PREVIEW_MESSAGE_TYPE);
+    expect(msg.page.title).toBe('Edited');
+    sender.destroy();
+  });
+
+  it('coalesces rapid edits into a single post (latest wins)', () => {
+    const sender = createPagePreviewSender({ debounceMs: 50 });
+    const frame = makeFrame();
+    sender.register(frame.element, ORIGIN);
+
+    sender.send(makePage({ title: 'one' }));
+    sender.send(makePage({ title: 'two' }));
+    sender.send(makePage({ title: 'three' }));
+    expect(frame.posts).toHaveLength(0);
+    vi.advanceTimersByTime(50);
+
+    expect(frame.posts).toHaveLength(1);
+    expect((frame.posts[0].message as PagePreviewMessage).page.title).toBe(
+      'three'
+    );
+    sender.destroy();
+  });
+
+  it('re-sends the latest draft to a frame that (re)loads', () => {
+    const sender = createPagePreviewSender({ debounceMs: 50 });
+    sender.send(makePage({ title: 'restored' }));
+    vi.advanceTimersByTime(50); // latest captured; no frames registered yet
+
+    const frame = makeFrame();
+    sender.register(frame.element, ORIGIN); // immediate re-send on load
+    expect(frame.posts).toHaveLength(1);
+    expect((frame.posts[0].message as PagePreviewMessage).page.title).toBe(
+      'restored'
+    );
+    expect(frame.posts[0].targetOrigin).toBe(ORIGIN);
+    sender.destroy();
+  });
+
+  it('does NOT reload or reassign src on a copy edit (no per-edit reload)', () => {
+    const sender = createPagePreviewSender({ debounceMs: 50 });
+    const frame = makeFrame();
+    const srcBefore = frame.src;
+    sender.register(frame.element, ORIGIN);
+
+    sender.send(makePage({ title: 'streamed' }));
+    vi.advanceTimersByTime(50);
+
+    expect(frame.posts).toHaveLength(1); // applied via message …
+    expect(frame.reload).not.toHaveBeenCalled(); // … not via reload
+    expect(frame.src).toBe(srcBefore); // … not via src swap
+    sender.destroy();
+  });
+
+  it('prunes a disconnected frame without throwing', () => {
+    const sender = createPagePreviewSender({ debounceMs: 10 });
+    const frame = makeFrame();
+    sender.register(frame.element, ORIGIN);
+    frame.setConnected(false); // split frame unmounted
+
+    sender.send(makePage());
+    expect(() => vi.advanceTimersByTime(10)).not.toThrow();
+    expect(frame.posts).toHaveLength(0);
+    sender.destroy();
+  });
+});
+
+describe('initPagePreviewBridge (iframe applier)', () => {
+  beforeEach(() => {
+    pageBuilder.close(); // reset the module-singleton store: pending → null
+  });
+  afterEach(() => {
+    pageBuilder.close();
+  });
+
+  it('applies the draft from a well-formed same-origin message sent by the parent frame', () => {
+    const win = makeTarget();
+    const teardown = initPagePreviewBridge(win.target);
+    expect(win.listenerCount()).toBe(1);
+    expect(pageBuilder.pending).toBeNull();
+
+    win.dispatch({
+      source: win.parent,
+      origin: ORIGIN,
+      data: {
+        type: PAGE_PREVIEW_MESSAGE_TYPE,
+        page: makePage({ title: 'live' }),
+      },
+    });
+
+    expect(pageBuilder.pending?.title).toBe('live');
+    expect(pageBuilder.isOpen).toBe(true);
+    // A preview frame never owns a persisted pageId.
+    expect(pageBuilder.pageId).toBeNull();
+    teardown();
+  });
+
+  it('is INERT on a standalone (non-embedded) page — adds no listener', () => {
+    const win = makeTarget();
+    win.makeStandalone(); // window.parent === window
+    const teardown = initPagePreviewBridge(win.target);
+
+    expect(win.listenerCount()).toBe(0);
+    expect(pageBuilder.pending).toBeNull();
+    expect(() => teardown()).not.toThrow();
+  });
+
+  it('ignores a message from a DIFFERENT origin (cross-origin)', () => {
+    const win = makeTarget();
+    const teardown = initPagePreviewBridge(win.target);
+
+    win.dispatch({
+      source: win.parent,
+      origin: 'https://evil.example',
+      data: { type: PAGE_PREVIEW_MESSAGE_TYPE, page: makePage() },
+    });
+
+    expect(pageBuilder.pending).toBeNull();
+    teardown();
+  });
+
+  it('ignores a message whose source is NOT the parent frame', () => {
+    const win = makeTarget();
+    const teardown = initPagePreviewBridge(win.target);
+
+    win.dispatch({
+      source: {} as Window,
+      origin: ORIGIN,
+      data: { type: PAGE_PREVIEW_MESSAGE_TYPE, page: makePage() },
+    });
+
+    expect(pageBuilder.pending).toBeNull();
+    teardown();
+  });
+
+  it('ignores a message with the wrong type', () => {
+    const win = makeTarget();
+    const teardown = initPagePreviewBridge(win.target);
+
+    win.dispatch({
+      source: win.parent,
+      origin: ORIGIN,
+      data: { type: 'codex:brand-preview:v1', page: makePage() },
+    });
+
+    expect(pageBuilder.pending).toBeNull();
+    teardown();
+  });
+
+  it('ignores a message with no page / non-object payload', () => {
+    const win = makeTarget();
+    const teardown = initPagePreviewBridge(win.target);
+
+    win.dispatch({
+      source: win.parent,
+      origin: ORIGIN,
+      data: { type: PAGE_PREVIEW_MESSAGE_TYPE }, // absent page
+    });
+    win.dispatch({ source: win.parent, origin: ORIGIN, data: 'not-an-object' });
+    win.dispatch({ source: win.parent, origin: ORIGIN, data: null });
+
+    expect(pageBuilder.pending).toBeNull();
+    teardown();
+  });
+
+  it('teardown removes the message listener', () => {
+    const win = makeTarget();
+    const teardown = initPagePreviewBridge(win.target);
+    expect(win.listenerCount()).toBe(1);
+
+    teardown();
+    expect(win.listenerCount()).toBe(0);
+
+    win.dispatch({
+      source: win.parent,
+      origin: ORIGIN,
+      data: {
+        type: PAGE_PREVIEW_MESSAGE_TYPE,
+        page: makePage({ title: 'late' }),
+      },
+    });
+    expect(pageBuilder.pending).toBeNull();
+  });
+});

--- a/apps/web/src/lib/page-builder/page-preview-bridge.ts
+++ b/apps/web/src/lib/page-builder/page-preview-bridge.ts
@@ -1,0 +1,163 @@
+/**
+ * Page-builder preview bridge — RUNTIME (Codex-2pryk.3.3 · WP-5).
+ *
+ * The live edit → preview channel for the journey/page builder, cloned from
+ * `$lib/brand-editor/brand-preview-bridge.ts`. It implements the RUNTIME for the
+ * frozen `codex:page-preview:v1` PROTOCOL (WP-0, `./preview-protocol`): the
+ * SENDER ({@link createPagePreviewSender}, in the studio builder document) and
+ * the APPLIER ({@link initPagePreviewBridge}, inside the framed public journey
+ * page). While a builder edits copy / toggles a section / reorders the page, the
+ * framed `(space)/journeys/[slug]` page reflects it INSTANTLY, no reload.
+ *
+ * Why the payload is the full pending {@link PageBuilderState} and not a
+ * pre-derived DOM patch: the framed page re-derives its render from the draft
+ * with its OWN render + branding-injection machinery (the WP-3 renderer + the
+ * brand-override seam), so a single message covers section copy, order, toggles,
+ * AND per-page brand overrides — reusing the render path rather than fighting it
+ * with fragile direct DOM writes. Mirrors the brand bridge's "send the state,
+ * not a var map" rationale.
+ *
+ * Security (per the frozen protocol): same-origin ONLY. The sender always
+ * targets an explicit origin (NEVER `'*'`); the applier is inert unless embedded
+ * and accepts a message only when source + origin + type all match. Treat as a
+ * security boundary.
+ *
+ * PUBLIC-SAFE PLACEMENT: lives under `$lib/page-builder` (a CE-4 public-lib scan
+ * root) so the public journey page can import the applier without tripping the
+ * import-boundary gate. It reuses the public-safe {@link pageBuilder} store and
+ * adds no heavy editor code — the same placement rule the brand bridge follows.
+ */
+
+import type { PageBuilderState } from '@codex/shared-types';
+import { browser } from '$app/environment';
+import { pageBuilder } from './page-builder-store.svelte';
+import {
+  isPagePreviewMessage,
+  PAGE_PREVIEW_MESSAGE_TYPE,
+  type PagePreviewMessage,
+  type PagePreviewSender,
+} from './preview-protocol';
+
+export interface PagePreviewSenderOptions {
+  /**
+   * Debounce window (ms) for coalescing rapid edits (e.g. typing into a copy
+   * field). Defaults to ~50ms ≈ one animation frame — the brand bridge default.
+   */
+  readonly debounceMs?: number;
+}
+
+/**
+ * Create a sender that broadcasts the builder's pending page draft to one or
+ * more preview iframes over `postMessage`. Implements the frozen
+ * {@link PagePreviewSender}. Frames are keyed by element so a route-change
+ * navigation (same element, new document) re-registers idempotently and an
+ * unmounted split frame is pruned on the next send.
+ */
+export function createPagePreviewSender(
+  options: PagePreviewSenderOptions = {}
+): PagePreviewSender {
+  const debounceMs = options.debounceMs ?? 50;
+  const frames = new Map<HTMLIFrameElement, string>();
+  let latest: PageBuilderState | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function postTo(
+    element: HTMLIFrameElement,
+    targetOrigin: string,
+    page: PageBuilderState
+  ): void {
+    // A detached (unmounted split) frame is dropped rather than posted to.
+    if (!element.isConnected) {
+      frames.delete(element);
+      return;
+    }
+    const win = element.contentWindow;
+    if (!win) return;
+    const message: PagePreviewMessage = {
+      type: PAGE_PREVIEW_MESSAGE_TYPE,
+      page,
+    };
+    try {
+      // Explicit targetOrigin — NEVER '*'. Studio + framed page are same-origin.
+      win.postMessage(message, targetOrigin);
+    } catch {
+      // Frame detached / navigating mid-post — drop it; the next onframeload
+      // re-registers a fresh handle.
+      frames.delete(element);
+    }
+  }
+
+  function broadcast(page: PageBuilderState): void {
+    for (const [element, targetOrigin] of frames) {
+      postTo(element, targetOrigin, page);
+    }
+  }
+
+  function clearTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  return {
+    register(element, targetOrigin) {
+      frames.set(element, targetOrigin);
+      // A freshly (re)loaded frame must reflect in-progress edits immediately —
+      // otherwise a route change / reload would show the un-previewed page until
+      // the next edit fires a broadcast.
+      if (latest) postTo(element, targetOrigin, latest);
+    },
+    send(page) {
+      latest = page;
+      clearTimer();
+      timer = setTimeout(() => {
+        timer = null;
+        if (latest) broadcast(latest);
+      }, debounceMs);
+    },
+    destroy() {
+      clearTimer();
+      frames.clear();
+      latest = null;
+    },
+  };
+}
+
+/**
+ * Attach the preview applier inside a framed public journey page.
+ *
+ * INERT unless embedded — on a standalone visit (`window.parent === window`, a
+ * normal visitor) it adds NO listener and returns a no-op teardown, so this
+ * ships harmlessly in the public bundle.
+ *
+ * When embedded, it accepts a message only when ALL hold: the message comes from
+ * the direct parent frame (the studio builder), it is same-origin as this
+ * document, and it carries the versioned `codex:page-preview:v1` type. Anything
+ * else is ignored. An accepted message drives {@link pageBuilder.applyPreviewState}
+ * — no reload. The applier NEVER posts a message, so it cannot echo back.
+ *
+ * @param target Window to bind to; defaults to the ambient window. Injectable for tests.
+ * @returns teardown that removes the listener (no-op when not embedded).
+ */
+export function initPagePreviewBridge(
+  target: Window = globalThis.window
+): () => void {
+  if (!browser || !target) return () => {};
+
+  const parentWindow = target.parent;
+  // Not embedded → a real visitor's own top window. Do nothing, attach nothing.
+  if (parentWindow === target) return () => {};
+
+  const expectedOrigin = target.location.origin;
+
+  function onMessage(event: MessageEvent): void {
+    if (event.source !== parentWindow) return; // only our parent studio frame
+    if (event.origin !== expectedOrigin) return; // same-origin only
+    if (!isPagePreviewMessage(event.data)) return; // only our versioned type
+    pageBuilder.applyPreviewState(event.data.page);
+  }
+
+  target.addEventListener('message', onMessage);
+  return () => target.removeEventListener('message', onMessage);
+}

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
@@ -1,0 +1,445 @@
+<!--
+  @component Studio Journeys — home / index (Codex-2pryk.3.3 · WP-5)
+
+  The creator's list of journeys + landing pages. Mirrors the studio `content/`
+  list page: a client `query()` reactive off a status filter (URL-driven), no
+  server load — the studio `+layout.server.ts` already gates creator/admin/owner,
+  and the studio subtree is `ssr = false`.
+
+  AGGRESSIVE-MODE MOCKS: data comes from `journey-queries.mock` (the frozen
+  `ListJourneysQuery` shape). The conductor swaps it for the real remote after
+  WP-2 — the `.current` / `.loading` access stays identical.
+-->
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import type { PageStatus } from '@codex/shared-types';
+  import EmptyState from '$lib/components/ui/EmptyState/EmptyState.svelte';
+  import { CompassIcon, PlusIcon } from '$lib/components/ui/Icon';
+  import { listJourneysMock } from '$lib/components/page-builder/journey-queries.mock.svelte';
+
+  const { data } = $props();
+
+  type StatusFilter = 'all' | PageStatus;
+  const FILTERS: readonly { id: StatusFilter; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'draft', label: 'Draft' },
+    { id: 'published', label: 'Published' },
+    { id: 'archived', label: 'Archived' },
+  ];
+
+  const urlStatus = $derived.by<StatusFilter>(() => {
+    const raw = page.url.searchParams.get('status');
+    if (raw === 'draft' || raw === 'published' || raw === 'archived') return raw;
+    return 'all';
+  });
+
+  const journeysQuery = $derived(
+    listJourneysMock({
+      organizationId: data.org.id,
+      ...(urlStatus !== 'all' && { status: urlStatus }),
+    })
+  );
+
+  const items = $derived(journeysQuery.current ?? []);
+  const loading = $derived(journeysQuery.loading);
+
+  const gbp = new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    maximumFractionDigits: 0,
+  });
+  function money(cents: number | null): string | null {
+    return cents == null ? null : gbp.format(cents / 100);
+  }
+
+  const relative = new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+  function when(iso: string): string {
+    return relative.format(new Date(iso));
+  }
+
+  function setStatus(next: StatusFilter): void {
+    const params = new URLSearchParams(page.url.searchParams);
+    if (next === 'all') params.delete('status');
+    else params.set('status', next);
+    const query = params.toString();
+    goto(`/studio/journeys${query ? `?${query}` : ''}`, {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  }
+</script>
+
+<svelte:head>
+  <title>Journeys | {data.org.name}</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="journeys">
+  <header class="journeys__bar">
+    <div class="journeys__heading">
+      <h1 class="journeys__title">Journeys</h1>
+      <p class="journeys__count" aria-live="polite">
+        {loading ? 'Loading…' : `${items.length} ${items.length === 1 ? 'page' : 'pages'}`}
+      </p>
+    </div>
+
+    <div class="journeys__filter" role="group" aria-label="Filter by status">
+      {#each FILTERS as f (f.id)}
+        <button
+          type="button"
+          class="journeys__filter-btn"
+          aria-pressed={urlStatus === f.id}
+          onclick={() => setStatus(f.id)}
+        >
+          {f.label}
+        </button>
+      {/each}
+    </div>
+
+    <a href="/studio/journeys/new" class="journeys__create">
+      <PlusIcon size={16} />
+      New journey
+    </a>
+  </header>
+
+  <div class="journeys__body">
+    {#if loading}
+      <ul class="journeys__rows" role="list">
+        {#each Array(3) as _, i (i)}
+          <li class="journeys__skeleton" aria-hidden="true"></li>
+        {/each}
+      </ul>
+    {:else if items.length > 0}
+      <ol class="journeys__rows" role="list">
+        {#each items as j (j.id)}
+          <li class="journey-row">
+            <div class="journey-row__main">
+              <div class="journey-row__title-line">
+                <a class="journey-row__title" href="/studio/journeys/{j.id}/page">
+                  {j.title}
+                </a>
+                <span class="journey-row__status" data-status={j.status}>{j.status}</span>
+              </div>
+              {#if j.tagline}
+                <p class="journey-row__tagline">{j.tagline}</p>
+              {/if}
+              <p class="journey-row__meta">
+                {#if j.stageCount != null}
+                  <span>{j.stageCount} stages</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{j.practiceCount} practices</span>
+                  <span aria-hidden="true">·</span>
+                {/if}
+                {#if j.enrolledCount != null}
+                  <span>{j.enrolledCount} enrolled</span>
+                  <span aria-hidden="true">·</span>
+                {/if}
+                {#if money(j.revenueCents)}
+                  <span>{money(j.revenueCents)}</span>
+                  <span aria-hidden="true">·</span>
+                {/if}
+                <span class="journey-row__updated">Updated {when(j.updatedAt)}</span>
+              </p>
+            </div>
+            <div class="journey-row__actions">
+              {#if j.subjectType === 'course'}
+                <a class="journey-row__action" href="/studio/journeys/{j.id}/curriculum">
+                  Curriculum
+                </a>
+              {/if}
+              <a class="journey-row__action journey-row__action--primary" href="/studio/journeys/{j.id}/page">
+                Edit page
+              </a>
+            </div>
+          </li>
+        {/each}
+      </ol>
+    {:else}
+      <div class="journeys__empty">
+        <EmptyState
+          title="No journeys yet"
+          description="Create a course landing page and start shaping its curriculum."
+          icon={CompassIcon}
+        >
+          {#snippet action()}
+            <a href="/studio/journeys/new" class="journeys__empty-cta">New journey</a>
+          {/snippet}
+        </EmptyState>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .journeys {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: var(--container-studio);
+  }
+
+  .journeys__bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    padding-bottom: var(--space-4);
+    border-bottom: var(--border-width) var(--border-style) var(--color-border);
+  }
+
+  .journeys__heading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    margin-right: auto;
+  }
+
+  .journeys__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .journeys__count {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .journeys__filter {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    background-color: var(--color-surface-secondary);
+    border-radius: var(--radius-full);
+  }
+
+  .journeys__filter-btn {
+    padding: var(--space-1) var(--space-3);
+    border: 0;
+    border-radius: var(--radius-full);
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .journeys__filter-btn:hover {
+    color: var(--color-text);
+  }
+
+  .journeys__filter-btn[aria-pressed='true'] {
+    background-color: var(--color-text);
+    color: var(--color-background);
+  }
+
+  .journeys__filter-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .journeys__create {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-full);
+    background-color: var(--color-interactive);
+    color: var(--color-text-on-brand, var(--color-background));
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    text-decoration: none;
+    transition: var(--transition-colors);
+  }
+
+  .journeys__create:hover {
+    background-color: var(--color-interactive-hover);
+  }
+
+  .journeys__create:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .journeys__body {
+    padding-top: var(--space-5);
+  }
+
+  .journeys__rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .journeys__skeleton {
+    height: var(--space-20, 5rem);
+    border-radius: var(--radius-lg);
+    background-image: linear-gradient(
+      100deg,
+      var(--color-surface-secondary) 30%,
+      var(--color-surface) 50%,
+      var(--color-surface-secondary) 70%
+    );
+    background-size: 200% 100%;
+    animation: journeys-shimmer var(--duration-slower) var(--ease-default) infinite;
+  }
+
+  @keyframes journeys-shimmer {
+    from {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .journeys__skeleton {
+      animation: none;
+    }
+  }
+
+  .journey-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-4);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+    transition: var(--transition-colors);
+  }
+
+  .journey-row:hover {
+    border-color: var(--color-border-strong, var(--color-interactive));
+  }
+
+  .journey-row__main {
+    min-width: 0;
+  }
+
+  .journey-row__title-line {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .journey-row__title {
+    font-family: var(--font-heading);
+    font-size: var(--text-base);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .journey-row__title:hover {
+    color: var(--color-interactive);
+  }
+
+  .journey-row__status {
+    padding: var(--space-0-5) var(--space-2);
+    border-radius: var(--radius-full);
+    font-size: var(--text-2xs, 0.6875rem);
+    font-weight: var(--font-medium);
+    text-transform: capitalize;
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text-secondary);
+  }
+
+  .journey-row__status[data-status='published'] {
+    background-color: var(--color-success-subtle, var(--color-surface-secondary));
+    color: var(--color-success, var(--color-text));
+  }
+
+  .journey-row__tagline {
+    margin: var(--space-1) 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .journey-row__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-1-5);
+    margin: var(--space-2) 0 0;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .journey-row__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .journey-row__action {
+    padding: var(--space-1-5) var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    transition: var(--transition-colors);
+  }
+
+  .journey-row__action:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .journey-row__action--primary {
+    border-color: transparent;
+    background-color: var(--color-interactive);
+    color: var(--color-text-on-brand, var(--color-background));
+  }
+
+  .journey-row__action--primary:hover {
+    background-color: var(--color-interactive-hover);
+    color: var(--color-text-on-brand, var(--color-background));
+  }
+
+  .journey-row__action:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .journeys__empty {
+    padding: var(--space-8) var(--space-4);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+    border: var(--border-width) dashed var(--color-border);
+  }
+
+  .journeys__empty-cta {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-full);
+    background-color: var(--color-interactive);
+    color: var(--color-text-on-brand, var(--color-background));
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    text-decoration: none;
+  }
+
+  .journeys__empty-cta:hover {
+    background-color: var(--color-interactive-hover);
+  }
+</style>

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/curriculum/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/curriculum/+page.server.ts
@@ -1,0 +1,21 @@
+/**
+ * Journey curriculum editor — server load (admin/owner gate).
+ *
+ * Curriculum editing is mutating, so it is admin/owner only (FRONTEND-MAP §E:
+ * course-editor uses an admin/owner server gate). Reuses the `userRole` the
+ * studio `+layout.server.ts` resolves — no second role source. Runs under the
+ * studio's `ssr = false`; SvelteKit still executes it on navigation, so a
+ * non-privileged user is redirected before the editor renders.
+ */
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { userRole } = await parent();
+
+  if (userRole !== 'admin' && userRole !== 'owner') {
+    redirect(303, '/studio');
+  }
+
+  return {};
+};

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/curriculum/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/curriculum/+page.svelte
@@ -1,0 +1,558 @@
+<!--
+  @component Journey curriculum editor (Codex-2pryk.3.3 · WP-5)
+
+  The course-editor surface: stages, each holding an ordered list of practices
+  (FRONTEND-MAP §5.3 item 6 — net-new). Add / rename / reorder / remove stages
+  and practices, then Save. Client-only (studio `ssr = false`); admin/owner gate
+  in +page.server.ts.
+
+  AGGRESSIVE-MODE MOCKS: the curriculum is not covered by a frozen read-model
+  (the frozen queries are the public/member/library/list/builder reads), so this
+  seeds local state and mocks Save. INTEGRATION SEAM: WP-1 backs stages/practices
+  and WP-5 BE adds a getCourseCurriculum query + stage/practice CRUD commands —
+  swap the seed + `handleSave` for those. Local edits mirror the shapes of the
+  frozen `JourneyStageView` / `JourneyPracticeView`.
+-->
+<script lang="ts">
+  import { page } from '$app/state';
+  import type { JourneyContentType } from '$lib/page-builder';
+  import { toast } from '$lib/components/ui/Toast/toast-store';
+  import {
+    ChevronUpIcon,
+    ChevronDownIcon,
+    PlusIcon,
+    TrashIcon,
+  } from '$lib/components/ui/Icon';
+
+  const { data } = $props();
+
+  const pageId = $derived(page.params.id ?? '');
+
+  interface EditorPractice {
+    id: string;
+    title: string;
+    contentType: JourneyContentType;
+  }
+  interface EditorStage {
+    id: string;
+    name: string;
+    gloss: string;
+    practices: EditorPractice[];
+  }
+
+  function uid(): string {
+    return crypto.randomUUID();
+  }
+
+  // Mock seed — the integration seam replaces this with a curriculum query.
+  let stages = $state<EditorStage[]>([
+    {
+      id: uid(),
+      name: 'Arriving',
+      gloss: 'Settling in — learning to land.',
+      practices: [
+        { id: uid(), title: 'The first breath', contentType: 'audio' },
+        { id: uid(), title: 'Why stillness is hard', contentType: 'video' },
+      ],
+    },
+    {
+      id: uid(),
+      name: 'Descending',
+      gloss: 'Going beneath the surface noise.',
+      practices: [{ id: uid(), title: 'The body scan', contentType: 'audio' }],
+    },
+  ]);
+
+  let saving = $state(false);
+  let dirty = $state(false);
+  function markDirty(): void {
+    dirty = true;
+  }
+
+  const CONTENT_TYPES: readonly JourneyContentType[] = ['video', 'audio', 'written'];
+
+  const practiceCount = $derived(stages.reduce((n, s) => n + s.practices.length, 0));
+
+  // ── Stage mutations ────────────────────────────────────────────────────────
+  function addStage(): void {
+    stages.push({ id: uid(), name: '', gloss: '', practices: [] });
+    markDirty();
+  }
+  function removeStage(id: string): void {
+    stages = stages.filter((s) => s.id !== id);
+    markDirty();
+  }
+  function moveStage(id: string, dir: -1 | 1): void {
+    const i = stages.findIndex((s) => s.id === id);
+    const target = i + dir;
+    if (i < 0 || target < 0 || target >= stages.length) return;
+    [stages[i], stages[target]] = [stages[target], stages[i]];
+    markDirty();
+  }
+
+  // ── Practice mutations ───────────────────────────────────────────────────────
+  function addPractice(stage: EditorStage): void {
+    stage.practices.push({ id: uid(), title: '', contentType: 'audio' });
+    markDirty();
+  }
+  function removePractice(stage: EditorStage, id: string): void {
+    stage.practices = stage.practices.filter((p) => p.id !== id);
+    markDirty();
+  }
+  function movePractice(stage: EditorStage, id: string, dir: -1 | 1): void {
+    const i = stage.practices.findIndex((p) => p.id === id);
+    const target = i + dir;
+    if (i < 0 || target < 0 || target >= stage.practices.length) return;
+    [stage.practices[i], stage.practices[target]] = [
+      stage.practices[target],
+      stage.practices[i],
+    ];
+    markDirty();
+  }
+
+  async function handleSave(): Promise<void> {
+    saving = true;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 250)); // mock persist
+      dirty = false;
+      toast.success('Curriculum saved');
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Curriculum | {data.org.name}</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="curriculum">
+  <header class="curriculum__head">
+    <nav class="curriculum__crumbs" aria-label="Breadcrumb">
+      <a href="/studio/journeys">Journeys</a>
+      <span aria-hidden="true">/</span>
+      <span aria-current="page">Curriculum</span>
+    </nav>
+    <div class="curriculum__head-row">
+      <div>
+        <h1 class="curriculum__title">Curriculum</h1>
+        <p class="curriculum__count">
+          {stages.length} {stages.length === 1 ? 'stage' : 'stages'} · {practiceCount}
+          {practiceCount === 1 ? 'practice' : 'practices'}
+        </p>
+      </div>
+      <div class="curriculum__head-actions">
+        <a href="/studio/journeys/{pageId}/page" class="curriculum__link">Edit sales page</a>
+        <button
+          type="button"
+          class="curriculum__save"
+          disabled={!dirty || saving}
+          onclick={handleSave}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <ol class="curriculum__stages" role="list">
+    {#each stages as stage, si (stage.id)}
+      <li class="stage">
+        <div class="stage__head">
+          <div class="stage__reorder">
+            <button
+              type="button"
+              class="icon-btn"
+              aria-label="Move stage up"
+              disabled={si === 0}
+              onclick={() => moveStage(stage.id, -1)}
+            >
+              <ChevronUpIcon size={15} />
+            </button>
+            <button
+              type="button"
+              class="icon-btn"
+              aria-label="Move stage down"
+              disabled={si === stages.length - 1}
+              onclick={() => moveStage(stage.id, 1)}
+            >
+              <ChevronDownIcon size={15} />
+            </button>
+          </div>
+          <span class="stage__ordinal">{(si + 1).toString().padStart(2, '0')}</span>
+          <div class="stage__fields">
+            <input
+              type="text"
+              class="stage__name"
+              placeholder="Stage name"
+              bind:value={stage.name}
+              oninput={markDirty}
+            />
+            <input
+              type="text"
+              class="stage__gloss"
+              placeholder="A short gloss for this stage…"
+              bind:value={stage.gloss}
+              oninput={markDirty}
+            />
+          </div>
+          <button
+            type="button"
+            class="icon-btn icon-btn--danger"
+            aria-label="Remove stage"
+            onclick={() => removeStage(stage.id)}
+          >
+            <TrashIcon size={16} />
+          </button>
+        </div>
+
+        <ul class="stage__practices" role="list">
+          {#each stage.practices as practice, pi (practice.id)}
+            <li class="practice">
+              <div class="practice__reorder">
+                <button
+                  type="button"
+                  class="icon-btn"
+                  aria-label="Move practice up"
+                  disabled={pi === 0}
+                  onclick={() => movePractice(stage, practice.id, -1)}
+                >
+                  <ChevronUpIcon size={13} />
+                </button>
+                <button
+                  type="button"
+                  class="icon-btn"
+                  aria-label="Move practice down"
+                  disabled={pi === stage.practices.length - 1}
+                  onclick={() => movePractice(stage, practice.id, 1)}
+                >
+                  <ChevronDownIcon size={13} />
+                </button>
+              </div>
+              <input
+                type="text"
+                class="practice__title"
+                placeholder="Practice title"
+                bind:value={practice.title}
+                oninput={markDirty}
+              />
+              <select
+                class="practice__type"
+                bind:value={practice.contentType}
+                onchange={markDirty}
+                aria-label="Practice type"
+              >
+                {#each CONTENT_TYPES as t (t)}
+                  <option value={t}>{t}</option>
+                {/each}
+              </select>
+              <button
+                type="button"
+                class="icon-btn icon-btn--danger"
+                aria-label="Remove practice"
+                onclick={() => removePractice(stage, practice.id)}
+              >
+                <TrashIcon size={15} />
+              </button>
+            </li>
+          {/each}
+        </ul>
+
+        <button type="button" class="stage__add-practice" onclick={() => addPractice(stage)}>
+          <PlusIcon size={14} />
+          Add practice
+        </button>
+      </li>
+    {/each}
+  </ol>
+
+  <button type="button" class="curriculum__add-stage" onclick={addStage}>
+    <PlusIcon size={16} />
+    Add stage
+  </button>
+</div>
+
+<style>
+  .curriculum {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    width: 100%;
+    max-width: var(--container-studio);
+  }
+
+  .curriculum__head {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding-bottom: var(--space-4);
+    border-bottom: var(--border-width) var(--border-style) var(--color-border);
+  }
+
+  .curriculum__crumbs {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .curriculum__crumbs a {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+  }
+
+  .curriculum__crumbs a:hover {
+    color: var(--color-text);
+  }
+
+  .curriculum__head-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .curriculum__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .curriculum__count {
+    margin: var(--space-1) 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .curriculum__head-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .curriculum__link {
+    padding: var(--space-2) var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    transition: var(--transition-colors);
+  }
+
+  .curriculum__link:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .curriculum__save {
+    padding: var(--space-2) var(--space-4);
+    border: var(--border-width) var(--border-style) transparent;
+    border-radius: var(--radius-md);
+    background-color: var(--color-interactive);
+    color: var(--color-text-on-brand, var(--color-background));
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .curriculum__save:hover:not(:disabled) {
+    background-color: var(--color-interactive-hover);
+  }
+
+  .curriculum__save:disabled {
+    opacity: var(--opacity-40);
+    cursor: not-allowed;
+  }
+
+  .curriculum__stages {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .stage {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+  }
+
+  .stage__head {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .stage__reorder {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .stage__ordinal {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    color: var(--color-text-muted);
+    padding-top: var(--space-2);
+  }
+
+  .stage__fields {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .stage__name,
+  .stage__gloss,
+  .practice__title,
+  .practice__type {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    transition: var(--transition-colors);
+  }
+
+  .stage__name {
+    font-weight: var(--font-semibold);
+  }
+
+  .stage__name:focus-visible,
+  .stage__gloss:focus-visible,
+  .practice__title:focus-visible,
+  .practice__type:focus-visible {
+    outline: none;
+    border-color: var(--color-interactive);
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .stage__practices {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .practice {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .practice__reorder {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .practice__title {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .practice__type {
+    width: auto;
+    flex-shrink: 0;
+    text-transform: capitalize;
+  }
+
+  .stage__add-practice {
+    align-self: flex-start;
+    margin-left: var(--space-6);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1-5) var(--space-3);
+    border: var(--border-width) dashed var(--color-border);
+    border-radius: var(--radius-md);
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .stage__add-practice:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .curriculum__add-stage {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border: var(--border-width) dashed var(--color-border);
+    border-radius: var(--radius-md);
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .curriculum__add-stage:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .icon-btn:hover:not(:disabled) {
+    color: var(--color-text);
+    background-color: color-mix(in oklch, var(--color-interactive) 12%, transparent);
+  }
+
+  .icon-btn--danger:hover:not(:disabled) {
+    color: var(--color-danger, var(--color-text));
+    background-color: color-mix(in oklch, var(--color-danger, red) 12%, transparent);
+  }
+
+  .icon-btn:disabled {
+    opacity: var(--opacity-40);
+    cursor: not-allowed;
+  }
+
+  .icon-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+</style>

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.server.ts
@@ -1,0 +1,24 @@
+/**
+ * Journey sales-page builder — server load (admin/owner gate).
+ *
+ * A byte-clone of `studio/brand/+page.server.ts` (Codex-2pryk.3.3 · WP-5):
+ * page *editing* is stricter than studio access — admin/owner only. We reuse the
+ * `userRole` the studio `+layout.server.ts` resolves via getMyMembership, so
+ * there is no second role source.
+ *
+ * Runs under the studio's `ssr = false`: SvelteKit still executes this load (via
+ * the data fetch) on navigation, so a non-privileged user is redirected before
+ * the builder renders.
+ */
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { userRole } = await parent();
+
+  if (userRole !== 'admin' && userRole !== 'owner') {
+    redirect(303, '/studio');
+  }
+
+  return {};
+};

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -1,0 +1,193 @@
+<!--
+  @component Journey sales-page builder (route shell + state spine)
+
+  The journey/page builder lives here (Codex-2pryk.3.3 · WP-5): a two-pane
+  workspace — section rail + live-preview canvas — an EXACT clone of the
+  `studio/brand` workspace (FRONTEND-MAP §5.4 / §6 rule 5), swapping the brand
+  store/rail/canvas for the page-builder equivalents:
+
+    · loads the page draft (`getJourneyForBuilderMock` → the frozen
+      `GetJourneyForBuilderQuery` shape) and OWNS the page-builder store:
+      open() on load → edit via rail → Save (saveJourneyPageMock + markSaved) →
+      close() on destroy.
+    · streams the pending draft to the same-origin preview iframe over the
+      `codex:page-preview:v1` bridge — copy / order / toggle edits go live with
+      NO reload.
+    · renders the SHARED `BrandStudioLayout` shell (pass different snippets — the
+      layout is generic; §5.4 "share as-is") with JourneyBuilderRail + canvas.
+
+  AGGRESSIVE-MODE MOCKS: `getJourneyForBuilderMock` / `saveJourneyPageMock` stand
+  in for the real remote fns; the conductor wires them after WP-2 (see
+  journey-queries.mock). Admin/owner gate lives in +page.server.ts.
+-->
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { beforeNavigate } from '$app/navigation';
+  import { page } from '$app/state';
+  import type { PageBuilderState } from '@codex/shared-types';
+  import { BrandStudioLayout } from '$lib/components/brand-studio';
+  import {
+    JourneyBuilderCanvas,
+    JourneyBuilderRail,
+    createJourneyPreviewWiring,
+    type JourneyPreviewFrameLoad,
+  } from '$lib/components/page-builder';
+  import {
+    getJourneyForBuilderMock,
+    saveJourneyPageMock,
+  } from '$lib/components/page-builder/journey-queries.mock.svelte';
+  import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
+  import { createPagePreviewSender } from '$lib/page-builder/page-preview-bridge';
+  import { toast } from '$lib/components/ui/Toast/toast-store';
+
+  const { data } = $props();
+
+  const pageId = $derived(page.params.id ?? '');
+
+  // Load the page draft — the reactive query the conductor swaps for the real
+  // remote after WP-2 (identical `.current` access).
+  const draftQuery = $derived(pageId ? getJourneyForBuilderMock({ id: pageId }) : null);
+
+  // ── Workspace view (mirrors studio/brand) ─────────────────────────────────
+  // Give the preview more room. Page-owned because the toggles live in the
+  // canvas toolbar (a sibling subtree) but the effect applies to the layout.
+  let railCollapsed = $state(false);
+  let fullscreen = $state(false);
+
+  function toggleRail(): void {
+    railCollapsed = !railCollapsed;
+  }
+  function toggleFullscreen(): void {
+    fullscreen = !fullscreen;
+  }
+
+  // Escape exits full-screen — but only if nothing nearer (a popover, a dialog)
+  // already handled the key (honour defaultPrevented — same as studio/brand).
+  function onWindowKeydown(event: KeyboardEvent): void {
+    if (fullscreen && event.key === 'Escape' && !event.defaultPrevented) {
+      fullscreen = false;
+    }
+  }
+
+  // Own the store: open once the draft loads; close on destroy. A guard flag
+  // keeps this to a single open() even as the query settles.
+  let opened = false;
+  $effect(() => {
+    const draft = draftQuery?.current;
+    if (!pageId || !draft || opened) return;
+    opened = true;
+    // The record extends PageBuilderState with row identity; the store's spine
+    // is the editable draft only (id/orgId/publishedAt live on the row).
+    const { id: _id, organizationId: _org, publishedAt: _pub, ...editable } = draft;
+    pageBuilder.open(pageId, editable);
+  });
+
+  onDestroy(() => {
+    pageBuilder.close();
+  });
+
+  // ── Live edit → preview bridge ────────────────────────────────────────────
+  // Broadcast the builder's pending draft to the same-origin preview iframe(s)
+  // so edits reflect INSTANTLY, no reload. The applier runs inside the framed
+  // public journey page (WP-3 renderer → initPagePreviewBridge).
+  const previewSender = createPagePreviewSender();
+  // The seam (register frame + push snapshot) lives in a pure, unit-tested
+  // helper so a dropped call can't ship green — see preview-wiring.ts.
+  const previewWiring = createJourneyPreviewWiring(previewSender);
+
+  // Push pending on every change. $state.snapshot deep-reads pending, so this
+  // $effect re-runs on any nested edit; the sender debounces the post (~50ms).
+  $effect(() => {
+    const pending = pageBuilder.pending;
+    if (!pending) return;
+    previewWiring.pushSnapshot($state.snapshot(pending) as PageBuilderState);
+  });
+
+  // Register each (re)loaded frame + immediately sync it to current pending, so
+  // a reload in the canvas reflects in-progress edits at once.
+  function handleFrameLoad(detail: JourneyPreviewFrameLoad): void {
+    previewWiring.registerFrame(detail);
+  }
+
+  onDestroy(() => {
+    previewSender.destroy();
+  });
+
+  let saving = $state(false);
+
+  // Persist the pending draft, then markSaved() so the dirty state resets. The
+  // real command will also invalidate the page:config + collection cache keys
+  // (HARDENING §E) — the conductor wires that with the real remote.
+  async function handleSave(): Promise<void> {
+    const payload = pageBuilder.getSavePayload();
+    const record = draftQuery?.current;
+    if (!payload || !record) return;
+    saving = true;
+    try {
+      await saveJourneyPageMock({
+        ...record,
+        ...payload,
+      });
+      pageBuilder.markSaved();
+      toast.success('Page saved');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save page');
+    } finally {
+      saving = false;
+    }
+  }
+
+  // Preserve the unsaved-changes guard (same as studio/brand's overlay).
+  beforeNavigate(({ cancel }) => {
+    if (pageBuilder.isDirty && !confirm('You have unsaved page changes. Discard?')) {
+      cancel();
+    }
+  });
+
+  const slug = $derived(pageBuilder.pending?.slug ?? '');
+</script>
+
+<svelte:head>
+  <title>Page builder | {data.org.name}</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<svelte:window onkeydown={onWindowKeydown} />
+
+{#if pageBuilder.isOpen}
+  <BrandStudioLayout {railCollapsed} {fullscreen} onToggleRail={toggleRail}>
+    {#snippet rail()}
+      <JourneyBuilderRail {saving} onsave={handleSave} />
+    {/snippet}
+    {#snippet canvas()}
+      <!--
+        The preview bridge: `onframeload` registers each (re)loaded frame with
+        the sender, which posts the pending draft to `detail.origin` (explicit
+        targetOrigin) for instant, no-reload preview. The applier runs inside the
+        framed journey page (WP-3 → initPagePreviewBridge).
+      -->
+      <JourneyBuilderCanvas
+        previewOrigin={page.url.origin}
+        {slug}
+        onframeload={handleFrameLoad}
+        {fullscreen}
+        onToggleFullscreen={toggleFullscreen}
+      />
+    {/snippet}
+  </BrandStudioLayout>
+{:else}
+  <div class="builder-loading" aria-busy="true">
+    <p>Loading page…</p>
+  </div>
+{/if}
+
+<style>
+  .builder-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: calc(100vh - var(--space-24));
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+  }
+</style>

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/new/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/new/+page.svelte
@@ -1,0 +1,261 @@
+<!--
+  @component Studio Journeys — create flow (Codex-2pryk.3.3 · WP-5)
+
+  Names a new journey/landing page and hands off to the builder. Mirrors
+  `content/new/` — client-only (studio `ssr = false`), a `command()`-shaped
+  create. AGGRESSIVE-MODE MOCKS: `createJourneyMock` stands in for the real
+  create command; the conductor swaps it after WP-2.
+-->
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { toast } from '$lib/components/ui/Toast/toast-store';
+  import { createJourneyMock } from '$lib/components/page-builder/journey-queries.mock.svelte';
+
+  const { data } = $props();
+
+  type NewPageType = 'course' | 'landing';
+
+  let title = $state('');
+  let pageType = $state<NewPageType>('course');
+  let submitting = $state(false);
+
+  const canSubmit = $derived(title.trim().length > 0 && !submitting);
+
+  const PAGE_TYPES: readonly { id: NewPageType; label: string; hint: string }[] = [
+    { id: 'course', label: 'Course', hint: 'A guided journey with stages, practices and a sales page.' },
+    { id: 'landing', label: 'Landing page', hint: 'A standalone marketing page with no curriculum.' },
+  ];
+
+  async function handleSubmit(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (!canSubmit) return;
+    submitting = true;
+    try {
+      const { id } = await createJourneyMock({ title: title.trim(), pageType });
+      toast.success('Journey created');
+      // Courses go to the curriculum first; landing pages straight to the builder.
+      const next = pageType === 'course' ? 'curriculum' : 'page';
+      await goto(`/studio/journeys/${id}/${next}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create journey');
+      submitting = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>New journey | {data.org.name}</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="new-journey">
+  <nav class="new-journey__crumbs" aria-label="Breadcrumb">
+    <a href="/studio/journeys">Journeys</a>
+    <span aria-hidden="true">/</span>
+    <span aria-current="page">New</span>
+  </nav>
+
+  <h1 class="new-journey__title">Create a journey</h1>
+
+  <form class="new-journey__form" onsubmit={handleSubmit}>
+    <label class="new-journey__field">
+      <span class="new-journey__label">Title</span>
+      <input
+        type="text"
+        class="new-journey__input"
+        placeholder="e.g. Stillness — a 6-week descent"
+        bind:value={title}
+        autocomplete="off"
+      />
+    </label>
+
+    <fieldset class="new-journey__field new-journey__types">
+      <legend class="new-journey__label">Type</legend>
+      {#each PAGE_TYPES as t (t.id)}
+        <label class="new-journey__type" class:new-journey__type--active={pageType === t.id}>
+          <input
+            type="radio"
+            name="pageType"
+            value={t.id}
+            checked={pageType === t.id}
+            onchange={() => (pageType = t.id)}
+          />
+          <span class="new-journey__type-label">{t.label}</span>
+          <span class="new-journey__type-hint">{t.hint}</span>
+        </label>
+      {/each}
+    </fieldset>
+
+    <div class="new-journey__actions">
+      <a href="/studio/journeys" class="new-journey__btn new-journey__btn--ghost">Cancel</a>
+      <button type="submit" class="new-journey__btn new-journey__btn--primary" disabled={!canSubmit}>
+        {submitting ? 'Creating…' : 'Create & continue'}
+      </button>
+    </div>
+  </form>
+</div>
+
+<style>
+  .new-journey {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    width: 100%;
+    max-width: var(--container-sm);
+  }
+
+  .new-journey__crumbs {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .new-journey__crumbs a {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+  }
+
+  .new-journey__crumbs a:hover {
+    color: var(--color-text);
+  }
+
+  .new-journey__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .new-journey__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
+  .new-journey__field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    border: 0;
+    padding: 0;
+    margin: 0;
+  }
+
+  .new-journey__label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text-secondary);
+  }
+
+  .new-journey__input {
+    padding: var(--space-2-5) var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
+    transition: var(--transition-colors);
+  }
+
+  .new-journey__input:focus-visible {
+    outline: none;
+    border-color: var(--color-interactive);
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .new-journey__types {
+    gap: var(--space-2);
+  }
+
+  .new-journey__type {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    column-gap: var(--space-2);
+    padding: var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .new-journey__type:hover {
+    background-color: var(--color-surface-secondary);
+  }
+
+  .new-journey__type--active {
+    border-color: var(--color-interactive);
+    background-color: var(--color-interactive-subtle, var(--color-surface-secondary));
+  }
+
+  .new-journey__type input {
+    grid-row: 1 / 3;
+    align-self: center;
+    accent-color: var(--color-interactive);
+  }
+
+  .new-journey__type-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+  }
+
+  .new-journey__type-hint {
+    grid-column: 2;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .new-journey__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+  }
+
+  .new-journey__btn {
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    text-decoration: none;
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .new-journey__btn--ghost {
+    display: inline-flex;
+    align-items: center;
+    border: var(--border-width) var(--border-style) var(--color-border);
+    background: none;
+    color: var(--color-text-secondary);
+  }
+
+  .new-journey__btn--ghost:hover {
+    color: var(--color-text);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .new-journey__btn--primary {
+    border: var(--border-width) var(--border-style) transparent;
+    background-color: var(--color-interactive);
+    color: var(--color-text-on-brand, var(--color-background));
+  }
+
+  .new-journey__btn--primary:hover:not(:disabled) {
+    background-color: var(--color-interactive-hover);
+  }
+
+  .new-journey__btn--primary:disabled {
+    opacity: var(--opacity-40);
+    cursor: not-allowed;
+  }
+
+  .new-journey__btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+</style>


### PR DESCRIPTION
WP-5 (Codex-2pryk.3.3) — aggressive-mode FE on WP-0 frozen contracts + mocked query(). Clones brand-studio into the journey builder + implements the codex:page-preview:v1 bridge; editor in $lib/components/page-builder behind the CE-4 import-boundary gate. Mocks wired to real remote fns at the WP-2 integration round. (CI red = Actions-credit cancellation, not this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)