### PR TITLE
feat(web): course dashboard + in-course player (Codex-2pryk.3.2)

### DIFF
--- a/apps/web/src/lib/collections/index.ts
+++ b/apps/web/src/lib/collections/index.ts
@@ -38,7 +38,14 @@ export {
   libraryCollection,
   loadLibraryFromServer,
 } from './library';
-export { progressCollection } from './progress';
+export {
+  isPracticeComplete,
+  loadCourseCompletionsFromServer,
+  markPracticeComplete,
+  type PlaybackProgress,
+  progressCollection,
+  syncCompletionsToServer,
+} from './progress';
 // QueryClient is defined in ./query-client.ts to avoid circular dependencies.
 // Collections import it directly from there; we re-export for external consumers.
 export { queryClient } from './query-client';

--- a/apps/web/src/lib/collections/progress-sync.ts
+++ b/apps/web/src/lib/collections/progress-sync.ts
@@ -11,7 +11,11 @@
  */
 
 import { browser } from '$app/environment';
-import { getUnsyncedProgress, syncProgressToServer } from './progress';
+import {
+  getUnsyncedProgress,
+  syncCompletionsToServer,
+  syncProgressToServer,
+} from './progress';
 
 let syncInterval: ReturnType<typeof setInterval> | null = null;
 let initializedForUser: string | null = null;
@@ -20,11 +24,21 @@ let initializedForUser: string | null = null;
 const SYNC_INTERVAL_MS = 120_000;
 
 /**
+ * Flush both server-bound queues: playback position AND course completions
+ * (SPEC §11 / D-E). Completions usually persist on the mark-complete action;
+ * this loop is the retry safety net for the ones that didn't land.
+ */
+function flushToServer(): void {
+  void syncProgressToServer();
+  void syncCompletionsToServer();
+}
+
+/**
  * Start the sync interval
  */
 function startSync(): void {
   if (syncInterval) return;
-  syncInterval = setInterval(syncProgressToServer, SYNC_INTERVAL_MS);
+  syncInterval = setInterval(flushToServer, SYNC_INTERVAL_MS);
 }
 
 /**
@@ -43,12 +57,12 @@ function stopSync(): void {
 function handleVisibilityChange(): void {
   if (document.visibilityState === 'visible') {
     // Page became visible - sync and start interval
-    syncProgressToServer();
+    flushToServer();
     startSync();
   } else {
     // Page hidden - stop interval and do final sync
     stopSync();
-    syncProgressToServer();
+    flushToServer();
   }
 }
 
@@ -158,5 +172,5 @@ export function cleanupProgressSync(): void {
  * Useful for syncing after important actions like completing a video.
  */
 export async function forceSync(): Promise<void> {
-  await syncProgressToServer();
+  await Promise.all([syncProgressToServer(), syncCompletionsToServer()]);
 }

--- a/apps/web/src/lib/collections/progress.test.ts
+++ b/apps/web/src/lib/collections/progress.test.ts
@@ -4,16 +4,83 @@
  * Tests for the localStorage-backed progress collection.
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearAllProgress,
   clearProgress,
   getProgress,
+  getUnsyncedCompletions,
+  isPracticeComplete,
+  loadCourseCompletionsFromServer,
+  markPracticeComplete,
   mergeServerProgress,
   progressCollection,
   syncProgressToServer,
   updateLocalProgress,
 } from './progress';
