### PR TITLE
feat(access): entitlements resolver + collapse decision core (Codex-2pryk.2.3)

### DIFF
--- a/apps/web/src/lib/server/content-detail.ts
+++ b/apps/web/src/lib/server/content-detail.ts
@@ -185,18 +185,24 @@ type StreamResult = Awaited<ReturnType<ServerApi['access']['getStreamingUrl']>>;
  * ONE place both content-detail routes resolve "granted?" — see the module
  * header for the two routes and the lockstep contract.
  *
- * BEHAVIOUR TODAY (must be preserved): access is inferred from the `/stream`
- * response. A resolved response — *even one whose `streamingUrl` is null*
- * (written articles have no media to sign) — means the backend access check
- * passed. A thrown call (captured by the caller as `streamResult === null`)
- * means denied. This is the historical "getStreamingUrl-throws" gate; the
- * null-streamingUrl-but-granted case must not regress.
+ * BEHAVIOUR (preserved): access is inferred from the `/stream` response. A
+ * resolved response — *even one whose `streamingUrl` is null* (written articles
+ * have no media to sign) — means the backend access check passed. A thrown call
+ * (captured by the caller as `streamResult === null`) means denied. This is the
+ * historical "getStreamingUrl-throws" gate; the null-streamingUrl-but-granted
+ * case must not regress.
  *
