### PR TITLE
feat(web): course reporting/insights — provenance-tagged live+course metrics (Codex-2pryk.3.4)

### DIFF
--- a/apps/web/src/lib/components/studio/journey-insights/JourneyInsightsPanel.svelte
+++ b/apps/web/src/lib/components/studio/journey-insights/JourneyInsightsPanel.svelte
@@ -1,0 +1,118 @@
+<!--
+  @component JourneyInsightsPanel
+
+  The studio journey/course insights surface (FRONTEND-MAP §5.3). Composes:
+  header (course title + period toggle) → provenance legend → one section per
+  provenance tier of KPICards. Presentation only: it takes the seam's data and
+  the pure metric model does the tier grouping.
+
+  Skeletons render until the first data arrives (the studio subtree is an
+  `ssr=false` SPA, so first client paint has no data yet).
+
+  @prop {JourneyInsightsData | undefined} data   Resolved insights, or undefined while loading.
+  @prop {InsightsPeriod} period                  Current reporting window.
+  @prop {(p: InsightsPeriod) => void} onPeriodChange  Period change handler.
+-->
+<script lang="ts">
+  import MetricTierGroup from './MetricTierGroup.svelte';
+  import PeriodToggle from './PeriodToggle.svelte';
+  import ProvenanceLegend from './ProvenanceLegend.svelte';
+  import {
+    buildJourneyMetricGroups,
+    METRIC_TIERS,
+    type InsightsPeriod,
+    type JourneyInsightsData,
+    type MetricTierGroupModel,
+  } from './metric-model';
+
+  interface Props {
+    data: JourneyInsightsData | undefined;
+    period: InsightsPeriod;
+    onPeriodChange: (period: InsightsPeriod) => void;
+  }
+
+  const { data, period, onPeriodChange }: Props = $props();
+
+  const groups = $derived(data ? buildJourneyMetricGroups(data) : null);
+
+  // Empty skeleton groups keep the tier layout stable during first load.
+  const liveSkeleton: MetricTierGroupModel = {
+    tier: 'live',
+    meta: METRIC_TIERS.live,
+    metrics: [],
+  };
+  const courseSkeleton: MetricTierGroupModel = {
+    tier: 'course',
+    meta: METRIC_TIERS.course,
+    metrics: [],
+  };
+</script>
+
+<section class="insights">
+  <header class="insights__header">
+    <div class="insights__titles">
+      <h1 class="insights__title">{data?.courseTitle ?? 'Insights'}</h1>
+      <p class="insights__subtitle">
+        Revenue and engagement for this journey.
+      </p>
+    </div>
+    <PeriodToggle value={period} onChange={onPeriodChange} />
+  </header>
+
+  <ProvenanceLegend />
+
+  <div class="insights__groups">
+    {#if groups}
+      {#each groups as group (group.tier)}
+        <MetricTierGroup {group} />
+      {/each}
+    {:else}
+      <MetricTierGroup group={liveSkeleton} loading skeletonCount={3} />
+      <MetricTierGroup group={courseSkeleton} loading skeletonCount={4} />
+    {/if}
+  </div>
+</section>
+
+<style>
+  .insights {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+    width: 100%;
+  }
+
+  .insights__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+  }
+
+  .insights__titles {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .insights__title {
+    font-size: var(--text-2xl);
+    font-weight: var(--font-bold);
+    color: var(--color-text);
+    line-height: var(--leading-tight);
+    margin: 0;
+  }
+
+  .insights__subtitle {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-normal);
+    margin: 0;
+  }
+
+  .insights__groups {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+  }
+</style>

--- a/apps/web/src/lib/components/studio/journey-insights/MetricTierGroup.svelte
+++ b/apps/web/src/lib/components/studio/journey-insights/MetricTierGroup.svelte
@@ -1,0 +1,111 @@
+<!--
+  @component MetricTierGroup
+
+  One provenance tier rendered as a section: a heading carrying the tier's
+  provenance Badge + source description, then a KPICard grid of that tier's
+  metrics. Reuses the studio analytics `KPICard` (money = GBP pence).
+
+  Provenance is STRUCTURAL here — the whole section is one tier, badged and
+  described, so the reader always knows where these numbers come from.
+
+  @prop {MetricTierGroupModel} group        Tier meta + its tagged metrics.
+  @prop {boolean} [loading=false]           Render skeleton tiles instead of data.
+  @prop {number}  [skeletonCount=3]         How many skeleton tiles when loading.
+-->
+<script lang="ts">
+  import { KPICard } from '$lib/components/studio/analytics';
+  import Badge from '$lib/components/ui/Badge/Badge.svelte';
+  import type { MetricTierGroupModel } from './metric-model';
+
+  interface Props {
+    group: MetricTierGroupModel;
+    loading?: boolean;
+    skeletonCount?: number;
+  }
+
+  const { group, loading = false, skeletonCount = 3 }: Props = $props();
+
+  // `live` reads as an active/derivable source → info; `course` is neutral.
+  const badgeVariant = $derived(group.tier === 'live' ? 'info' : 'neutral');
+  const headingId = $derived(`insights-tier-${group.tier}`);
+  const skeletonKeys = $derived(
+    Array.from({ length: skeletonCount }, (_, i) => `skeleton-${i}`)
+  );
+</script>
+
+<section class="tier-group" aria-labelledby={headingId}>
+  <header class="tier-group__header">
+    <h2 id={headingId} class="tier-group__title">{group.meta.label}</h2>
+    <Badge variant={badgeVariant}>{group.meta.label}</Badge>
+  </header>
+  <p class="tier-group__desc">{group.meta.description}</p>
+
+  <div class="tier-group__grid">
+    {#if loading}
+      {#each skeletonKeys as key (key)}
+        <KPICard label="" value={0} loading />
+      {/each}
+    {:else}
+      {#each group.metrics as metric (metric.key)}
+        {@const kpiFormat = metric.format === 'money' ? 'money' : 'number'}
+        {@const kpiUnit = metric.format === 'percent' ? '%' : metric.unit}
+        <KPICard
+          label={metric.label}
+          value={metric.value}
+          format={kpiFormat}
+          previousValue={metric.previousValue}
+          sparkline={metric.trend}
+          unit={kpiUnit}
+        />
+      {/each}
+    {/if}
+  </div>
+</section>
+
+<style>
+  .tier-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .tier-group__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .tier-group__title {
+    font-size: var(--text-lg);
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
+    line-height: var(--leading-tight);
+    margin: 0;
+  }
+
+  .tier-group__desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-normal);
+    margin: 0;
+  }
+
+  /* KPI grid: 4-up desktop, 2-up tablet, 1-up mobile — mirrors studio analytics. */
+  .tier-group__grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--space-4);
+  }
+
+  @media (--below-lg) {
+    .tier-group__grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (--below-sm) {
+    .tier-group__grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/studio/journey-insights/PeriodToggle.svelte
+++ b/apps/web/src/lib/components/studio/journey-insights/PeriodToggle.svelte
@@ -1,0 +1,82 @@
+<!--
+  @component PeriodToggle
+
+  Controlled segmented control for the reporting window. The parent owns the
+  value (driven by the `?period=` URL param on the insights page) and re-fires
+  the query on change.
+
+  @prop {InsightsPeriod} value               Current period.
+  @prop {(p: InsightsPeriod) => void} onChange Called with the chosen period.
+-->
+<script lang="ts">
+  import type { InsightsPeriod } from './metric-model';
+
+  interface Props {
+    value: InsightsPeriod;
+    onChange: (period: InsightsPeriod) => void;
+  }
+
+  const { value, onChange }: Props = $props();
+
+  const options: { id: InsightsPeriod; label: string }[] = [
+    { id: '7d', label: '7 days' },
+    { id: '30d', label: '30 days' },
+    { id: '90d', label: '90 days' },
+    { id: 'all', label: 'All time' },
+  ];
+</script>
+
+<div class="period-toggle" role="group" aria-label="Reporting period">
+  {#each options as option (option.id)}
+    <button
+      type="button"
+      class="period-toggle__btn"
+      data-active={value === option.id}
+      aria-pressed={value === option.id}
+      onclick={() => onChange(option.id)}
+    >
+      {option.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .period-toggle {
+    display: inline-flex;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    background-color: var(--color-surface-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-md);
+  }
+
+  .period-toggle__btn {
+    appearance: none;
+    border: none;
+    background: transparent;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-none);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .period-toggle__btn:hover {
+    color: var(--color-text);
+  }
+
+  .period-toggle__btn[data-active='true'] {
+    background-color: var(--color-surface-card);
+    color: var(--color-text);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .period-toggle__btn:focus-visible {
+    outline: var(--border-width-thick) var(--border-style) var(--color-focus-ring);
+    outline-offset: var(--space-1);
+  }
+</style>

--- a/apps/web/src/lib/components/studio/journey-insights/ProvenanceLegend.svelte
+++ b/apps/web/src/lib/components/studio/journey-insights/ProvenanceLegend.svelte
@@ -1,0 +1,80 @@
+<!--
+  @component ProvenanceLegend
+
+  Explains the provenance tiers that tag every metric on the insights surface
+  (SPEC §14.4). Lists the two tiers that ship (`live`, `course`) with their data
+  sources, then the `track` tier as an explicit "not captured yet" note — so the
+  omission of reach / traffic metrics is visible and honest, not silent.
+-->
+<script lang="ts">
+  import Badge from '$lib/components/ui/Badge/Badge.svelte';
+  import { METRIC_TIERS, UNTRACKED_TIER } from './metric-model';
+
+  const tiers = [METRIC_TIERS.live, METRIC_TIERS.course];
+</script>
+
+<aside class="legend" aria-label="What the metric tiers mean">
+  <p class="legend__intro">
+    Each metric is tagged by where its data comes from.
+  </p>
+  <ul class="legend__list">
+    {#each tiers as tier (tier.id)}
+      <li class="legend__item">
+        <Badge variant={tier.id === 'live' ? 'info' : 'neutral'}>
+          {tier.label}
+        </Badge>
+        <span class="legend__desc">{tier.description}</span>
+      </li>
+    {/each}
+    <li class="legend__item legend__item--muted">
+      <Badge variant="neutral">{UNTRACKED_TIER.label}</Badge>
+      <span class="legend__desc">{UNTRACKED_TIER.description}</span>
+    </li>
+  </ul>
+</aside>
+
+<style>
+  .legend {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    background-color: var(--color-surface-secondary);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .legend__intro {
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-normal);
+    margin: 0;
+  }
+
+  .legend__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .legend__item {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+  }
+
+  .legend__desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-normal);
+  }
+
+  /* The un-instrumented `track` tier reads as unavailable, not active. */
+  .legend__item--muted .legend__desc {
+    color: var(--color-text-tertiary);
+  }
+</style>

--- a/apps/web/src/lib/components/studio/journey-insights/__tests__/metric-model.test.ts
+++ b/apps/web/src/lib/components/studio/journey-insights/__tests__/metric-model.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCourseMetrics,
+  buildJourneyMetricGroups,
+  buildLiveMetrics,
+  completionRate,
+  type JourneyInsightsData,
+  METRIC_TIERS,
+  type MetricSample,
+  UNTRACKED_TIER,
+} from '../metric-model';
+
+const s = (
+  value: number,
+  previousValue: number | null = null
+): MetricSample => ({
+  value,
+  previousValue,
+});
+
+function fixture(
+  overrides: Partial<JourneyInsightsData> = {}
+): JourneyInsightsData {
+  return {
+    courseId: 'course-1',
+    courseTitle: 'Test Course',
+    period: '30d',
+    financials: {
+      revenueCents: s(120_000, 100_000),
+      purchaseCount: s(40, 30),
+      subscriptionCount: s(12, 10),
+      revenueTrend: [
+        { date: 't-2', value: 1000 },
+        { date: 't-1', value: 1200 },
+      ],
+    },
+    engagement: {
+      enrolledCount: s(200, 100),
+      activeCount: s(120, 60),
+      completedCount: s(50, 20),
+    },
+    ...overrides,
+  };
+}
+
+describe('completionRate', () => {
+  it('guards div-by-zero — no enrolments reports 0%, never NaN/Infinity', () => {
+    expect(completionRate(0, 0)).toBe(0);
+    expect(completionRate(5, 0)).toBe(0);
+    expect(Number.isFinite(completionRate(5, 0))).toBe(true);
+  });
+
+  it('rounds to an integer percentage', () => {
+    expect(completionRate(50, 200)).toBe(25);
+    expect(completionRate(1, 3)).toBe(33);
+    expect(completionRate(2, 3)).toBe(67);
+  });
+});
+
+describe('buildLiveMetrics', () => {
+  it('tags every metric with the live tier', () => {
+    const metrics = buildLiveMetrics(fixture().financials);
+    expect(metrics).toHaveLength(3);
+    expect(metrics.every((m) => m.tier === 'live')).toBe(true);
+  });
+
+  it('renders revenue as GBP pence (money) and carries the trend', () => {
+    const revenue = buildLiveMetrics(fixture().financials).find(
+      (m) => m.key === 'revenue'
+    );
+    expect(revenue?.format).toBe('money');
+    expect(revenue?.value).toBe(120_000);
+    expect(revenue?.previousValue).toBe(100_000);
+    expect(revenue?.trend).toHaveLength(2);
+  });
+
+  it('renders counts as plain numbers', () => {
+    const metrics = buildLiveMetrics(fixture().financials);
+    const purchases = metrics.find((m) => m.key === 'purchases');
+    expect(purchases?.format).toBe('number');
+    expect(purchases?.value).toBe(40);
+  });
+});
+
+describe('buildCourseMetrics', () => {
+  it('tags every metric with the course tier', () => {
+    const metrics = buildCourseMetrics(fixture().engagement);
+    expect(metrics.every((m) => m.tier === 'course')).toBe(true);
+  });
+
+  it('derives completion rate as a percent from completed ÷ enrolled', () => {
+    const rate = buildCourseMetrics(fixture().engagement).find(
+      (m) => m.key === 'completionRate'
+    );
+    expect(rate?.format).toBe('percent');
+    expect(rate?.unit).toBe('%');
+    expect(rate?.value).toBe(25); // 50 / 200
+    expect(rate?.previousValue).toBe(20); // 20 / 100
+  });
+
+  it('leaves the previous completion rate null when the prior period is absent', () => {
+    const { engagement } = fixture({
+      engagement: {
+        enrolledCount: s(200, null),
+        activeCount: s(120, null),
+        completedCount: s(50, null),
+      },
+    });
+    const rate = buildCourseMetrics(engagement).find(
+      (m) => m.key === 'completionRate'
+    );
+    expect(rate?.previousValue).toBeNull();
+  });
+});
+
+describe('buildJourneyMetricGroups — structural provenance', () => {
+  it('returns exactly the two v1 tiers, live before course', () => {
+    const groups = buildJourneyMetricGroups(fixture());
+    expect(groups.map((g) => g.tier)).toEqual(['live', 'course']);
+  });
+
+  it('attaches the correct legend meta to each group', () => {
+    const groups = buildJourneyMetricGroups(fixture());
+    expect(groups[0].meta).toBe(METRIC_TIERS.live);
+    expect(groups[1].meta).toBe(METRIC_TIERS.course);
+  });
+
+  it('every metric carries the tier of the group it lives in', () => {
+    for (const group of buildJourneyMetricGroups(fixture())) {
+      expect(group.metrics.every((m) => m.tier === group.tier)).toBe(true);
+    }
+  });
+
+  it('never emits a track tier — track is dropped for v1', () => {
+    const tiers = new Set(
+      buildJourneyMetricGroups(fixture()).flatMap((g) =>
+        g.metrics.map((m) => m.tier)
+      )
+    );
+    expect([...tiers].sort()).toEqual(['course', 'live']);
+    expect(tiers.has('track' as never)).toBe(false);
+  });
+});
+
+describe('track tier is acknowledged but not built', () => {
+  it('exposes UNTRACKED_TIER for the legend without producing metrics', () => {
+    expect(UNTRACKED_TIER.id).toBe('track');
+    // METRIC_TIERS (the built tiers) must not contain track.
+    expect(Object.keys(METRIC_TIERS).sort()).toEqual(['course', 'live']);
+  });
+});

--- a/apps/web/src/lib/components/studio/journey-insights/index.ts
+++ b/apps/web/src/lib/components/studio/journey-insights/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Journey insights — studio reporting surface (WP-7, Codex-2pryk.3.4).
+ *
+ * Provenance-tagged course reporting: `live` (financial) + `course`
+ * (engagement) tiers. The pure metric model does the tier grouping; the data
+ * source is the single Round-D seam `$lib/remote/journey-insights.remote.ts`.
+ */
+export { default as JourneyInsightsPanel } from './JourneyInsightsPanel.svelte';
+export { default as MetricTierGroup } from './MetricTierGroup.svelte';
+export * from './metric-model';
+export { default as PeriodToggle } from './PeriodToggle.svelte';
+export { default as ProvenanceLegend } from './ProvenanceLegend.svelte';

--- a/apps/web/src/lib/components/studio/journey-insights/metric-model.ts
+++ b/apps/web/src/lib/components/studio/journey-insights/metric-model.ts
@@ -1,0 +1,279 @@
+/**
+ * Journey insights — metric model & provenance tagging (WP-7, Codex-2pryk.3.4).
+ *
+ * The reporting surface (SPEC §11, §14.4 · FRONTEND-MAP §5.3) ships metrics in
+ * PROVENANCE tiers. Provenance is STRUCTURAL, not cosmetic: every metric is
+ * constructed carrying its `tier`, and metrics are physically grouped by tier
+ * for rendering. The legend (`METRIC_TIERS`) is the single source of truth for
+ * what each tier means and why it exists.
+ *
+ * Two tiers ship for v1:
+ *   • `live`   — financial data derivable TODAY from purchases / subscriptions /
+ *                payouts (revenue, purchase mix, subscription mix).
+ *   • `course` — engagement data from the WP-1 tables `course_enrollments` +
+ *                `practice_completions` (enrolled / active / completed / rate).
+ *
+ * The third tier from the spec — `track` (sales-page views, referrer, campaign)
+ * — is DELIBERATELY NOT BUILT: it is instrumented nowhere today and is not yet
+ * planned (maps to the unstarted Codex-arhvd pipeline). It is surfaced in the
+ * legend only, as an explicit "not tracked yet" note, so the provenance model
+ * stays honest without fabricating data. See `UNTRACKED_TIER`.
+ *
+ * This module is PURE (no Svelte, no I/O, no DB): it transforms the seam's
+ * contract-shaped data into render-ready, tier-tagged metrics. It is the unit
+ * under test — the raw data source is mocked at the seam (`journey-insights.remote.ts`).
+ */
+
+/** Data-provenance tiers that ship for v1. `track` is intentionally absent. */
+export type MetricTier = 'live' | 'course';
+
+/** How a metric's value should be rendered. */
+export type MetricFormat = 'money' | 'number' | 'percent';
+
+/** A single point on a metric's trend sparkline. */
+export interface TrendPoint {
+  date: string;
+  value: number;
+}
+
+/**
+ * A current value paired with the equivalent from the previous comparison
+ * window. `previousValue` is `null` when there is no comparable prior period
+ * (KPICard suppresses the delta row in that case).
+ */
+export interface MetricSample {
+  value: number;
+  previousValue: number | null;
+}
+
+/**
+ * `live`-tier source data — the money path. Values are GBP **pence** (matching
+ * the platform convention: `courses.priceCents`, `RevenueStats.totalRevenueCents`).
+ * Derivable today from `@codex/purchase` + `@codex/subscription` + payouts,
+ * scoped to the course's creator/org.
+ */
+export interface LiveFinancials {
+  /** Gross course revenue in GBP pence (one-off purchases + course subscriptions). */
+  revenueCents: MetricSample;
+  /** Count of one-off course purchases. */
+  purchaseCount: MetricSample;
+  /** Count of active course-specific subscriptions. */
+  subscriptionCount: MetricSample;
+  /** Optional revenue trend for the sparkline (pence per bucket). */
+  revenueTrend: TrendPoint[];
+}
+
+/**
+ * `course`-tier source data — the engagement path. Needs the WP-1 tables
+ * `course_enrollments` (enrolled / active-via-`lastActivityAt` / completed-via-
+ * `completedAt`) and `practice_completions` (rollup). Completion rate is DERIVED
+ * from completed ÷ enrolled, not stored.
+ */
+export interface CourseEngagement {
+  /** Rows in `course_enrollments` for the course. */
+  enrolledCount: MetricSample;
+  /** Enrollments with recent `lastActivityAt` (active learners). */
+  activeCount: MetricSample;
+  /** Enrollments with a non-null `completedAt`. */
+  completedCount: MetricSample;
+}
+
+/** The supported reporting windows. Drives the period toggle + query re-key. */
+export type InsightsPeriod = '7d' | '30d' | '90d' | 'all';
+
+/**
+ * The seam's return contract — everything the insights surface needs for one
+ * course/journey in one period. Produced by `getJourneyInsights` (mocked today,
+ * real aggregation at Round-D).
+ */
+export interface JourneyInsightsData {
+  courseId: string;
+  courseTitle: string;
+  period: InsightsPeriod;
+  financials: LiveFinancials;
+  engagement: CourseEngagement;
+}
+
+/** A render-ready metric, tagged with its provenance tier. */
+export interface JourneyMetric {
+  /** Stable key for `{#each}` and testing. */
+  key: string;
+  /** Human label (already in display language). */
+  label: string;
+  /** Provenance tier — matches the group this metric lives in. */
+  tier: MetricTier;
+  format: MetricFormat;
+  value: number;
+  previousValue: number | null;
+  /** Suffix for `number`/`percent` metrics (e.g. "%", "learners"). */
+  unit?: string;
+  /** Optional sparkline series (money/number only). */
+  trend?: TrendPoint[];
+}
+
+/** Legend metadata for a provenance tier. */
+export interface MetricTierMeta {
+  id: MetricTier;
+  label: string;
+  /** One-line explanation of the data source — shown in the legend. */
+  description: string;
+}
+
+/**
+ * Single source of truth for provenance semantics. The legend renders from
+ * this; the group builders tag metrics with the matching `id`. `live` is listed
+ * first because it ships first (SPEC §14.4: "ship `live` first").
+ */
+export const METRIC_TIERS = {
+  live: {
+    id: 'live',
+    label: 'Live',
+    description:
+      'Financial data from real purchases, subscriptions and payouts — available now.',
+  },
+  course: {
+    id: 'course',
+    label: 'Course',
+    description:
+      'Engagement data from course enrolments and practice completions.',
+  },
+} as const satisfies Record<MetricTier, MetricTierMeta>;
+
+/**
+ * The `track` tier from SPEC §14.4, surfaced in the legend but NOT built for v1.
+ * Sales-page views / referrer / campaign source are captured nowhere today, so
+ * reach and top-of-funnel metrics are intentionally omitted rather than faked.
+ */
+export const UNTRACKED_TIER = {
+  id: 'track',
+  label: 'Traffic',
+  description:
+    'Sales-page views, referrer and campaign source are not captured yet, so reach and top-of-funnel metrics are intentionally omitted.',
+} as const;
+
+/**
+ * Completion rate as an integer percentage (0–100). Guards div-by-zero: a
+ * course with no enrolments reports 0%, never NaN or Infinity.
+ */
+export function completionRate(completed: number, enrolled: number): number {
+  if (enrolled <= 0) return 0;
+  return Math.round((completed / enrolled) * 100);
+}
+
+/** Build the `live`-tier (financial) metrics. Every metric is tagged `live`. */
+export function buildLiveMetrics(financials: LiveFinancials): JourneyMetric[] {
+  return [
+    {
+      key: 'revenue',
+      label: 'Course revenue',
+      tier: 'live',
+      format: 'money',
+      value: financials.revenueCents.value,
+      previousValue: financials.revenueCents.previousValue,
+      trend: financials.revenueTrend,
+    },
+    {
+      key: 'purchases',
+      label: 'One-off purchases',
+      tier: 'live',
+      format: 'number',
+      value: financials.purchaseCount.value,
+      previousValue: financials.purchaseCount.previousValue,
+    },
+    {
+      key: 'subscriptions',
+      label: 'Course subscriptions',
+      tier: 'live',
+      format: 'number',
+      value: financials.subscriptionCount.value,
+      previousValue: financials.subscriptionCount.previousValue,
+    },
+  ];
+}
+
+/**
+ * Build the `course`-tier (engagement) metrics. Every metric is tagged `course`.
+ * Completion rate is derived from completed ÷ enrolled (current and previous).
+ */
+export function buildCourseMetrics(
+  engagement: CourseEngagement
+): JourneyMetric[] {
+  const { enrolledCount, activeCount, completedCount } = engagement;
+
+  const ratePrevious =
+    enrolledCount.previousValue !== null &&
+    completedCount.previousValue !== null
+      ? completionRate(
+          completedCount.previousValue,
+          enrolledCount.previousValue
+        )
+      : null;
+
+  return [
+    {
+      key: 'enrolled',
+      label: 'Enrolled',
+      tier: 'course',
+      format: 'number',
+      value: enrolledCount.value,
+      previousValue: enrolledCount.previousValue,
+      unit: 'learners',
+    },
+    {
+      key: 'active',
+      label: 'Active learners',
+      tier: 'course',
+      format: 'number',
+      value: activeCount.value,
+      previousValue: activeCount.previousValue,
+      unit: 'learners',
+    },
+    {
+      key: 'completed',
+      label: 'Completed',
+      tier: 'course',
+      format: 'number',
+      value: completedCount.value,
+      previousValue: completedCount.previousValue,
+      unit: 'learners',
+    },
+    {
+      key: 'completionRate',
+      label: 'Completion rate',
+      tier: 'course',
+      format: 'percent',
+      value: completionRate(completedCount.value, enrolledCount.value),
+      previousValue: ratePrevious,
+      unit: '%',
+    },
+  ];
+}
+
+/** A provenance-tagged group of metrics ready to render as one section. */
+export interface MetricTierGroupModel {
+  tier: MetricTier;
+  meta: MetricTierMeta;
+  metrics: JourneyMetric[];
+}
+
+/**
+ * Group all metrics by provenance tier — the structural expression of
+ * provenance. Returns exactly the two v1 tiers, `live` before `course`. The
+ * `track` tier is never produced here (it is legend-only, `UNTRACKED_TIER`).
+ */
+export function buildJourneyMetricGroups(
+  data: JourneyInsightsData
+): MetricTierGroupModel[] {
+  return [
+    {
+      tier: 'live',
+      meta: METRIC_TIERS.live,
+      metrics: buildLiveMetrics(data.financials),
+    },
+    {
+      tier: 'course',
+      meta: METRIC_TIERS.course,
+      metrics: buildCourseMetrics(data.engagement),
+    },
+  ];
+}

--- a/apps/web/src/lib/remote/journey-insights.remote.ts
+++ b/apps/web/src/lib/remote/journey-insights.remote.ts
@@ -1,0 +1,188 @@
+/**
+ * Journey insights — data seam (WP-7, Codex-2pryk.3.4).
+ *
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │ ⚠️  ROUND-D SEAM — THE SINGLE UNWIRED MODULE.                              │
+ * │                                                                            │
+ * │ `getJourneyInsights` returns CONTRACT-SHAPED MOCK data today. Every        │
+ * │ number is fabricated deterministically from (courseId, organizationId,     │
+ * │ period) so the surface renders stably — NONE of it reads the database.     │
+ * │                                                                            │
+ * │ Round-D replaces ONLY the body of `getJourneyInsights` (the call site and  │
+ * │ the `JourneyInsightsData` contract are frozen). Wire it to the real        │
+ * │ aggregations, then delete `mockJourneyInsights` and this banner:           │
+ * │                                                                            │
+ * │   live  (financial)  → scope purchase/subscription/payout to the course's  │
+ * │                        creator+org (reuse @codex/purchase + @codex/        │
+ * │                        subscription; the money is GBP pence). Mirror        │
+ * │                        `sales.remote.ts`: `const { platform, cookies } =`  │
+ * │                        `getRequestEvent(); createServerApi(...)`; the       │
+ * │                        worker enforces `requireOrgManagement` + re-derives  │
+ * │                        scope from the session.                             │
+ * │   course (engagement) → aggregate `course_enrollments` (enrolled / active   │
+ * │                        via recent `lastActivityAt` / completed via          │
+ * │                        `completedAt`) + `practice_completions` rollup for   │
+ * │                        the course.                                         │
+ * │                                                                            │
+ * │ `track` (views/referrer) is NOT part of the contract and MUST NOT be       │
+ * │ added here — it is instrumented nowhere (SPEC §14.4). See `UNTRACKED_TIER`. │
+ * └──────────────────────────────────────────────────────────────────────────┘
+ *
+ * Snapshot query semantics (like `sales.remote.ts`): every period change
+ * re-fires the query; no TanStack DB live collection.
+ */
+
+import { z } from 'zod';
+import { query } from '$app/server';
+import type {
+  CourseEngagement,
+  InsightsPeriod,
+  JourneyInsightsData,
+  LiveFinancials,
+  TrendPoint,
+} from '$lib/components/studio/journey-insights/metric-model';
+
+const insightsQueryArgsSchema = z.object({
+  organizationId: z.string().uuid(),
+  courseId: z.string().uuid(),
+  period: z.enum(['7d', '30d', '90d', 'all']).default('30d'),
+});
+
+/**
+ * Studio journey insights for one course in one period.
+ *
+ * @example
+ * const insights = getJourneyInsights({
+ *   organizationId: data.org.id,
+ *   courseId: page.params.id,
+ *   period: '30d',
+ * });
+ * // insights.current → JourneyInsightsData
+ */
+export const getJourneyInsights = query(
+  insightsQueryArgsSchema,
+  async ({
+    organizationId,
+    courseId,
+    period,
+  }): Promise<JourneyInsightsData> => {
+    // ROUND-D: replace this line with the real aggregations (see banner above).
+    return mockJourneyInsights({ organizationId, courseId, period });
+  }
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MOCK — everything below is deleted at Round-D.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Deterministic 32-bit hash so mock numbers are stable per (course, org). */
+function seedFrom(...parts: string[]): number {
+  let h = 2166136261;
+  for (const part of parts) {
+    for (let i = 0; i < part.length; i++) {
+      h ^= part.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+  }
+  return h >>> 0;
+}
+
+/** Mulberry32 PRNG — deterministic, seedable. */
+function makeRng(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s |= 0;
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Volume multiplier per window — larger windows accumulate more activity. */
+const PERIOD_SCALE: Record<InsightsPeriod, number> = {
+  '7d': 0.25,
+  '30d': 1,
+  '90d': 2.6,
+  all: 5.2,
+};
+
+/** Number of sparkline buckets to synthesise per window. */
+const PERIOD_BUCKETS: Record<InsightsPeriod, number> = {
+  '7d': 7,
+  '30d': 10,
+  '90d': 12,
+  all: 12,
+};
+
+function mockJourneyInsights({
+  organizationId,
+  courseId,
+  period,
+}: {
+  organizationId: string;
+  courseId: string;
+  period: InsightsPeriod;
+}): JourneyInsightsData {
+  const rng = makeRng(seedFrom(courseId, organizationId, period));
+  const scale = PERIOD_SCALE[period];
+
+  // Draw a current value and a plausible previous-period value (±25%).
+  const sample = (base: number) => {
+    const value = Math.round(base * scale * (0.75 + rng() * 0.5));
+    const previousValue = Math.round(value * (0.7 + rng() * 0.45));
+    return { value, previousValue };
+  };
+
+  const enrolled = sample(180);
+  // Active/completed are constrained subsets of enrolled (active ≤ enrolled, etc.).
+  const active = {
+    value: Math.round(enrolled.value * (0.45 + rng() * 0.25)),
+    previousValue: Math.round((enrolled.previousValue ?? 0) * 0.5),
+  };
+  const completed = {
+    value: Math.round(active.value * (0.35 + rng() * 0.3)),
+    previousValue: Math.round((active.previousValue ?? 0) * 0.4),
+  };
+
+  const purchaseCount = sample(90);
+  const subscriptionCount = sample(45);
+
+  // Revenue is roughly (purchases · ~£29) + (subs · ~£12), in GBP pence.
+  const revenueValue =
+    purchaseCount.value * 2900 + subscriptionCount.value * 1200;
+  const revenueCents = {
+    value: revenueValue,
+    previousValue: Math.round(revenueValue * (0.7 + rng() * 0.4)),
+  };
+
+  const buckets = PERIOD_BUCKETS[period];
+  const revenueTrend: TrendPoint[] = Array.from(
+    { length: buckets },
+    (_, i) => ({
+      date: `t-${buckets - i}`,
+      value: Math.round((revenueValue / buckets) * (0.6 + rng() * 0.9)),
+    })
+  );
+
+  const financials: LiveFinancials = {
+    revenueCents,
+    purchaseCount,
+    subscriptionCount,
+    revenueTrend,
+  };
+
+  const engagement: CourseEngagement = {
+    enrolledCount: enrolled,
+    activeCount: active,
+    completedCount: completed,
+  };
+
+  return {
+    courseId,
+    courseTitle: `Course ${courseId.slice(0, 8)}`,
+    period,
+    financials,
+    engagement,
+  };
+}

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/insights/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/insights/+page.svelte
@@ -1,0 +1,78 @@
+<!--
+  @component StudioJourneyInsights
+
+  Studio reporting surface for one journey/course (WP-7, Codex-2pryk.3.4 ·
+  FRONTEND-MAP §5.3). Sits under the `ssr=false` studio subtree, so it loads
+  client-side via the `getJourneyInsights` remote query and mirrors the
+  studio/analytics auth-guard + URL-param pattern.
+
+  `[id]` is the course id. The reporting window is driven by `?period=`.
+  Data is provenance-tagged: `live` (financial) + `course` (engagement). The
+  data source is the single Round-D seam — see journey-insights.remote.ts.
+
+  @prop data - Inherited studio layout data: { org, userRole, ... }.
+-->
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import {
+    JourneyInsightsPanel,
+    type InsightsPeriod,
+  } from '$lib/components/studio/journey-insights';
+  import { getJourneyInsights } from '$lib/remote/journey-insights.remote';
+
+  let { data } = $props();
+
+  // ─── Auth / role guard ────────────────────────────────────────────────
+  // Owner + admin only, matching studio/analytics. ssr=false means the first
+  // client render has data.userRole === undefined — wait for it to populate
+  // before redirecting, or we'd bounce authorised users.
+  $effect(() => {
+    if (
+      data.userRole !== undefined &&
+      data.userRole !== 'admin' &&
+      data.userRole !== 'owner'
+    ) {
+      goto('/studio');
+    }
+  });
+
+  const isAuthorized = $derived(
+    data.userRole === 'admin' || data.userRole === 'owner'
+  );
+
+  const courseId = $derived(page.params.id ?? '');
+
+  // ─── URL → period ─────────────────────────────────────────────────────
+  const VALID_PERIODS: InsightsPeriod[] = ['7d', '30d', '90d', 'all'];
+  const period = $derived.by<InsightsPeriod>(() => {
+    const raw = page.url.searchParams.get('period');
+    return VALID_PERIODS.includes(raw as InsightsPeriod)
+      ? (raw as InsightsPeriod)
+      : '30d';
+  });
+
+  // ─── Remote query ─────────────────────────────────────────────────────
+  // Re-keys off (orgId, courseId, period) so period changes refetch.
+  const insightsQuery = $derived(
+    isAuthorized && courseId
+      ? getJourneyInsights({
+          organizationId: data.org.id,
+          courseId,
+          period,
+        })
+      : null
+  );
+
+  const insights = $derived(insightsQuery?.current);
+
+  function setPeriod(next: InsightsPeriod) {
+    const url = new URL(page.url);
+    url.searchParams.set('period', next);
+    goto(url, { replaceState: true, keepFocus: true, noScroll: true });
+  }
+</script>
+
+{#if isAuthorized}
+  <JourneyInsightsPanel data={insights} {period} onPeriodChange={setPeriod} />
+{/if}


### PR DESCRIPTION
## WP-7 — Reporting / insights (Epic 2, Codex-2pryk.3.4) — STACKED on WP-2 (#412)

**Base is WP-2's branch** (branched off 0b7f53c9 for WP-1 tables + financial data). Merge after the BE spine. Disjoint from WP-5 (adds only `studio/journeys/[id]/insights` leaf; WP-5 owns journeys/{curriculum,page}).

### What landed (9 files)
- Route `_org/[slug]/studio/journeys/[id]/insights/+page.svelte` (inherits studio `ssr=false` + owner/admin guard).
- **Two provenance-tagged metric tiers** (decision D-F), structural not cosmetic — each metric carries its `tier`, grouped + badged; `METRIC_TIERS` single source of truth:
  - **live** (financial): course revenue (GBP pence), one-off purchases, course subscriptions.
  - **course** (engagement): enrolled, active, completed, completion-rate (div-by-zero guarded) — from WP-1 `course_enrollments` + `practice_completions`.
  - **track** (views): NOT BUILT — `MetricTier` type = `'live'|'course'` (no track); shown in legend as UNTRACKED only; a unit test asserts the tier set is exactly {live,course}.
- Reuses KPICard/StatCard look. Pure `metric-model.ts` (rollup + provenance) fully real + unit-tested (13/13).

### Real vs mocked (single Round-D seam)
No per-course aggregation `query()` exists yet → both tiers source from ONE seam `journey-insights.remote.ts` (real query() handle, deterministic mock body). Round-D swaps ONLY the body (contract `JourneyInsightsData` frozen; in-file banner names the real sources: purchase/subscription/payout scoped to course creator+org for live; WP-1 tables rollup for course).

### Round-D notes
`[id]` treated as courseId (zod uuid) — reconcile against WP-5's journeys index id-space at wire-up. Auth mirrors studio/analytics (owner/admin, redirect /studio). No new paraglide keys (avoided shared-i18n hazard).

### Verification (local, warm)
build ✓ · svelte-check 0 in changed files (86 phantom baseline) · biome clean · metric-model 13/13 unit. MCP visual gate DEFERRED to Round-D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)