+
+// A synchronous, Map-backed stand-in for the TanStack DB localStorage
+// collection: the real one doesn't reflect writes synchronously in jsdom, so
+// the codebase mocks `@tanstack/db` in collection tests (see library.test.ts).
+// Here `insert`/`update`/`delete` mutate the Map immediately so read-after-write
+// assertions on the store logic are deterministic. `vi.hoisted` + hoisted
+// `vi.mock` run before the imports above resolve, so the mocks are in place.
+const { mockCollection } = vi.hoisted(() => {
+  const state = new Map<string, Record<string, unknown>>();
+  return {
+    mockCollection: {
+      state,
+      insert: (item: { contentId: string }) => {
+        state.set(item.contentId, { ...item });
+      },
+      update: (
+        key: string,
+        updater: (draft: Record<string, unknown>) => void
+      ) => {
+        const current = state.get(key);
+        if (!current) return;
+        const draft = { ...current };
+        updater(draft);
+        state.set(key, draft);
+      },
+      delete: (key: string) => {
+        state.delete(key);
+      },
+    },
+  };
+});
+
+vi.mock('@tanstack/db', () => ({
+  createCollection: () => mockCollection,
+  localStorageCollectionOptions: (options: unknown) => options,
+}));
+
+vi.mock('$app/environment', () => ({
+  browser: true,
+  dev: false,
+  building: false,
+  version: 'test',
+}));
+
+vi.mock('$lib/remote/library.remote', () => ({
+  savePlaybackProgress: vi.fn(async () => ({})),
+  getPlaybackProgress: vi.fn(async () => ({
+    positionSeconds: 0,
+    durationSeconds: 0,
+    completed: false,
+    updatedAt: null,
+  })),
+}));
+
+// The mark-complete command is exercised by its own contract; here the store
+// unit test mocks it so the optimistic write is hermetic (no network).
+vi.mock('$lib/remote/journeys.remote', () => ({
+  markPracticeCompleted: vi.fn(async (input: { contentId: string }) => ({
+    contentId: input.contentId,
+    completedAt: new Date().toISOString(),
+    source: 'manual' as const,
+  })),
+}));
 
 describe('collections/progress', () => {
   describe('progressCollection', () => {
@@ -108,6 +175,77 @@ describe('collections/progress', () => {
 
     it('accepts no arguments', () => {
       expect(clearAllProgress.length).toBe(0);
+    });
+  });
+
+  // ── Course completion (F19 store extension · SPEC §11 / D-E) ───────────────
+  describe('course completion', () => {
+    const ID = 'aaaaaaaa-0000-4000-8000-000000000001';
+    beforeEach(() => clearAllProgress());
+
+    it('markPracticeComplete optimistically writes the completion row', () => {
+      markPracticeComplete(ID, 'manual');
+      expect(isPracticeComplete(ID)).toBe(true);
+      const row = getProgress(ID);
+      expect(row?.practiceCompletedAt).toBeTruthy();
+      expect(row?.practiceCompletionSource).toBe('manual');
+      // Optimistic: not yet confirmed by the server (sync runs async).
+      expect(row?.practiceCompletionSyncedAt).toBeNull();
+    });
+
+    it('records the completion source (auto for media finish)', () => {
+      markPracticeComplete(ID, 'auto');
+      expect(getProgress(ID)?.practiceCompletionSource).toBe('auto');
+    });
+
+    it('is idempotent — a second mark does not overwrite the first', () => {
+      markPracticeComplete(ID, 'auto');
+      const first = getProgress(ID)?.practiceCompletedAt;
+      markPracticeComplete(ID, 'manual');
+      const row = getProgress(ID);
+      expect(row?.practiceCompletedAt).toBe(first);
+      expect(row?.practiceCompletionSource).toBe('auto');
+    });
+
+    it('surfaces unsynced completions until they persist', () => {
+      markPracticeComplete(ID, 'manual');
+      expect(getUnsyncedCompletions().map((e) => e.contentId)).toContain(ID);
+    });
+
+    it('does not treat playback-only progress as a completion', () => {
+      updateLocalProgress(ID, 10, 100);
+      expect(isPracticeComplete(ID)).toBe(false);
+      expect(getUnsyncedCompletions()).toHaveLength(0);
+    });
+
+    it('loadCourseCompletionsFromServer hydrates rows as already-synced', () => {
+      loadCourseCompletionsFromServer([
+        {
+          contentId: ID,
+          completedAt: '2026-07-01T00:00:00.000Z',
+          source: 'auto',
+        },
+      ]);
+      const row = getProgress(ID);
+      expect(row?.practiceCompletedAt).toBe('2026-07-01T00:00:00.000Z');
+      expect(row?.practiceCompletionSource).toBe('auto');
+      expect(row?.practiceCompletionSyncedAt).toBeTruthy();
+      // Server-known ⇒ not queued for re-sync.
+      expect(getUnsyncedCompletions()).toHaveLength(0);
+    });
+
+    it('preserves existing playback fields when hydrating a completion', () => {
+      updateLocalProgress(ID, 42, 100);
+      loadCourseCompletionsFromServer([
+        {
+          contentId: ID,
+          completedAt: '2026-07-01T00:00:00.000Z',
+          source: 'manual',
+        },
+      ]);
+      const row = getProgress(ID);
+      expect(row?.positionSeconds).toBe(42);
+      expect(row?.practiceCompletedAt).toBe('2026-07-01T00:00:00.000Z');
     });
   });
 });

--- a/apps/web/src/lib/collections/progress.ts
+++ b/apps/web/src/lib/collections/progress.ts
@@ -14,16 +14,36 @@
 import { VIDEO_PROGRESS } from '@codex/constants';
 import { createCollection, localStorageCollectionOptions } from '@tanstack/db';
 import { browser } from '$app/environment';
+import type {
+  CompletionSource,
+  PracticeCompletionRecord,
+} from '$lib/journeys/types';
 import { logger } from '$lib/observability';
+import { markPracticeCompleted } from '$lib/remote/journeys.remote';
 import {
   getPlaybackProgress,
   savePlaybackProgress,
 } from '$lib/remote/library.remote';
 
 /**
- * Playback progress data structure
+ * Playback + course-completion progress for one content item.
+ *
+ * F19 (HARDENING §E): this is the SINGLE progress store — the course dashboard
+ * / in-course player extend it rather than forking a parallel store. Two
+ * distinct concerns share one row (keyed by `contentId`):
+ *
+ *   1. PLAYBACK (`positionSeconds`/`completed`/`percentComplete`) — the resume
+ *      heartbeat. `completed` flips at the 95% `VIDEO_PROGRESS.COMPLETION_THRESHOLD`
+ *      and is a WATCHED/RESUME signal only.
+ *   2. COURSE COMPLETION (`practiceCompleted*`) — the `practice_completions`
+ *      row, the SOURCE OF TRUTH for course progress (SPEC §11 / D-E). Written
+ *      explicitly for `written` practices and auto on genuine 100% finish for
+ *      media. NEVER derived from the 95% playback flag.
+ *
+ * The completion fields are optional so pre-existing localStorage rows (and the
+ * playback-only `updateLocalProgress` insert path) remain valid.
  */
-interface PlaybackProgress {
+export interface PlaybackProgress {
   contentId: string;
   positionSeconds: number;
   durationSeconds: number;
@@ -31,6 +51,16 @@ interface PlaybackProgress {
   percentComplete: number;
   updatedAt: string;
   syncedAt: string | null; // null = not yet synced to server
+  /**
+   * ISO timestamp of the `practice_completions` row (source of truth). Set =
+   * this practice is complete; absent/null = not complete. Distinct from the
+   * 95% `completed` playback flag.
+   */
+  practiceCompletedAt?: string | null;
+  /** How the completion was recorded — 'manual' (explicit) or 'auto' (finish). */
+  practiceCompletionSource?: CompletionSource | null;
+  /** null = completion written locally but not yet persisted server-side. */
+  practiceCompletionSyncedAt?: string | null;
 }
 
 /**
@@ -192,6 +222,150 @@ export async function syncProgressToServer(): Promise<void> {
         error: error instanceof Error ? error.message : String(error),
       });
       // Will retry next sync
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Course completion (practice_completions — SPEC §11 / D-E)
+//
+// The completion ROW is the source of truth for course progress, kept in the
+// same store as playback (F19). Completion is a once-per-user event: an explicit
+// "Mark complete" for written practices, an auto-write on genuine 100% finish
+// for media. Optimistic: mutate locally now, persist via the mark-complete
+// command; `syncCompletionsToServer` retries the ones that didn't land.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Whether this content has a completion row (locally or synced). */
+export function isPracticeComplete(contentId: string): boolean {
+  return Boolean(progressCollection?.state.get(contentId)?.practiceCompletedAt);
+}
+
+/**
+ * Mark a practice complete (optimistic). Idempotent — completion is
+ * once-per-user, so a second call for an already-complete practice is a no-op
+ * (mirrors the `uq_practice_completion_user_content` unique index). Writes the
+ * store immediately, then fires the server write; failures are retried by
+ * `syncCompletionsToServer`.
+ *
+ * @param source 'manual' for an explicit action, 'auto' for a media finish.
+ */
+export function markPracticeComplete(
+  contentId: string,
+  source: CompletionSource = 'manual'
+): void {
+  if (!progressCollection) return;
+  const now = new Date().toISOString();
+  const existing = progressCollection.state.get(contentId);
+
+  if (existing) {
+    if (existing.practiceCompletedAt) return; // already complete — idempotent
+    progressCollection.update(contentId, (draft) => {
+      draft.practiceCompletedAt = now;
+      draft.practiceCompletionSource = source;
+      draft.practiceCompletionSyncedAt = null;
+    });
+  } else {
+    progressCollection.insert({
+      contentId,
+      positionSeconds: 0,
+      durationSeconds: 0,
+      completed: false,
+      percentComplete: 0,
+      updatedAt: now,
+      syncedAt: null,
+      practiceCompletedAt: now,
+      practiceCompletionSource: source,
+      practiceCompletionSyncedAt: null,
+    });
+  }
+
+  // Fire the server write; retried on failure by syncCompletionsToServer.
+  void syncCompletionsToServer();
+}
+
+/** Completion entries written locally but not yet persisted server-side. */
+export function getUnsyncedCompletions(): PlaybackProgress[] {
+  if (!progressCollection) return [];
+  const all: PlaybackProgress[] = [];
+  progressCollection.state.forEach((value) => {
+    if (value.practiceCompletedAt && !value.practiceCompletionSyncedAt) {
+      all.push(value);
+    }
+  });
+  return all;
+}
+
+/**
+ * Persist locally-marked completions to the server. Mirrors
+ * `syncProgressToServer`: retry on transient failure, and on a 403 (access
+ * revoked) mark the entry synced so we stop hammering the endpoint — the local
+ * completion is preserved and the user learns of the change on next navigation.
+ */
+export async function syncCompletionsToServer(): Promise<void> {
+  if (!browser || !progressCollection) return;
+
+  for (const entry of getUnsyncedCompletions()) {
+    try {
+      await markPracticeCompleted({
+        contentId: entry.contentId,
+        source: entry.practiceCompletionSource ?? 'manual',
+      });
+      progressCollection.update(entry.contentId, (draft) => {
+        draft.practiceCompletionSyncedAt = new Date().toISOString();
+      });
+    } catch (error) {
+      if (isForbiddenError(error)) {
+        logger.info('Completion save forbidden — access revoked, dropping', {
+          contentId: entry.contentId,
+        });
+        progressCollection.update(entry.contentId, (draft) => {
+          draft.practiceCompletionSyncedAt = new Date().toISOString();
+        });
+        continue;
+      }
+      logger.error('Failed to sync completion', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Will retry next sync.
+    }
+  }
+}
+
+/**
+ * Hydrate the store with the server's known completions (the
+ * `practice_completions` rows). Reconciles into the single store so live
+ * queries over the dashboard / player reflect server truth on first paint.
+ * Server rows are authoritative and land as already-synced; local unsynced
+ * completions (never seen by the server yet) are left untouched.
+ */
+export function loadCourseCompletionsFromServer(
+  completions: readonly PracticeCompletionRecord[]
+): void {
+  if (!progressCollection) return;
+  const now = new Date().toISOString();
+
+  for (const record of completions) {
+    const existing = progressCollection.state.get(record.contentId);
+    if (existing) {
+      progressCollection.update(record.contentId, (draft) => {
+        draft.practiceCompletedAt = record.completedAt;
+        draft.practiceCompletionSource = record.source;
+        draft.practiceCompletionSyncedAt = now;
+      });
+    } else {
+      progressCollection.insert({
+        contentId: record.contentId,
+        positionSeconds: 0,
+        durationSeconds: 0,
+        completed: false,
+        percentComplete: 0,
+        updatedAt: record.completedAt,
+        syncedAt: now,
+        practiceCompletedAt: record.completedAt,
+        practiceCompletionSource: record.source,
+        practiceCompletionSyncedAt: now,
+      });
     }
   }
 }

--- a/apps/web/src/lib/components/journeys/CurriculumMap.svelte
+++ b/apps/web/src/lib/components/journeys/CurriculumMap.svelte
@@ -1,0 +1,223 @@
+<!--
+  @component CurriculumMap
+
+  The journey dashboard's curriculum: ordered stages (gates), each with its
+  concurrent practice pool and a per-stage progress ring. Practices link into
+  the in-course player and show completion state (the `practice_completions`
+  row — source of truth). Presentational: completion + rollup are supplied.
+
+  @prop {JourneyStage[]} stages - Ordered curriculum from the server load.
+  @prop {ReadonlySet<string>} completedIds - Content ids with a completion row.
+  @prop {CourseRollup} rollup - Per-stage + overall counts (computed by caller).
+  @prop {string} courseSlug - For building /journeys/{slug}/practice/{slug} hrefs.
+-->
+<script lang="ts">
+  import {
+    CheckCircleIcon,
+    CircleIcon,
+    FileTextIcon,
+    MusicIcon,
+    VideoIcon,
+  } from '$lib/components/ui/Icon';
+  import type { CourseRollup } from '$lib/journeys/rollup';
+  import type {
+    JourneyPractice,
+    JourneyStage,
+    PracticeContentType,
+  } from '$lib/journeys/types';
+  import ProgressRing from './ProgressRing.svelte';
+
+  interface Props {
+    stages: JourneyStage[];
+    completedIds: ReadonlySet<string>;
+    rollup: CourseRollup;
+    courseSlug: string;
+  }
+
+  const { stages, completedIds, rollup, courseSlug }: Props = $props();
+
+  const orderedStages = $derived(
+    [...stages].sort((a, b) => a.sortOrder - b.sortOrder)
+  );
+
+  function iconFor(type: PracticeContentType) {
+    if (type === 'video') return VideoIcon;
+    if (type === 'audio') return MusicIcon;
+    return FileTextIcon;
+  }
+
+  function practiceHref(practice: JourneyPractice): string {
+    return `/journeys/${courseSlug}/practice/${practice.slug ?? practice.contentId}`;
+  }
+
+  const EMPTY_COUNTS = { done: 0, total: 0, percent: 0 };
+</script>
+
+<div class="curriculum">
+  {#each orderedStages as stage, stageIndex (stage.id)}
+    {@const counts = rollup.byStage.get(stage.id) ?? EMPTY_COUNTS}
+    {@const orderedPractices = [...stage.practices].sort(
+      (a, b) => a.sortOrder - b.sortOrder
+    )}
+    <section class="stage">
+      <header class="stage__header">
+        <div class="stage__heading">
+          <span class="stage__index">Stage {stageIndex + 1}</span>
+          <h2 class="stage__name">{stage.name}</h2>
+          {#if stage.gloss}
+            <p class="stage__gloss">{stage.gloss}</p>
+          {/if}
+        </div>
+        <div class="stage__progress">
+          <ProgressRing
+            percent={counts.percent}
+            size="var(--space-14)"
+            ariaLabel="{stage.name}: {counts.done} of {counts.total} practices complete"
+          />
+          <span class="stage__count">{counts.done}/{counts.total}</span>
+        </div>
+      </header>
+
+      <ul class="practices">
+        {#each orderedPractices as practice (practice.contentId)}
+          {@const done = completedIds.has(practice.contentId)}
+          {@const Icon = iconFor(practice.contentType)}
+          <li class="practice" class:practice--done={done}>
+            <a class="practice__link" href={practiceHref(practice)}>
+              <span class="practice__status" aria-hidden="true">
+                {#if done}
+                  <CheckCircleIcon />
+                {:else}
+                  <CircleIcon />
+                {/if}
+              </span>
+              <span class="practice__type" aria-hidden="true"><Icon /></span>
+              <span class="practice__title">{practice.title}</span>
+              <span class="practice__meta">
+                {#if done}Complete{:else}{practice.contentType}{/if}
+              </span>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .curriculum {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+  }
+
+  .stage__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding-bottom: var(--space-3);
+    margin-bottom: var(--space-4);
+    border-bottom: var(--border-width) var(--border-style) var(--color-border-subtle);
+  }
+
+  .stage__index {
+    display: block;
+    font-size: var(--text-xs);
+    text-transform: var(--text-transform-label);
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+  }
+
+  .stage__name {
+    margin: var(--space-0-5) 0 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    color: var(--color-heading);
+  }
+
+  .stage__gloss {
+    margin: var(--space-1) 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    max-width: 52ch;
+  }
+
+  .stage__progress {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-1);
+    flex-shrink: 0;
+  }
+
+  .stage__count {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  .practices {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .practice__link {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-card);
+    color: var(--color-text);
+    text-decoration: none;
+    transition:
+      background-color var(--duration-fast) ease,
+      transform var(--duration-fast) ease;
+  }
+
+  .practice__link:hover {
+    background: var(--color-surface-secondary);
+  }
+
+  .practice__link:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .practice__status {
+    display: inline-flex;
+    color: var(--color-text-muted);
+  }
+
+  .practice--done .practice__status {
+    color: var(--color-success);
+  }
+
+  .practice__type {
+    display: inline-flex;
+    color: var(--color-text-muted);
+  }
+
+  .practice__title {
+    flex: 1;
+    font-size: var(--text-base);
+    color: var(--color-heading);
+  }
+
+  .practice--done .practice__title {
+    color: var(--color-text-secondary);
+  }
+
+  .practice__meta {
+    font-size: var(--text-xs);
+    text-transform: var(--text-transform-meta);
+    color: var(--color-text-muted);
+  }
+
+  .practice--done .practice__meta {
+    color: var(--color-success);
+  }
+</style>

--- a/apps/web/src/lib/components/journeys/PracticePlaylist.svelte
+++ b/apps/web/src/lib/components/journeys/PracticePlaylist.svelte
@@ -1,0 +1,174 @@
+<!--
+  @component PracticePlaylist
+
+  The in-course player's left rail: the whole course sequence grouped by stage,
+  the current practice highlighted, completion state per row, each linking to
+  its practice page. Presentational — completion set + current id are supplied.
+
+  @prop {PlaylistEntry[]} playlist - Ordered course sequence from the load.
+  @prop {ReadonlySet<string>} completedIds - Content ids with a completion row.
+  @prop {string} currentContentId - The practice open in the working pane.
+  @prop {string} courseSlug - For building practice hrefs.
+-->
+<script lang="ts">
+  import {
+    CheckCircleIcon,
+    CircleIcon,
+    FileTextIcon,
+    MusicIcon,
+    VideoIcon,
+  } from '$lib/components/ui/Icon';
+  import type { PlaylistEntry, PracticeContentType } from '$lib/journeys/types';
+
+  interface Props {
+    playlist: PlaylistEntry[];
+    completedIds: ReadonlySet<string>;
+    currentContentId: string;
+    courseSlug: string;
+  }
+
+  const { playlist, completedIds, currentContentId, courseSlug }: Props =
+    $props();
+
+  interface Group {
+    stageId: string;
+    stageName: string;
+    entries: PlaylistEntry[];
+  }
+
+  // Group the flattened playlist by stage, preserving order.
+  const groups = $derived.by(() => {
+    const out: Group[] = [];
+    for (const entry of playlist) {
+      let group = out.at(-1);
+      if (!group || group.stageId !== entry.stageId) {
+        group = {
+          stageId: entry.stageId,
+          stageName: entry.stageName,
+          entries: [],
+        };
+        out.push(group);
+      }
+      group.entries.push(entry);
+    }
+    return out;
+  });
+
+  function iconFor(type: PracticeContentType) {
+    if (type === 'video') return VideoIcon;
+    if (type === 'audio') return MusicIcon;
+    return FileTextIcon;
+  }
+
+  function entryHref(entry: PlaylistEntry): string {
+    return `/journeys/${courseSlug}/practice/${entry.slug ?? entry.contentId}`;
+  }
+</script>
+
+<nav class="playlist" aria-label="Course practices">
+  {#each groups as group (group.stageId)}
+    <div class="playlist__group">
+      <h2 class="playlist__stage">{group.stageName}</h2>
+      <ul class="playlist__items">
+        {#each group.entries as entry (entry.contentId)}
+          {@const done = completedIds.has(entry.contentId)}
+          {@const current = entry.contentId === currentContentId}
+          {@const Icon = iconFor(entry.contentType)}
+          <li>
+            <a
+              class="item"
+              class:item--current={current}
+              class:item--done={done}
+              href={entryHref(entry)}
+              aria-current={current ? 'page' : undefined}
+            >
+              <span class="item__status" aria-hidden="true">
+                {#if done}
+                  <CheckCircleIcon />
+                {:else}
+                  <CircleIcon />
+                {/if}
+              </span>
+              <span class="item__type" aria-hidden="true"><Icon /></span>
+              <span class="item__title">{entry.title}</span>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/each}
+</nav>
+
+<style>
+  .playlist {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+  }
+
+  .playlist__stage {
+    margin: 0 0 var(--space-2);
+    padding: 0 var(--space-3);
+    font-size: var(--text-xs);
+    text-transform: var(--text-transform-label);
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+  }
+
+  .playlist__items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    transition: background-color var(--duration-fast) ease;
+  }
+
+  .item:hover {
+    background: var(--color-surface-secondary);
+  }
+
+  .item:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .item--current {
+    background: var(--color-surface-secondary);
+    color: var(--color-heading);
+    font-weight: var(--font-medium);
+  }
+
+  .item__status {
+    display: inline-flex;
+    color: var(--color-text-muted);
+  }
+
+  .item--done .item__status {
+    color: var(--color-success);
+  }
+
+  .item__type {
+    display: inline-flex;
+    color: var(--color-text-muted);
+  }
+
+  .item__title {
+    flex: 1;
+    font-size: var(--text-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/apps/web/src/lib/components/journeys/PracticeWorkingPane.svelte
+++ b/apps/web/src/lib/components/journeys/PracticeWorkingPane.svelte
@@ -1,0 +1,291 @@
+<!--
+  @component PracticeWorkingPane
+
+  The in-course player's working pane: the practice itself + its completion
+  affordance + prev/next nav. Completion follows the D-E boundary (SPEC §14.3):
+
+    - video / audio → completion AUTO-writes on genuine 100% finish. No button;
+      a caption states "completes when you finish". Genuine finish is detected
+      from the SINGLE progress store: the player's tracker saves position on the
+      native `ended` event, so `playbackPercent` reaches 100 only on a true
+      finish (the 95% "watched" flag never reaches 100). Idempotent.
+    - written → an EXPLICIT "Mark complete" button (no playback signal).
+
+  Playback (no unmuted hover-autoplay — the players are click-initiated).
+
+  @prop {JourneyPractice} practice - The open practice.
+  @prop {string | null} streamingUrl - Signed HLS URL (media); null → degraded.
+  @prop {string | null} waveformUrl - Signed waveform URL (audio).
+  @prop {string | null} bodyHtml - Rendered body (written); server-sanitised.
+  @prop {number} initialProgressSeconds - Resume position (media).
+  @prop {boolean} isComplete - Reactive completion (parent live query).
+  @prop {number} playbackPercent - Reactive watch % (parent live query).
+  @prop {string | null} prevHref - Previous practice, or null at the start.
+  @prop {string | null} nextHref - Next practice, or null at the end.
+-->
+<script lang="ts">
+  import AudioPlayer from '$lib/components/AudioPlayer/AudioPlayer.svelte';
+  import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '$lib/components/ui/Icon';
+  import VideoPlayer from '$lib/components/VideoPlayer/VideoPlayer.svelte';
+  import { markPracticeComplete } from '$lib/collections';
+  import type { JourneyPractice } from '$lib/journeys/types';
+
+  interface Props {
+    practice: JourneyPractice;
+    streamingUrl: string | null;
+    waveformUrl: string | null;
+    bodyHtml: string | null;
+    initialProgressSeconds: number;
+    isComplete: boolean;
+    playbackPercent: number;
+    prevHref: string | null;
+    nextHref: string | null;
+  }
+
+  const {
+    practice,
+    streamingUrl,
+    waveformUrl,
+    bodyHtml,
+    initialProgressSeconds,
+    isComplete,
+    playbackPercent,
+    prevHref,
+    nextHref,
+  }: Props = $props();
+
+  const isMedia = $derived(
+    practice.contentType === 'video' || practice.contentType === 'audio'
+  );
+
+  // D-E auto-write: media completes on genuine 100% finish (not the 95% watch
+  // flag). `markPracticeComplete` is idempotent so re-fires are safe.
+  $effect(() => {
+    if (!isMedia || isComplete) return;
+    if (playbackPercent >= 100) {
+      markPracticeComplete(practice.contentId, 'auto');
+    }
+  });
+
+  function handleMarkComplete(): void {
+    markPracticeComplete(practice.contentId, 'manual');
+  }
+</script>
+
+<article class="pane">
+  <header class="pane__header">
+    <h1 class="pane__title">{practice.title}</h1>
+    {#if isComplete}
+      <span class="pane__badge" aria-label="Completed">
+        <CheckIcon /> Completed
+      </span>
+    {/if}
+  </header>
+
+  <div class="pane__stage">
+    {#if isMedia}
+      {#if streamingUrl}
+        {#if practice.contentType === 'video'}
+          <VideoPlayer
+            src={streamingUrl}
+            contentId={practice.contentId}
+            contentTitle={practice.title}
+            initialProgress={initialProgressSeconds}
+          />
+        {:else}
+          <AudioPlayer
+            src={streamingUrl}
+            contentId={practice.contentId}
+            initialProgress={initialProgressSeconds}
+            {waveformUrl}
+            title={practice.title}
+          />
+        {/if}
+      {:else}
+        <!-- Round-D signs the R2 stream URL; until then, a degraded state. -->
+        <div class="pane__placeholder">
+          <p>This {practice.contentType} streams once the access plumbing lands.</p>
+        </div>
+      {/if}
+    {:else if bodyHtml}
+      <!-- Server-rendered, sanitised body (mirrors the standalone content page). -->
+      <div class="pane__body">
+        {@html bodyHtml}
+      </div>
+    {:else}
+      <div class="pane__placeholder">
+        <p>This practice has no content yet.</p>
+      </div>
+    {/if}
+  </div>
+
+  <footer class="pane__footer">
+    <div class="pane__completion">
+      {#if isMedia}
+        {#if isComplete}
+          <span class="pane__complete-note">
+            <CheckIcon /> Completed on finish
+          </span>
+        {:else}
+          <span class="pane__auto-note">Completes when you finish</span>
+        {/if}
+      {:else if isComplete}
+        <span class="pane__complete-note">
+          <CheckIcon /> Marked complete
+        </span>
+      {:else}
+        <button type="button" class="pane__mark" onclick={handleMarkComplete}>
+          <CheckIcon /> Mark complete
+        </button>
+      {/if}
+    </div>
+
+    <nav class="pane__nav" aria-label="Practice navigation">
+      {#if prevHref}
+        <a class="pane__nav-link" href={prevHref}>
+          <ArrowLeftIcon /> Previous
+        </a>
+      {/if}
+      {#if nextHref}
+        <a class="pane__nav-link pane__nav-link--next" href={nextHref}>
+          Next <ArrowRightIcon />
+        </a>
+      {/if}
+    </nav>
+  </footer>
+</article>
+
+<style>
+  .pane {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    min-width: 0;
+  }
+
+  .pane__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+
+  .pane__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    color: var(--color-heading);
+  }
+
+  .pane__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-full);
+    background: var(--color-success-100);
+    color: var(--color-success-700);
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+  }
+
+  .pane__stage {
+    border-radius: var(--radius-card);
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .pane__placeholder {
+    display: grid;
+    place-items: center;
+    aspect-ratio: 16 / 9;
+    padding: var(--space-8);
+    text-align: center;
+    background: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+    border-radius: var(--radius-card);
+  }
+
+  .pane__body {
+    padding: var(--space-2) 0;
+    color: var(--color-text);
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+  }
+
+  .pane__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+    padding-top: var(--space-4);
+    border-top: var(--border-width) var(--border-style) var(--color-border-subtle);
+  }
+
+  .pane__auto-note,
+  .pane__complete-note {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .pane__complete-note {
+    color: var(--color-success);
+  }
+
+  .pane__mark {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    border: var(--border-width) var(--border-style) var(--color-primary-600);
+    border-radius: var(--radius-button);
+    background: var(--color-primary-600);
+    color: var(--color-text-on-brand);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+    transition: background-color var(--duration-fast) ease;
+  }
+
+  .pane__mark:hover {
+    background: var(--color-primary-700);
+  }
+
+  .pane__mark:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .pane__nav {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .pane__nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-button);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    transition: background-color var(--duration-fast) ease;
+  }
+
+  .pane__nav-link:hover {
+    background: var(--color-surface-secondary);
+    color: var(--color-heading);
+  }
+
+  .pane__nav-link:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+</style>

--- a/apps/web/src/lib/components/journeys/ProgressRing.svelte
+++ b/apps/web/src/lib/components/journeys/ProgressRing.svelte
@@ -1,0 +1,129 @@
+<!--
+  @component ProgressRing
+
+  Token-driven circular completion indicator (FRONTEND-MAP §5.3 — net-new).
+  Used for course + stage progress on the journey dashboard. Presentational:
+  the caller supplies an already-computed integer percent.
+
+  @prop {number} percent - Completion 0–100 (clamped).
+  @prop {string} [size] - CSS length for the ring diameter. Default 1 stage tile.
+  @prop {boolean} [showLabel=true] - Render the "N%" (or check at 100%) in-ring.
+  @prop {string} [ariaLabel] - Accessible label; falls back to "N% complete".
+-->
+<script lang="ts">
+  import { CheckIcon } from '$lib/components/ui/Icon';
+
+  interface Props {
+    percent: number;
+    size?: string;
+    showLabel?: boolean;
+    ariaLabel?: string;
+  }
+
+  const {
+    percent,
+    size = 'var(--space-16)',
+    showLabel = true,
+    ariaLabel,
+  }: Props = $props();
+
+  // Clamp to a valid integer percentage.
+  const pct = $derived(Math.max(0, Math.min(100, Math.round(percent))));
+  const isComplete = $derived(pct >= 100);
+
+  // Geometry lives in the SVG viewBox coordinate space (unitless — not CSS px).
+  const RADIUS = 16;
+  const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+  const dashOffset = $derived(CIRCUMFERENCE * (1 - pct / 100));
+  const label = $derived(ariaLabel ?? `${pct}% complete`);
+</script>
+
+<div
+  class="ring"
+  class:ring--complete={isComplete}
+  style="--journey-ring-size: {size};"
+  role="img"
+  aria-label={label}
+>
+  <svg viewBox="0 0 40 40" aria-hidden="true">
+    <circle class="ring__track" cx="20" cy="20" r={RADIUS} />
+    <circle
+      class="ring__value"
+      cx="20"
+      cy="20"
+      r={RADIUS}
+      stroke-dasharray={CIRCUMFERENCE}
+      stroke-dashoffset={dashOffset}
+    />
+  </svg>
+  {#if showLabel}
+    <span class="ring__label">
+      {#if isComplete}
+        <CheckIcon />
+      {:else}
+        {pct}<span class="ring__pct">%</span>
+      {/if}
+    </span>
+  {/if}
+</div>
+
+<style>
+  .ring {
+    position: relative;
+    display: inline-grid;
+    place-items: center;
+    width: var(--journey-ring-size);
+    height: var(--journey-ring-size);
+  }
+
+  svg {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+  }
+
+  .ring__track {
+    fill: none;
+    stroke: var(--color-border-subtle);
+    stroke-width: 3;
+  }
+
+  .ring__value {
+    fill: none;
+    stroke: var(--color-primary-600);
+    stroke-width: 3;
+    stroke-linecap: round;
+    transition: stroke-dashoffset var(--duration-slow) ease;
+  }
+
+  .ring--complete .ring__value {
+    stroke: var(--color-success);
+  }
+
+  .ring__label {
+    position: absolute;
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-0-5);
+    font-family: var(--font-heading);
+    font-weight: var(--font-semibold);
+    font-size: var(--text-sm);
+    color: var(--color-heading);
+    line-height: var(--leading-none);
+  }
+
+  .ring--complete .ring__label {
+    color: var(--color-success);
+  }
+
+  .ring__pct {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ring__value {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/journeys/gate.test.ts
+++ b/apps/web/src/lib/journeys/gate.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateCourseGate } from './gate';
+
+describe('evaluateCourseGate', () => {
+  it('404s when no course resolves for the slug', () => {
+    expect(
+      evaluateCourseGate({
+        courseExists: false,
+        isAuthenticated: true,
+        canEnterCourse: true,
+      })
+    ).toEqual({ kind: 'not-found' });
+  });
+
+  it('redirects an anonymous visitor to the sales page', () => {
+    expect(
+      evaluateCourseGate({
+        courseExists: true,
+        isAuthenticated: false,
+        canEnterCourse: false,
+      })
+    ).toEqual({ kind: 'redirect-to-sales' });
+  });
+
+  it('redirects an authed-but-not-entitled user to the sales page', () => {
+    expect(
+      evaluateCourseGate({
+        courseExists: true,
+        isAuthenticated: true,
+        canEnterCourse: false,
+      })
+    ).toEqual({ kind: 'redirect-to-sales' });
+  });
+
+  it('proceeds for an entitled member', () => {
+    expect(
+      evaluateCourseGate({
+        courseExists: true,
+        isAuthenticated: true,
+        canEnterCourse: true,
+      })
+    ).toEqual({ kind: 'ok' });
+  });
+
+  it('404 takes precedence over the auth/entitlement checks', () => {
+    // Nothing to sell → never leak "sign in to buy this" for a missing course.
+    expect(
+      evaluateCourseGate({
+        courseExists: false,
+        isAuthenticated: false,
+        canEnterCourse: false,
+      })
+    ).toEqual({ kind: 'not-found' });
+  });
+});

--- a/apps/web/src/lib/journeys/gate.ts
+++ b/apps/web/src/lib/journeys/gate.ts
@@ -1,0 +1,41 @@
+/**
+ * Course entitlement gate — the PURE decision (Codex-2pryk · WP-4).
+ *
+ * The `canEnterCourse` gate (SPEC §6.3 / HARDENING §E) is enforced server-side
+ * in the dashboard / player `+page.server.ts`. The I/O (resolve slug→course,
+ * call the resolver) lives in the load; the DECISION — 404 vs redirect-to-sell
+ * vs proceed — is extracted here so it is unit-testable without SvelteKit or a
+ * live resolver.
+ *
+ * Surface states (SPEC §6.3 / §14.2):
+ *   - no course row for slug           → 404 (nothing to sell).
+ *   - anonymous visitor                → redirect to the public sales page.
+ *   - authed but `!canEnterCourse`     → redirect to sales (`?notenrolled` is
+ *     `canView && !canEnterCourse`; the sales page owns that upsell surface).
+ *   - authed and `canEnterCourse`      → proceed.
+ */
+
+export type CourseGateOutcome =
+  | { kind: 'ok' }
+  | { kind: 'not-found' }
+  | { kind: 'redirect-to-sales' };
+
+export interface CourseGateInput {
+  /** Whether a course row resolved for the requested slug. */
+  courseExists: boolean;
+  /** Whether the request carries an authenticated user. */
+  isAuthenticated: boolean;
+  /** The resolver's answer for this (user, course). Meaningless when anon. */
+  canEnterCourse: boolean;
+}
+
+/**
+ * Decide what a course member surface should do for a given request. Pure —
+ * no I/O, no redirect throwing; the caller acts on the outcome.
+ */
+export function evaluateCourseGate(input: CourseGateInput): CourseGateOutcome {
+  if (!input.courseExists) return { kind: 'not-found' };
+  if (!input.isAuthenticated) return { kind: 'redirect-to-sales' };
+  if (!input.canEnterCourse) return { kind: 'redirect-to-sales' };
+  return { kind: 'ok' };
+}

--- a/apps/web/src/lib/journeys/rollup.test.ts
+++ b/apps/web/src/lib/journeys/rollup.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeCourseRollup,
+  selectContinuePractice,
+  toPlaylist,
+} from './rollup';
+import type { JourneyPractice, JourneyStage } from './types';
+
+function practice(
+  contentId: string,
+  sortOrder: number,
+  overrides: Partial<JourneyPractice> = {}
+): JourneyPractice {
+  return {
+    contentId,
+    slug: contentId,
+    title: contentId,
+    contentType: 'written',
+    durationSeconds: null,
+    thumbnailUrl: null,
+    sortOrder,
+    ...overrides,
+  };
+}
+
+// Two stages, out of sort order to prove the helpers sort deterministically.
+const stages: JourneyStage[] = [
+  {
+    id: 's2',
+    name: 'Second',
+    gloss: null,
+    sortOrder: 1,
+    practices: [practice('c3', 1), practice('c2', 0)],
+  },
+  {
+    id: 's1',
+    name: 'First',
+    gloss: null,
+    sortOrder: 0,
+    practices: [practice('c1', 0)],
+  },
+];
+
+describe('computeCourseRollup', () => {
+  it('rolls up overall + per-stage counts and percentages', () => {
+    const rollup = computeCourseRollup(stages, new Set(['c1', 'c2']));
+    expect(rollup.overall).toEqual({ done: 2, total: 3, percent: 67 });
+    expect(rollup.byStage.get('s1')).toEqual({
+      done: 1,
+      total: 1,
+      percent: 100,
+    });
+    expect(rollup.byStage.get('s2')).toEqual({
+      done: 1,
+      total: 2,
+      percent: 50,
+    });
+    expect(rollup.isComplete).toBe(false);
+  });
+
+  it('reports completion only when every practice is done', () => {
+    const rollup = computeCourseRollup(stages, new Set(['c1', 'c2', 'c3']));
+    expect(rollup.overall.percent).toBe(100);
+    expect(rollup.isComplete).toBe(true);
+  });
+
+  it('never divides by zero for an empty curriculum', () => {
+    const rollup = computeCourseRollup([], new Set());
+    expect(rollup.overall).toEqual({ done: 0, total: 0, percent: 0 });
+    expect(rollup.isComplete).toBe(false);
+  });
+
+  it('ignores completed ids that are not part of the course', () => {
+    const rollup = computeCourseRollup(stages, new Set(['not-in-course']));
+    expect(rollup.overall.done).toBe(0);
+  });
+});
+
+describe('toPlaylist', () => {
+  it('flattens by stage order then practice order', () => {
+    expect(toPlaylist(stages).map((e) => e.contentId)).toEqual([
+      'c1',
+      'c2',
+      'c3',
+    ]);
+  });
+});
+
+describe('selectContinuePractice', () => {
+  it('returns the first incomplete practice in course order', () => {
+    const next = selectContinuePractice(stages, new Set(['c1']));
+    expect(next?.contentId).toBe('c2');
+  });
+
+  it('prefers an in-progress practice over the first incomplete', () => {
+    const next = selectContinuePractice(
+      stages,
+      new Set(['c1']),
+      new Set(['c3'])
+    );
+    expect(next?.contentId).toBe('c3');
+  });
+
+  it('returns null when every practice is complete', () => {
+    expect(
+      selectContinuePractice(stages, new Set(['c1', 'c2', 'c3']))
+    ).toBeNull();
+  });
+
+  it('returns null for an empty curriculum', () => {
+    expect(selectContinuePractice([], new Set())).toBeNull();
+  });
+});

--- a/apps/web/src/lib/journeys/rollup.ts
+++ b/apps/web/src/lib/journeys/rollup.ts
@@ -1,0 +1,110 @@
+/**
+ * Progress rollup + resume selection — PURE helpers (Codex-2pryk · WP-4).
+ *
+ * The rollup is `practice_completions ⋈ stage_practices` scoped to the
+ * enrollment (SPEC §11). Here the curriculum (`stages`) comes from the server
+ * load and the completed set comes from the progress store (the
+ * `practice_completions` rows are the source of truth — D-E). Keeping the math
+ * pure makes the dashboard's overall/per-stage bars and the
+ * continue-where-left-off pointer unit-testable in isolation.
+ */
+
+import type { JourneyStage, PlaylistEntry } from './types';
+
+export interface RollupCounts {
+  done: number;
+  total: number;
+  /** Integer 0–100. `0` when the stage/course has no practices. */
+  percent: number;
+}
+
+export interface CourseRollup {
+  overall: RollupCounts;
+  /** stageId → counts, in stage order. */
+  byStage: Map<string, RollupCounts>;
+  /** Whether every practice in the course is complete (course completion). */
+  isComplete: boolean;
+}
+
+function percentOf(done: number, total: number): number {
+  return total > 0 ? Math.round((done / total) * 100) : 0;
+}
+
+/**
+ * Roll completions up over the curriculum. `completedIds` is the set of content
+ * ids with a completion row (source of truth), typically derived from the
+ * progress store's `practiceCompletedAt`.
+ */
+export function computeCourseRollup(
+  stages: readonly JourneyStage[],
+  completedIds: ReadonlySet<string>
+): CourseRollup {
+  const byStage = new Map<string, RollupCounts>();
+  let overallDone = 0;
+  let overallTotal = 0;
+
+  for (const stage of stages) {
+    let done = 0;
+    for (const practice of stage.practices) {
+      if (completedIds.has(practice.contentId)) done += 1;
+    }
+    const total = stage.practices.length;
+    byStage.set(stage.id, { done, total, percent: percentOf(done, total) });
+    overallDone += done;
+    overallTotal += total;
+  }
+
+  return {
+    overall: {
+      done: overallDone,
+      total: overallTotal,
+      percent: percentOf(overallDone, overallTotal),
+    },
+    byStage,
+    isComplete: overallTotal > 0 && overallDone === overallTotal,
+  };
+}
+
+/**
+ * Flatten the curriculum into the ordered player sequence: stages by
+ * `sortOrder`, practices by `sortOrder` within a stage.
+ */
+export function toPlaylist(stages: readonly JourneyStage[]): PlaylistEntry[] {
+  const entries: PlaylistEntry[] = [];
+  const orderedStages = [...stages].sort((a, b) => a.sortOrder - b.sortOrder);
+  for (const stage of orderedStages) {
+    const orderedPractices = [...stage.practices].sort(
+      (a, b) => a.sortOrder - b.sortOrder
+    );
+    for (const practice of orderedPractices) {
+      entries.push({
+        contentId: practice.contentId,
+        slug: practice.slug,
+        title: practice.title,
+        contentType: practice.contentType,
+        stageId: stage.id,
+        stageName: stage.name,
+        sortOrder: practice.sortOrder,
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Pick where to resume (continue-where-left-off). Prefer an in-progress
+ * practice (started but not complete); otherwise the first incomplete practice
+ * in course order; `null` when everything is complete or the course is empty.
+ */
+export function selectContinuePractice(
+  stages: readonly JourneyStage[],
+  completedIds: ReadonlySet<string>,
+  inProgressIds: ReadonlySet<string> = new Set()
+): PlaylistEntry | null {
+  const playlist = toPlaylist(stages);
+  const incomplete = playlist.filter((e) => !completedIds.has(e.contentId));
+  if (incomplete.length === 0) return null;
+  return (
+    incomplete.find((e) => inProgressIds.has(e.contentId)) ?? incomplete[0]
+  );
+}

--- a/apps/web/src/lib/journeys/types.ts
+++ b/apps/web/src/lib/journeys/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Journey member-surface view types (Codex-2pryk · WP-4).
+ *
+ * The shapes the course DASHBOARD and IN-COURSE PLAYER consume. These are the
+ * FE-facing projections of the WP-1 schema (`courses`, `course_stages`,
+ * `stage_practices`, `course_enrollments`, `practice_completions`) — NOT the raw
+ * Drizzle rows. The Round-D seam (`$lib/server/journeys/round-d-seam.ts`)
+ * produces them; the real `@codex/access` API will return the same shapes when
+ * the web→worker plumbing lands, so the UI never changes.
+ *
+ * Universal module (no server-only imports) so both the server seam and the
+ * client components / progress store can import it.
+ */
+
+/**
+ * Practice content type (SPEC §14.3). Drives the D-E completion boundary:
+ *   - `video` / `audio` → completion AUTO-writes on genuine 100% finish.
+ *   - `written`         → completion is an EXPLICIT "Mark complete" action.
+ * Mirrors `content.contentType` (`'video' | 'audio' | 'written'`).
+ */
+export type PracticeContentType = 'video' | 'audio' | 'written';
+
+/** How a `practice_completions` row was written (SPEC §11 / schema CHECK). */
+export type CompletionSource = 'manual' | 'auto';
+
+/** A summary of a course, enough to render chrome + build URLs. */
+export interface JourneyCourseSummary {
+  id: string;
+  slug: string | null;
+  title: string;
+  organizationSlug: string | null;
+}
+
+/**
+ * One practice (a `content` row inside a stage), as the member surfaces read it.
+ * `durationSeconds` is present for media (drives the resume + finish signal).
+ */
+export interface JourneyPractice {
+  contentId: string;
+  slug: string | null;
+  title: string;
+  contentType: PracticeContentType;
+  durationSeconds: number | null;
+  thumbnailUrl: string | null;
+  sortOrder: number;
+}
+
+/** An ordered stage (a "gate") with its concurrent practice pool (SPEC §5). */
+export interface JourneyStage {
+  id: string;
+  name: string;
+  gloss: string | null;
+  sortOrder: number;
+  practices: JourneyPractice[];
+}
+
+/** The current user's enrollment in a course (SPEC §11). */
+export interface JourneyEnrollment {
+  courseId: string;
+  enrolledAt: string;
+  lastActivityAt: string | null;
+  /** Stamped when every required practice is complete. */
+  completedAt: string | null;
+}
+
+/**
+ * A completion the SERVER knows about — the `practice_completions` row, the
+ * SOURCE OF TRUTH for course progress (SPEC §11 / D-E). Hydrated into the
+ * progress store so live queries reflect server truth on first paint.
+ */
+export interface PracticeCompletionRecord {
+  contentId: string;
+  completedAt: string;
+  source: CompletionSource;
+}
+
+/**
+ * Everything the dashboard needs after the `canEnterCourse` gate passes:
+ * enrollment, the ordered curriculum, and the server-known completions.
+ */
+export interface CourseDashboardData {
+  course: JourneyCourseSummary;
+  enrollment: JourneyEnrollment;
+  stages: JourneyStage[];
+  completions: PracticeCompletionRecord[];
+}
+
+/** One row of the in-course playlist rail (the whole course sequence, flattened). */
+export interface PlaylistEntry {
+  contentId: string;
+  slug: string | null;
+  title: string;
+  contentType: PracticeContentType;
+  stageId: string;
+  stageName: string;
+  sortOrder: number;
+}
+
+/**
+ * Everything the in-course player needs after `canEnterCourse` (+ `canView` for
+ * the stream) pass. `streamingUrl` / `waveformUrl` are signed R2 URLs for media;
+ * `null` for `written` practices (their body renders from `bodyHtml`).
+ */
+export interface InCoursePracticeData {
+  course: JourneyCourseSummary;
+  stage: { id: string; name: string };
+  practice: JourneyPractice;
+  /** Signed HLS URL — media only; null for written / when stream not viewable. */
+  streamingUrl: string | null;
+  waveformUrl: string | null;
+  /** Rendered body HTML for `written` practices; null for media. */
+  bodyHtml: string | null;
+  /** Resume position for media (seconds). */
+  initialProgressSeconds: number;
+  /** The whole course sequence, for the playlist rail + prev/next. */
+  playlist: PlaylistEntry[];
+  /** Server-known completions across the course (hydrates the store). */
+  completions: PracticeCompletionRecord[];
+}

--- a/apps/web/src/lib/remote/journeys.remote.ts
+++ b/apps/web/src/lib/remote/journeys.remote.ts
@@ -1,0 +1,40 @@
+/**
+ * Journeys remote functions (Codex-2pryk · WP-4).
+ *
+ * Client→server mutations for the course member surfaces. The dashboard /
+ * player DATA is loaded server-side in their `+page.server.ts` (via the Round-D
+ * seam); this module carries only the mark-complete COMMAND, which the progress
+ * store fires optimistically.
+ */
+
+import { error } from '@sveltejs/kit';
+import { z } from 'zod';
+import { command, getRequestEvent } from '$app/server';
+import type { PracticeCompletionRecord } from '$lib/journeys/types';
+import { persistPracticeCompletion } from '$lib/server/journeys/round-d-seam';
+
+const markCompleteSchema = z.object({
+  contentId: z.string().uuid(),
+  source: z.enum(['manual', 'auto']),
+});
+
+/**
+ * Record a practice completion (SPEC §11 / D-E). Writes the
+ * `practice_completions` row — the SOURCE OF TRUTH for course progress — once
+ * per (user, content). Called for an explicit "Mark complete" (`manual`) and on
+ * a media's genuine 100% finish (`auto`). Auth-gated: completion belongs to a
+ * signed-in member.
+ *
+ * The actual DB write is Round-D (mocked in the seam today); the command
+ * contract, auth gate, and validation are real.
+ */
+export const markPracticeCompleted = command(
+  markCompleteSchema,
+  async ({ contentId, source }): Promise<PracticeCompletionRecord> => {
+    const event = getRequestEvent();
+    const userId = event.locals.user?.id;
+    if (!userId) error(401, 'Sign in to record progress');
+
+    return persistPracticeCompletion(event, userId, { contentId, source });
+  }
+);

--- a/apps/web/src/lib/server/journeys/round-d-seam.ts
+++ b/apps/web/src/lib/server/journeys/round-d-seam.ts
@@ -1,0 +1,279 @@
+/**
+ * Round-D integration seam (Codex-2pryk · WP-4) — THE SINGLE MOCK BOUNDARY.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ *  WHY THIS FILE EXISTS
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WP-4 (dashboard + in-course player) is stacked on WP-2's resolver, but the
+ * web→worker PLUMBING — the routes/endpoints the SSR gate and the mark-complete
+ * command call — is a Round-D integration task. So every not-yet-wired
+ * web→worker call this WP needs is ISOLATED here, returning CONTRACT-SHAPED mock
+ * data. The FE, the progress-store extension, the gate structure, and the
+ * mark-complete flow are all REAL against these shapes.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ *  WHAT ROUND-D DOES
+ * ═══════════════════════════════════════════════════════════════════════════
+ * Replace each function BODY with the real `createServerApi(platform, cookies)`
+ * call — the SIGNATURES and RETURN SHAPES are frozen against
+ * `$lib/journeys/types` and the `EntitlementResolver` contract
+ * (`@codex/shared-types` · `journeys.ts`), so no caller changes:
+ *
+ *   resolveCanEnterCourse   → api.access.canEnterCourse(userId, courseId)      [WP-2]
+ *   resolveCanView          → api.access.canView(userId, contentId)            [WP-2]
+ *   resolveCourseBySlug     → content-api course lookup by (orgId, slug)
+ *   fetchCourseDashboard    → enrollment + rollup query (practice_completions
+ *                             ⋈ stage_practices scoped to enrollment, SPEC §11)
+ *   fetchInCoursePractice   → practice + signed stream URL + playlist
+ *   persistPracticeCompletion → INSERT practice_completions (once per user)
+ *
+ * Entitlement reads are per-request / never cross-user cached (HARDENING §E).
+ *
+ * server-only ($lib/server/*): never bundled to the client.
+ */
+
+import type { RequestEvent } from '@sveltejs/kit';
+import { toPlaylist } from '$lib/journeys/rollup';
+import type {
+  CompletionSource,
+  CourseDashboardData,
+  InCoursePracticeData,
+  JourneyCourseSummary,
+  JourneyStage,
+  PracticeCompletionRecord,
+} from '$lib/journeys/types';
+
+/**
+ * The request context each seam call needs. Structurally satisfied by both a
+ * SvelteKit server-load event and a remote-function `getRequestEvent()`. Round-D
+ * uses `platform` + `cookies` to build the server API; `url` carries dev-only
+ * mock walkthrough flags; `locals` carries the resolved user.
+ */
+export type SeamContext = Pick<
+  RequestEvent,
+  'platform' | 'cookies' | 'locals' | 'url'
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock fixture — a single sample course ("Rootwork") mirroring the prototype.
+// Stable, valid RFC4122 v4 UUIDs so the mark-complete command's
+// `z.string().uuid()` accepts them and the store keys stay consistent.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_COURSE: JourneyCourseSummary = {
+  id: '2c000000-0000-4000-8000-000000000001',
+  slug: 'rootwork',
+  title: 'Rootwork',
+  organizationSlug: null,
+};
+
+const uid = (n: number): string =>
+  `2c000000-0000-4000-8000-0000000001${String(n).padStart(2, '0')}`;
+
+const MOCK_STAGES: JourneyStage[] = [
+  {
+    id: '2c000000-0000-4000-8000-0000000000a1',
+    name: 'Orientation',
+    gloss: 'Find your footing before the work begins.',
+    sortOrder: 0,
+    practices: [
+      {
+        contentId: uid(1),
+        slug: 'welcome',
+        title: 'Welcome to the journey',
+        contentType: 'video',
+        durationSeconds: 320,
+        thumbnailUrl: null,
+        sortOrder: 0,
+      },
+      {
+        contentId: uid(2),
+        slug: 'set-your-intention',
+        title: 'Set your intention',
+        contentType: 'written',
+        durationSeconds: null,
+        thumbnailUrl: null,
+        sortOrder: 1,
+      },
+    ],
+  },
+  {
+    id: '2c000000-0000-4000-8000-0000000000a2',
+    name: 'The Practice',
+    gloss: 'Daily reps that compound.',
+    sortOrder: 1,
+    practices: [
+      {
+        contentId: uid(3),
+        slug: 'morning-sit',
+        title: 'The morning sit',
+        contentType: 'audio',
+        durationSeconds: 600,
+        thumbnailUrl: null,
+        sortOrder: 0,
+      },
+      {
+        contentId: uid(4),
+        slug: 'field-notes',
+        title: 'Field notes',
+        contentType: 'written',
+        durationSeconds: null,
+        thumbnailUrl: null,
+        sortOrder: 1,
+      },
+      {
+        contentId: uid(5),
+        slug: 'deep-work-session',
+        title: 'Deep work session',
+        contentType: 'video',
+        durationSeconds: 1500,
+        thumbnailUrl: null,
+        sortOrder: 2,
+      },
+    ],
+  },
+];
+
+/** Dev-only walkthrough flags carried on the URL (mock only; ignored in Round-D). */
+function mockFlags(ctx: SeamContext): { denied: boolean; firstRun: boolean } {
+  const p = ctx.url.searchParams;
+  return {
+    denied: p.get('mock') === 'denied',
+    firstRun: p.has('first') || p.get('state') === 'new',
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Seam functions (mock bodies — Round-D swaps each for a real API call)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ROUND-D: content-api course lookup by (orgId, slug). */
+export async function resolveCourseBySlug(
+  _ctx: SeamContext,
+  slug: string
+): Promise<JourneyCourseSummary | null> {
+  // MOCK: only the sample course resolves.
+  return slug === MOCK_COURSE.slug ? MOCK_COURSE : null;
+}
+
+/** ROUND-D: `api.access.canEnterCourse(userId, courseId)` (WP-2 resolver). */
+export async function resolveCanEnterCourse(
+  ctx: SeamContext,
+  userId: string | null,
+  _courseId: string
+): Promise<boolean> {
+  // MOCK: entitled when authenticated, unless the dev denied-walk flag is set.
+  if (mockFlags(ctx).denied) return false;
+  return userId !== null;
+}
+
+/** ROUND-D: `api.access.canView(userId, contentId)` (gates the signed stream). */
+export async function resolveCanView(
+  ctx: SeamContext,
+  userId: string | null,
+  _contentId: string
+): Promise<boolean> {
+  // MOCK: a course member can view its practices (canEnterCourse ⇒ canView here).
+  if (mockFlags(ctx).denied) return false;
+  return userId !== null;
+}
+
+/**
+ * ROUND-D: enrollment + progress rollup (`practice_completions ⋈ stage_practices`
+ * scoped to the enrollment — SPEC §11). MOCK: sample curriculum with a couple of
+ * pre-existing completions (or none under the first-run flag).
+ */
+export async function fetchCourseDashboard(
+  ctx: SeamContext,
+  _userId: string,
+  _courseId: string
+): Promise<CourseDashboardData | null> {
+  const { firstRun } = mockFlags(ctx);
+  const completions: PracticeCompletionRecord[] = firstRun
+    ? []
+    : [
+        { contentId: uid(1), completedAt: isoDaysAgo(3), source: 'auto' },
+        { contentId: uid(2), completedAt: isoDaysAgo(2), source: 'manual' },
+      ];
+
+  return {
+    course: MOCK_COURSE,
+    enrollment: {
+      courseId: MOCK_COURSE.id,
+      enrolledAt: isoDaysAgo(4),
+      lastActivityAt: firstRun ? null : isoDaysAgo(1),
+      completedAt: null,
+    },
+    stages: MOCK_STAGES,
+    completions,
+  };
+}
+
+/**
+ * ROUND-D: practice + SIGNED stream URL + playlist. MOCK: resolves the practice
+ * by slug; `streamingUrl` stays null (no R2 signing in the mock — the player
+ * degrades to a "stream loads when access plumbing lands" placeholder). Written
+ * practices get a small body; the playlist is the full ordered course sequence.
+ */
+export async function fetchInCoursePractice(
+  ctx: SeamContext,
+  _userId: string,
+  _courseId: string,
+  contentSlug: string
+): Promise<InCoursePracticeData | null> {
+  let found: { stage: JourneyStage; practiceIndex: number } | null = null;
+  for (const stage of MOCK_STAGES) {
+    const idx = stage.practices.findIndex((p) => p.slug === contentSlug);
+    if (idx !== -1) {
+      found = { stage, practiceIndex: idx };
+      break;
+    }
+  }
+  if (!found) return null;
+
+  const practice = found.stage.practices[found.practiceIndex];
+  const { firstRun } = mockFlags(ctx);
+
+  return {
+    course: MOCK_COURSE,
+    stage: { id: found.stage.id, name: found.stage.name },
+    practice,
+    // ROUND-D: api.access.getStreamingUrl(contentId) for media.
+    streamingUrl: null,
+    waveformUrl: null,
+    // ROUND-D: rendered content body for written practices.
+    bodyHtml:
+      practice.contentType === 'written'
+        ? '<p>This practice loads its written body when the content plumbing lands in Round-D.</p>'
+        : null,
+    initialProgressSeconds: 0,
+    playlist: toPlaylist(MOCK_STAGES),
+    completions: firstRun
+      ? []
+      : [
+          { contentId: uid(1), completedAt: isoDaysAgo(3), source: 'auto' },
+          { contentId: uid(2), completedAt: isoDaysAgo(2), source: 'manual' },
+        ],
+  };
+}
+
+/**
+ * ROUND-D: INSERT a `practice_completions` row (once per user — the unique
+ * index makes a repeat a no-op). MOCK: echoes the completion back so the
+ * optimistic store write can settle to `synced`.
+ */
+export async function persistPracticeCompletion(
+  _ctx: SeamContext,
+  _userId: string,
+  input: { contentId: string; source: CompletionSource }
+): Promise<PracticeCompletionRecord> {
+  return {
+    contentId: input.contentId,
+    completedAt: new Date().toISOString(),
+    source: input.source,
+  };
+}
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
+}

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.server.ts
@@ -1,0 +1,70 @@
+/**
+ * Journey dashboard — server gate + data (Codex-2pryk · WP-4).
+ *
+ * `ssr = false` (HARDENING §E): the dashboard is an authed SPA subtree (instant
+ * nav, not SEO-significant). The server `load` STILL runs — SvelteKit fetches
+ * it — so the `canEnterCourse` gate and its redirect are enforced server-side
+ * before any client render. `initProgressSync` is already initialised by the
+ * org layout, so this subtree inherits cross-device progress sync.
+ *
+ * Gate ordering (secure): resolve slug→course, THEN `canEnterCourse`, THEN load
+ * the enrollment + rollup — so a non-entitled user never receives progress data.
+ *
+ * ─── ROUND-D SEAM ───────────────────────────────────────────────────────────
+ * `resolveCourseBySlug` / `resolveCanEnterCourse` / `fetchCourseDashboard` are
+ * mocked in `$lib/server/journeys/round-d-seam.ts` (contract-shaped). Round-D
+ * swaps those bodies for real `@codex/access` calls; this file does not change.
+ */
+import { error, redirect } from '@sveltejs/kit';
+import { evaluateCourseGate } from '$lib/journeys/gate';
+import {
+  fetchCourseDashboard,
+  resolveCanEnterCourse,
+  resolveCourseBySlug,
+} from '$lib/server/journeys/round-d-seam';
+import { buildJourneyUrl } from '$lib/utils/subdomain';
+import type { PageServerLoad } from './$types';
+
+// SPA subtree — client-rendered, but the load (and its gate) run server-side.
+export const ssr = false;
+
+export const load: PageServerLoad = async (event) => {
+  const { params, parent, url } = event;
+  event.depends('app:auth');
+
+  const { org, user } = await parent();
+  const course = await resolveCourseBySlug(event, params.journeySlug);
+
+  const canEnter =
+    user && course
+      ? await resolveCanEnterCourse(event, user.id, course.id)
+      : false;
+
+  const outcome = evaluateCourseGate({
+    courseExists: course !== null,
+    isAuthenticated: Boolean(user),
+    canEnterCourse: canEnter,
+  });
+
+  if (outcome.kind === 'not-found') error(404, 'Course not found');
+  if (outcome.kind === 'redirect-to-sales') {
+    redirect(
+      303,
+      buildJourneyUrl(
+        url,
+        {
+          slug: params.journeySlug,
+          id: course?.id ?? params.journeySlug,
+          organizationSlug: org?.slug ?? null,
+        },
+        { surface: 'sales' }
+      )
+    );
+  }
+
+  // Gate passed → user + course are non-null.
+  const dashboard = await fetchCourseDashboard(event, user!.id, course!.id);
+  if (!dashboard) error(404, 'Course not found');
+
+  return { dashboard };
+};

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte
@@ -1,0 +1,197 @@
+<!--
+  @component JourneyDashboardPage
+
+  The authed course dashboard (SPEC §8.3): enrollment + progress rollup, the
+  curriculum map with completion overlay, and continue-where-left-off. Client-
+  rendered (ssr=false); the server gate already enforced `canEnterCourse`.
+
+  Progress reads the SINGLE progress store (F19): the store hydrates from the
+  server's known completions, and completing a practice in the player updates
+  it reactively here (cross-tab + cross-device via `initProgressSync`).
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    loadCourseCompletionsFromServer,
+    type PlaybackProgress,
+    progressCollection,
+    useLiveQuery,
+  } from '$lib/collections';
+  import CurriculumMap from '$lib/components/journeys/CurriculumMap.svelte';
+  import ProgressRing from '$lib/components/journeys/ProgressRing.svelte';
+  import { ArrowRightIcon, PlayIcon } from '$lib/components/ui/Icon';
+  import {
+    computeCourseRollup,
+    selectContinuePractice,
+  } from '$lib/journeys/rollup';
+
+  let { data } = $props();
+
+  const dashboard = $derived(data.dashboard);
+  const courseSlug = $derived(dashboard.course.slug ?? dashboard.course.id);
+
+  // Hydrate the store with the server's known completions, then let the live
+  // query drive. Before hydration completes, fall back to the server list so
+  // the rollup never flashes empty ([[feedback_uselivequery_empty_array_fallback]]:
+  // gate on `hydrated`, not `data ?? ssrData`).
+  let hydrated = $state(false);
+  onMount(() => {
+    loadCourseCompletionsFromServer(dashboard.completions);
+    hydrated = true;
+  });
+
+  const progressQuery = useLiveQuery(
+    (q) => q.from({ item: progressCollection }),
+    undefined,
+    { ssrData: [] as PlaybackProgress[] }
+  );
+
+  const rows = $derived((progressQuery.data ?? []) as PlaybackProgress[]);
+
+  const completedIds = $derived.by(() => {
+    if (!hydrated) {
+      return new Set(dashboard.completions.map((c) => c.contentId));
+    }
+    return new Set(
+      rows.filter((r) => r.practiceCompletedAt).map((r) => r.contentId)
+    );
+  });
+
+  const inProgressIds = $derived.by(
+    () =>
+      new Set(
+        rows
+          .filter((r) => r.positionSeconds > 0 && !r.practiceCompletedAt)
+          .map((r) => r.contentId)
+      )
+  );
+
+  const rollup = $derived(computeCourseRollup(dashboard.stages, completedIds));
+  const continueEntry = $derived(
+    selectContinuePractice(dashboard.stages, completedIds, inProgressIds)
+  );
+
+  const continueHref = $derived(
+    continueEntry
+      ? `/journeys/${courseSlug}/practice/${continueEntry.slug ?? continueEntry.contentId}`
+      : null
+  );
+
+  const isFresh = $derived(rollup.overall.done === 0);
+</script>
+
+<svelte:head>
+  <title>{dashboard.course.title} · Your journey</title>
+</svelte:head>
+
+<div class="dashboard">
+  <header class="dashboard__hero">
+    <div class="dashboard__intro">
+      <span class="dashboard__eyebrow">Your journey</span>
+      <h1 class="dashboard__title">{dashboard.course.title}</h1>
+      <p class="dashboard__status">
+        {#if rollup.isComplete}
+          You've completed every practice. Revisit anything, anytime.
+        {:else if isFresh}
+          Begin when you're ready — your first practice is one tap away.
+        {:else}
+          {rollup.overall.done} of {rollup.overall.total} practices complete.
+        {/if}
+      </p>
+
+      {#if continueHref}
+        <a class="dashboard__continue" href={continueHref}>
+          <PlayIcon />
+          {isFresh ? 'Begin the journey' : 'Continue where you left off'}
+          <ArrowRightIcon />
+        </a>
+      {/if}
+    </div>
+
+    <div class="dashboard__ring" aria-hidden={rollup.overall.total === 0}>
+      <ProgressRing
+        percent={rollup.overall.percent}
+        size="var(--space-24)"
+        ariaLabel="Overall course progress: {rollup.overall.percent}%"
+      />
+    </div>
+  </header>
+
+  <CurriculumMap
+    stages={dashboard.stages}
+    {completedIds}
+    {rollup}
+    {courseSlug}
+  />
+</div>
+
+<style>
+  .dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-10);
+    max-width: 64rem;
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .dashboard__hero {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-6);
+    flex-wrap: wrap;
+  }
+
+  .dashboard__intro {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .dashboard__eyebrow {
+    font-size: var(--text-xs);
+    text-transform: var(--text-transform-label);
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  .dashboard__title {
+    margin: var(--space-1) 0 var(--space-2);
+    font-family: var(--font-heading);
+    font-size: var(--text-3xl);
+    color: var(--color-heading);
+  }
+
+  .dashboard__status {
+    margin: 0 0 var(--space-4);
+    font-size: var(--text-base);
+    color: var(--color-text-secondary);
+  }
+
+  .dashboard__continue {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-5);
+    border-radius: var(--radius-button);
+    background: var(--color-primary-600);
+    color: var(--color-text-on-brand);
+    font-size: var(--text-base);
+    font-weight: var(--font-medium);
+    text-decoration: none;
+    transition: background-color var(--duration-fast) ease;
+  }
+
+  .dashboard__continue:hover {
+    background: var(--color-primary-700);
+  }
+
+  .dashboard__continue:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .dashboard__ring {
+    flex-shrink: 0;
+  }
+</style>

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.server.ts
@@ -1,0 +1,85 @@
+/**
+ * In-course practice player — server gate + data (Codex-2pryk · WP-4).
+ *
+ * `ssr = false` (HARDENING §E): authed SPA. The server `load` runs and enforces
+ * BOTH gates before any client render (SPEC §8.6 / §6.3):
+ *   - `canEnterCourse` → the in-course chrome (playlist, progress, mark-complete).
+ *   - `canView`        → the signed practice STREAM (media only; written bodies
+ *                        are gated by course entry).
+ * A member who can enter the course but somehow can't view a specific stream
+ * still gets the chrome; the stream URL is withheld.
+ *
+ * ─── ROUND-D SEAM ───────────────────────────────────────────────────────────
+ * The resolver + practice fetch are mocked in
+ * `$lib/server/journeys/round-d-seam.ts`; Round-D swaps them for real
+ * `@codex/access` calls (incl. R2-signed stream URLs). This file is unchanged.
+ */
+import { error, redirect } from '@sveltejs/kit';
+import { evaluateCourseGate } from '$lib/journeys/gate';
+import {
+  fetchInCoursePractice,
+  resolveCanEnterCourse,
+  resolveCanView,
+  resolveCourseBySlug,
+} from '$lib/server/journeys/round-d-seam';
+import { buildJourneyUrl } from '$lib/utils/subdomain';
+import type { PageServerLoad } from './$types';
+
+export const ssr = false;
+
+export const load: PageServerLoad = async (event) => {
+  const { params, parent, url } = event;
+  event.depends('app:auth');
+
+  const { org, user } = await parent();
+  const course = await resolveCourseBySlug(event, params.journeySlug);
+
+  const canEnter =
+    user && course
+      ? await resolveCanEnterCourse(event, user.id, course.id)
+      : false;
+
+  const outcome = evaluateCourseGate({
+    courseExists: course !== null,
+    isAuthenticated: Boolean(user),
+    canEnterCourse: canEnter,
+  });
+
+  if (outcome.kind === 'not-found') error(404, 'Course not found');
+  if (outcome.kind === 'redirect-to-sales') {
+    redirect(
+      303,
+      buildJourneyUrl(
+        url,
+        {
+          slug: params.journeySlug,
+          id: course?.id ?? params.journeySlug,
+          organizationSlug: org?.slug ?? null,
+        },
+        { surface: 'sales' }
+      )
+    );
+  }
+
+  const practice = await fetchInCoursePractice(
+    event,
+    user!.id,
+    course!.id,
+    params.contentSlug
+  );
+  if (!practice) error(404, 'Practice not found');
+
+  // `canView` gates the media stream. Written practices are gated by course
+  // entry alone. Withhold the stream URL if the view check fails.
+  const streamViewable =
+    practice.practice.contentType === 'written'
+      ? true
+      : await resolveCanView(event, user!.id, practice.practice.contentId);
+
+  return {
+    practice: {
+      ...practice,
+      streamingUrl: streamViewable ? practice.streamingUrl : null,
+    },
+  };
+};

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
@@ -1,0 +1,164 @@
+<!--
+  @component InCoursePracticePage
+
+  The in-course player (SPEC §8.3 / §8.6): playlist rail + working pane. The
+  SAME content item renders differently INSIDE a course (stage context, next/
+  prev, progress, completion) than standalone — route context selects this UI.
+  Client-rendered (ssr=false); the server gate enforced canEnterCourse + canView.
+
+  Completion + playback read the SINGLE progress store (F19): the working pane
+  auto-marks media on genuine 100% finish and writes explicit completions for
+  written practices; both update the playlist + dashboard reactively.
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    loadCourseCompletionsFromServer,
+    type PlaybackProgress,
+    progressCollection,
+    useLiveQuery,
+  } from '$lib/collections';
+  import PracticePlaylist from '$lib/components/journeys/PracticePlaylist.svelte';
+  import PracticeWorkingPane from '$lib/components/journeys/PracticeWorkingPane.svelte';
+  import { ArrowLeftIcon } from '$lib/components/ui/Icon';
+
+  let { data } = $props();
+
+  const practiceData = $derived(data.practice);
+  const current = $derived(practiceData.practice);
+  const courseSlug = $derived(
+    practiceData.course.slug ?? practiceData.course.id
+  );
+  const dashboardHref = $derived(`/journeys/${courseSlug}/dashboard`);
+
+  // Hydrate the store with the course's known completions, then live-query it.
+  let hydrated = $state(false);
+  onMount(() => {
+    loadCourseCompletionsFromServer(practiceData.completions);
+    hydrated = true;
+  });
+
+  const progressQuery = useLiveQuery(
+    (q) => q.from({ item: progressCollection }),
+    undefined,
+    { ssrData: [] as PlaybackProgress[] }
+  );
+  const rows = $derived((progressQuery.data ?? []) as PlaybackProgress[]);
+
+  const completedIds = $derived.by(() => {
+    if (!hydrated) {
+      return new Set(practiceData.completions.map((c) => c.contentId));
+    }
+    return new Set(
+      rows.filter((r) => r.practiceCompletedAt).map((r) => r.contentId)
+    );
+  });
+
+  // Current practice completion + watch % — drive the working pane's affordance
+  // and the D-E media auto-write (fires at 100%).
+  const currentRow = $derived(
+    rows.find((r) => r.contentId === current.contentId) ?? null
+  );
+  const isComplete = $derived(completedIds.has(current.contentId));
+  const playbackPercent = $derived(currentRow?.percentComplete ?? 0);
+
+  // Prev/next within the flattened course sequence.
+  const currentIndex = $derived(
+    practiceData.playlist.findIndex((e) => e.contentId === current.contentId)
+  );
+  function hrefFor(index: number): string | null {
+    const entry = practiceData.playlist[index];
+    if (!entry) return null;
+    return `/journeys/${courseSlug}/practice/${entry.slug ?? entry.contentId}`;
+  }
+  const prevHref = $derived(hrefFor(currentIndex - 1));
+  const nextHref = $derived(hrefFor(currentIndex + 1));
+</script>
+
+<svelte:head>
+  <title>{current.title} · {practiceData.course.title}</title>
+</svelte:head>
+
+<div class="player">
+  <aside class="player__rail">
+    <a class="player__back" href={dashboardHref}>
+      <ArrowLeftIcon />
+      {practiceData.course.title}
+    </a>
+    <PracticePlaylist
+      playlist={practiceData.playlist}
+      {completedIds}
+      currentContentId={current.contentId}
+      {courseSlug}
+    />
+  </aside>
+
+  <main class="player__main">
+    <PracticeWorkingPane
+      practice={current}
+      streamingUrl={practiceData.streamingUrl}
+      waveformUrl={practiceData.waveformUrl}
+      bodyHtml={practiceData.bodyHtml}
+      initialProgressSeconds={practiceData.initialProgressSeconds}
+      {isComplete}
+      {playbackPercent}
+      {prevHref}
+      {nextHref}
+    />
+  </main>
+</div>
+
+<style>
+  .player {
+    display: grid;
+    grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+    gap: var(--space-8);
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: var(--space-6) var(--space-4);
+    align-items: start;
+  }
+
+  .player__rail {
+    position: sticky;
+    top: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    min-width: 0;
+  }
+
+  .player__back {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+  }
+
+  .player__back:hover {
+    color: var(--color-heading);
+  }
+
+  .player__back:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+    border-radius: var(--radius-sm);
+  }
+
+  .player__main {
+    min-width: 0;
+  }
+
+  /* Rail drops above the working pane on narrow viewports. */
+  @media (max-width: 48rem) {
+    .player {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .player__rail {
+      position: static;
+    }
+  }
+</style>


### PR DESCRIPTION
## WP-4 — Course dashboard + in-course player (Epic 2, Codex-2pryk.3.2) — STACKED on WP-2 (#412)

**Base is WP-2's branch** (WP-4 branched off it for WP-1 schema + WP-2 resolver contract). Merge after #411→#412. Aggressive-mode: real schema + frozen resolver contract; ONLY the web→worker plumbing is mocked (single Round-D seam `round-d-seam.ts`).

### What landed (19 files)
- **Routes** (both `ssr=false`, leaf load still gates+redirects): `journeys/[journeySlug]/dashboard` + `practice/[contentSlug]`. Gate ordering (secure): slug→course → `canEnterCourse` (+`canView` for the player stream) → THEN load; pure unit-tested `evaluateCourseGate()`; 404/redirect-to-sales via `buildJourneyUrl`.
- **Player/components**: ProgressRing, CurriculumMap, PracticePlaylist, PracticeWorkingPane.
- **progressCollection extension** (F19 SINGLE store): 3 optional completion fields; optimistic+idempotent `markPracticeComplete`; syncs via the existing progress-sync loop. Zero changes to shared VideoPlayer/AudioPlayer.
- **D-E reconciliation (as documented, §H5)**: the `practice_completions` row is the single source of truth, NEVER `videoPlayback.completed`; written→button, video/audio→auto on genuine 100% finish.
- **mark-complete** `command()` → `practice_completions` (Round-D seam).

### ⚠️ Round-D / merge coordination
- WP-3 (#410) created placeholder `journeys/[journeySlug]/{dashboard,checkout}` SHELLS (deferred to WP-4/WP-6). This PR's REAL dashboard supersedes WP-3's dashboard shell; WP-6's real checkout supersedes WP-3's checkout shell — reconcile at merge/integration (real wins). Param name `[journeySlug]` is consistent across WP-3/WP-4.
- Round-D swaps each `round-d-seam.ts` body for `createServerApi(...).access.*`; signatures frozen → no caller changes.

### Verification (local, warm)
build ✓ · svelte-check 0 in changed files (86 phantom baseline unchanged) · biome clean · 39/39 unit (gate 5, rollup 9, progress store 25). MCP visual gate DEFERRED to Round-D (real data + signed streams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)