- * WP-2 (Codex-2pryk · `@codex/access` rewire) replaces the BODY of this
- * function with an explicit `canView` entitlement resolver. The signature may
- * widen (e.g. to take contentId / accessType / platform / cookies) — keep that
- * change inside this function so both routes inherit it in one swap and cannot
- * diverge by route.
+ * WP-2 (Codex-2pryk · `@codex/access` rewire) LANDED: the content-api worker's
+ * `getStreamingUrl` now gates on the collapsed `canView` entitlement resolver
+ * (`ContentAccessService.canView`, which folds the §6.1 policy flags + purchase
+ * + subscription-tier + stored `entitlements` grants + course entitlements). So
+ * a resolved `/stream` response now reflects `canView === true`, and this seam
+ * transitively resolves `canView` for BOTH content routes at once.
+ *
+ * The resolver is NOT imported here: `@codex/access` is worker-only and must
+ * never enter the SSR bundle (see {@link AccessRevocationReason}). It is invoked
+ * over the `/stream` API instead — so the single decision point stays in the
+ * worker while this remains the single web-side seam both routes reach through.
  * ─────────────────────────────────────────────────────────────────────────
  */
 export function resolveAccessGranted(

--- a/packages/access/src/__tests__/ContentAccessService.integration.test.ts
+++ b/packages/access/src/__tests__/ContentAccessService.integration.test.ts
@@ -24,10 +24,15 @@ import {
 import { ContentService, MediaItemService } from '@codex/content';
 import {
   content,
+  courseStages,
+  courses,
+  courseTierAccess,
+  entitlements,
   organizationFollowers,
   organizationMemberships,
   organizations,
   purchases,
+  stagePractices,
   stripeConnectAccounts,
   subscriptions,
   subscriptionTiers,
@@ -3233,6 +3238,505 @@ describe('ContentAccessService Integration', () => {
           expirySeconds: 3600,
         });
         expect(result.streamingUrl).toContain('/hls/master.m3u8?token=');
+      });
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Entitlement resolver — canView / canEnterCourse / canEnterCoursesBatch
+  // (Codex-2pryk.2.3 · WP-2). The collapsed resolver both content routes gate
+  // through. The web `content-detail.ts` seam routes BOTH the org route
+  // (`_org/[slug]/(space)/content/[contentSlug]`) and the creator route
+  // (`_creators/[username]/content/[contentSlug]`) to the SAME worker
+  // `getStreamingUrl` (→ `canView`), so proving grant/deny on org-scoped
+  // content (org-route surface) AND on personal content (creator-route
+  // surface) proves route parity: a partial rollout can't leak on one URL what
+  // the other denies (J4). Every gated case asserts BOTH `canView` (boolean)
+  // and `getStreamingUrl` (throwing) so they can never disagree.
+  // ───────────────────────────────────────────────────────────────────────
+  describe('Entitlement resolver (canView / canEnterCourse) — Codex-2pryk.2.3', () => {
+    /** Create a published video, then patch it to the target access policy. */
+    async function makeContent(opts: {
+      slug: string;
+      organizationId: string | null;
+      creator?: string;
+      policy: Partial<{
+        isFree: boolean;
+        isPurchasable: boolean;
+        priceCents: number | null;
+        includedInTierId: string | null;
+        courseOnly: boolean;
+        isFollowerGated: boolean;
+        isTeamOnly: boolean;
+      }>;
+    }): Promise<string> {
+      const creator = opts.creator ?? userId;
+      const media = await mediaService.create(
+        {
+          title: `${opts.slug} Video`,
+          mediaType: 'video',
+          mimeType: 'video/mp4',
+          r2Key: getOriginalKey(
+            creator,
+            crypto.randomUUID(),
+            `${opts.slug}.mp4`
+          ),
+          fileSizeBytes: 1024,
+        },
+        creator
+      );
+      await mediaService.markAsReady(
+        media.id,
+        {
+          hlsMasterPlaylistKey: `hls/${opts.slug}/master.m3u8`,
+          thumbnailKey: `thumbnails/${opts.slug}.jpg`,
+          durationSeconds: 120,
+        },
+        creator
+      );
+      // Create as free/public (clears the publish gate), then patch the policy.
+      const item = await contentService.create(
+        {
+          ...(opts.organizationId
+            ? { organizationId: opts.organizationId }
+            : {}),
+          title: `${opts.slug} Content`,
+          slug: createUniqueSlug(opts.slug),
+          contentType: 'video',
+          mediaItemId: media.id,
+          visibility: 'public',
+          priceCents: 0,
+          tags: [],
+        },
+        creator
+      );
+      await contentService.publish(item.id, creator);
+      await db
+        .update(content)
+        .set({
+          organizationId: opts.organizationId,
+          isFree: opts.policy.isFree ?? false,
+          isPurchasable: opts.policy.isPurchasable ?? false,
+          priceCents: opts.policy.priceCents ?? null,
+          includedInTierId: opts.policy.includedInTierId ?? null,
+          courseOnly: opts.policy.courseOnly ?? false,
+          isFollowerGated: opts.policy.isFollowerGated ?? false,
+          isTeamOnly: opts.policy.isTeamOnly ?? false,
+        })
+        .where(eq(content.id, item.id));
+      return item.id;
+    }
+
+    // Tiers are unique on (organizationId, sortOrder); these tests reuse the
+    // shared org, so hand out a distinct sortOrder per tier from a counter.
+    let tierSortSeq = 100;
+
+    /** Seed an org tier and return its id. */
+    async function seedTier(orgId: string): Promise<string> {
+      const [tier] = await db
+        .insert(subscriptionTiers)
+        .values(
+          createTestTierInput(orgId, {
+            name: `Resolver Tier ${crypto.randomUUID().slice(0, 6)}`,
+            sortOrder: ++tierSortSeq,
+          })
+        )
+        .returning();
+      if (!tier) throw new Error('Failed to seed tier');
+      return tier.id;
+    }
+
+    /** Seed a published course + one stage; returns both ids. */
+    async function makeCourse(
+      orgId: string,
+      creator = userId
+    ): Promise<{ courseId: string; stageId: string }> {
+      const [course] = await db
+        .insert(courses)
+        .values({
+          organizationId: orgId,
+          creatorId: creator,
+          slug: createUniqueSlug('course'),
+          title: 'Resolver Test Course',
+          status: 'published',
+        })
+        .returning();
+      if (!course) throw new Error('Failed to seed course');
+      const [stage] = await db
+        .insert(courseStages)
+        .values({ courseId: course.id, name: 'Stage 1', sortOrder: 1 })
+        .returning();
+      if (!stage) throw new Error('Failed to seed stage');
+      return { courseId: course.id, stageId: stage.id };
+    }
+
+    async function linkPractice(stageId: string, contentId: string) {
+      await db
+        .insert(stagePractices)
+        .values({ stageId, contentId, sortOrder: 0 });
+    }
+
+    async function grantCourse(
+      uid: string,
+      orgId: string,
+      courseId: string,
+      source:
+        | 'course_purchase'
+        | 'course_subscription'
+        | 'grant' = 'course_purchase',
+      overrides: { revokedAt?: Date; expiresAt?: Date } = {}
+    ) {
+      await db.insert(entitlements).values({
+        userId: uid,
+        organizationId: orgId,
+        courseId,
+        source,
+        ...overrides,
+      });
+    }
+
+    async function grantContent(
+      uid: string,
+      orgId: string,
+      contentId: string,
+      source: 'content_purchase' | 'grant' = 'content_purchase'
+    ) {
+      await db
+        .insert(entitlements)
+        .values({ userId: uid, organizationId: orgId, contentId, source });
+    }
+
+    async function expectStreamDenied(uid: string, contentId: string) {
+      await expect(
+        accessService.getStreamingUrl(uid, { contentId, expirySeconds: 3600 })
+      ).rejects.toThrow(AccessDeniedError);
+    }
+
+    async function expectStreamGranted(uid: string, contentId: string) {
+      const result = await accessService.getStreamingUrl(uid, {
+        contentId,
+        expirySeconds: 3600,
+      });
+      expect(result.streamingUrl).toContain('/hls/master.m3u8?token=');
+    }
+
+    // ── canView — ORG route (org-scoped content) ─────────────────────────
+
+    describe('canView — org route (org-scoped content)', () => {
+      it('tier-gated: DENIES a non-subscriber, GRANTS an at-tier subscriber (canView + getStreamingUrl)', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        const tierId = await seedTier(organizationId);
+        const contentId = await makeContent({
+          slug: 'org-tier',
+          organizationId,
+          policy: { includedInTierId: tierId },
+        });
+
+        // NEGATIVE — no subscription.
+        const [outsider] = await seedTestUsers(db, 1);
+        expect(await accessService.canView(outsider, contentId)).toBe(false);
+        await expectStreamDenied(outsider, contentId);
+
+        // POSITIVE — active subscription at the tier.
+        const [subscriber] = await seedTestUsers(db, 1);
+        await db.insert(subscriptions).values(
+          createTestSubscriptionInput(subscriber, organizationId, tierId, {
+            status: 'active',
+          })
+        );
+        expect(await accessService.canView(subscriber, contentId)).toBe(true);
+        await expectStreamGranted(subscriber, contentId);
+      });
+
+      it('courseOnly: SUPPRESSES the free path for a non-owner, GRANTS via an owned course', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        // courseOnly wins even though isFree=true — proves suppression.
+        const contentId = await makeContent({
+          slug: 'org-courseonly',
+          organizationId,
+          policy: { courseOnly: true, isFree: true },
+        });
+        const { courseId, stageId } = await makeCourse(organizationId);
+        await linkPractice(stageId, contentId);
+
+        // NEGATIVE — user holds no entitlement over the containing course.
+        const [outsider] = await seedTestUsers(db, 1);
+        expect(await accessService.canView(outsider, contentId)).toBe(false);
+        await expectStreamDenied(outsider, contentId);
+
+        // POSITIVE — a course purchase reaches the shared practice.
+        const [owner] = await seedTestUsers(db, 1);
+        await grantCourse(owner, organizationId, courseId, 'course_purchase');
+        expect(await accessService.canView(owner, contentId)).toBe(true);
+        await expectStreamGranted(owner, contentId);
+      });
+
+      it('follower-gated: DENIES a non-follower, GRANTS a follower (canView + getStreamingUrl)', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        const contentId = await makeContent({
+          slug: 'org-follower',
+          organizationId,
+          policy: { isFollowerGated: true },
+        });
+
+        const [stranger] = await seedTestUsers(db, 1);
+        expect(await accessService.canView(stranger, contentId)).toBe(false);
+        await expectStreamDenied(stranger, contentId);
+
+        const [follower] = await seedTestUsers(db, 1);
+        await db
+          .insert(organizationFollowers)
+          .values({ userId: follower, organizationId });
+        expect(await accessService.canView(follower, contentId)).toBe(true);
+        await expectStreamGranted(follower, contentId);
+      });
+
+      it('management role bypasses courseOnly (sees all org content)', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        const contentId = await makeContent({
+          slug: 'org-courseonly-mgmt',
+          organizationId,
+          policy: { courseOnly: true },
+        });
+        const { stageId } = await makeCourse(organizationId);
+        await linkPractice(stageId, contentId);
+
+        const [manager] = await seedTestUsers(db, 1);
+        await db.insert(organizationMemberships).values({
+          userId: manager,
+          organizationId,
+          role: 'admin',
+          status: 'active',
+        });
+        expect(await accessService.canView(manager, contentId)).toBe(true);
+        await expectStreamGranted(manager, contentId);
+      });
+    });
+
+    // ── canView — CREATOR route (personal content, orgId = null) ─────────
+
+    describe('canView — creator route (personal content, no org)', () => {
+      it('purchasable personal content: DENIES without purchase, GRANTS with purchase', async () => {
+        // NEGATIVE — no purchase.
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+        const contentId = await makeContent({
+          slug: 'personal-paid',
+          organizationId: null,
+          policy: { isPurchasable: true, priceCents: 1500 },
+        });
+        const [buyer] = await seedTestUsers(db, 1);
+        expect(await accessService.canView(buyer, contentId)).toBe(false);
+        await expectStreamDenied(buyer, contentId);
+
+        // POSITIVE — purchase verified (PurchaseService is the authority).
+        mockPurchaseService.verifyPurchase.mockResolvedValue(true);
+        expect(await accessService.canView(buyer, contentId)).toBe(true);
+        await expectStreamGranted(buyer, contentId);
+      });
+    });
+
+    // ── canView — entitlements-table additive grant (the new source) ─────
+
+    describe('canView — stored entitlements grant (WP-6 forward-compat)', () => {
+      it('a content_purchase entitlement grants tier-gated content with no subscription', async () => {
+        mockPurchaseService.verifyPurchase.mockClear();
+        mockPurchaseService.verifyPurchase.mockResolvedValue(false);
+
+        const tierId = await seedTier(organizationId);
+        const contentId = await makeContent({
+          slug: 'entitlement-grant',
+          organizationId,
+          policy: { includedInTierId: tierId },
+        });
+
+        const [holder] = await seedTestUsers(db, 1);
+        // No subscription, no purchase — denied first (baseline).
+        expect(await accessService.canView(holder, contentId)).toBe(false);
+
+        // Stored entitlement is unioned in → now granted.
+        await grantContent(
+          holder,
+          organizationId,
+          contentId,
+          'content_purchase'
+        );
+        expect(await accessService.canView(holder, contentId)).toBe(true);
+        await expectStreamGranted(holder, contentId);
+      });
+    });
+
+    // ── canEnterCourse ───────────────────────────────────────────────────
+
+    describe('canEnterCourse', () => {
+      it('grants entry on a course_purchase entitlement', async () => {
+        const { courseId } = await makeCourse(organizationId);
+        const [buyer] = await seedTestUsers(db, 1);
+        expect(await accessService.canEnterCourse(buyer, courseId)).toBe(false);
+        await grantCourse(buyer, organizationId, courseId, 'course_purchase');
+        expect(await accessService.canEnterCourse(buyer, courseId)).toBe(true);
+      });
+
+      it('grants entry via a derived tier (course_tier_access + active subscription)', async () => {
+        const tierId = await seedTier(organizationId);
+        const { courseId } = await makeCourse(organizationId);
+        await db.insert(courseTierAccess).values({ courseId, tierId });
+
+        // Subscriber to the granting tier — derived, no stored row.
+        const [subscriber] = await seedTestUsers(db, 1);
+        await db.insert(subscriptions).values(
+          createTestSubscriptionInput(subscriber, organizationId, tierId, {
+            status: 'active',
+          })
+        );
+        expect(await accessService.canEnterCourse(subscriber, courseId)).toBe(
+          true
+        );
+
+        // A user with no subscription to that tier is denied.
+        const [outsider] = await seedTestUsers(db, 1);
+        expect(await accessService.canEnterCourse(outsider, courseId)).toBe(
+          false
+        );
+      });
+
+      it('denies entry with no entitlement, and denies anonymous (null user)', async () => {
+        const { courseId } = await makeCourse(organizationId);
+        const [stranger] = await seedTestUsers(db, 1);
+        expect(await accessService.canEnterCourse(stranger, courseId)).toBe(
+          false
+        );
+        expect(await accessService.canEnterCourse(null, courseId)).toBe(false);
+      });
+
+      it('denies entry on a revoked or expired grant (instant revocation)', async () => {
+        const { courseId: revokedCourse } = await makeCourse(organizationId);
+        const { courseId: expiredCourse } = await makeCourse(organizationId);
+        const [user] = await seedTestUsers(db, 1);
+
+        await grantCourse(
+          user,
+          organizationId,
+          revokedCourse,
+          'course_purchase',
+          {
+            revokedAt: new Date(),
+          }
+        );
+        await grantCourse(
+          user,
+          organizationId,
+          expiredCourse,
+          'course_purchase',
+          {
+            expiresAt: new Date(Date.now() - 60_000),
+          }
+        );
+
+        expect(await accessService.canEnterCourse(user, revokedCourse)).toBe(
+          false
+        );
+        expect(await accessService.canEnterCourse(user, expiredCourse)).toBe(
+          false
+        );
+      });
+    });
+
+    // ── canEnterCoursesBatch — correctness + no-N+1 ──────────────────────
+
+    describe('canEnterCoursesBatch', () => {
+      it('resolves a mix of entitled and non-entitled courses', async () => {
+        const tierId = await seedTier(organizationId);
+        const purchased = await makeCourse(organizationId);
+        const tierGranted = await makeCourse(organizationId);
+        const locked = await makeCourse(organizationId);
+        await db.insert(courseTierAccess).values({
+          courseId: tierGranted.courseId,
+          tierId,
+        });
+
+        const [user] = await seedTestUsers(db, 1);
+        await grantCourse(
+          user,
+          organizationId,
+          purchased.courseId,
+          'course_purchase'
+        );
+        await db.insert(subscriptions).values(
+          createTestSubscriptionInput(user, organizationId, tierId, {
+            status: 'active',
+          })
+        );
+
+        const map = await accessService.canEnterCoursesBatch(user, [
+          purchased.courseId,
+          tierGranted.courseId,
+          locked.courseId,
+        ]);
+        expect(map.get(purchased.courseId)).toBe(true);
+        expect(map.get(tierGranted.courseId)).toBe(true);
+        expect(map.get(locked.courseId)).toBe(false);
+      });
+
+      it('empty input and anonymous user return all-false without querying', async () => {
+        const [user] = await seedTestUsers(db, 1);
+        const empty = await accessService.canEnterCoursesBatch(user, []);
+        expect(empty.size).toBe(0);
+        const anon = await accessService.canEnterCoursesBatch(null, [
+          crypto.randomUUID(),
+        ]);
+        expect([...anon.values()].every((v) => v === false)).toBe(true);
+      });
+
+      it('issues a BOUNDED query count independent of N (no N+1 on Neon HTTP)', async () => {
+        // Wrap the db so every `.select()` (one per SQL round-trip in the batch
+        // resolver) is counted; the count must not scale with N.
+        const counts = { select: 0 };
+        const countingDb = new Proxy(db, {
+          get(target, prop, receiver) {
+            if (prop === 'select') {
+              return (...args: unknown[]) => {
+                counts.select++;
+                return (
+                  target.select as unknown as (...a: unknown[]) => unknown
+                )(...args);
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === 'function' ? value.bind(target) : value;
+          },
+        }) as typeof db;
+
+        const batchService = new ContentAccessService({
+          db: countingDb,
+          environment: 'test',
+          r2: r2Client,
+          obs: new ObservabilityClient('content-access-test', 'test'),
+          purchaseService: mockPurchaseService as unknown as PurchaseService,
+        });
+
+        const [user] = await seedTestUsers(db, 1);
+        const many = Array.from({ length: 25 }, () => crypto.randomUUID());
+
+        counts.select = 0;
+        await batchService.canEnterCoursesBatch(user, many);
+        const selectsForMany = counts.select;
+
+        counts.select = 0;
+        await batchService.canEnterCoursesBatch(user, [crypto.randomUUID()]);
+        const selectsForOne = counts.select;
+
+        // Constant round-trips (two SELECTs) regardless of course count.
+        expect(selectsForMany).toBe(selectsForOne);
+        expect(selectsForMany).toBeLessThanOrEqual(2);
       });
     });
   });

--- a/packages/access/src/index.ts
+++ b/packages/access/src/index.ts
@@ -19,6 +19,15 @@
  * - Access control: Paid content requires purchase verification
  */
 
+// Entitlements read-resolution (Codex-2pryk.2.3 · WP-2). The frozen resolver
+// contract lives in @codex/shared-types; re-exported here for consumers that
+// already import @codex/access.
+export type {
+  Entitlement,
+  EntitlementResolver,
+  EntitlementSource,
+  ResourceType,
+} from '@codex/shared-types';
 // Re-export validation schemas for convenience
 export {
   type GetPlaybackProgressInput,
@@ -71,6 +80,7 @@ export {
   createContentAccessService,
   DEFAULT_STREAMING_URL_TTL_SECONDS,
 } from './services/ContentAccessService';
+export { EntitlementsService } from './services/entitlements-service';
 export type {
   PlaybackProgressResponse,
   StreamingUrlResponse,

--- a/packages/access/src/services/ContentAccessService.ts
+++ b/packages/access/src/services/ContentAccessService.ts
@@ -13,6 +13,7 @@ import {
   type ServiceConfig,
   ValidationError,
 } from '@codex/service-errors';
+import type { EntitlementResolver } from '@codex/shared-types';
 import { buildServiceUrl } from '@codex/urls';
 import type {
   GetPlaybackProgressInput,
@@ -28,6 +29,10 @@ import {
   assertStreamingAccess,
   resolveHasContentAccess,
 } from './content-access/access-decision';
+import {
+  hasCourseEntitlement,
+  resolveCourseEntitlementsBatch,
+} from './content-access/entitlements-resolver';
 import {
   listUserLibrary as buildUserLibrary,
   type UserLibraryResponse,
@@ -127,7 +132,10 @@ export interface ContentAccessServiceConfig extends ServiceConfig {
  * delegates to them, injecting the collaborators (`db`, `obs`, `r2`,
  * `purchaseService`, `revocation`) they need.
  */
-export class ContentAccessService extends BaseService {
+export class ContentAccessService
+  extends BaseService
+  implements EntitlementResolver
+{
   private readonly r2: R2Signer;
   private readonly purchaseService: PurchaseService;
   private readonly revocation: AccessRevocation | undefined;
@@ -144,14 +152,13 @@ export class ContentAccessService extends BaseService {
   }
 
   /**
-   * Check whether a user currently has access to a piece of content.
-   *
-   * This is the boolean equivalent of the access-decision logic embedded in
-   * `getStreamingUrl`'s transaction — it does NOT throw `AccessDeniedError`
-   * and does NOT generate signed URLs. See
-   * `./content-access/access-decision.ts` for the full contract.
+   * `EntitlementResolver.canView` (frozen contract, SPEC §6.3) — may the user
+   * open this content ANYWHERE? The single authority `getStreamingUrl` gates on;
+   * the boolean adapter over the collapsed decision core (see
+   * `./content-access/access-decision.ts`). Does NOT throw on denial and does NOT
+   * sign URLs. `userId` is `null` for anonymous visitors (public / free content).
    */
-  async hasContentAccess(userId: string, contentId: string): Promise<boolean> {
+  async canView(userId: string | null, contentId: string): Promise<boolean> {
     return resolveHasContentAccess(
       {
         db: this.db,
@@ -161,6 +168,58 @@ export class ContentAccessService extends BaseService {
       userId,
       contentId
     );
+  }
+
+  /**
+   * Check whether a user currently has access to a piece of content.
+   *
+   * Retained name for existing callers (`savePlaybackProgress` gate, content
+   * invalidation fanout); delegates to {@link canView}, the collapsed resolver.
+   */
+  async hasContentAccess(userId: string, contentId: string): Promise<boolean> {
+    return this.canView(userId, contentId);
+  }
+
+  /**
+   * `EntitlementResolver.canEnterCourse` (frozen contract, SPEC §6.3) — may the
+   * user open this course's DASHBOARD / journey? Course-scoped, so shared content
+   * never leaks course access ("bought Course A that shares practice X with B" ⇒
+   * can view X, cannot enter B). Grants on a course entitlement: a stored grant
+   * (`course_purchase` / `course_subscription` / `grant`) OR a derived tier grant
+   * (an active subscription intersecting `course_tier_access`). Tier grants are
+   * derived live, so a lapsed tier loses course entry instantly — this is why the
+   * gate is entitlement-based, NOT a stale `course_enrollments` row.
+   */
+  async canEnterCourse(
+    userId: string | null,
+    courseId: string
+  ): Promise<boolean> {
+    if (userId == null) return false;
+    return hasCourseEntitlement(this.db, userId, courseId);
+  }
+
+  /**
+   * `EntitlementResolver.canEnterCoursesBatch` (frozen contract) — resolve MANY
+   * courses in a BOUNDED number of queries (two `SELECT`s, independent of N) so a
+   * dashboard/library grid avoids N+1 on Neon HTTP (HARDENING §D/§E/§12). Returns
+   * a map keyed by every requested course id (missing/denied ⇒ `false`).
+   */
+  async canEnterCoursesBatch(
+    userId: string | null,
+    courseIds: readonly string[]
+  ): Promise<ReadonlyMap<string, boolean>> {
+    const result = new Map<string, boolean>(courseIds.map((id) => [id, false]));
+    if (userId == null || courseIds.length === 0) return result;
+
+    const entitled = await resolveCourseEntitlementsBatch(
+      this.db,
+      userId,
+      courseIds
+    );
+    for (const id of courseIds) {
+      result.set(id, entitled.has(id));
+    }
+    return result;
   }
 
   /**

--- a/packages/access/src/services/__tests__/content-access-service-followers-subscription.test.ts
+++ b/packages/access/src/services/__tests__/content-access-service-followers-subscription.test.ts
@@ -65,6 +65,25 @@ interface StubDb {
 }
 
 /**
+ * Chainable empty `.select()` stub. The collapsed resolver (Codex-2pryk.2.3)
+ * reads the `entitlements` / course tables via `db.select(...).from(...)` on the
+ * tier/paid deny paths; these unit mocks seed no such rows, so every additive
+ * read resolves to [] and the grant/deny OUTCOMES are unchanged.
+ */
+function emptySelect() {
+  const builder = {
+    from: () => builder,
+    innerJoin: () => builder,
+    leftJoin: () => builder,
+    where: () => builder,
+    limit: () => builder,
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mimics Drizzle's awaitable query builder so `await db.select()...` resolves to [].
+    then: (resolve: (rows: never[]) => unknown) => resolve([]),
+  };
+  return builder;
+}
+
+/**
  * Build a DB stub where `db.transaction(fn)` invokes the callback with a
  * transaction surface that exposes the same `.query.<table>.findFirst`
  * mocks. The real `getStreamingUrl` passes the `tx` argument (a
@@ -80,7 +99,7 @@ function createStubDb(): StubDb {
     subscriptionTiers: { findFirst: vi.fn() },
   };
 
-  const tx = { query: mocks };
+  const tx = { query: mocks, select: emptySelect };
 
   // Drizzle transaction signature: `transaction(callback, options?)`. We
   // only care about the callback — the isolationLevel/accessMode options
@@ -100,6 +119,7 @@ function buildService(stub: StubDb) {
     // transaction revocation gate, which we skip by omitting `revocation`.
     query: stub.mocks,
     transaction: stub.transaction,
+    select: emptySelect,
   } as unknown as ServiceDb;
 
   const signer = {

--- a/packages/access/src/services/__tests__/content-access-service-progress.test.ts
+++ b/packages/access/src/services/__tests__/content-access-service-progress.test.ts
@@ -59,6 +59,26 @@ interface StubDb {
   insertSpy: InsertSpy;
 }
 
+/**
+ * Chainable empty `.select()` stub. The collapsed resolver (Codex-2pryk.2.3)
+ * reads the `entitlements` / course tables via `db.select(...).from(...)` on the
+ * tier/paid deny paths; this mock seeds no such rows, so every additive read
+ * resolves to [] and the access-gate OUTCOME (deny → ForbiddenError) is
+ * unchanged.
+ */
+function emptySelect() {
+  const builder = {
+    from: () => builder,
+    innerJoin: () => builder,
+    leftJoin: () => builder,
+    where: () => builder,
+    limit: () => builder,
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mimics Drizzle's awaitable query builder so `await db.select()...` resolves to [].
+    then: (resolve: (rows: never[]) => unknown) => resolve([]),
+  };
+  return builder;
+}
+
 function createStubDb(): StubDb {
   const mocks: QueryMocks = {
     content: { findFirst: vi.fn() },
@@ -88,6 +108,7 @@ function buildService(stub: StubDb, revocation?: AccessRevocation) {
   const dbForService = {
     query: stub.mocks,
     insert: stub.insert,
+    select: emptySelect,
   } as unknown as ServiceDb;
 
   const verifyPurchase = vi.fn(async () => false);

--- a/packages/access/src/services/content-access/access-decision.ts
+++ b/packages/access/src/services/content-access/access-decision.ts
@@ -1,27 +1,47 @@
 /**
  * Content access-decision logic for ContentAccessService.
  *
- * This module is the KEYSTONE of the CE-1 decomposition (Codex-2pryk.1.1). It
- * holds the two access-decision trees that were previously inlined and
- * duplicated inside `ContentAccessService`:
+ * # The single collapsed resolver (Codex-2pryk.2.3 · WP-2)
  *
- *   - `resolveHasContentAccess` — the BOOLEAN tree (from `hasContentAccess`).
- *     Answers "does this (userId, contentId) pair pass the access rules?" and
- *     NEVER throws / NEVER signs URLs. Self-fetches the content row.
+ * WP-1 (Codex-2pryk.1.1) split the access decision into two behaviour-preserving
+ * trees so this collapse would be tractable. WP-2 collapses them: there is now
+ * ONE decision core — {@link decideContentAccess} — and the two historical
+ * entry points are thin adapters over it:
  *
- *   - `assertStreamingAccess` — the THROWING tree (from `getStreamingUrl`'s
- *     read-only transaction). Runs against a transaction client, logs the
- *     grant/deny decision, and throws `AccessDeniedError` on denial.
+ *   - {@link resolveHasContentAccess} — the BOOLEAN adapter (backs
+ *     `ContentAccessService.canView` / `hasContentAccess`). Self-fetches the
+ *     content row, returns `true`/`false`, never signs URLs, never throws on a
+ *     plain denial.
+ *   - {@link assertStreamingAccess} — the THROWING adapter (backs
+ *     `getStreamingUrl`). Runs against the read-only transaction snapshot, logs
+ *     the security-relevant denial, and throws `AccessDeniedError`.
  *
- * The two trees are DELIBERATELY kept separate here — they differ in return
- * shape (boolean vs throw), logging, query columns, and parallelism. Collapsing
- * them into one resolver is WP-2's job (the entitlements rewrite); this
- * refactor is behaviour-preserving and only makes the duplication visible and
- * side-by-side so that collapse becomes tractable.
+ * Both call the SAME core, so a boolean `canView` and the streaming gate can
+ * never disagree — the J4 "shared seam" guarantee at the service layer.
+ *
+ * ## What the core decides (SPEC §6.1/§6.3 + HARDENING §C/§B.6)
+ *
+ * The core folds the 7 per-content policy flags (`isFree` / `isPurchasable` +
+ * `priceCents` / `includedInTierId` / `courseOnly` / `isFollowerGated` /
+ * `isTeamOnly`) together with the live grant sources:
+ *   - `PurchaseService.verifyPurchase` (the authoritative content-purchase read),
+ *   - the STORED `entitlements` grants (`content_purchase` / `grant`) — additive,
+ *     forward-compatible with WP-6 (empty until it writes; see entitlements-resolver.ts),
+ *   - the DERIVED subscription-tier grant (`includedInTierId` "this tier and above"),
+ *   - and the "reachable via a course you own" arm (`courseOnly` + fallthrough).
+ *
+ * Precedence is preserved from WP-1 EXACTLY — team > followers > tier > paid >
+ * free — because the 185-case integration suite pins query ORDER (e.g. the
+ * management-role bypass is a per-branch FALLBACK checked AFTER the primary
+ * purchase/subscription read, never a global short-circuit; a global bypass would
+ * skip `verifyPurchase` and break the call-count assertions). The two arms the
+ * SPEC pseudocode omits but live code requires (HARDENING §B.6) are kept: the
+ * management-role bypass and the orgless-content-with-tier fail-closed deny
+ * (Codex-up7bx). `courseOnly` suppresses every standalone path (reachable only via
+ * a course entitlement, plus the management bypass).
  */
 
 import {
-  CONTENT_ACCESS_TYPE,
   CONTENT_STATUS,
   ORGANIZATION_ROLES,
   SUBSCRIPTION_STATUS,
@@ -39,6 +59,11 @@ import type { PurchaseService } from '@codex/purchase';
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { LOG_EVENTS, LOG_SEVERITY } from '../../constants';
 import { AccessDeniedError } from '../../errors';
+import {
+  type AccessQueryClient,
+  contentReachableViaOwnedCourse,
+  hasStoredContentEntitlement,
+} from './entitlements-resolver';
 
 /**
  * Transaction client type — derived from the DB client's `transaction` method
@@ -58,8 +83,8 @@ const MANAGEMENT_ROLES: string[] = [
   ORGANIZATION_ROLES.CREATOR,
 ];
 
-/** Content fields the streaming-access tree reads. */
-interface StreamingAccessContent {
+/** The per-content access-policy flags the decision core reads (SPEC §6.1). */
+export interface ContentAccessPolicyRow {
   organizationId: string | null;
   isFree: boolean;
   isPurchasable: boolean;
@@ -67,103 +92,95 @@ interface StreamingAccessContent {
   includedInTierId: string | null;
   isFollowerGated: boolean;
   isTeamOnly: boolean;
+  courseOnly: boolean;
 }
 
 /**
- * Boolean access check — the equivalent of the access-decision logic embedded
- * in `getStreamingUrl`'s transaction, factored out so the progress save path
- * (and future callers) can gate writes without duplicating the rules. It
- * deliberately does NOT throw `AccessDeniedError` and does NOT generate signed
- * URLs; it only answers "does this (userId, contentId) pair pass the current
- * access rules?".
- *
- * Not run inside a transaction — progress saves don't require a snapshot
- * across the access read + the videoPlayback upsert. A race where access is
- * revoked between this check and the upsert is acceptable (the next heartbeat
- * will be blocked) and bounded by the short KV TTL on the revocation key.
- *
- * Returns `false` for:
- *   - Content not found / unpublished / soft-deleted (treated as no access)
- *   - Team-only content when user lacks a management role
- *   - Followers-only content when user is neither follower, active subscriber,
- *     nor management. Note: as of Codex-xybr3 the access hierarchy is
- *     `subscribers ⊇ followers ⊇ public` — an active subscription to the
- *     content's org grants followers-only access without needing a follower
- *     row. Ex-subscribers (status=cancelled) with an active follower row
- *     still get access via the follower fallback.
- *   - Subscribers-only content when user has neither an active subscription
- *     meeting the minimum tier, a purchase, nor management
- *   - Paid content when user has neither purchased nor (via tier) subscribed
- *     nor holds a management role
- *
- * Returns `true` for free content the user can see, and for any of the above
- * paths when satisfied.
+ * Content fields the streaming-access adapter reads. Superset of the boolean
+ * adapter's whitelist; kept as an alias so `getStreamingUrl`'s already-fetched
+ * full row satisfies it structurally.
  */
-export async function resolveHasContentAccess(
-  deps: {
-    db: DatabaseClient;
-    purchaseService: PurchaseService;
-    obs: ObservabilityClient;
-  },
-  userId: string,
-  contentId: string
-): Promise<boolean> {
-  const { db, purchaseService, obs } = deps;
+export type StreamingAccessContent = ContentAccessPolicyRow;
 
-  const contentRecord = await db.query.content.findFirst({
-    where: and(
-      eq(content.id, contentId),
-      eq(content.status, CONTENT_STATUS.PUBLISHED),
-      isNull(content.deletedAt)
-    ),
-    columns: {
-      id: true,
-      organizationId: true,
-      isFree: true,
-      isPurchasable: true,
-      priceCents: true,
-      includedInTierId: true,
-      isFollowerGated: true,
-      isTeamOnly: true,
-    },
-  });
+/** Reason codes for a denial — logged, and threaded into `AccessDeniedError`. */
+type DenyReason =
+  | 'orgless_tier_gate'
+  | 'course_only'
+  | 'team_only'
+  | 'team_only_requires_org'
+  | 'followers_only'
+  | 'followers_only_requires_org'
+  | 'subscribers_only'
+  | 'subscribers_only_requires_org'
+  | 'paid'
+  | 'paid_requires_purchase';
 
-  if (!contentRecord) {
-    // Missing/unpublished content → treat as no access. Don't leak the
-    // distinction between "doesn't exist" and "you can't see it" at this
-    // layer — the caller translates the boolean.
-    return false;
+/**
+ * Which arm granted — the streaming adapter maps this to the WP-1 grant log
+ * (preserved because the observability suite pins the follower grant messages;
+ * see content-access-service-followers-subscription.test.ts).
+ */
+type GrantVia =
+  | 'free'
+  | 'course'
+  | 'management'
+  | 'team_management'
+  | 'followers_subscription'
+  | 'followers_follower'
+  | 'followers_management'
+  | 'subscribers_subscription'
+  | 'subscribers_purchase'
+  | 'subscribers_entitlement'
+  | 'subscribers_course'
+  | 'subscribers_management'
+  | 'paid_purchase'
+  | 'paid_entitlement'
+  | 'paid_course'
+  | 'paid_management';
+
+type AccessDecision =
+  | { granted: true; via: GrantVia }
+  | { granted: false; reason: DenyReason };
+
+const grant = (via: GrantVia): AccessDecision => ({ granted: true, via });
+const deny = (reason: DenyReason): AccessDecision => ({
+  granted: false,
+  reason,
+});
+
+/**
+ * THE decision core — pure (no logging, no throw, no URL signing). Returns a
+ * grant or a reasoned denial for the (userId, content) pair. `userId` is `null`
+ * for anonymous visitors (public sales pages / free content) — every user-scoped
+ * grant source then evaluates to "no grant", so only free content (and the
+ * WP-1-preserving free fallthrough) is viewable.
+ *
+ * Runs against any query client — the base `db` (boolean path) or a read-only
+ * `tx` (streaming path). `verifyPurchase` uses the PurchaseService's own db, as
+ * in WP-1.
+ */
+export async function decideContentAccess(
+  deps: { db: AccessQueryClient; purchaseService: PurchaseService },
+  userId: string | null,
+  contentId: string,
+  policy: ContentAccessPolicyRow
+): Promise<AccessDecision> {
+  const { db, purchaseService } = deps;
+  const orgId = policy.organizationId;
+
+  // Fail-closed guard: orgless content can never tier-gate (Codex-up7bx).
+  // `subscription_tiers` is org-scoped, so a `includedInTierId` on content with
+  // NO `organizationId` is a semantically invalid row — deny before any branch.
+  if (orgId == null && policy.includedInTierId != null) {
+    return deny('orgless_tier_gate');
   }
 
-  const orgId = contentRecord.organizationId;
-
-  // ── Fail-closed guard: orgless content can never tier-gate (Codex-up7bx) ──
-  // `subscription_tiers` is org-scoped (FK to organizations, unique per org),
-  // so a `minimumTierId` on content with NO `organizationId` is a semantically
-  // invalid row — there is no org against which a subscription/tier could be
-  // checked. Earlier this slipped through every branch that conjoined the
-  // subscription check with `orgId` being truthy, silently SKIPPING the tier
-  // gate and granting access. Deny here, before any branch, so a pre-existing
-  // bad row (regardless of how it was written) is never silently unlocked.
-  if (orgId == null && contentRecord.includedInTierId != null) {
-    obs.warn('Access denied - orgless content with tier gate', {
-      userId,
-      contentId,
-      includedInTierId: contentRecord.includedInTierId,
-      securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-      severity: LOG_SEVERITY.MEDIUM,
-      eventType: LOG_EVENTS.ACCESS_CONTROL,
-    });
-    return false;
-  }
-
-  // Inline reusable helpers — mirror the branches in getStreamingUrl.
-  const hasManagementMembership = async (
-    organizationId: string
-  ): Promise<boolean> => {
+  // User-scoped grant helpers. All return false for an anonymous (null) user.
+  const hasManagementMembership = async (): Promise<boolean> => {
+    if (userId == null || orgId == null) return false;
     const row = await db.query.organizationMemberships.findFirst({
       where: and(
-        eq(organizationMemberships.organizationId, organizationId),
+        eq(organizationMemberships.organizationId, orgId),
         eq(organizationMemberships.userId, userId),
         eq(organizationMemberships.status, 'active'),
         inArray(organizationMemberships.role, MANAGEMENT_ROLES)
@@ -173,10 +190,11 @@ export async function resolveHasContentAccess(
     return !!row;
   };
 
-  const hasFollower = async (organizationId: string): Promise<boolean> => {
+  const hasFollower = async (): Promise<boolean> => {
+    if (userId == null || orgId == null) return false;
     const row = await db.query.organizationFollowers.findFirst({
       where: and(
-        eq(organizationFollowers.organizationId, organizationId),
+        eq(organizationFollowers.organizationId, orgId),
         eq(organizationFollowers.userId, userId)
       ),
       columns: { id: true },
@@ -184,14 +202,16 @@ export async function resolveHasContentAccess(
     return !!row;
   };
 
+  // Active subscription meeting the content's minimum tier (by sortOrder).
+  // `minimumTierId === null` → any active subscription grants (community gate).
   const hasSubscriptionAccess = async (
-    organizationId: string,
     minimumTierId: string | null
   ): Promise<boolean> => {
+    if (userId == null || orgId == null) return false;
     const userSub = await db.query.subscriptions.findFirst({
       where: and(
         eq(subscriptions.userId, userId),
-        eq(subscriptions.organizationId, organizationId),
+        eq(subscriptions.organizationId, orgId),
         inArray(subscriptions.status, [
           SUBSCRIPTION_STATUS.ACTIVE,
           SUBSCRIPTION_STATUS.CANCELLING,
@@ -210,76 +230,193 @@ export async function resolveHasContentAccess(
     return userSub.tier.sortOrder >= contentTier.sortOrder;
   };
 
-  // Branch on the access-policy flags — behavior-preserving translation of the
-  // former mutually-exclusive `accessType` chain (WP-1); WP-2 replaces this with
-  // the entitlements resolver. Precedence: team > followers > tier > paid > free
-  // (matches the old accessType chain; migrated single-mode rows set exactly one
-  // gate, so precedence is observable only for future multi-flag content).
-  if (contentRecord.isTeamOnly) {
-    if (!orgId) return false;
-    return hasManagementMembership(orgId);
+  const verifyPurchase = async (): Promise<boolean> => {
+    if (userId == null) return false;
+    return purchaseService.verifyPurchase(contentId, userId);
+  };
+
+  const viaOwnedCourse = async (): Promise<boolean> => {
+    if (userId == null) return false;
+    return contentReachableViaOwnedCourse(db, userId, contentId);
+  };
+
+  const viaContentEntitlement = async (): Promise<boolean> => {
+    if (userId == null) return false;
+    return hasStoredContentEntitlement(db, userId, contentId);
+  };
+
+  // ── courseOnly — suppresses EVERY standalone path (SPEC §6.1). Reachable only
+  // via a course entitlement; the management bypass still applies (sees all org
+  // content). Placed before the standalone flag branches so it wins "regardless
+  // of the other flags".
+  if (policy.courseOnly) {
+    if (await viaOwnedCourse()) return grant('course');
+    if (await hasManagementMembership()) return grant('management');
+    return deny('course_only');
   }
 
-  if (contentRecord.isFollowerGated) {
-    if (!orgId) return false;
-    // Codex-xybr3: subscribers ⊇ followers. Active subscribers to the
-    // content's org get followers-only access without needing a follower
-    // row. Either a subscription OR a follower row grants access — both
-    // are independent reads so launch them in parallel (R12 hard rule).
-    // The deny path was previously 3 sequential round-trips; the cheap
-    // pair now overlaps, falling through to management only when both
-    // come back falsey. On grant either truthy result short-circuits.
-    const [subscribed, followed] = await Promise.all([
-      hasSubscriptionAccess(orgId, null),
-      hasFollower(orgId),
-    ]);
-    if (subscribed || followed) return true;
-    return hasManagementMembership(orgId);
+  // ── team-only — management role only (WP-1). ──────────────────────────────
+  if (policy.isTeamOnly) {
+    if (!orgId) return deny('team_only_requires_org');
+    return (await hasManagementMembership())
+      ? grant('team_management')
+      : deny('team_only');
   }
 
-  if (contentRecord.includedInTierId != null) {
-    if (!orgId) return false;
-    // Subscription and purchase are independent gates — launch in parallel
-    // (R12 hard rule). Falls through to management only when both deny.
+  // ── followers-only — active subscription OR follower row OR management. ────
+  // (Codex-xybr3: subscribers ⊇ followers.) Checked SEQUENTIALLY, subscription
+  // FIRST: an active subscriber is granted without the follower lookup ever
+  // running (the short-circuit the WP-1 streaming tree + its observability suite
+  // pin). Then the follower fallback (ex-subscribers with a live follow), then
+  // the management bypass.
+  if (policy.isFollowerGated) {
+    if (!orgId) return deny('followers_only_requires_org');
+    if (await hasSubscriptionAccess(null))
+      return grant('followers_subscription');
+    if (await hasFollower()) return grant('followers_follower');
+    return (await hasManagementMembership())
+      ? grant('followers_management')
+      : deny('followers_only');
+  }
+
+  // ── tier-gated (subscribers) — includedInTierId set (orgId guaranteed by the
+  // orgless guard above). Subscription + purchase are independent → parallel;
+  // then the additive entitlements-table grant and the "via a course you own"
+  // arm; then management fallback.
+  if (policy.includedInTierId != null) {
+    if (!orgId) return deny('subscribers_only_requires_org');
     const [subscribed, purchased] = await Promise.all([
-      hasSubscriptionAccess(orgId, contentRecord.includedInTierId),
-      purchaseService.verifyPurchase(contentId, userId),
+      hasSubscriptionAccess(policy.includedInTierId),
+      verifyPurchase(),
     ]);
-    if (subscribed || purchased) return true;
-    return hasManagementMembership(orgId);
+    if (subscribed) return grant('subscribers_subscription');
+    if (purchased) return grant('subscribers_purchase');
+    if (await viaContentEntitlement()) return grant('subscribers_entitlement');
+    if (await viaOwnedCourse()) return grant('subscribers_course');
+    return (await hasManagementMembership())
+      ? grant('subscribers_management')
+      : deny('subscribers_only');
   }
 
-  // Paid content (priceCents > 0) — check purchase, optional tier, membership.
-  if (contentRecord.priceCents && contentRecord.priceCents > 0) {
-    // Purchase + (optional) subscription gates are independent — launch in
-    // parallel when both apply (R12 hard rule). When no minimumTierId is
-    // set the subscription path doesn't apply, so only purchase runs.
-    if (orgId && contentRecord.includedInTierId) {
-      const [purchased, subscribed] = await Promise.all([
-        purchaseService.verifyPurchase(contentId, userId),
-        hasSubscriptionAccess(orgId, contentRecord.includedInTierId),
-      ]);
-      if (purchased || subscribed) return true;
-      return hasManagementMembership(orgId);
-    }
-    if (await purchaseService.verifyPurchase(contentId, userId)) {
-      return true;
-    }
-    if (!orgId) return false;
-    return hasManagementMembership(orgId);
+  // ── paid (priceCents > 0, no tier) — purchase first (WP-1), then the additive
+  // entitlements-table grant and via-course arm, then management fallback.
+  if ((policy.priceCents ?? 0) > 0) {
+    if (await verifyPurchase()) return grant('paid_purchase');
+    if (await viaContentEntitlement()) return grant('paid_entitlement');
+    if (await viaOwnedCourse()) return grant('paid_course');
+    if (!orgId) return deny('paid_requires_purchase');
+    return (await hasManagementMembership())
+      ? grant('paid_management')
+      : deny('paid');
   }
 
-  // Free content with no price — access granted.
-  return true;
+  // ── free / fallthrough — WP-1 granted here (free content, no price). ───────
+  return grant('free');
 }
 
 /**
- * Throwing access check for the streaming path. Runs inside `getStreamingUrl`'s
- * read-only transaction against the already-fetched content row, logs the
- * grant/deny decision, and throws `AccessDeniedError` on denial. Returns
- * normally when access is granted.
+ * Map a grant `via` to the WP-1 streaming grant log. Only the two follower
+ * messages are asserted by the observability suite (analytics distinguishes the
+ * community-signal paths); every other arm logs a single generic grant line.
+ */
+function logGrant(
+  obs: ObservabilityClient,
+  via: GrantVia,
+  ctx: { userId: string; contentId: string; organizationId: string | null }
+): void {
+  if (via === 'followers_subscription') {
+    obs.info('Access granted via subscription (followers content)', {
+      ...ctx,
+      reason: 'followers_content_granted_via_subscription',
+    });
+    return;
+  }
+  if (via === 'followers_follower') {
+    obs.info('Access granted via follower (followers content)', ctx);
+    return;
+  }
+  obs.info('Access granted', { ...ctx, via });
+}
+
+/**
+ * Content fields the boolean adapter reads. Whitelisted so the self-fetch only
+ * pulls the policy columns (matches WP-1; adds `courseOnly`).
+ */
+const POLICY_COLUMNS = {
+  id: true,
+  organizationId: true,
+  isFree: true,
+  isPurchasable: true,
+  priceCents: true,
+  includedInTierId: true,
+  isFollowerGated: true,
+  isTeamOnly: true,
+  courseOnly: true,
+} as const;
+
+/**
+ * BOOLEAN adapter — backs `ContentAccessService.canView` / `hasContentAccess`.
+ * Answers "may this (userId, contentId) pair open this content ANYWHERE?"
+ * without throwing or signing URLs. Returns `false` for missing / unpublished /
+ * soft-deleted content (the distinction is not leaked at this layer). `userId`
+ * is `null` for anonymous visitors.
  *
- * Preserves the exact behaviour of the previously-inlined tree, including the
+ * Not run inside a transaction — progress saves and public reads don't need a
+ * snapshot across the access read + a follow-on write; a race where access is
+ * revoked between this check and a downstream write is bounded by the KV
+ * revocation TTL.
+ */
+export async function resolveHasContentAccess(
+  deps: {
+    db: DatabaseClient;
+    purchaseService: PurchaseService;
+    obs: ObservabilityClient;
+  },
+  userId: string | null,
+  contentId: string
+): Promise<boolean> {
+  const { db, purchaseService, obs } = deps;
+
+  const contentRecord = await db.query.content.findFirst({
+    where: and(
+      eq(content.id, contentId),
+      eq(content.status, CONTENT_STATUS.PUBLISHED),
+      isNull(content.deletedAt)
+    ),
+    columns: POLICY_COLUMNS,
+  });
+
+  if (!contentRecord) return false;
+
+  const decision = await decideContentAccess(
+    { db, purchaseService },
+    userId,
+    contentId,
+    contentRecord
+  );
+
+  // Surface the data-integrity denial (a bad orgless+tier row exists) as a
+  // security warning even on the non-throwing path — preserves the WP-1
+  // boolean-tree log (Codex-up7bx). Other denials return false silently, as
+  // before, to avoid log-spamming public/anonymous canView calls.
+  if (!decision.granted && decision.reason === 'orgless_tier_gate') {
+    obs.warn('Access denied - orgless content with tier gate', {
+      userId,
+      contentId,
+      includedInTierId: contentRecord.includedInTierId,
+      securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
+      severity: LOG_SEVERITY.MEDIUM,
+      eventType: LOG_EVENTS.ACCESS_CONTROL,
+    });
+  }
+
+  return decision.granted;
+}
+
+/**
+ * THROWING adapter — backs `getStreamingUrl`. Runs the SAME decision core against
+ * the read-only transaction snapshot, logs the security-relevant denial, and
+ * throws `AccessDeniedError` on denial; returns normally on grant. Preserves the
  * orgless fail-closed guard (Codex-up7bx), the management-role bypass, and the
  * `subscribers ⊇ followers ⊇ public` hierarchy (Codex-xybr3).
  */
@@ -292,386 +429,36 @@ export async function assertStreamingAccess(
 ): Promise<void> {
   const { purchaseService, obs } = deps;
 
-  // ── Fail-closed guard: orgless content can never tier-gate ──
-  // (Codex-up7bx) `subscription_tiers` is org-scoped, so content
-  // with a `minimumTierId` but NO `organizationId` is a semantically
-  // invalid row: there is no org against which the tier/subscription
-  // could be resolved. Every accessType branch below conjoins the
-  // subscription check with `organizationId` being present, which
-  // for such a row silently SKIPS the gate and (in the free/paid
-  // arms) grants access. Deny up front so a pre-existing bad row —
-  // however it was written — is never silently unlocked. This must
-  // precede the accessType branching.
-  if (
-    contentRecord.organizationId == null &&
-    contentRecord.includedInTierId != null
-  ) {
-    obs.warn('Access denied - orgless content with tier gate', {
-      userId,
-      contentId,
-      includedInTierId: contentRecord.includedInTierId,
-      securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-      severity: LOG_SEVERITY.MEDIUM,
-      eventType: LOG_EVENTS.ACCESS_CONTROL,
-    });
-    throw new AccessDeniedError(userId, contentId, {
-      reason: 'orgless_tier_gate',
-    });
-  }
+  const decision = await decideContentAccess(
+    { db: tx, purchaseService },
+    userId,
+    contentId,
+    contentRecord
+  );
 
-  // ── Reusable helper: check active subscription access ──────
-  // Returns true if user has an active subscription to the org
-  // that meets the content's minimum tier requirement.
-  // When minimumTierId is null, any active subscription grants access.
-  const checkSubscriptionAccess = async (
-    orgId: string,
-    minimumTierId: string | null
-  ): Promise<boolean> => {
-    const userSub = await tx.query.subscriptions.findFirst({
-      where: and(
-        eq(subscriptions.userId, userId),
-        eq(subscriptions.organizationId, orgId),
-        inArray(subscriptions.status, [
-          SUBSCRIPTION_STATUS.ACTIVE,
-          SUBSCRIPTION_STATUS.CANCELLING,
-        ]),
-        gt(subscriptions.currentPeriodEnd, new Date())
-      ),
-      with: { tier: true },
-    });
-
-    if (!userSub) return false;
-
-    // No minimum tier set — any active subscription grants access
-    if (!minimumTierId) {
-      obs.info('Access granted via subscription (any tier)', {
-        userId,
-        contentId,
-        subscriptionTier: userSub.tier.name,
-      });
-      return true;
-    }
-
-    // Minimum tier set — compare sortOrder.
-    // Archived (soft-deleted) tiers MUST still resolve here: a
-    // creator who deletes a tier leaves historic content gated
-    // against it, and active subscribers whose own subscription
-    // predates the delete still need their access decision to
-    // compare sort orders. The deletedAt filter is therefore
-    // omitted intentionally — mirror of TierService.getTierForAccessCheck.
-    const contentTier = await tx.query.subscriptionTiers.findFirst({
-      where: eq(subscriptionTiers.id, minimumTierId),
-    });
-
-    if (contentTier && userSub.tier.sortOrder >= contentTier.sortOrder) {
-      obs.info('Access granted via subscription', {
-        userId,
-        contentId,
-        subscriptionTier: userSub.tier.name,
-        contentMinTier: contentTier.name,
-      });
-      return true;
-    }
-
-    return false;
-  };
-
-  // ── Reusable helper: check management membership ────────────
-  // Only owner/admin/creator roles bypass payment requirements.
-  // Regular 'member' and 'subscriber' roles must purchase or
-  // subscribe to access paid/subscriber content.
-  const checkManagementMembership = async (orgId: string) => {
-    return tx.query.organizationMemberships.findFirst({
-      where: and(
-        eq(organizationMemberships.organizationId, orgId),
-        eq(organizationMemberships.userId, userId),
-        eq(organizationMemberships.status, 'active'),
-        inArray(organizationMemberships.role, MANAGEMENT_ROLES)
-      ),
-    });
-  };
-
-  // ── Reusable helper: check follower relationship ────────────
-  const checkFollower = async (orgId: string) => {
-    return tx.query.organizationFollowers.findFirst({
-      where: and(
-        eq(organizationFollowers.organizationId, orgId),
-        eq(organizationFollowers.userId, userId)
-      ),
-    });
-  };
-
-  // ── Access decision: branch on the access-policy flags ─────
-  // Behavior-preserving translation of the former accessType else-if chain
-  // (WP-1); precedence team > followers > tier > paid > free. WP-2 replaces
-  // this with the entitlements resolver.
-
-  // (a) Team-only: require management role (owner/admin/creator)
-  if (contentRecord.isTeamOnly) {
-    if (!contentRecord.organizationId) {
-      throw new AccessDeniedError(userId, contentId, {
-        reason: 'team_only_requires_org',
-      });
-    }
-
-    const membership = await checkManagementMembership(
-      contentRecord.organizationId
-    );
-
-    if (!membership) {
-      obs.warn('Access denied - team-only content', {
-        userId,
-        contentId,
-        organizationId: contentRecord.organizationId,
-        securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-        severity: LOG_SEVERITY.MEDIUM,
-        eventType: LOG_EVENTS.ACCESS_CONTROL,
-      });
-      throw new AccessDeniedError(userId, contentId, {
-        organizationId: contentRecord.organizationId,
-        reason: 'team_only',
-      });
-    }
-
-    obs.info('Access granted via management role (team content)', {
+  if (decision.granted) {
+    logGrant(obs, decision.via, {
       userId,
       contentId,
       organizationId: contentRecord.organizationId,
-      membershipRole: membership.role,
     });
+    return;
   }
-  // (b) Followers-only: require active subscription, follower row,
-  // or management role. Codex-xybr3 inverted the prior orthogonality:
-  // the access hierarchy is now `subscribers ⊇ followers ⊇ public`,
-  // so an active subscription to the content's org grants followers-
-  // only access without needing a follower row. The subscriber check
-  // runs FIRST so subscribers don't require the (free) follow action;
-  // the follower check remains as a fallback so ex-subscribers
-  // (status=cancelled) with an active follower row still see
-  // followers-only content via the community signal.
-  //
-  // Paused / past_due / expired subscriptions are filtered out by
-  // `checkSubscriptionAccess` (status IN (active, cancelling) AND
-  // currentPeriodEnd > now) — consistent with the PR #5 filter used
-  // for subscribers-only content.
-  else if (contentRecord.isFollowerGated) {
-    if (!contentRecord.organizationId) {
-      throw new AccessDeniedError(userId, contentId, {
-        reason: 'followers_only_requires_org',
-      });
-    }
 
-    let granted = false;
-    const orgId = contentRecord.organizationId;
+  obs.warn('Access denied', {
+    userId,
+    contentId,
+    organizationId: contentRecord.organizationId,
+    reason: decision.reason,
+    securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
+    severity: LOG_SEVERITY.MEDIUM,
+    eventType: LOG_EVENTS.ACCESS_CONTROL,
+  });
 
-    // Primary check (new): active subscription grants followers-only
-    // access. `minimumTierId` is passed as null — any active tier
-    // qualifies, because the content is gated to the community
-    // (followers), not to a specific paid tier.
-    const hasSubAccess = await checkSubscriptionAccess(orgId, null);
-    if (hasSubAccess) {
-      obs.info('Access granted via subscription (followers content)', {
-        userId,
-        contentId,
-        organizationId: orgId,
-        reason: 'followers_content_granted_via_subscription',
-      });
-      granted = true;
-    }
-
-    // Fallback: explicit follower row — preserves access for
-    // ex-subscribers (status=cancelled) who followed before their
-    // subscription lapsed, plus free-tier followers.
-    if (!granted) {
-      const follower = await checkFollower(orgId);
-      if (follower) {
-        obs.info('Access granted via follower (followers content)', {
-          userId,
-          contentId,
-          organizationId: orgId,
-        });
-        granted = true;
-      }
-    }
-
-    // Fallback: management membership (team implicitly has access)
-    if (!granted) {
-      const membership = await checkManagementMembership(orgId);
-      if (membership) {
-        obs.info('Access granted via management role (followers content)', {
-          userId,
-          contentId,
-          organizationId: orgId,
-          membershipRole: membership.role,
-        });
-        granted = true;
-      }
-    }
-
-    if (!granted) {
-      obs.warn('Access denied - followers-only content', {
-        userId,
-        contentId,
-        organizationId: orgId,
-        securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-        severity: LOG_SEVERITY.MEDIUM,
-        eventType: LOG_EVENTS.ACCESS_CONTROL,
-      });
-      throw new AccessDeniedError(userId, contentId, {
-        organizationId: orgId,
-        reason: 'followers_only',
-      });
-    }
-  }
-  // (c) Subscribers-only: require active subscription (with optional tier check)
-  else if (contentRecord.includedInTierId != null) {
-    if (!contentRecord.organizationId) {
-      throw new AccessDeniedError(userId, contentId, {
-        reason: 'subscribers_only_requires_org',
-      });
-    }
-
-    let granted = false;
-
-    // Primary check: active subscription to the org
-    const hasSubAccess = await checkSubscriptionAccess(
-      contentRecord.organizationId,
-      contentRecord.includedInTierId
-    );
-
-    if (hasSubAccess) {
-      granted = true;
-    }
-
-    // Fallback: individual purchase (user may have bought it separately)
-    if (!granted) {
-      const hasPurchased = await purchaseService.verifyPurchase(
-        contentId,
-        userId
-      );
-      if (hasPurchased) {
-        obs.info('Access granted via purchase (subscriber content)', {
-          userId,
-          contentId,
-        });
-        granted = true;
-      }
-    }
-
-    // Fallback: management membership (owner/admin/creator only)
-    // Regular 'member' and 'subscriber' roles must subscribe or purchase
-    if (!granted) {
-      const membership = await checkManagementMembership(
-        contentRecord.organizationId
-      );
-      if (membership) {
-        obs.info(
-          'Access granted via management membership (subscriber content)',
-          {
-            userId,
-            contentId,
-            organizationId: contentRecord.organizationId,
-            membershipRole: membership.role,
-          }
-        );
-        granted = true;
-      }
-    }
-
-    if (!granted) {
-      obs.warn('Access denied - subscriber-only content', {
-        userId,
-        contentId,
-        organizationId: contentRecord.organizationId,
-        includedInTierId: contentRecord.includedInTierId,
-        securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-        severity: LOG_SEVERITY.MEDIUM,
-        eventType: LOG_EVENTS.ACCESS_CONTROL,
-      });
-      throw new AccessDeniedError(userId, contentId, {
-        organizationId: contentRecord.organizationId,
-        reason: 'subscribers_only',
-      });
-    }
-  }
-  // (c) Paid content: check purchase, then subscription, then membership
-  else if (contentRecord.priceCents && contentRecord.priceCents > 0) {
-    // Paid content - check purchase via PurchaseService
-    const hasPurchased = await purchaseService.verifyPurchase(
-      contentId,
-      userId
-    );
-
-    if (hasPurchased) {
-      obs.info('Access granted via purchase', {
-        userId,
-        contentId,
-      });
-    } else {
-      // No purchase — check subscription tier access ONLY if content
-      // is also subscriber-gated (has minimumTierId). Pure paid content
-      // (accessType='paid', no minimumTierId) requires a purchase.
-      let hasSubscriptionAccess = false;
-
-      if (contentRecord.organizationId && contentRecord.includedInTierId) {
-        hasSubscriptionAccess = await checkSubscriptionAccess(
-          contentRecord.organizationId,
-          contentRecord.includedInTierId
-        );
-      }
-
-      if (!hasSubscriptionAccess) {
-        // No subscription access — fall back to org membership check
-        const contentOrgId = contentRecord.organizationId;
-
-        if (!contentOrgId) {
-          // Personal content with no org - requires purchase
-          obs.warn('Access denied - paid personal content requires purchase', {
-            userId,
-            contentId,
-            priceCents: contentRecord.priceCents,
-            securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-            severity: LOG_SEVERITY.MEDIUM,
-            eventType: LOG_EVENTS.ACCESS_CONTROL,
-          });
-          throw new AccessDeniedError(userId, contentId, {
-            priceCents: contentRecord.priceCents,
-          });
-        }
-
-        // Check if user is a management member (owner/admin/creator)
-        // Regular 'member' and 'subscriber' roles must purchase or subscribe
-        const membership = await checkManagementMembership(contentOrgId);
-
-        if (!membership) {
-          obs.warn('Access denied - no purchase and not management member', {
-            userId,
-            contentId,
-            organizationId: contentOrgId,
-            priceCents: contentRecord.priceCents,
-            securityEvent: LOG_EVENTS.UNAUTHORIZED_ACCESS,
-            severity: LOG_SEVERITY.MEDIUM,
-            eventType: LOG_EVENTS.ACCESS_CONTROL,
-          });
-          throw new AccessDeniedError(userId, contentId, {
-            priceCents: contentRecord.priceCents,
-            organizationId: contentOrgId,
-          });
-        }
-
-        obs.info('Access granted via management membership', {
-          userId,
-          contentId,
-          organizationId: contentOrgId,
-          membershipRole: membership.role,
-        });
-      } // end if (!hasSubscriptionAccess)
-    }
-  }
-  // (d) Free content: grant access
-  else {
-    obs.info('Free content - access granted', {
-      contentId,
-    });
-  }
+  throw new AccessDeniedError(userId, contentId, {
+    reason: decision.reason,
+    ...(contentRecord.organizationId
+      ? { organizationId: contentRecord.organizationId }
+      : {}),
+  });
 }

--- a/packages/access/src/services/content-access/entitlements-resolver.ts
+++ b/packages/access/src/services/content-access/entitlements-resolver.ts
@@ -1,0 +1,260 @@
+/**
+ * Entitlement read-resolution for the access decision (Codex-2pryk.2.3 · WP-2).
+ *
+ * The greenfield access core (SPEC §6.2 / §6.3, HARDENING §C). These are the
+ * DB-backed reads the {@link import('@codex/shared-types').EntitlementResolver}
+ * composes over: stored `entitlements` grants + the DERIVED tier-subscription
+ * grant. They are PURE functions taking a query client so they run identically
+ * against the base `db` (boolean `canView` path) and against a read-only `tx`
+ * (the `getStreamingUrl` transaction) — mirroring the `access-decision.ts`
+ * collaborator style.
+ *
+ * ## Stored vs derived (SPEC §6.2 [H])
+ * - **Stored** grants live in `entitlements` (`content_purchase` / `course_purchase`
+ *   / `course_subscription` / `grant`). WP-6 writes them; until then the table is
+ *   sparsely populated, so these reads simply return no rows and the existing
+ *   purchase/subscription sources in `access-decision.ts` still decide — the
+ *   forward-compatible UNION the WP-2 brief mandates.
+ * - **Derived** tier-subscription access is computed LIVE from the user's active
+ *   `subscriptions` row ∩ the explicit `course_tier_access(courseId, tierId)` join
+ *   — never materialised, so a tier change (or lapse) takes effect instantly and
+ *   can never strand a stale grant. `course_tier_access` is an EXACT tier→course
+ *   grant (SPEC §7: "not just min-tier"), so membership is by explicit `tierId`,
+ *   NOT by `sortOrder ≥` (that "and above" semantic is content-only, via
+ *   `content.includedInTierId`).
+ *
+ * ## No N+1 on Neon HTTP (HARDENING §D / §E / §12)
+ * {@link resolveCourseEntitlementsBatch} answers N courses in a BOUNDED number of
+ * round-trips (two `SELECT`s) regardless of N — the dashboard/library grid gate.
+ * Every user-scoped grant read is a `revokedAt IS NULL` + not-expired filter, so
+ * revocation is instant.
+ */
+
+import { SUBSCRIPTION_STATUS } from '@codex/constants';
+import type { DatabaseClient } from '@codex/database';
+import {
+  courseStages,
+  courseTierAccess,
+  entitlements,
+  stagePractices,
+  subscriptions,
+} from '@codex/database/schema';
+import { and, eq, gt, inArray, isNull, or } from 'drizzle-orm';
+
+/**
+ * Read-only query client. Both the base `DatabaseClient` and the transaction
+ * client expose `.select` / `.query`, so a resolver read runs under either
+ * without an `as any` cast (`feedback_tx_callback_type_derivation`).
+ */
+type Tx = Parameters<Parameters<DatabaseClient['transaction']>[0]>[0];
+export type AccessQueryClient = DatabaseClient | Tx;
+
+/** Subscription statuses that currently grant access (mirrors access-decision.ts). */
+const GRANTING_SUBSCRIPTION_STATUSES: string[] = [
+  SUBSCRIPTION_STATUS.ACTIVE,
+  SUBSCRIPTION_STATUS.CANCELLING,
+];
+
+/**
+ * `entitlements.source` values that grant a CONTENT resource (SPEC §6.2). Course
+ * purchases/subscriptions never target content; `tier_subscription` is derived,
+ * never stored. `grant` is the manual admin grant.
+ */
+const CONTENT_GRANT_SOURCES: string[] = ['content_purchase', 'grant'];
+
+/**
+ * `entitlements.source` values that grant a COURSE resource (SPEC §6.2). Note
+ * `course_subscription` is STORED (WP-6 writes it in the self-heal helper) — so
+ * a live course-subscription grant is read here, not derived. `grant` is manual.
+ */
+const COURSE_GRANT_SOURCES: string[] = [
+  'course_purchase',
+  'course_subscription',
+  'grant',
+];
+
+/** A stored grant is live when not revoked and not past its optional expiry. */
+function liveGrant(now: Date) {
+  return and(
+    isNull(entitlements.revokedAt),
+    or(isNull(entitlements.expiresAt), gt(entitlements.expiresAt, now))
+  );
+}
+
+/**
+ * Does the user hold a live STORED entitlement over this content? (`content_purchase`
+ * / `grant`.) Additive to `PurchaseService.verifyPurchase` — the two are unioned by
+ * the caller (forward-compatible: purchases still authoritative until WP-6 writes
+ * grants).
+ */
+export async function hasStoredContentEntitlement(
+  db: AccessQueryClient,
+  userId: string,
+  contentId: string
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: entitlements.id })
+    .from(entitlements)
+    .where(
+      and(
+        eq(entitlements.userId, userId),
+        eq(entitlements.contentId, contentId),
+        inArray(entitlements.source, CONTENT_GRANT_SOURCES),
+        liveGrant(new Date())
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/** Does the user hold a live STORED entitlement over this course? */
+async function hasStoredCourseEntitlement(
+  db: AccessQueryClient,
+  userId: string,
+  courseId: string
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: entitlements.id })
+    .from(entitlements)
+    .where(
+      and(
+        eq(entitlements.userId, userId),
+        eq(entitlements.courseId, courseId),
+        inArray(entitlements.source, COURSE_GRANT_SOURCES),
+        liveGrant(new Date())
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Does the user's active subscription unlock this course via an EXPLICIT
+ * `course_tier_access(courseId, tierId)` grant? Derived live — never a stored row.
+ */
+async function hasDerivedCourseTierAccess(
+  db: AccessQueryClient,
+  userId: string,
+  courseId: string
+): Promise<boolean> {
+  const rows = await db
+    .select({ courseId: courseTierAccess.courseId })
+    .from(courseTierAccess)
+    .innerJoin(subscriptions, eq(subscriptions.tierId, courseTierAccess.tierId))
+    .where(
+      and(
+        eq(courseTierAccess.courseId, courseId),
+        eq(subscriptions.userId, userId),
+        inArray(subscriptions.status, GRANTING_SUBSCRIPTION_STATUSES),
+        gt(subscriptions.currentPeriodEnd, new Date())
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Does the user hold ANY course entitlement — stored (purchase / course-sub /
+ * grant) OR derived tier (SPEC §6.3 `hasCourseEntitlement`)? Backs
+ * `canEnterCourse` and the "via a course you own" content arm. The two reads are
+ * independent, so they run in parallel.
+ */
+export async function hasCourseEntitlement(
+  db: AccessQueryClient,
+  userId: string,
+  courseId: string
+): Promise<boolean> {
+  const [stored, derived] = await Promise.all([
+    hasStoredCourseEntitlement(db, userId, courseId),
+    hasDerivedCourseTierAccess(db, userId, courseId),
+  ]);
+  return stored || derived;
+}
+
+/**
+ * BATCHED course-entitlement resolution — the set of course ids (from `courseIds`)
+ * the user may enter, in exactly TWO `SELECT`s regardless of N (no N+1 on Neon
+ * HTTP; HARDENING §D/§E/§12). Backs `canEnterCoursesBatch` (dashboard/library grid)
+ * and, unioned once, the "via a course you own" content arm.
+ */
+export async function resolveCourseEntitlementsBatch(
+  db: AccessQueryClient,
+  userId: string,
+  courseIds: readonly string[]
+): Promise<ReadonlySet<string>> {
+  const entitled = new Set<string>();
+  if (courseIds.length === 0) return entitled;
+
+  const ids = [...courseIds];
+  const now = new Date();
+
+  // Query 1 — stored grants over any of the requested courses.
+  const stored = await db
+    .select({ courseId: entitlements.courseId })
+    .from(entitlements)
+    .where(
+      and(
+        eq(entitlements.userId, userId),
+        inArray(entitlements.courseId, ids),
+        inArray(entitlements.source, COURSE_GRANT_SOURCES),
+        liveGrant(now)
+      )
+    );
+  for (const row of stored) {
+    if (row.courseId) entitled.add(row.courseId);
+  }
+
+  // Query 2 — derived tier grants: any requested course whose explicit tier
+  // grant intersects an active subscription of this user.
+  const derived = await db
+    .select({ courseId: courseTierAccess.courseId })
+    .from(courseTierAccess)
+    .innerJoin(subscriptions, eq(subscriptions.tierId, courseTierAccess.tierId))
+    .where(
+      and(
+        inArray(courseTierAccess.courseId, ids),
+        eq(subscriptions.userId, userId),
+        inArray(subscriptions.status, GRANTING_SUBSCRIPTION_STATUSES),
+        gt(subscriptions.currentPeriodEnd, now)
+      )
+    );
+  for (const row of derived) {
+    if (row.courseId) entitled.add(row.courseId);
+  }
+
+  return entitled;
+}
+
+/**
+ * Is this content reachable through a course the user is entitled to? (SPEC §6.3
+ * — the `courseOnly` arm and the standalone "via a course you own" fallthrough.)
+ *
+ * A practice IS a `content` row joined to a course via `stage_practices ⋈
+ * course_stages`; soft-deleted stages are excluded. Bounded: ONE query to find
+ * the containing courses, then the batched two-query entitlement resolve — three
+ * round-trips total, independent of how many courses share the content.
+ */
+export async function contentReachableViaOwnedCourse(
+  db: AccessQueryClient,
+  userId: string,
+  contentId: string
+): Promise<boolean> {
+  const courseRows = await db
+    .select({ courseId: courseStages.courseId })
+    .from(stagePractices)
+    .innerJoin(courseStages, eq(stagePractices.stageId, courseStages.id))
+    .where(
+      and(
+        eq(stagePractices.contentId, contentId),
+        isNull(courseStages.deletedAt)
+      )
+    );
+
+  const courseIds = [
+    ...new Set(courseRows.map((row) => row.courseId).filter(Boolean)),
+  ];
+  if (courseIds.length === 0) return false;
+
+  const entitled = await resolveCourseEntitlementsBatch(db, userId, courseIds);
+  return entitled.size > 0;
+}

--- a/packages/access/src/services/entitlements-service.ts
+++ b/packages/access/src/services/entitlements-service.ts
@@ -1,0 +1,110 @@
+/**
+ * EntitlementsService — READ resolution of stored grants (Codex-2pryk.2.3 · WP-2).
+ *
+ * The registry-facing read surface over the `entitlements` grant table (SPEC
+ * §6.2). It answers "does user U hold a live grant over resource R?" and lists a
+ * user's live grants mapped back to the frozen
+ * {@link import('@codex/shared-types').Entitlement} domain shape.
+ *
+ * READ-ONLY. The WRITE path (grant-on-purchase / grant-on-course-subscription /
+ * manual grant) is WP-6 — this service never inserts. The access decision itself
+ * (`canView` / `canEnterCourse`) lives on {@link ContentAccessService}, co-located
+ * with `getStreamingUrl`; both this service and the resolver share the same pure
+ * reads in `content-access/entitlements-resolver.ts`, so a grant reads identically
+ * wherever it's consulted.
+ *
+ * The `entitlements` table is a SPLIT-FK (`contentId` / `courseId`, exactly one
+ * set); this service maps `(contentId ?? courseId)` back to the domain
+ * `{ resourceType, resourceId }` pair so callers never touch the split.
+ */
+
+import { toIso } from '@codex/database';
+import { entitlements } from '@codex/database/schema';
+import { BaseService } from '@codex/service-errors';
+import type { Entitlement } from '@codex/shared-types';
+import { and, eq, gt, isNull, or } from 'drizzle-orm';
+import {
+  hasCourseEntitlement,
+  hasStoredContentEntitlement,
+  resolveCourseEntitlementsBatch,
+} from './content-access/entitlements-resolver';
+
+/** Map a split-FK DB row to the frozen `Entitlement` domain shape. */
+function toDomainEntitlement(
+  row: typeof entitlements.$inferSelect
+): Entitlement {
+  const isCourse = row.courseId != null;
+  return {
+    id: row.id,
+    userId: row.userId,
+    organizationId: row.organizationId,
+    resourceType: isCourse ? 'course' : 'content',
+    // Split-FK CHECK guarantees exactly one of contentId/courseId is set.
+    resourceId: (isCourse ? row.courseId : row.contentId) as string,
+    source: row.source as Entitlement['source'],
+    sourceRef: row.sourceRef,
+    grantedAt: toIso(row.grantedAt),
+    expiresAt: row.expiresAt ? toIso(row.expiresAt) : null,
+    revokedAt: row.revokedAt ? toIso(row.revokedAt) : null,
+  };
+}
+
+export class EntitlementsService extends BaseService {
+  /**
+   * Does the user hold a live STORED entitlement over this content
+   * (`content_purchase` / `grant`)? Additive to `PurchaseService.verifyPurchase`
+   * — the resolver unions them.
+   */
+  async hasContentEntitlement(
+    userId: string,
+    contentId: string
+  ): Promise<boolean> {
+    return hasStoredContentEntitlement(this.db, userId, contentId);
+  }
+
+  /**
+   * Does the user hold ANY course entitlement — stored (purchase / course-sub /
+   * grant) OR derived tier (active subscription ∩ `course_tier_access`)?
+   */
+  async hasCourseEntitlement(
+    userId: string,
+    courseId: string
+  ): Promise<boolean> {
+    return hasCourseEntitlement(this.db, userId, courseId);
+  }
+
+  /**
+   * Batched course-entitlement resolution — the set of the requested course ids
+   * the user may enter, in two `SELECT`s regardless of N (no N+1 on Neon HTTP).
+   */
+  async resolveCourseEntitlements(
+    userId: string,
+    courseIds: readonly string[]
+  ): Promise<ReadonlySet<string>> {
+    return resolveCourseEntitlementsBatch(this.db, userId, courseIds);
+  }
+
+  /**
+   * List a user's LIVE stored grants (not revoked, not past expiry), optionally
+   * scoped to one organization, mapped to the frozen domain shape. Backs WP-7
+   * reporting and the library's course-entitlement arm. Derived tier grants are
+   * NOT materialised, so they never appear here (SPEC §6.2 [H]).
+   */
+  async getUserEntitlements(
+    userId: string,
+    organizationId?: string
+  ): Promise<Entitlement[]> {
+    const now = new Date();
+    const rows = await this.db.query.entitlements.findMany({
+      where: and(
+        eq(entitlements.userId, userId),
+        organizationId
+          ? eq(entitlements.organizationId, organizationId)
+          : undefined,
+        isNull(entitlements.revokedAt),
+        or(isNull(entitlements.expiresAt), gt(entitlements.expiresAt, now))
+      ),
+    });
+    return rows.map(toDomainEntitlement);
+  }
+}

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -6,7 +6,11 @@
  * creation of unused services and enabling proper cleanup.
  */
 
-import { AccessRevocation, ContentAccessService } from '@codex/access';
+import {
+  AccessRevocation,
+  ContentAccessService,
+  EntitlementsService,
+} from '@codex/access';
 import {
   AdminAnalyticsService,
   AdminContentManagementService,
@@ -136,6 +140,7 @@ export function createServiceRegistry(
   let _categories: CategoriesService | undefined;
   let _media: MediaItemService | undefined;
   let _access: ContentAccessService | undefined;
+  let _entitlements: EntitlementsService | undefined;
   let _imageProcessing: ImageProcessingService | undefined;
   let _organization: OrganizationService | undefined;
   let _devDomain: DevDomainService | undefined;
@@ -380,6 +385,18 @@ export function createServiceRegistry(
         });
       }
       return _access;
+    },
+
+    get entitlements() {
+      if (!_entitlements) {
+        // READ resolution of stored `entitlements` grants (Codex-2pryk.2.3).
+        // Read-only — the write path (grant-on-purchase / course-sub) is WP-6.
+        _entitlements = new EntitlementsService({
+          db: getSharedDb(),
+          environment: getEnvironment(),
+        });
+      }
+      return _entitlements;
     },
 
     get imageProcessing() {

--- a/packages/worker-utils/src/procedure/types.ts
+++ b/packages/worker-utils/src/procedure/types.ts
@@ -8,7 +8,7 @@
  * - Procedure context with full typing
  */
 
-import type { ContentAccessService } from '@codex/access';
+import type { ContentAccessService, EntitlementsService } from '@codex/access';
 import type {
   AdminAnalyticsService,
   AdminContentManagementService,
@@ -133,6 +133,12 @@ export interface ServiceRegistry {
    */
   categories: CategoriesService;
   access: ContentAccessService;
+  /**
+   * Read-resolution of stored `entitlements` grants (Codex-2pryk.2.3 · WP-2).
+   * READ-ONLY — the grant write path (purchase / course-subscription) is WP-6.
+   * The access DECISION (`canView` / `canEnterCourse`) lives on `access`.
+   */
+  entitlements: EntitlementsService;
   imageProcessing: ImageProcessingService;
 
   // Organization domain


### PR DESCRIPTION
## WP-2 — Entitlements resolver + @codex/access rewire (Epic 1, Codex-2pryk.2.3) — STACKED on #411

**Base is WP-1's branch (#411)** so this diff shows only WP-2. When #411 merges to dev, retarget this to dev.

### What landed
- **Collapse**: WP-1's two access trees (`resolveHasContentAccess` boolean + `assertStreamingAccess` throwing) refactored into thin adapters over ONE pure `decideContentAccess` core — the boolean gate and the streaming gate can no longer disagree. Branch order preserves WP-1 EXACTLY (orgless+tier deny > courseOnly > team > follower > tier > paid > free); management = per-branch fallback.
- **`EntitlementResolver`** (frozen sig): `ContentAccessService` implements `canView`/`canEnterCourse`/`canEnterCoursesBatch`. New `entitlements-resolver.ts` + `EntitlementsService` (READ-only; grant WRITE = WP-6). Registry lazy getter.
- **Additive entitlements**: tier/paid arms also grant on a live (non-revoked/non-expired) stored entitlement or owned-course — purely additive (empty tables ⇒ behaviour == WP-1; anon ⇒ free-only).
- **canEnterCourse = entitlement ONLY** (stored grant OR derived tier = active sub ∩ course_tier_access, EXACT tier match) — NOT enrollment, per SPEC §6.3 + §6.2 instant-revocation. Batch = 2 SELECTs (no N+1).

### Review (3-reviewer swarm — all SAFE-TO-STAGE)
Collapse preserves WP-1 value-for-value; additive union proven no-over-grant; canEnterCourse instant-revocation intact; J4 route-parity via the single `getStreamingUrl`→`canView` seam both routes funnel through; 17-case IDOR matrix genuine (real Neon rows).

### Forward note (WP-6, non-blocking)
N1: `course_tier_access` join trusts row integrity — WP-6 must enforce `course.org == tier.org` at the write path + a DB CHECK (prevents cross-org tier access from a malformed row).

### Verification (local, warm)
build 32/32 ✓ · typecheck 57/57 ✓ · svelte-check 0 on changed (phantom baseline) ✓ · biome 0 new ✓ · @codex/access **198 passed / 0 failed** (185 baseline + 13 new) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)