### PR TITLE
feat(commerce): course monetization — 3 access paths + entitlement writes + payout reuse (Codex-2pryk.2.4)

### DIFF
--- a/packages/access/src/__tests__/ContentAccessService.integration.test.ts
+++ b/packages/access/src/__tests__/ContentAccessService.integration.test.ts
@@ -3588,7 +3588,11 @@ describe('ContentAccessService Integration', () => {
       it('grants entry via a derived tier (course_tier_access + active subscription)', async () => {
         const tierId = await seedTier(organizationId);
         const { courseId } = await makeCourse(organizationId);
-        await db.insert(courseTierAccess).values({ courseId, tierId });
+        // Codex-2pryk WP-6: course_tier_access now carries organization_id
+        // (N1 composite-FK guarantee) — course + tier share this org.
+        await db
+          .insert(courseTierAccess)
+          .values({ courseId, tierId, organizationId });
 
         // Subscriber to the granting tier — derived, no stored row.
         const [subscriber] = await seedTestUsers(db, 1);
@@ -3661,6 +3665,7 @@ describe('ContentAccessService Integration', () => {
         await db.insert(courseTierAccess).values({
           courseId: tierGranted.courseId,
           tierId,
+          organizationId,
         });
 
         const [user] = await seedTestUsers(db, 1);

--- a/packages/access/src/index.ts
+++ b/packages/access/src/index.ts
@@ -80,6 +80,8 @@ export {
   createContentAccessService,
   DEFAULT_STREAMING_URL_TTL_SECONDS,
 } from './services/ContentAccessService';
+// Course monetization: tier-access management (N1 guard) + offer read (WP-6).
+export { CourseAccessService } from './services/course-access-service';
 export { EntitlementsService } from './services/entitlements-service';
 export type {
   PlaybackProgressResponse,

--- a/packages/access/src/services/__tests__/course-monetization.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-monetization.integration.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Course monetization round-trip (Codex-2pryk · WP-6 · SPEC §7).
+ *
+ * The critical WRITE→READ round-trip for every §7 path: a purchase / grant /
+ * tier subscription writes the row the WP-2 resolver reads, and the resolver
+ * then GRANTS. Runs against live Postgres (LOCAL_PROXY) so the split-FK CHECK,
+ * the partial-unique idempotency indexes, and the N1 composite FKs are all
+ * exercised for real — not stubbed.
+ *
+ * Covered:
+ *   1. One-off course purchase → entitlement + auto-enroll → canEnterCourse ✓;
+ *      replay is idempotent (no duplicate grant/enrollment/purchase).
+ *   2. Course-subscription grant (the write seam the service uses) →
+ *      canEnterCourse ✓; expiry fails closed; revoke cuts access.
+ *   3. Tier access (exact grant) + active subscription → canEnterCourse ✓ (derived).
+ *   4. N1: a cross-org tier grant is REJECTED (service guard AND DB composite FK).
+ *   5. One-off content purchase → content entitlement → resolver reads it.
+ *   6. getCourseOffer composes all three paths + the viewer's entitlement.
+ *   7. Payout idempotency: the Option-B fan-out writes each ledger row once.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  content,
+  courses,
+  courseTierAccess,
+  entitlements,
+  organizationMemberships,
+  organizations,
+  purchases,
+  stripeConnectAccounts,
+  subscriptions,
+  subscriptionTiers,
+} from '@codex/database/schema';
+import {
+  ForbiddenError,
+  PurchaseService,
+  revokeCourseSubscriptionEntitlement,
+  writeCourseSubscriptionEntitlement,
+} from '@codex/purchase';
+import {
+  createTestConnectAccountInput,
+  createTestContentInput,
+  createTestSubscriptionInput,
+  createTestTierInput,
+  createUniqueSlug,
+  type Database,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from '@codex/test-utils';
+import { and, eq } from 'drizzle-orm';
+import type Stripe from 'stripe';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  hasCourseEntitlement,
+  hasStoredContentEntitlement,
+} from '../content-access/entitlements-resolver';
+import { CourseAccessService } from '../course-access-service';
+
+/** Minimal Stripe stub — only `transfers.create` is reached by the payout path. */
+function makeStripeStub() {
+  const transferCreate = vi.fn(async () => ({ id: `tr_${randomUUID()}` }));
+  const stripe = {
+    transfers: { create: transferCreate },
+  } as unknown as Stripe;
+  return { stripe, transferCreate };
+}
+
+async function createCourse(
+  db: Database,
+  orgId: string,
+  creatorId: string,
+  overrides: { priceCents?: number | null; status?: string } = {}
+): Promise<string> {
+  const [row] = await db
+    .insert(courses)
+    .values({
+      organizationId: orgId,
+      creatorId,
+      slug: createUniqueSlug('course'),
+      title: 'Test Course',
+      status: overrides.status ?? 'published',
+      priceCents: overrides.priceCents ?? 5000,
+    })
+    .returning({ id: courses.id });
+  if (!row) throw new Error('failed to create course');
+  return row.id;
+}
+
+describe('Course monetization round-trip (WP-6)', () => {
+  let db: Database;
+  let buyerId: string;
+  let buyer2Id: string;
+  let tierSubUserId: string;
+  let creatorId: string;
+  let creatorBId: string;
+  let orgAId: string;
+  let orgBId: string;
+  let tierAId: string;
+  let tierBId: string;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    [buyerId, buyer2Id, tierSubUserId, creatorId, creatorBId] =
+      await seedTestUsers(db, 5);
+
+    // Creator's Connect account (receives creator + org-fee slices for org A,
+    // since the creator is org A's owner → org's primary Connect account).
+    await db
+      .insert(stripeConnectAccounts)
+      .values(createTestConnectAccountInput(null, creatorId))
+      .onConflictDoNothing();
+
+    const [orgA] = await db
+      .insert(organizations)
+      .values({ name: 'Org A', slug: createUniqueSlug('org-a') })
+      .returning({ id: organizations.id });
+    const [orgB] = await db
+      .insert(organizations)
+      .values({ name: 'Org B', slug: createUniqueSlug('org-b') })
+      .returning({ id: organizations.id });
+    if (!orgA || !orgB) throw new Error('failed to create orgs');
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    await db.insert(organizationMemberships).values([
+      {
+        organizationId: orgAId,
+        userId: creatorId,
+        role: 'owner',
+        status: 'active',
+      },
+      {
+        organizationId: orgBId,
+        userId: creatorBId,
+        role: 'owner',
+        status: 'active',
+      },
+    ]);
+
+    const [tierA] = await db
+      .insert(subscriptionTiers)
+      .values(createTestTierInput(orgAId, { sortOrder: 1 }))
+      .returning({ id: subscriptionTiers.id });
+    const [tierB] = await db
+      .insert(subscriptionTiers)
+      .values(createTestTierInput(orgBId, { sortOrder: 1 }))
+      .returning({ id: subscriptionTiers.id });
+    if (!tierA || !tierB) throw new Error('failed to create tiers');
+    tierAId = tierA.id;
+    tierBId = tierB.id;
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  it('1. course purchase writes entitlement + enrollment → canEnterCourse grants; replay is idempotent', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId);
+    const { stripe } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    // Before: no access.
+    expect(await hasCourseEntitlement(db, buyerId, courseId)).toBe(false);
+
+    const pi = `pi_${randomUUID()}`;
+    await svc.completeCoursePurchase(pi, {
+      customerId: buyerId,
+      courseId,
+      amountPaidCents: 5000,
+      currency: 'gbp',
+      // No stripeChargeId → payouts intentionally skipped for the entitlement leg.
+    });
+
+    // Round-trip: the resolver now GRANTS.
+    expect(await hasCourseEntitlement(db, buyerId, courseId)).toBe(true);
+
+    const grants = await db
+      .select()
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyerId),
+          eq(entitlements.courseId, courseId)
+        )
+      );
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.source).toBe('course_purchase');
+
+    const enrollCount = await db.query.courseEnrollments.findMany({
+      where: (t, { and: a, eq: e }) =>
+        a(e(t.userId, buyerId), e(t.courseId, courseId)),
+    });
+    expect(enrollCount).toHaveLength(1);
+
+    // Replay with the SAME payment intent — idempotent (no dup grant/enrollment).
+    await svc.completeCoursePurchase(pi, {
+      customerId: buyerId,
+      courseId,
+      amountPaidCents: 5000,
+      currency: 'gbp',
+    });
+    const grantsAfter = await db
+      .select()
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyerId),
+          eq(entitlements.courseId, courseId)
+        )
+      );
+    expect(grantsAfter).toHaveLength(1);
+    const purchasesForPi = await db
+      .select()
+      .from(purchases)
+      .where(eq(purchases.stripePaymentIntentId, pi));
+    expect(purchasesForPi).toHaveLength(1);
+    expect(purchasesForPi[0]?.courseId).toBe(courseId);
+    expect(purchasesForPi[0]?.contentId).toBeNull();
+  });
+
+  it('2. course-subscription grant → canEnterCourse grants; expiry fails closed; revoke cuts access', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: null,
+    });
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+    await writeCourseSubscriptionEntitlement(db, {
+      userId: buyerId,
+      organizationId: orgAId,
+      courseId,
+      courseSubscriptionId: randomUUID(),
+      expiresAt: future,
+    });
+    expect(await hasCourseEntitlement(db, buyerId, courseId)).toBe(true);
+
+    // Revoke (subscription cancelled) → resolver stops granting.
+    await revokeCourseSubscriptionEntitlement(db, {
+      userId: buyerId,
+      courseId,
+    });
+    expect(await hasCourseEntitlement(db, buyerId, courseId)).toBe(false);
+
+    // A grant already expired fails closed (never grants).
+    const expiredCourseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: null,
+    });
+    await writeCourseSubscriptionEntitlement(db, {
+      userId: buyer2Id,
+      organizationId: orgAId,
+      courseId: expiredCourseId,
+      courseSubscriptionId: randomUUID(),
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await hasCourseEntitlement(db, buyer2Id, expiredCourseId)).toBe(
+      false
+    );
+  });
+
+  it('3. tier access + active subscription → canEnterCourse grants (derived)', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: null,
+    });
+    const svc = new CourseAccessService({ db, environment: 'test' });
+
+    await svc.setTierAccess(courseId, [tierAId]);
+
+    // No subscription yet → no derived access.
+    expect(await hasCourseEntitlement(db, tierSubUserId, courseId)).toBe(false);
+
+    await db
+      .insert(subscriptions)
+      .values(createTestSubscriptionInput(tierSubUserId, orgAId, tierAId));
+
+    // Active subscription intersecting the exact tier grant → derived access.
+    expect(await hasCourseEntitlement(db, tierSubUserId, courseId)).toBe(true);
+  });
+
+  it('4. N1: a cross-org tier grant is rejected by the service guard AND the DB', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: null,
+    });
+    const svc = new CourseAccessService({ db, environment: 'test' });
+
+    // Service guard: tier B (org B) cannot unlock a course in org A.
+    await expect(svc.setTierAccess(courseId, [tierBId])).rejects.toBeInstanceOf(
+      ForbiddenError
+    );
+
+    // Durable DB backstop: a direct cross-org insert violates the composite FK.
+    await expect(
+      db.insert(courseTierAccess).values({
+        courseId,
+        tierId: tierBId,
+        organizationId: orgAId,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('5. content purchase writes a content entitlement the resolver reads', async () => {
+    const [contentRow] = await db
+      .insert(content)
+      .values(
+        createTestContentInput(creatorId, {
+          organizationId: orgAId,
+          status: 'published',
+          isFree: false,
+          isPurchasable: true,
+          priceCents: 3000,
+        })
+      )
+      .returning({ id: content.id });
+    if (!contentRow) throw new Error('failed to create content');
+
+    const { stripe } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    expect(await hasStoredContentEntitlement(db, buyerId, contentRow.id)).toBe(
+      false
+    );
+
+    await svc.completePurchase(`pi_${randomUUID()}`, {
+      customerId: buyerId,
+      contentId: contentRow.id,
+      organizationId: orgAId,
+      amountPaidCents: 3000,
+      currency: 'gbp',
+    });
+
+    expect(await hasStoredContentEntitlement(db, buyerId, contentRow.id)).toBe(
+      true
+    );
+  });
+
+  it('6. getCourseOffer composes purchase + tier paths + viewer entitlement', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: 7500,
+    });
+    const svc = new CourseAccessService({ db, environment: 'test' });
+    await svc.setTierAccess(courseId, [tierAId]);
+
+    const anonOffer = await svc.getCourseOffer(courseId, null);
+    expect(anonOffer.purchase).toEqual({ priceCents: 7500 });
+    expect(anonOffer.paths).toContain('purchase');
+    expect(anonOffer.paths).toContain('tier');
+    expect(anonOffer.tiers.map((t) => t.tierId)).toContain(tierAId);
+    expect(anonOffer.entitled).toBe(false);
+
+    // A buyer who purchases sees entitled=true.
+    const { stripe } = makeStripeStub();
+    const purchase = new PurchaseService({ db, environment: 'test' }, stripe);
+    await purchase.completeCoursePurchase(`pi_${randomUUID()}`, {
+      customerId: buyer2Id,
+      courseId,
+      amountPaidCents: 7500,
+      currency: 'gbp',
+    });
+    const ownerOffer = await svc.getCourseOffer(courseId, buyer2Id);
+    expect(ownerOffer.entitled).toBe(true);
+  });
+
+  it('7. course purchase payouts write each ledger row once and replay is idempotent', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: 5000,
+    });
+    const { stripe, transferCreate } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    const pi = `pi_${randomUUID()}`;
+    const chargeId = `ch_${randomUUID()}`;
+    const meta = {
+      customerId: tierSubUserId,
+      courseId,
+      amountPaidCents: 5000,
+      currency: 'gbp',
+      stripeChargeId: chargeId,
+    };
+
+    await svc.completeCoursePurchase(pi, meta);
+
+    const purchaseRow = await db
+      .select({ id: purchases.id })
+      .from(purchases)
+      .where(eq(purchases.stripePaymentIntentId, pi));
+    const purchaseId = purchaseRow[0]?.id;
+    expect(purchaseId).toBeDefined();
+
+    const payoutRows = await db.query.payouts.findMany({
+      where: (t, { eq: e }) => e(t.purchaseId, purchaseId as string),
+    });
+    // platform_fee + creator_payout + organization_fee, one each.
+    const byType = payoutRows.reduce<Record<string, number>>((acc, r) => {
+      acc[r.payoutType] = (acc[r.payoutType] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(byType.platform_fee).toBe(1);
+    expect(byType.creator_payout).toBe(1);
+    expect(byType.organization_fee).toBe(1);
+    // Split sums exactly to the amount (DB CHECK also enforces on purchase row).
+    const total = payoutRows.reduce((s, r) => s + r.amountCents, 0);
+    expect(total).toBe(5000);
+    const transfersAfterFirst = transferCreate.mock.calls.length;
+    expect(transfersAfterFirst).toBe(2); // creator + org secondary transfers
+
+    // Replay same PI → isNew=false → payouts skipped, no new transfers/rows.
+    await svc.completeCoursePurchase(pi, meta);
+    const payoutRowsAfter = await db.query.payouts.findMany({
+      where: (t, { eq: e }) => e(t.purchaseId, purchaseId as string),
+    });
+    expect(payoutRowsAfter).toHaveLength(payoutRows.length);
+    expect(transferCreate.mock.calls.length).toBe(transfersAfterFirst);
+  });
+});

--- a/packages/access/src/services/__tests__/course-monetization.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-monetization.integration.test.ts
@@ -17,6 +17,14 @@
  *   5. One-off content purchase → content entitlement → resolver reads it.
  *   6. getCourseOffer composes all three paths + the viewer's entitlement.
  *   7. Payout idempotency: the Option-B fan-out writes each ledger row once.
+ *   8. Refund a one-off COURSE purchase → the grant is revoked → canEnterCourse
+ *      DENIES (the money-critical refund-revokes-access invariant).
+ *   9. Refund a one-off CONTENT purchase → the grant is revoked → canView DENIES.
+ *  10. Dispute/chargeback a one-off COURSE purchase → the SAME sourceRef-keyed
+ *      revoke fires → canEnterCourse DENIES. Higher-severity than the content
+ *      case: a course_purchase grant is permanent and has NO verifyPurchase
+ *      backstop, so the entitlement row is the sole access record.
+ *  11. Dispute a one-off CONTENT purchase → the grant is revoked → canView DENIES.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -410,5 +418,241 @@ describe('Course monetization round-trip (WP-6)', () => {
     });
     expect(payoutRowsAfter).toHaveLength(payoutRows.length);
     expect(transferCreate.mock.calls.length).toBe(transfersAfterFirst);
+  });
+
+  it('8. refunding a one-off course purchase revokes the grant → canEnterCourse denies', async () => {
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: 5000,
+    });
+    const { stripe } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    // No stripeChargeId → payouts (and thus the refund's payout-reversal) are
+    // skipped: this test isolates the access invariant, not the money movement
+    // (transfer reversal is covered by the purchase-service refund suite).
+    const pi = `pi_${randomUUID()}`;
+    await svc.completeCoursePurchase(pi, {
+      customerId: buyerId,
+      courseId,
+      amountPaidCents: 5000,
+      currency: 'gbp',
+    });
+
+    // Round-trip: the resolver GRANTS and the stored grant is LIVE.
+    expect(await hasCourseEntitlement(db, buyerId, courseId)).toBe(true);
+    const [grantBefore] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyerId),
+          eq(entitlements.courseId, courseId),
+          eq(entitlements.source, 'course_purchase')
+        )
+      );
+    expect(grantBefore?.revokedAt).toBeNull();
+
+    // Refund the charge → the entitlement this purchase granted is revoked.
+    await svc.processRefund(pi, {
+      stripeRefundId: `re_${randomUUID()}`,
+      refundAmountCents: 5000,
+      refundReason: 'requested_by_customer',
+    });
+
+    // The grant now carries a revokedAt AND the resolver DENIES on next read.
+    const [grantAfter] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyerId),
+          eq(entitlements.courseId, courseId),
+          eq(entitlements.source, 'course_purchase')
+        )
+      );
+    expect(grantAfter?.revokedAt).toBeInstanceOf(Date);
+    expect(await hasCourseEntitlement(db, buyerId, courseId)).toBe(false);
+  });
+
+  it('9. refunding a one-off content purchase revokes the grant → canView denies', async () => {
+    const [contentRow] = await db
+      .insert(content)
+      .values(
+        createTestContentInput(creatorId, {
+          organizationId: orgAId,
+          status: 'published',
+          isFree: false,
+          isPurchasable: true,
+          priceCents: 3000,
+        })
+      )
+      .returning({ id: content.id });
+    if (!contentRow) throw new Error('failed to create content');
+
+    const { stripe } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    const pi = `pi_${randomUUID()}`;
+    await svc.completePurchase(pi, {
+      customerId: buyerId,
+      contentId: contentRow.id,
+      organizationId: orgAId,
+      amountPaidCents: 3000,
+      currency: 'gbp',
+    });
+
+    // Round-trip: the resolver reads a LIVE stored content grant.
+    expect(await hasStoredContentEntitlement(db, buyerId, contentRow.id)).toBe(
+      true
+    );
+    const [grantBefore] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyerId),
+          eq(entitlements.contentId, contentRow.id),
+          eq(entitlements.source, 'content_purchase')
+        )
+      );
+    expect(grantBefore?.revokedAt).toBeNull();
+
+    await svc.processRefund(pi, {
+      stripeRefundId: `re_${randomUUID()}`,
+      refundAmountCents: 3000,
+      refundReason: 'requested_by_customer',
+    });
+
+    const [grantAfter] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyerId),
+          eq(entitlements.contentId, contentRow.id),
+          eq(entitlements.source, 'content_purchase')
+        )
+      );
+    expect(grantAfter?.revokedAt).toBeInstanceOf(Date);
+    expect(await hasStoredContentEntitlement(db, buyerId, contentRow.id)).toBe(
+      false
+    );
+  });
+
+  it('10. disputing a one-off course purchase revokes the grant → canEnterCourse denies', async () => {
+    // Higher-severity than the refund/content cases: a course_purchase grant is
+    // PERMANENT (no expiresAt) with NO verifyPurchase backstop, so if the
+    // chargeback failed to revoke it the buyer would keep paid-for course access
+    // after the money is clawed back. processDispute runs the SAME sourceRef=
+    // purchase.id revoke as processRefund; this pins that invariant.
+    const courseId = await createCourse(db, orgAId, creatorId, {
+      priceCents: 5000,
+    });
+    const { stripe } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    const pi = `pi_${randomUUID()}`;
+    await svc.completeCoursePurchase(pi, {
+      customerId: buyer2Id,
+      courseId,
+      amountPaidCents: 5000,
+      currency: 'gbp',
+    });
+
+    // Round-trip: the resolver GRANTS and the stored grant is LIVE.
+    expect(await hasCourseEntitlement(db, buyer2Id, courseId)).toBe(true);
+    const [grantBefore] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyer2Id),
+          eq(entitlements.courseId, courseId),
+          eq(entitlements.source, 'course_purchase')
+        )
+      );
+    expect(grantBefore?.revokedAt).toBeNull();
+
+    // Chargeback (charge.dispute.created) → access-reducing, same as a refund.
+    await svc.processDispute(pi, {
+      stripeDisputeId: `dp_${randomUUID()}`,
+      disputeReason: 'fraudulent',
+    });
+
+    const [grantAfter] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyer2Id),
+          eq(entitlements.courseId, courseId),
+          eq(entitlements.source, 'course_purchase')
+        )
+      );
+    expect(grantAfter?.revokedAt).toBeInstanceOf(Date);
+    expect(await hasCourseEntitlement(db, buyer2Id, courseId)).toBe(false);
+  });
+
+  it('11. disputing a one-off content purchase revokes the grant → canView denies', async () => {
+    const [contentRow] = await db
+      .insert(content)
+      .values(
+        createTestContentInput(creatorId, {
+          organizationId: orgAId,
+          status: 'published',
+          isFree: false,
+          isPurchasable: true,
+          priceCents: 3000,
+        })
+      )
+      .returning({ id: content.id });
+    if (!contentRow) throw new Error('failed to create content');
+
+    const { stripe } = makeStripeStub();
+    const svc = new PurchaseService({ db, environment: 'test' }, stripe);
+
+    const pi = `pi_${randomUUID()}`;
+    await svc.completePurchase(pi, {
+      customerId: buyer2Id,
+      contentId: contentRow.id,
+      organizationId: orgAId,
+      amountPaidCents: 3000,
+      currency: 'gbp',
+    });
+
+    expect(await hasStoredContentEntitlement(db, buyer2Id, contentRow.id)).toBe(
+      true
+    );
+    const [grantBefore] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyer2Id),
+          eq(entitlements.contentId, contentRow.id),
+          eq(entitlements.source, 'content_purchase')
+        )
+      );
+    expect(grantBefore?.revokedAt).toBeNull();
+
+    await svc.processDispute(pi, {
+      stripeDisputeId: `dp_${randomUUID()}`,
+      disputeReason: 'fraudulent',
+    });
+
+    const [grantAfter] = await db
+      .select({ revokedAt: entitlements.revokedAt })
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, buyer2Id),
+          eq(entitlements.contentId, contentRow.id),
+          eq(entitlements.source, 'content_purchase')
+        )
+      );
+    expect(grantAfter?.revokedAt).toBeInstanceOf(Date);
+    expect(await hasStoredContentEntitlement(db, buyer2Id, contentRow.id)).toBe(
+      false
+    );
   });
 });

--- a/packages/access/src/services/course-access-service.ts
+++ b/packages/access/src/services/course-access-service.ts
@@ -1,0 +1,191 @@
+/**
+ * CourseAccessService (Codex-2pryk · WP-6 · SPEC §7).
+ *
+ * The course-monetization surface that is neither purchase (`@codex/purchase`)
+ * nor course-subscription (`@codex/subscription`):
+ *   - {@link setTierAccess} — manage the EXACT set of org tiers that unlock a
+ *     course (SPEC §7 tier-access, "not just min-tier"), with the N1 write-path
+ *     guard that a tier must belong to the course's org.
+ *   - {@link getCourseOffer} — the read that composes all three §7 paths + the
+ *     viewer's entitlement into the frozen {@link CourseOffer} the sales/landing
+ *     surfaces render.
+ *
+ * Placement: `@codex/access` is downstream of purchase + subscription and is
+ * where the entitlement READ side (`EntitlementsService`, the resolver) already
+ * lives, so the offer read reuses `hasCourseEntitlement` directly.
+ */
+
+import {
+  courseSubscriptionPlans,
+  courses,
+  courseTierAccess,
+  subscriptionTiers,
+} from '@codex/database/schema';
+import {
+  BaseService,
+  ForbiddenError,
+  NotFoundError,
+} from '@codex/service-errors';
+import type {
+  CourseAccessPath,
+  CourseOffer,
+  CourseTierOffer,
+} from '@codex/shared-types';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { hasCourseEntitlement } from './content-access/entitlements-resolver';
+
+export class CourseAccessService extends BaseService {
+  /** WebSocket-capable client for the delete+insert replace transaction. */
+  private get txDb(): typeof import('@codex/database').dbWs {
+    return this.db as typeof import('@codex/database').dbWs;
+  }
+
+  /**
+   * Replace the set of org tiers that grant access to `courseId` with `tierIds`
+   * (exact grants, SPEC §7). Passing an empty array clears all tier access.
+   *
+   * N1 GUARD: every tier MUST belong to the course's organization. This is the
+   * write-path defence; the `course_tier_access` composite FKs are the durable
+   * DB backstop (a cross-org row is rejected at INSERT regardless of caller).
+   */
+  async setTierAccess(courseId: string, tierIds: string[]): Promise<void> {
+    try {
+      const course = await this.db.query.courses.findFirst({
+        where: and(eq(courses.id, courseId), isNull(courses.deletedAt)),
+        columns: { id: true, organizationId: true },
+      });
+      if (!course) {
+        throw new NotFoundError('Course not found', { courseId });
+      }
+
+      const uniqueTierIds = [...new Set(tierIds)];
+
+      if (uniqueTierIds.length > 0) {
+        // N1: reject any tier that is not a live tier in the course's org.
+        const validTiers = await this.db
+          .select({ id: subscriptionTiers.id })
+          .from(subscriptionTiers)
+          .where(
+            and(
+              inArray(subscriptionTiers.id, uniqueTierIds),
+              eq(subscriptionTiers.organizationId, course.organizationId),
+              isNull(subscriptionTiers.deletedAt)
+            )
+          );
+        if (validTiers.length !== uniqueTierIds.length) {
+          throw new ForbiddenError(
+            'Tier access grants must reference tiers in the same organization as the course',
+            { courseId, organizationId: course.organizationId }
+          );
+        }
+      }
+
+      await this.txDb.transaction(async (tx) => {
+        await tx
+          .delete(courseTierAccess)
+          .where(eq(courseTierAccess.courseId, courseId));
+        if (uniqueTierIds.length > 0) {
+          await tx
+            .insert(courseTierAccess)
+            .values(
+              uniqueTierIds.map((tierId) => ({
+                courseId,
+                tierId,
+                organizationId: course.organizationId,
+              }))
+            )
+            .onConflictDoNothing();
+        }
+      });
+    } catch (error) {
+      this.handleError(error, 'setTierAccess');
+    }
+  }
+
+  /**
+   * Build the complete monetization offer for a course (SPEC §7): every
+   * available acquisition path + whether the viewer already holds access.
+   */
+  async getCourseOffer(
+    courseId: string,
+    userId: string | null
+  ): Promise<CourseOffer> {
+    try {
+      const course = await this.db.query.courses.findFirst({
+        where: and(eq(courses.id, courseId), isNull(courses.deletedAt)),
+        columns: { id: true, organizationId: true, priceCents: true },
+      });
+      if (!course) {
+        throw new NotFoundError('Course not found', { courseId });
+      }
+
+      const [plan, tierRows, entitled] = await Promise.all([
+        this.db.query.courseSubscriptionPlans.findFirst({
+          where: and(
+            eq(courseSubscriptionPlans.courseId, courseId),
+            eq(courseSubscriptionPlans.isActive, true),
+            isNull(courseSubscriptionPlans.deletedAt)
+          ),
+        }),
+        this.db
+          .select({
+            tierId: subscriptionTiers.id,
+            tierName: subscriptionTiers.name,
+            priceMonthly: subscriptionTiers.priceMonthly,
+            priceAnnual: subscriptionTiers.priceAnnual,
+          })
+          .from(courseTierAccess)
+          .innerJoin(
+            subscriptionTiers,
+            eq(subscriptionTiers.id, courseTierAccess.tierId)
+          )
+          .where(
+            and(
+              eq(courseTierAccess.courseId, courseId),
+              isNull(subscriptionTiers.deletedAt)
+            )
+          ),
+        userId
+          ? hasCourseEntitlement(this.db, userId, courseId)
+          : Promise.resolve(false),
+      ]);
+
+      const paths: CourseAccessPath[] = [];
+
+      const purchase =
+        course.priceCents != null && course.priceCents > 0
+          ? { priceCents: course.priceCents }
+          : null;
+      if (purchase) paths.push('purchase');
+
+      const subscription = plan
+        ? {
+            planId: plan.id,
+            priceMonthly: plan.priceMonthly,
+            priceAnnual: plan.priceAnnual,
+          }
+        : null;
+      if (subscription) paths.push('subscription');
+
+      const tiers: CourseTierOffer[] = tierRows.map((t) => ({
+        tierId: t.tierId,
+        tierName: t.tierName,
+        priceMonthly: t.priceMonthly,
+        priceAnnual: t.priceAnnual,
+      }));
+      if (tiers.length > 0) paths.push('tier');
+
+      return {
+        courseId: course.id,
+        organizationId: course.organizationId,
+        paths,
+        purchase,
+        subscription,
+        tiers,
+        entitled,
+      };
+    } catch (error) {
+      this.handleError(error, 'getCourseOffer');
+    }
+  }
+}

--- a/packages/admin/src/services/analytics-service.ts
+++ b/packages/admin/src/services/analytics-service.ts
@@ -575,7 +575,10 @@ export class AdminAnalyticsService extends BaseService {
 
       const result = await this.db
         .select({
-          contentId: schema.purchases.contentId,
+          // Codex-2pryk WP-6: use content.id (non-null via the inner join) —
+          // purchases.contentId is now nullable for course purchases, which the
+          // inner join already excludes from this content-revenue leaderboard.
+          contentId: schema.content.id,
           contentTitle: schema.content.title,
           thumbnailUrl: schema.content.thumbnailUrl,
           revenueCents: sql<number>`COALESCE(SUM(${schema.purchases.amountPaidCents}), 0)::int`,
@@ -599,7 +602,7 @@ export class AdminAnalyticsService extends BaseService {
           )
         )
         .groupBy(
-          schema.purchases.contentId,
+          schema.content.id,
           schema.content.title,
           schema.content.thumbnailUrl
         )

--- a/packages/admin/src/services/customer-management-service.ts
+++ b/packages/admin/src/services/customer-management-service.ts
@@ -259,7 +259,9 @@ export class AdminCustomerManagementService extends BaseService {
       const purchaseHistory = await this.db
         .select({
           purchaseId: schema.purchases.id,
-          contentId: schema.purchases.contentId,
+          // content.id is non-null via the inner join; purchases.contentId is
+          // nullable for course purchases (excluded by the join). Codex-2pryk WP-6.
+          contentId: schema.content.id,
           contentTitle: schema.content.title,
           amountPaidCents: schema.purchases.amountPaidCents,
           purchasedAt: schema.purchases.purchasedAt,

--- a/packages/database/src/migrations/0080_clumsy_forge.sql
+++ b/packages/database/src/migrations/0080_clumsy_forge.sql
@@ -1,0 +1,34 @@
+ALTER TABLE "course_tier_access" DROP CONSTRAINT "course_tier_access_course_id_courses_id_fk";
+--> statement-breakpoint
+ALTER TABLE "course_tier_access" DROP CONSTRAINT "course_tier_access_tier_id_subscription_tiers_id_fk";
+--> statement-breakpoint
+ALTER TABLE "purchases" ALTER COLUMN "content_id" DROP NOT NULL;--> statement-breakpoint
+-- Add course_tier_access.organization_id nullable, backfill it from the owning
+-- course, then enforce NOT NULL. The join table pre-dates this column (WP-1),
+-- so a bare `ADD COLUMN ... NOT NULL` fails on existing rows. Backfilling from
+-- the COURSE is the correct semantic (the org that owns the course); the tier
+-- composite FK below then verifies the tier lives in that SAME org — any
+-- pre-existing cross-org grant surfaces here as an FK violation (the N1
+-- guarantee doing its job) rather than being silently admitted.
+ALTER TABLE "course_tier_access" ADD COLUMN "organization_id" uuid;--> statement-breakpoint
+UPDATE "course_tier_access" cta SET "organization_id" = c."organization_id" FROM "courses" c WHERE cta."course_id" = c."id";--> statement-breakpoint
+ALTER TABLE "course_tier_access" ALTER COLUMN "organization_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "purchases" ADD COLUMN "course_id" uuid;--> statement-breakpoint
+ALTER TABLE "payouts" ADD COLUMN "course_subscription_id" uuid;--> statement-breakpoint
+-- Parent unique indexes MUST exist before the composite FKs that reference
+-- them (Postgres requires a matching unique constraint/index on the referenced
+-- columns at FK-creation time). drizzle-kit emitted the CREATE INDEX after the
+-- ADD CONSTRAINT; reordered here so the migration applies cleanly.
+CREATE UNIQUE INDEX "uq_courses_id_org" ON "courses" USING btree ("id","organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_subscription_tiers_id_org" ON "subscription_tiers" USING btree ("id","organization_id");--> statement-breakpoint
+ALTER TABLE "course_tier_access" ADD CONSTRAINT "fk_course_tier_access_course_org" FOREIGN KEY ("course_id","organization_id") REFERENCES "public"."courses"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_tier_access" ADD CONSTRAINT "fk_course_tier_access_tier_org" FOREIGN KEY ("tier_id","organization_id") REFERENCES "public"."subscription_tiers"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "purchases" ADD CONSTRAINT "purchases_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "payouts" ADD CONSTRAINT "payouts_course_subscription_id_course_subscriptions_id_fk" FOREIGN KEY ("course_subscription_id") REFERENCES "public"."course_subscriptions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_course_tier_access_org_id" ON "course_tier_access" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_purchases_course_id" ON "purchases" USING btree ("course_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_entitlement_live_content" ON "entitlements" USING btree ("user_id","content_id","source") WHERE "entitlements"."revoked_at" IS NULL AND "entitlements"."content_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_entitlement_live_course" ON "entitlements" USING btree ("user_id","course_id","source") WHERE "entitlements"."revoked_at" IS NULL AND "entitlements"."course_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_payouts_course_subscription" ON "payouts" USING btree ("course_subscription_id");--> statement-breakpoint
+ALTER TABLE "purchases" ADD CONSTRAINT "check_purchase_target_one" CHECK ((CASE WHEN "purchases"."content_id" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN "purchases"."course_id" IS NULL THEN 0 ELSE 1 END) = 1);--> statement-breakpoint
+ALTER TABLE "payouts" ADD CONSTRAINT "check_payouts_source_ref_one" CHECK ((CASE WHEN "payouts"."subscription_id" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN "payouts"."purchase_id" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN "payouts"."course_subscription_id" IS NULL THEN 0 ELSE 1 END) <= 1);

--- a/packages/database/src/migrations/meta/0080_snapshot.json
+++ b/packages/database/src/migrations/meta/0080_snapshot.json
@@ -1,0 +1,9070 @@
+{
+  "id": "cbe75739-fd58-4097-9b15-eb6912b92f13",
+  "prevId": "d0a638b9-b4d1-414b-b048-0867521a897f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_username": {
+          "name": "idx_unique_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_users_stripe_customer_id": {
+          "name": "idx_unique_users_stripe_customer_id",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"stripe_customer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_key": {
+          "name": "cover_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_categories_org_id": {
+          "name": "idx_categories_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_creator_id": {
+          "name": "idx_categories_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_category_slug_per_org": {
+          "name": "idx_unique_category_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"categories\".\"organization_id\" IS NOT NULL AND \"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_category_slug_personal": {
+          "name": "idx_unique_category_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"categories\".\"organization_id\" IS NULL AND \"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_organization_id_organizations_id_fk": {
+          "name": "categories_organization_id_organizations_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_creator_id_users_id_fk": {
+          "name": "categories_creator_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_categories": {
+      "name": "content_categories",
+      "schema": "",
+      "columns": {
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_content_categories_category_id": {
+          "name": "idx_content_categories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_categories_content_id": {
+          "name": "idx_content_categories_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_categories_content_id_content_id_fk": {
+          "name": "content_categories_content_id_content_id_fk",
+          "tableFrom": "content_categories",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_categories_category_id_categories_id_fk": {
+          "name": "content_categories_category_id_categories_id_fk",
+          "tableFrom": "content_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "content_categories_content_id_category_id_pk": {
+          "name": "content_categories_content_id_category_id_pk",
+          "columns": [
+            "content_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body": {
+          "name": "content_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body_json": {
+          "name": "content_body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "shader_preset": {
+          "name": "shader_preset",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shader_config": {
+          "name": "shader_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_purchasable": {
+          "name": "is_purchasable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_in_tier_id": {
+          "name": "included_in_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_only": {
+          "name": "course_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_follower_gated": {
+          "name": "is_follower_gated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_team_only": {
+          "name": "is_team_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_creator_id": {
+          "name": "idx_content_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_organization_id": {
+          "name": "idx_content_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_media_item_id": {
+          "name": "idx_content_media_item_id",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_slug_org": {
+          "name": "idx_content_slug_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_status": {
+          "name": "idx_content_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_published_at": {
+          "name": "idx_content_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_category": {
+          "name": "idx_content_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_included_in_tier": {
+          "name": "idx_content_included_in_tier",
+          "columns": [
+            {
+              "expression": "included_in_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_published": {
+          "name": "idx_content_org_published",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_creator_org_published": {
+          "name": "idx_content_creator_org_published",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_featured": {
+          "name": "idx_content_org_featured",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"featured\" = true AND \"content\".\"status\" = 'published' AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_per_org": {
+          "name": "idx_unique_content_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NOT NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_personal": {
+          "name": "idx_unique_content_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_creator_id_users_id_fk": {
+          "name": "content_creator_id_users_id_fk",
+          "tableFrom": "content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_organization_id_organizations_id_fk": {
+          "name": "content_organization_id_organizations_id_fk",
+          "tableFrom": "content",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_media_item_id_media_items_id_fk": {
+          "name": "content_media_item_id_media_items_id_fk",
+          "tableFrom": "content",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_included_in_tier_id_subscription_tiers_id_fk": {
+          "name": "content_included_in_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "content",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "included_in_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_content_status": {
+          "name": "check_content_status",
+          "value": "\"content\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_content_type": {
+          "name": "check_content_type",
+          "value": "\"content\".\"content_type\" IN ('video', 'audio', 'written')"
+        },
+        "check_price_non_negative": {
+          "name": "check_price_non_negative",
+          "value": "\"content\".\"price_cents\" IS NULL OR \"content\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_master_playlist_key": {
+          "name": "hls_master_playlist_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_preview_key": {
+          "name": "hls_preview_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_key": {
+          "name": "waveform_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_image_key": {
+          "name": "waveform_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runpod_job_id": {
+          "name": "runpod_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_error": {
+          "name": "transcoding_error",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_attempts": {
+          "name": "transcoding_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transcoding_priority": {
+          "name": "transcoding_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "transcoding_progress": {
+          "name": "transcoding_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_step": {
+          "name": "transcoding_step",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_key": {
+          "name": "mezzanine_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_status": {
+          "name": "mezzanine_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_variants": {
+          "name": "ready_variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_integrated": {
+          "name": "loudness_integrated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_peak": {
+          "name": "loudness_peak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_range": {
+          "name": "loudness_range",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_creator_id": {
+          "name": "idx_media_items_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_status": {
+          "name": "idx_media_items_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_type": {
+          "name": "idx_media_items_type",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_runpod_job_id": {
+          "name": "idx_media_items_runpod_job_id",
+          "columns": [
+            {
+              "expression": "runpod_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_transcoding_status": {
+          "name": "idx_media_items_transcoding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcoding_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_items_creator_id_users_id_fk": {
+          "name": "media_items_creator_id_users_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_media_status": {
+          "name": "check_media_status",
+          "value": "\"media_items\".\"status\" IN ('uploading', 'uploaded', 'transcoding', 'ready', 'failed')"
+        },
+        "check_media_type": {
+          "name": "check_media_type",
+          "value": "\"media_items\".\"media_type\" IN ('video', 'audio')"
+        },
+        "check_mezzanine_status": {
+          "name": "check_mezzanine_status",
+          "value": "\"media_items\".\"mezzanine_status\" IS NULL OR \"media_items\".\"mezzanine_status\" IN ('pending', 'processing', 'ready', 'failed')"
+        },
+        "check_transcoding_priority": {
+          "name": "check_transcoding_priority",
+          "value": "\"media_items\".\"transcoding_priority\" >= 0 AND \"media_items\".\"transcoding_priority\" <= 4"
+        },
+        "check_max_transcoding_attempts": {
+          "name": "check_max_transcoding_attempts",
+          "value": "\"media_items\".\"transcoding_attempts\" >= 0 AND \"media_items\".\"transcoding_attempts\" <= 3"
+        },
+        "check_transcoding_progress_range": {
+          "name": "check_transcoding_progress_range",
+          "value": "\"media_items\".\"transcoding_progress\" IS NULL OR (\"media_items\".\"transcoding_progress\" >= 0 AND \"media_items\".\"transcoding_progress\" <= 100)"
+        },
+        "status_ready_requires_keys": {
+          "name": "status_ready_requires_keys",
+          "value": "\"media_items\".\"status\" != 'ready' OR (\n        \"media_items\".\"hls_master_playlist_key\" IS NOT NULL\n        AND \"media_items\".\"duration_seconds\" IS NOT NULL\n        AND (\n          (\"media_items\".\"media_type\" = 'video' AND \"media_items\".\"thumbnail_key\" IS NOT NULL)\n          OR (\"media_items\".\"media_type\" = 'audio' AND \"media_items\".\"waveform_key\" IS NOT NULL)\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_membership": {
+          "name": "idx_unique_org_membership",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_id": {
+          "name": "idx_org_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_user_id": {
+          "name": "idx_org_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_role": {
+          "name": "idx_org_memberships_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_status": {
+          "name": "idx_org_memberships_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_active_role": {
+          "name": "idx_org_memberships_org_active_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organization_memberships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_membership_role": {
+          "name": "check_membership_role",
+          "value": "\"organization_memberships\".\"role\" IN ('owner', 'admin', 'creator', 'subscriber', 'member')"
+        },
+        "check_membership_status": {
+          "name": "check_membership_status",
+          "value": "\"organization_memberships\".\"status\" IN ('active', 'inactive', 'invited')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.course_subscription_plans": {
+      "name": "course_subscription_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_sub_plans_course_id": {
+          "name": "idx_course_sub_plans_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_course_sub_plans_course": {
+          "name": "uq_course_sub_plans_course",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_subscription_plans\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_subscription_plans_course_id_courses_id_fk": {
+          "name": "course_subscription_plans_course_id_courses_id_fk",
+          "tableFrom": "course_subscription_plans",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_course_plan_price_monthly": {
+          "name": "check_course_plan_price_monthly",
+          "value": "\"course_subscription_plans\".\"price_monthly\" >= 0"
+        },
+        "check_course_plan_price_annual": {
+          "name": "check_course_plan_price_annual",
+          "value": "\"course_subscription_plans\".\"price_annual\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.course_subscriptions": {
+      "name": "course_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_course_subscriptions_user_id": {
+          "name": "idx_course_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_subscriptions_course_id": {
+          "name": "idx_course_subscriptions_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_subscriptions_plan_id": {
+          "name": "idx_course_subscriptions_plan_id",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_subscriptions_stripe_id": {
+          "name": "idx_course_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_course_subscription_per_user_course": {
+          "name": "uq_active_course_subscription_per_user_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_subscriptions_user_id_users_id_fk": {
+          "name": "course_subscriptions_user_id_users_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_subscriptions_course_id_courses_id_fk": {
+          "name": "course_subscriptions_course_id_courses_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_subscriptions_plan_id_course_subscription_plans_id_fk": {
+          "name": "course_subscriptions_plan_id_course_subscription_plans_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "course_subscription_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_subscriptions_organization_id_organizations_id_fk": {
+          "name": "course_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_subscriptions_stripe_subscription_id_unique": {
+          "name": "course_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_course_subscription_status": {
+          "name": "check_course_subscription_status",
+          "value": "\"course_subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_course_subscription_billing_interval": {
+          "name": "check_course_subscription_billing_interval",
+          "value": "\"course_subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.course_tier_access": {
+      "name": "course_tier_access",
+      "schema": "",
+      "columns": {
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_course_tier_access_tier_id": {
+          "name": "idx_course_tier_access_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_tier_access_org_id": {
+          "name": "idx_course_tier_access_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_course_tier_access_course_org": {
+          "name": "fk_course_tier_access_course_org",
+          "tableFrom": "course_tier_access",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_course_tier_access_tier_org": {
+          "name": "fk_course_tier_access_tier_org",
+          "tableFrom": "course_tier_access",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_tier_access_course_id_tier_id_pk": {
+          "name": "course_tier_access_course_id_tier_id_pk",
+          "columns": [
+            "course_id",
+            "tier_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_enrollments": {
+      "name": "course_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_course_enrollments_user_id": {
+          "name": "idx_course_enrollments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_enrollments_course_id": {
+          "name": "idx_course_enrollments_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_course_enrollment_user_course": {
+          "name": "uq_course_enrollment_user_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_enrollments_user_id_users_id_fk": {
+          "name": "course_enrollments_user_id_users_id_fk",
+          "tableFrom": "course_enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_enrollments_course_id_courses_id_fk": {
+          "name": "course_enrollments_course_id_courses_id_fk",
+          "tableFrom": "course_enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_completions": {
+      "name": "practice_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_practice_completions_user_id": {
+          "name": "idx_practice_completions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_practice_completions_content_id": {
+          "name": "idx_practice_completions_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_practice_completion_user_content": {
+          "name": "uq_practice_completion_user_content",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_completions_user_id_users_id_fk": {
+          "name": "practice_completions_user_id_users_id_fk",
+          "tableFrom": "practice_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_completions_content_id_content_id_fk": {
+          "name": "practice_completions_content_id_content_id_fk",
+          "tableFrom": "practice_completions",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_practice_completion_source": {
+          "name": "check_practice_completion_source",
+          "value": "\"practice_completions\".\"source\" IN ('manual', 'auto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_onboarding": {
+      "name": "creator_onboarding",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'essentials'"
+        },
+        "welcome_seen_at": {
+          "name": "welcome_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creator_onboarding_user_id_users_id_fk": {
+          "name": "creator_onboarding_user_id_users_id_fk",
+          "tableFrom": "creator_onboarding",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agreement_proposals": {
+      "name": "agreement_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_proposal_id": {
+          "name": "parent_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_role": {
+          "name": "proposed_by_role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_creator_share_percent": {
+          "name": "proposed_creator_share_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_term_months": {
+          "name": "proposed_term_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_effective_from": {
+          "name": "proposed_effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agreement_proposals_thread": {
+          "name": "idx_agreement_proposals_thread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_creator_status": {
+          "name": "idx_agreement_proposals_creator_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_org_status": {
+          "name": "idx_agreement_proposals_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agreement_proposals_organization_id_organizations_id_fk": {
+          "name": "agreement_proposals_organization_id_organizations_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_creator_id_users_id_fk": {
+          "name": "agreement_proposals_creator_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk": {
+          "name": "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "parent_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_proposed_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_proposed_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_responded_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_responded_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_agreement_proposals_revenue_type": {
+          "name": "check_agreement_proposals_revenue_type",
+          "value": "\"agreement_proposals\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_agreement_proposals_proposed_by_role": {
+          "name": "check_agreement_proposals_proposed_by_role",
+          "value": "\"agreement_proposals\".\"proposed_by_role\" IN ('owner', 'creator')"
+        },
+        "check_agreement_proposals_status": {
+          "name": "check_agreement_proposals_status",
+          "value": "\"agreement_proposals\".\"status\" IN ('open', 'accepted', 'declined', 'countered', 'withdrawn', 'superseded')"
+        },
+        "check_agreement_proposals_share_bps": {
+          "name": "check_agreement_proposals_share_bps",
+          "value": "\"agreement_proposals\".\"proposed_creator_share_percent\" >= 0 AND \"agreement_proposals\".\"proposed_creator_share_percent\" <= 10000"
+        },
+        "check_agreement_proposals_round_positive": {
+          "name": "check_agreement_proposals_round_positive",
+          "value": "\"agreement_proposals\".\"round_number\" >= 1"
+        },
+        "check_agreement_proposals_term_positive": {
+          "name": "check_agreement_proposals_term_positive",
+          "value": "\"agreement_proposals\".\"proposed_term_months\" IS NULL OR \"agreement_proposals\".\"proposed_term_months\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_access": {
+      "name": "content_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_access_user_id": {
+          "name": "idx_content_access_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_content_id": {
+          "name": "idx_content_access_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_organization_id": {
+          "name": "idx_content_access_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_access_user_id_users_id_fk": {
+          "name": "content_access_user_id_users_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_content_id_content_id_fk": {
+          "name": "content_access_content_id_content_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_organization_id_organizations_id_fk": {
+          "name": "content_access_organization_id_organizations_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_access_user_content_unique": {
+          "name": "content_access_user_content_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_access_type": {
+          "name": "check_access_type",
+          "value": "\"content_access\".\"access_type\" IN ('purchased', 'subscription', 'complimentary', 'preview')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_organization_agreements": {
+      "name": "creator_organization_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_fee_percentage": {
+          "name": "organization_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_by_user_id": {
+          "name": "terminated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_proposal_id": {
+          "name": "current_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiring_soon_email_sent_at": {
+          "name": "expiring_soon_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_creator_org_agreement_creator_id": {
+          "name": "idx_creator_org_agreement_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_org_id": {
+          "name": "idx_creator_org_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_effective": {
+          "name": "idx_creator_org_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_active_lookup": {
+          "name": "idx_creator_org_agreement_active_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_creator_org_agreement_active_per_type": {
+          "name": "uq_creator_org_agreement_active_per_type",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"creator_organization_agreements\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_organization_agreements_creator_id_users_id_fk": {
+          "name": "creator_organization_agreements_creator_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_organization_id_organizations_id_fk": {
+          "name": "creator_organization_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_terminated_by_user_id_users_id_fk": {
+          "name": "creator_organization_agreements_terminated_by_user_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "terminated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk": {
+          "name": "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "current_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "creator_org_agreement_unique": {
+          "name": "creator_org_agreement_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "organization_id",
+            "effective_from",
+            "revenue_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_org_fee_percentage": {
+          "name": "check_org_fee_percentage",
+          "value": "\"creator_organization_agreements\".\"organization_fee_percentage\" >= 0 AND \"creator_organization_agreements\".\"organization_fee_percentage\" <= 10000"
+        },
+        "check_creator_org_agreement_revenue_type": {
+          "name": "check_creator_org_agreement_revenue_type",
+          "value": "\"creator_organization_agreements\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_creator_org_agreement_status": {
+          "name": "check_creator_org_agreement_status",
+          "value": "\"creator_organization_agreements\".\"status\" IN ('active', 'terminated', 'expired')"
+        },
+        "check_creator_org_agreement_terminated_shape": {
+          "name": "check_creator_org_agreement_terminated_shape",
+          "value": "(\"creator_organization_agreements\".\"status\" = 'terminated') = (\"creator_organization_agreements\".\"terminated_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_platform_agreements": {
+      "name": "organization_platform_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_platform_agreement_org_id": {
+          "name": "idx_org_platform_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_platform_agreement_effective": {
+          "name": "idx_org_platform_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_platform_agreements_organization_id_organizations_id_fk": {
+          "name": "organization_platform_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "organization_platform_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percentage": {
+          "name": "check_org_platform_fee_percentage",
+          "value": "\"organization_platform_agreements\".\"platform_fee_percentage\" >= 0 AND \"organization_platform_agreements\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_fee_config": {
+      "name": "platform_fee_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_fee_config_effective": {
+          "name": "idx_platform_fee_config_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_platform_fee_percentage": {
+          "name": "check_platform_fee_percentage",
+          "value": "\"platform_fee_config\".\"platform_fee_percentage\" >= 0 AND \"platform_fee_config\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platform_agreement_id": {
+          "name": "platform_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_org_agreement_id": {
+          "name": "creator_org_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount_cents": {
+          "name": "refund_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispute_reason": {
+          "name": "dispute_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_dispute_id": {
+          "name": "stripe_dispute_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_purchases_customer_id": {
+          "name": "idx_purchases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_content_id": {
+          "name": "idx_purchases_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_course_id": {
+          "name": "idx_purchases_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_organization_id": {
+          "name": "idx_purchases_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_stripe_payment_intent": {
+          "name": "idx_purchases_stripe_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_created_at": {
+          "name": "idx_purchases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_purchased_at": {
+          "name": "idx_purchases_purchased_at",
+          "columns": [
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_platform_agreement": {
+          "name": "idx_purchases_platform_agreement",
+          "columns": [
+            {
+              "expression": "platform_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_creator_org_agreement": {
+          "name": "idx_purchases_creator_org_agreement",
+          "columns": [
+            {
+              "expression": "creator_org_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_purchased": {
+          "name": "idx_purchases_customer_purchased",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_status_content": {
+          "name": "idx_purchases_customer_status_content",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_created": {
+          "name": "idx_purchases_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_purchased": {
+          "name": "idx_purchases_org_status_purchased",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "purchases_customer_id_users_id_fk": {
+          "name": "purchases_customer_id_users_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchases_content_id_content_id_fk": {
+          "name": "purchases_content_id_content_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_course_id_courses_id_fk": {
+          "name": "purchases_course_id_courses_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_organization_id_organizations_id_fk": {
+          "name": "purchases_organization_id_organizations_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_platform_agreement_id_organization_platform_agreements_id_fk": {
+          "name": "purchases_platform_agreement_id_organization_platform_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organization_platform_agreements",
+          "columnsFrom": [
+            "platform_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk": {
+          "name": "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "creator_organization_agreements",
+          "columnsFrom": [
+            "creator_org_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchases_stripe_payment_intent_id_unique": {
+          "name": "purchases_stripe_payment_intent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_payment_intent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_purchase_target_one": {
+          "name": "check_purchase_target_one",
+          "value": "(CASE WHEN \"purchases\".\"content_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"purchases\".\"course_id\" IS NULL THEN 0 ELSE 1 END) = 1"
+        },
+        "check_purchase_status": {
+          "name": "check_purchase_status",
+          "value": "\"purchases\".\"status\" IN ('pending', 'completed', 'refunded', 'failed')"
+        },
+        "check_amount_positive": {
+          "name": "check_amount_positive",
+          "value": "\"purchases\".\"amount_paid_cents\" >= 0"
+        },
+        "check_platform_fee_positive": {
+          "name": "check_platform_fee_positive",
+          "value": "\"purchases\".\"platform_fee_cents\" >= 0"
+        },
+        "check_org_fee_positive": {
+          "name": "check_org_fee_positive",
+          "value": "\"purchases\".\"organization_fee_cents\" >= 0"
+        },
+        "check_creator_payout_positive": {
+          "name": "check_creator_payout_positive",
+          "value": "\"purchases\".\"creator_payout_cents\" >= 0"
+        },
+        "check_revenue_split_equals_total": {
+          "name": "check_revenue_split_equals_total",
+          "value": "\"purchases\".\"amount_paid_cents\" = \"purchases\".\"platform_fee_cents\" + \"purchases\".\"organization_fee_cents\" + \"purchases\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_user_id": {
+          "name": "idx_entitlements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_org_id": {
+          "name": "idx_entitlements_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_content_id": {
+          "name": "idx_entitlements_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_course_id": {
+          "name": "idx_entitlements_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_user_content": {
+          "name": "idx_entitlements_user_content",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_user_course": {
+          "name": "idx_entitlements_user_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_entitlement_live_content": {
+          "name": "uq_entitlement_live_content",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"entitlements\".\"revoked_at\" IS NULL AND \"entitlements\".\"content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_entitlement_live_course": {
+          "name": "uq_entitlement_live_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"entitlements\".\"revoked_at\" IS NULL AND \"entitlements\".\"course_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_user_id_users_id_fk": {
+          "name": "entitlements_user_id_users_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_organization_id_organizations_id_fk": {
+          "name": "entitlements_organization_id_organizations_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_content_id_content_id_fk": {
+          "name": "entitlements_content_id_content_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_course_id_courses_id_fk": {
+          "name": "entitlements_course_id_courses_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_entitlement_resource_one": {
+          "name": "check_entitlement_resource_one",
+          "value": "(CASE WHEN \"entitlements\".\"content_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"entitlements\".\"course_id\" IS NULL THEN 0 ELSE 1 END) = 1"
+        },
+        "check_entitlement_source": {
+          "name": "check_entitlement_source",
+          "value": "\"entitlements\".\"source\" IN ('content_purchase', 'course_purchase', 'course_subscription', 'grant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_audit_log": {
+      "name": "fee_config_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_creator_id": {
+          "name": "scope_creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_config_audit_scope": {
+          "name": "idx_fee_config_audit_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_org": {
+          "name": "idx_fee_config_audit_org",
+          "columns": [
+            {
+              "expression": "scope_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_creator": {
+          "name": "idx_fee_config_audit_creator",
+          "columns": [
+            {
+              "expression": "scope_creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_changed_by": {
+          "name": "idx_fee_config_audit_changed_by",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_audit_log_scope_org_id_organizations_id_fk": {
+          "name": "fee_config_audit_log_scope_org_id_organizations_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "scope_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_scope_creator_id_users_id_fk": {
+          "name": "fee_config_audit_log_scope_creator_id_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scope_creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_changed_by_users_id_fk": {
+          "name": "fee_config_audit_log_changed_by_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_audit_scope": {
+          "name": "check_fee_config_audit_scope",
+          "value": "\"fee_config_audit_log\".\"scope\" IN ('platform', 'org', 'override')"
+        },
+        "check_fee_config_audit_scope_org_id": {
+          "name": "check_fee_config_audit_scope_org_id",
+          "value": "(\"fee_config_audit_log\".\"scope\" = 'platform' AND \"fee_config_audit_log\".\"scope_org_id\" IS NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'org' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'override' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org": {
+      "name": "fee_config_org",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_org_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_updated_by_users_id_fk": {
+          "name": "fee_config_org_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percent_bps": {
+          "name": "check_org_platform_fee_percent_bps",
+          "value": "\"fee_config_org\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org\".\"platform_fee_percent\" >= 0 AND \"fee_config_org\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_org_org_fee_percent_bps": {
+          "name": "check_org_org_fee_percent_bps",
+          "value": "\"fee_config_org\".\"org_fee_percent\" IS NULL OR (\"fee_config_org\".\"org_fee_percent\" >= 0 AND \"fee_config_org\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_org_min_platform_fee_non_negative": {
+          "name": "check_org_min_platform_fee_non_negative",
+          "value": "\"fee_config_org\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_org_min_transfer_non_negative": {
+          "name": "check_org_min_transfer_non_negative",
+          "value": "\"fee_config_org\".\"min_transfer_cents\" IS NULL OR \"fee_config_org\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org_creator": {
+      "name": "fee_config_org_creator",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fee_config_org_creator_org": {
+          "name": "idx_fee_config_org_creator_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_org_creator_creator": {
+          "name": "idx_fee_config_org_creator_creator",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_org_creator_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_creator_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_creator_id_users_id_fk": {
+          "name": "fee_config_org_creator_creator_id_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_updated_by_users_id_fk": {
+          "name": "fee_config_org_creator_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fee_config_org_creator_pkey": {
+          "name": "fee_config_org_creator_pkey",
+          "columns": [
+            "organization_id",
+            "creator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_override_platform_fee_percent_bps": {
+          "name": "check_override_platform_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"platform_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_override_org_fee_percent_bps": {
+          "name": "check_override_org_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"org_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"org_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_override_min_platform_fee_non_negative": {
+          "name": "check_override_min_platform_fee_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org_creator\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_override_min_transfer_non_negative": {
+          "name": "check_override_min_transfer_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_transfer_cents\" IS NULL OR \"fee_config_org_creator\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_platform": {
+      "name": "fee_config_platform",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_org_fee_percent": {
+          "name": "subscription_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "one_off_org_fee_percent": {
+          "name": "one_off_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_platform_updated_by_users_id_fk": {
+          "name": "fee_config_platform_updated_by_users_id_fk",
+          "tableFrom": "fee_config_platform",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_platform_singleton": {
+          "name": "check_fee_config_platform_singleton",
+          "value": "\"fee_config_platform\".\"id\" = 'singleton'"
+        },
+        "check_platform_fee_percent_bps": {
+          "name": "check_platform_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"platform_fee_percent\" >= 0 AND \"fee_config_platform\".\"platform_fee_percent\" <= 10000"
+        },
+        "check_subscription_org_fee_percent_bps": {
+          "name": "check_subscription_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"subscription_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"subscription_org_fee_percent\" <= 10000"
+        },
+        "check_one_off_org_fee_percent_bps": {
+          "name": "check_one_off_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"one_off_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"one_off_org_fee_percent\" <= 10000"
+        },
+        "check_min_platform_fee_non_negative": {
+          "name": "check_min_platform_fee_non_negative",
+          "value": "\"fee_config_platform\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_min_transfer_non_negative": {
+          "name": "check_min_transfer_non_negative",
+          "value": "\"fee_config_platform\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_followers": {
+      "name": "organization_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_follower": {
+          "name": "idx_unique_org_follower",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_org": {
+          "name": "idx_org_followers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_user": {
+          "name": "idx_org_followers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_followers_organization_id_organizations_id_fk": {
+          "name": "organization_followers_organization_id_organizations_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_followers_user_id_users_id_fk": {
+          "name": "organization_followers_user_id_users_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_stages": {
+      "name": "course_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss": {
+          "name": "gloss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_stages_course_id": {
+          "name": "idx_course_stages_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_course_stages_course_sort": {
+          "name": "uq_course_stages_course_sort",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_stages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_stages_course_id_courses_id_fk": {
+          "name": "course_stages_course_id_courses_id_fk",
+          "tableFrom": "course_stages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_testimonials": {
+      "name": "course_testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_context": {
+          "name": "author_context",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_media_id": {
+          "name": "avatar_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_testimonials_course_id": {
+          "name": "idx_course_testimonials_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_testimonials_course_id_courses_id_fk": {
+          "name": "course_testimonials_course_id_courses_id_fk",
+          "tableFrom": "course_testimonials",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_testimonials_avatar_media_id_media_items_id_fk": {
+          "name": "course_testimonials_avatar_media_id_media_items_id_fk",
+          "tableFrom": "course_testimonials",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "avatar_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicker": {
+          "name": "kicker",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lede": {
+          "name": "lede",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guide": {
+          "name": "guide",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_media_id": {
+          "name": "intro_video_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_video_media_id": {
+          "name": "preview_video_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guide_video_media_id": {
+          "name": "guide_video_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_courses_org_id": {
+          "name": "idx_courses_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_courses_creator_id": {
+          "name": "idx_courses_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_courses_org_status": {
+          "name": "idx_courses_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"courses\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_courses_org_slug": {
+          "name": "uq_courses_org_slug",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"courses\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_courses_id_org": {
+          "name": "uq_courses_id_org",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_organization_id_organizations_id_fk": {
+          "name": "courses_organization_id_organizations_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "courses_creator_id_users_id_fk": {
+          "name": "courses_creator_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "courses_intro_video_media_id_media_items_id_fk": {
+          "name": "courses_intro_video_media_id_media_items_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "courses_preview_video_media_id_media_items_id_fk": {
+          "name": "courses_preview_video_media_id_media_items_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "preview_video_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "courses_guide_video_media_id_media_items_id_fk": {
+          "name": "courses_guide_video_media_id_media_items_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "guide_video_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_course_status": {
+          "name": "check_course_status",
+          "value": "\"courses\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_course_price_non_negative": {
+          "name": "check_course_price_non_negative",
+          "value": "\"courses\".\"price_cents\" IS NULL OR \"courses\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.landing_pages": {
+      "name": "landing_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_overrides": {
+          "name": "brand_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_landing_pages_org_id": {
+          "name": "idx_landing_pages_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_landing_pages_creator_id": {
+          "name": "idx_landing_pages_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_landing_pages_subject": {
+          "name": "idx_landing_pages_subject",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_landing_pages_org_status": {
+          "name": "idx_landing_pages_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"landing_pages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_landing_pages_org_slug": {
+          "name": "uq_landing_pages_org_slug",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"landing_pages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "landing_pages_organization_id_organizations_id_fk": {
+          "name": "landing_pages_organization_id_organizations_id_fk",
+          "tableFrom": "landing_pages",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "landing_pages_creator_id_users_id_fk": {
+          "name": "landing_pages_creator_id_users_id_fk",
+          "tableFrom": "landing_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_landing_page_status": {
+          "name": "check_landing_page_status",
+          "value": "\"landing_pages\".\"status\" IN ('draft', 'published', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stage_practices": {
+      "name": "stage_practices",
+      "schema": "",
+      "columns": {
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_stage_practices_content_id": {
+          "name": "idx_stage_practices_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stage_practices_stage_id_course_stages_id_fk": {
+          "name": "stage_practices_stage_id_course_stages_id_fk",
+          "tableFrom": "stage_practices",
+          "tableTo": "course_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stage_practices_content_id_content_id_fk": {
+          "name": "stage_practices_content_id_content_id_fk",
+          "tableFrom": "stage_practices",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stage_practices_stage_id_content_id_pk": {
+          "name": "stage_practices_stage_id_content_id_pk",
+          "columns": [
+            "stage_id",
+            "content_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_audit_logs": {
+      "name": "email_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "email_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_audit_logs_organization_id_organizations_id_fk": {
+          "name": "email_audit_logs_organization_id_organizations_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_audit_logs_creator_id_users_id_fk": {
+          "name": "email_audit_logs_creator_id_users_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "template_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_templates_org_id": {
+          "name": "idx_email_templates_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_creator_id": {
+          "name": "idx_email_templates_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_scope": {
+          "name": "idx_email_templates_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_status": {
+          "name": "idx_email_templates_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_global": {
+          "name": "idx_unique_template_global",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'global' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_org": {
+          "name": "idx_unique_template_org",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'organization' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_creator": {
+          "name": "idx_unique_template_creator",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'creator' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_org_scope": {
+          "name": "idx_templates_org_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_creator_scope": {
+          "name": "idx_templates_creator_scope",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_created_by_deleted_at": {
+          "name": "idx_templates_created_by_deleted_at",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope_deleted_at": {
+          "name": "idx_templates_status_scope_deleted_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope": {
+          "name": "idx_templates_status_scope",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_active": {
+          "name": "idx_templates_active",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_template_lookup": {
+          "name": "idx_template_lookup",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_organization_id_organizations_id_fk": {
+          "name": "email_templates_organization_id_organizations_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_creator_id_users_id_fk": {
+          "name": "email_templates_creator_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_created_by_users_id_fk": {
+          "name": "email_templates_created_by_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "global_scope_no_owners": {
+          "name": "global_scope_no_owners",
+          "value": "\"email_templates\".\"scope\" != 'global' OR (\"email_templates\".\"organization_id\" IS NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "org_scope_requires_org": {
+          "name": "org_scope_requires_org",
+          "value": "\"email_templates\".\"scope\" != 'organization' OR (\"email_templates\".\"organization_id\" IS NOT NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "creator_scope_requires_creator": {
+          "name": "creator_scope_requires_creator",
+          "value": "\"email_templates\".\"scope\" != 'creator' OR \"email_templates\".\"creator_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_marketing": {
+          "name": "email_marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_transactional": {
+          "name": "email_transactional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_digest": {
+          "name": "email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_connect_account_user_id": {
+          "name": "primary_connect_account_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_slug": {
+          "name": "idx_organizations_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_org_slug": {
+          "name": "idx_unique_org_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_primary_connect_account_user_id_users_id_fk": {
+          "name": "organizations_primary_connect_account_user_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_connect_account_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payouts": {
+      "name": "payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_subscription_id": {
+          "name": "course_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group": {
+          "name": "transfer_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "payout_type": {
+          "name": "payout_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payouts_stripe_transfer_id": {
+          "name": "uq_payouts_stripe_transfer_id",
+          "columns": [
+            {
+              "expression": "stripe_transfer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"stripe_transfer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_created": {
+          "name": "idx_payouts_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_status_created": {
+          "name": "idx_payouts_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_pending": {
+          "name": "idx_payouts_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payouts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_user_org_created": {
+          "name": "idx_payouts_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_subscription": {
+          "name": "idx_payouts_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_purchase": {
+          "name": "idx_payouts_purchase",
+          "columns": [
+            {
+              "expression": "purchase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_course_subscription": {
+          "name": "idx_payouts_course_subscription",
+          "columns": [
+            {
+              "expression": "course_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_source_created": {
+          "name": "idx_payouts_org_source_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_payouts_platform_fee_per_charge": {
+          "name": "uq_payouts_platform_fee_per_charge",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"payout_type\" = 'platform_fee'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payouts_organization_id_organizations_id_fk": {
+          "name": "payouts_organization_id_organizations_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_user_id_users_id_fk": {
+          "name": "payouts_user_id_users_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_subscription_id_subscriptions_id_fk": {
+          "name": "payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payouts_purchase_id_purchases_id_fk": {
+          "name": "payouts_purchase_id_purchases_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payouts_course_subscription_id_course_subscriptions_id_fk": {
+          "name": "payouts_course_subscription_id_course_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "course_subscriptions",
+          "columnsFrom": [
+            "course_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_payouts_amount_positive": {
+          "name": "check_payouts_amount_positive",
+          "value": "\"payouts\".\"amount_cents\" > 0"
+        },
+        "check_payouts_status": {
+          "name": "check_payouts_status",
+          "value": "\"payouts\".\"status\" IN ('paid', 'pending', 'failed', 'reversed', 'cancelled_by_refund')"
+        },
+        "check_payouts_reason": {
+          "name": "check_payouts_reason",
+          "value": "\"payouts\".\"reason\" IS NULL OR \"payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        },
+        "check_payouts_type": {
+          "name": "check_payouts_type",
+          "value": "\"payouts\".\"payout_type\" IN ('platform_fee', 'organization_fee', 'creator_payout', 'creator_payout_to_owner')"
+        },
+        "check_payouts_source": {
+          "name": "check_payouts_source",
+          "value": "\"payouts\".\"source_type\" IN ('purchase', 'subscription')"
+        },
+        "check_payouts_source_ref_one": {
+          "name": "check_payouts_source_ref_one",
+          "value": "(CASE WHEN \"payouts\".\"subscription_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"payouts\".\"purchase_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"payouts\".\"course_subscription_id\" IS NULL THEN 0 ELSE 1 END) <= 1"
+        },
+        "check_payouts_user_required": {
+          "name": "check_payouts_user_required",
+          "value": "(\"payouts\".\"payout_type\" = 'platform_fee') OR (\"payouts\".\"user_id\" IS NOT NULL)"
+        },
+        "check_payouts_paid_invariant": {
+          "name": "check_payouts_paid_invariant",
+          "value": "(\"payouts\".\"status\" NOT IN ('paid', 'reversed')) OR ((\"payouts\".\"stripe_transfer_id\" IS NOT NULL OR \"payouts\".\"stripe_charge_id\" IS NOT NULL) AND \"payouts\".\"resolved_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.video_playback": {
+      "name": "video_playback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_video_playback_user_id": {
+          "name": "idx_video_playback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_video_playback_content_id": {
+          "name": "idx_video_playback_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_playback_user_id_users_id_fk": {
+          "name": "video_playback_user_id_users_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_playback_content_id_content_id_fk": {
+          "name": "video_playback_content_id_content_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_playback_user_id_content_id_unique": {
+          "name": "video_playback_user_id_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refund_reviews": {
+      "name": "refund_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_reversal_cents": {
+          "name": "attempted_reversal_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_refund_reviews_open_per_payout": {
+          "name": "uq_refund_reviews_open_per_payout",
+          "columns": [
+            {
+              "expression": "payout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"refund_reviews\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refund_reviews_purchase_id_purchases_id_fk": {
+          "name": "refund_reviews_purchase_id_purchases_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_payout_id_payouts_id_fk": {
+          "name": "refund_reviews_payout_id_payouts_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "payouts",
+          "columnsFrom": [
+            "payout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_creator_user_id_users_id_fk": {
+          "name": "refund_reviews_creator_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_resolved_by_user_id_users_id_fk": {
+          "name": "refund_reviews_resolved_by_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_refund_reviews_amount_positive": {
+          "name": "check_refund_reviews_amount_positive",
+          "value": "\"refund_reviews\".\"attempted_reversal_cents\" > 0"
+        },
+        "check_refund_reviews_resolution": {
+          "name": "check_refund_reviews_resolution",
+          "value": "\"refund_reviews\".\"resolution\" IS NULL OR \"refund_reviews\".\"resolution\" IN ('creator_absorbed', 'platform_absorbed', 'manually_reversed')"
+        },
+        "check_refund_reviews_resolved_pair": {
+          "name": "check_refund_reviews_resolved_pair",
+          "value": "(\"refund_reviews\".\"resolved_at\" IS NULL AND \"refund_reviews\".\"resolution\" IS NULL) OR (\"refund_reviews\".\"resolved_at\" IS NOT NULL AND \"refund_reviews\".\"resolution\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.branding_settings": {
+      "name": "branding_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_r2_path": {
+          "name": "logo_r2_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color_hex": {
+          "name": "primary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "secondary_color_hex": {
+          "name": "secondary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color_hex": {
+          "name": "accent_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_color_hex": {
+          "name": "background_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_body": {
+          "name": "font_body",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_heading": {
+          "name": "font_heading",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_value": {
+          "name": "radius_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "density_value": {
+          "name": "density_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "intro_video_media_item_id": {
+          "name": "intro_video_media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_url": {
+          "name": "intro_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_overrides": {
+          "name": "token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_mode_overrides": {
+          "name": "dark_mode_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_token_overrides": {
+          "name": "dark_token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_layout": {
+          "name": "hero_layout",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "pricing_faq": {
+          "name": "pricing_faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "branding_settings_updated_at_idx": {
+          "name": "branding_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branding_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "branding_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branding_settings_intro_video_media_item_id_media_items_id_fk": {
+          "name": "branding_settings_intro_video_media_item_id_media_items_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_settings": {
+      "name": "contact_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Codex Platform'"
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'support@example.com'"
+        },
+        "contact_url": {
+          "name": "contact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "twitter_url": {
+          "name": "twitter_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok_url": {
+          "name": "tiktok_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_settings_updated_at_idx": {
+          "name": "contact_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "contact_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "contact_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_settings": {
+      "name": "feature_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enable_signups": {
+          "name": "enable_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_purchases": {
+          "name": "enable_purchases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_subscriptions": {
+          "name": "enable_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_settings_updated_at_idx": {
+          "name": "feature_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "feature_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "feature_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_settings": {
+      "name": "platform_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_settings_updated_at_idx": {
+          "name": "platform_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_settings_organization_id_organizations_id_fk": {
+          "name": "platform_settings_organization_id_organizations_id_fk",
+          "tableFrom": "platform_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orphaned_image_files": {
+      "name": "orphaned_image_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_entity_id": {
+          "name": "original_entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_entity_type": {
+          "name": "original_entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orphaned_files_status": {
+          "name": "idx_orphaned_files_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_orphaned_at": {
+          "name": "idx_orphaned_files_orphaned_at",
+          "columns": [
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_type_status": {
+          "name": "idx_orphaned_files_type_status",
+          "columns": [
+            {
+              "expression": "image_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_pending_cleanup": {
+          "name": "idx_orphaned_files_pending_cleanup",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_image_type": {
+          "name": "check_image_type",
+          "value": "\"orphaned_image_files\".\"image_type\" IN ('avatar', 'logo', 'content_thumbnail', 'transcoding_artifact')"
+        },
+        "check_entity_type": {
+          "name": "check_entity_type",
+          "value": "\"orphaned_image_files\".\"original_entity_type\" IS NULL OR \"orphaned_image_files\".\"original_entity_type\" IN ('user', 'organization', 'content', 'media_item')"
+        },
+        "check_orphan_status": {
+          "name": "check_orphan_status",
+          "value": "\"orphaned_image_files\".\"status\" IN ('pending', 'deleted', 'failed', 'retained')"
+        },
+        "check_cleanup_attempts": {
+          "name": "check_cleanup_attempts",
+          "value": "\"orphaned_image_files\".\"cleanup_attempts\" >= 0 AND \"orphaned_image_files\".\"cleanup_attempts\" <= 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_payouts": {
+      "name": "pending_payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_payouts_user_id": {
+          "name": "idx_pending_payouts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_org_id": {
+          "name": "idx_pending_payouts_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_unresolved": {
+          "name": "idx_pending_payouts_unresolved",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_payouts_user_id_users_id_fk": {
+          "name": "pending_payouts_user_id_users_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_organization_id_organizations_id_fk": {
+          "name": "pending_payouts_organization_id_organizations_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_subscription_id_subscriptions_id_fk": {
+          "name": "pending_payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_pending_payout_positive": {
+          "name": "check_pending_payout_positive",
+          "value": "\"pending_payouts\".\"amount_cents\" > 0"
+        },
+        "check_pending_payout_reason": {
+          "name": "check_pending_payout_reason",
+          "value": "\"pending_payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stripe_connect_accounts": {
+      "name": "stripe_connect_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_connect_org_id": {
+          "name": "idx_stripe_connect_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_connect_stripe_id": {
+          "name": "idx_stripe_connect_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_connect_accounts_organization_id_organizations_id_fk": {
+          "name": "stripe_connect_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_connect_accounts_user_id_users_id_fk": {
+          "name": "stripe_connect_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_connect_accounts_stripe_account_id_unique": {
+          "name": "stripe_connect_accounts_stripe_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_account_id"
+          ]
+        },
+        "uq_stripe_connect_user": {
+          "name": "uq_stripe_connect_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_connect_status": {
+          "name": "check_connect_status",
+          "value": "\"stripe_connect_accounts\".\"status\" IN ('onboarding', 'active', 'restricted', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_org_id": {
+          "name": "idx_subscription_tiers_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_tiers_org_active": {
+          "name": "idx_subscription_tiers_org_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_org_sort": {
+          "name": "uq_subscription_tiers_org_sort",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_tiers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_id_org": {
+          "name": "uq_subscription_tiers_id_org",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_tiers_organization_id_organizations_id_fk": {
+          "name": "subscription_tiers_organization_id_organizations_id_fk",
+          "tableFrom": "subscription_tiers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_tier_price_monthly_positive": {
+          "name": "check_tier_price_monthly_positive",
+          "value": "\"subscription_tiers\".\"price_monthly\" >= 0"
+        },
+        "check_tier_price_annual_positive": {
+          "name": "check_tier_price_annual_positive",
+          "value": "\"subscription_tiers\".\"price_annual\" >= 0"
+        },
+        "check_tier_sort_order_positive": {
+          "name": "check_tier_sort_order_positive",
+          "value": "\"subscription_tiers\".\"sort_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_reason": {
+          "name": "churn_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_user_id": {
+          "name": "idx_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_id": {
+          "name": "idx_subscriptions_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_tier_id": {
+          "name": "idx_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_stripe_id": {
+          "name": "idx_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_status": {
+          "name": "idx_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user_org": {
+          "name": "idx_subscriptions_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_subscription_per_user_org": {
+          "name": "uq_active_subscription_per_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_subscription_status": {
+          "name": "check_subscription_status",
+          "value": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_billing_interval": {
+          "name": "check_billing_interval",
+          "value": "\"subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        },
+        "check_churn_reason": {
+          "name": "check_churn_reason",
+          "value": "\"subscriptions\".\"churn_reason\" IS NULL OR \"subscriptions\".\"churn_reason\" IN ('too_expensive', 'not_enough_content', 'found_alternative', 'not_using_it', 'technical_issues', 'other')"
+        },
+        "check_sub_amount_positive": {
+          "name": "check_sub_amount_positive",
+          "value": "\"subscriptions\".\"amount_cents\" >= 0"
+        },
+        "check_sub_platform_fee_positive": {
+          "name": "check_sub_platform_fee_positive",
+          "value": "\"subscriptions\".\"platform_fee_cents\" >= 0"
+        },
+        "check_sub_org_fee_positive": {
+          "name": "check_sub_org_fee_positive",
+          "value": "\"subscriptions\".\"organization_fee_cents\" >= 0"
+        },
+        "check_sub_creator_payout_positive": {
+          "name": "check_sub_creator_payout_positive",
+          "value": "\"subscriptions\".\"creator_payout_cents\" >= 0"
+        },
+        "check_sub_revenue_split_equals_total": {
+          "name": "check_sub_revenue_split_equals_total",
+          "value": "\"subscriptions\".\"amount_cents\" = \"subscriptions\".\"platform_fee_cents\" + \"subscriptions\".\"organization_fee_cents\" + \"subscriptions\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_table": {
+      "name": "test_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_table_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.email_send_status": {
+      "name": "email_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.template_scope": {
+      "name": "template_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "organization",
+        "creator"
+      ]
+    },
+    "public.template_status": {
+      "name": "template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -561,6 +561,13 @@
       "when": 1784815988651,
       "tag": "0079_foamy_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1784857425980,
+      "tag": "0080_clumsy_forge",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/course-commerce.ts
+++ b/packages/database/src/schema/course-commerce.ts
@@ -2,6 +2,7 @@ import { relations, sql } from 'drizzle-orm';
 import {
   boolean,
   check,
+  foreignKey,
   index,
   integer,
   pgTable,
@@ -154,16 +155,36 @@ export const courseSubscriptions = pgTable(
 export const courseTierAccess = pgTable(
   'course_tier_access',
   {
-    courseId: uuid('course_id')
-      .notNull()
-      .references(() => courses.id, { onDelete: 'cascade' }),
-    tierId: uuid('tier_id')
-      .notNull()
-      .references(() => subscriptionTiers.id, { onDelete: 'cascade' }),
+    courseId: uuid('course_id').notNull(),
+    tierId: uuid('tier_id').notNull(),
+    // Codex-2pryk WP-6 (N1): the organization BOTH the course and the tier
+    // belong to. Denormalised so the composite FKs below can pin them to the
+    // SAME org — a course from org A can never be unlocked by a tier from org B.
+    organizationId: uuid('organization_id').notNull(),
   },
   (table) => [
     primaryKey({ columns: [table.courseId, table.tierId] }),
     index('idx_course_tier_access_tier_id').on(table.tierId),
+    index('idx_course_tier_access_org_id').on(table.organizationId),
+
+    // N1 DURABLE GUARANTEE (Codex-2pryk WP-6 review): a cross-org tier→course
+    // grant is IMPOSSIBLE at the DB level, not merely rejected by the service.
+    // Each composite FK forces the row's (resource, organization_id) pair to
+    // exist as a real row in the parent, so BOTH course and tier must share the
+    // one `organization_id` on this row. Requires the parent unique indexes
+    // `uq_courses_id_org` / `uq_subscription_tiers_id_org`. Both cascade so a
+    // deleted course OR tier sweeps its grants (the tier-delete sweep, SPEC §7),
+    // preserving the WP-1 `onDelete: cascade` behaviour.
+    foreignKey({
+      columns: [table.courseId, table.organizationId],
+      foreignColumns: [courses.id, courses.organizationId],
+      name: 'fk_course_tier_access_course_org',
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.tierId, table.organizationId],
+      foreignColumns: [subscriptionTiers.id, subscriptionTiers.organizationId],
+      name: 'fk_course_tier_access_tier_org',
+    }).onDelete('cascade'),
   ]
 );
 
@@ -212,6 +233,10 @@ export const courseTierAccessRelations = relations(
     tier: one(subscriptionTiers, {
       fields: [courseTierAccess.tierId],
       references: [subscriptionTiers.id],
+    }),
+    organization: one(organizations, {
+      fields: [courseTierAccess.organizationId],
+      references: [organizations.id],
     }),
   })
 );

--- a/packages/database/src/schema/ecommerce.ts
+++ b/packages/database/src/schema/ecommerce.ts
@@ -13,6 +13,7 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 import { content } from './content';
+import { courses } from './journeys';
 import { organizations } from './organizations';
 import { users } from './users';
 
@@ -421,9 +422,19 @@ export const purchases = pgTable(
     customerId: text('customer_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    contentId: uuid('content_id')
-      .notNull()
-      .references(() => content.id, { onDelete: 'restrict' }),
+    // Split purchase target (Codex-2pryk WP-6): a purchase pays for EITHER a
+    // piece of `content` OR a `course` — exactly one is set (CHECK below),
+    // mirroring the `entitlements` split-FK. `contentId` became nullable so a
+    // one-off COURSE purchase (`courses.priceCents`) reuses this exact revenue
+    // flow (fee split snapshot + payouts ledger) with a course target instead
+    // of content. Both keep `onDelete: 'restrict'` so a sold course/content
+    // can never be hard-deleted out from under its immutable purchase record.
+    contentId: uuid('content_id').references(() => content.id, {
+      onDelete: 'restrict',
+    }),
+    courseId: uuid('course_id').references(() => courses.id, {
+      onDelete: 'restrict',
+    }),
     // Nullable (Codex-69t7c WP1): orgless creator-direct purchases have no
     // organization. Org-scoped purchases still populate it; the Phase-1 gate
     // that required it is removed in WP5.
@@ -495,6 +506,7 @@ export const purchases = pgTable(
     // Indexes
     index('idx_purchases_customer_id').on(table.customerId),
     index('idx_purchases_content_id').on(table.contentId),
+    index('idx_purchases_course_id').on(table.courseId),
     index('idx_purchases_organization_id').on(table.organizationId),
     index('idx_purchases_stripe_payment_intent').on(
       table.stripePaymentIntentId
@@ -531,6 +543,14 @@ export const purchases = pgTable(
       table.organizationId,
       table.status,
       table.purchasedAt
+    ),
+
+    // Split purchase target: EXACTLY ONE of content / course is set (WP-6).
+    // Mirrors the entitlements split-FK invariant so a purchase always names a
+    // single resource its revenue snapshot + payouts ledger rows attribute to.
+    check(
+      'check_purchase_target_one',
+      sql`(CASE WHEN ${table.contentId} IS NULL THEN 0 ELSE 1 END) + (CASE WHEN ${table.courseId} IS NULL THEN 0 ELSE 1 END) = 1`
     ),
 
     // CHECK constraint for status enum values
@@ -584,6 +604,10 @@ export const purchasesRelations = relations(purchases, ({ one }) => ({
   content: one(content, {
     fields: [purchases.contentId],
     references: [content.id],
+  }),
+  course: one(courses, {
+    fields: [purchases.courseId],
+    references: [courses.id],
   }),
   organization: one(organizations, {
     fields: [purchases.organizationId],

--- a/packages/database/src/schema/entitlements.ts
+++ b/packages/database/src/schema/entitlements.ts
@@ -5,6 +5,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core';
@@ -78,6 +79,22 @@ export const entitlements = pgTable(
     // Fast "does user U hold a live grant on resource R?" lookups (resolver hot path).
     index('idx_entitlements_user_content').on(table.userId, table.contentId),
     index('idx_entitlements_user_course').on(table.userId, table.courseId),
+
+    // Idempotency of the WP-6 grant-write path (webhook redelivery / concurrent
+    // completion). At most one LIVE (`revokedAt IS NULL`) grant per
+    // (user, resource, source): the writers INSERT ... ON CONFLICT DO NOTHING,
+    // so a Stripe replay is a no-op and never duplicates a grant. Scoped to
+    // `revokedAt IS NULL` so a lawful re-purchase / re-subscribe AFTER
+    // revocation still inserts a fresh row (the revoked row persists for audit).
+    // Partial on the non-null resource FK so the split-FK CHECK stays honoured.
+    uniqueIndex('uq_entitlement_live_content')
+      .on(table.userId, table.contentId, table.source)
+      .where(
+        sql`${table.revokedAt} IS NULL AND ${table.contentId} IS NOT NULL`
+      ),
+    uniqueIndex('uq_entitlement_live_course')
+      .on(table.userId, table.courseId, table.source)
+      .where(sql`${table.revokedAt} IS NULL AND ${table.courseId} IS NOT NULL`),
 
     // Exactly one resource target is set (split-FK polymorphism).
     check(

--- a/packages/database/src/schema/journeys.ts
+++ b/packages/database/src/schema/journeys.ts
@@ -169,6 +169,12 @@ export const courses = pgTable(
       .on(table.organizationId, table.slug)
       .where(sql`${table.deletedAt} IS NULL`),
 
+    // Codex-2pryk WP-6: composite-FK target for `course_tier_access`'s N1
+    // guarantee (see subscriptions.ts `uq_subscription_tiers_id_org`). `id` is
+    // already unique via the PK; this redundant unique on (id, organization_id)
+    // is what the composite FK referencing (id, organization_id) requires.
+    uniqueIndex('uq_courses_id_org').on(table.id, table.organizationId),
+
     check(
       'check_course_status',
       sql`${table.status} IN ('draft', 'published', 'archived')`

--- a/packages/database/src/schema/payouts.ts
+++ b/packages/database/src/schema/payouts.ts
@@ -11,6 +11,7 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 
+import { courseSubscriptions } from './course-commerce';
 import { purchases } from './ecommerce';
 import { organizations } from './organizations';
 import { subscriptions } from './subscriptions';
@@ -50,6 +51,16 @@ export const payouts = pgTable(
     purchaseId: uuid('purchase_id').references(() => purchases.id, {
       onDelete: 'set null',
     }),
+    // Codex-2pryk WP-6 (HARDENING §H3): course-specific subscriptions are NOT
+    // org `subscriptions` rows, so their recurring-invoice payouts cannot hang
+    // off `subscriptionId` (which hard-FKs org subscriptions). This third
+    // nullable source-FK attributes a course-sub payout to its
+    // `course_subscriptions` row. `set null` mirrors the other source refs so
+    // deleting the source never destroys the immutable ledger row.
+    courseSubscriptionId: uuid('course_subscription_id').references(
+      () => courseSubscriptions.id,
+      { onDelete: 'set null' }
+    ),
 
     // Stripe correlation
     stripeChargeId: varchar('stripe_charge_id', { length: 255 }),
@@ -116,6 +127,7 @@ export const payouts = pgTable(
     ),
     index('idx_payouts_subscription').on(table.subscriptionId),
     index('idx_payouts_purchase').on(table.purchaseId),
+    index('idx_payouts_course_subscription').on(table.courseSubscriptionId),
     index('idx_payouts_org_source_created').on(
       table.organizationId,
       table.sourceType,
@@ -150,6 +162,15 @@ export const payouts = pgTable(
       'check_payouts_source',
       sql`${table.sourceType} IN ('purchase', 'subscription')`
     ),
+    // Codex-2pryk WP-6 (HARDENING §H3 "CHECK-one"): a ledger row attributes to
+    // AT MOST ONE money source — an org subscription, a one-off purchase, or a
+    // course subscription. (Not exactly-one: platform_fee rows and legacy rows
+    // may reference none.) Prevents a single payout being double-attributed
+    // across the reporting source filters.
+    check(
+      'check_payouts_source_ref_one',
+      sql`(CASE WHEN ${table.subscriptionId} IS NULL THEN 0 ELSE 1 END) + (CASE WHEN ${table.purchaseId} IS NULL THEN 0 ELSE 1 END) + (CASE WHEN ${table.courseSubscriptionId} IS NULL THEN 0 ELSE 1 END) <= 1`
+    ),
     // platform_fee rows may have a null user_id (platform isn't a user);
     // every other row type must name its recipient.
     check(
@@ -183,6 +204,10 @@ export const payoutsRelations = relations(payouts, ({ one }) => ({
   purchase: one(purchases, {
     fields: [payouts.purchaseId],
     references: [purchases.id],
+  }),
+  courseSubscription: one(courseSubscriptions, {
+    fields: [payouts.courseSubscriptionId],
+    references: [courseSubscriptions.id],
   }),
 }));
 

--- a/packages/database/src/schema/subscriptions.ts
+++ b/packages/database/src/schema/subscriptions.ts
@@ -70,6 +70,15 @@ export const subscriptionTiers = pgTable(
       .on(table.organizationId, table.sortOrder)
       .where(sql`${table.deletedAt} IS NULL`),
 
+    // Codex-2pryk WP-6: composite-FK target for `course_tier_access`'s N1
+    // guarantee (a tier can only unlock a course in the SAME org). `id` is
+    // already unique via the PK; this redundant unique on (id, organization_id)
+    // is what a composite FK referencing (id, organization_id) requires.
+    uniqueIndex('uq_subscription_tiers_id_org').on(
+      table.id,
+      table.organizationId
+    ),
+
     // CHECK constraints
     check('check_tier_price_monthly_positive', sql`${table.priceMonthly} >= 0`),
     check('check_tier_price_annual_positive', sql`${table.priceAnnual} >= 0`),

--- a/packages/purchase/src/errors.ts
+++ b/packages/purchase/src/errors.ts
@@ -84,6 +84,46 @@ export class ContentNotPurchasableError extends BusinessLogicError {
 }
 
 /**
+ * Course not purchasable error (Codex-2pryk WP-6)
+ * Thrown when a course has no one-off price, is unpublished, or is deleted.
+ */
+export class CourseNotPurchasableError extends BusinessLogicError {
+  constructor(
+    courseId: string,
+    reason: 'no_price' | 'not_published' | 'deleted',
+    context?: Record<string, unknown>
+  ) {
+    const messages = {
+      no_price: 'Course is not sold as a one-off purchase',
+      not_published: 'Course must be published before it can be purchased',
+      deleted: 'Course is no longer available',
+    };
+
+    super(messages[reason], {
+      courseId,
+      reason,
+      code: 'COURSE_NOT_PURCHASABLE',
+      ...context,
+    });
+  }
+}
+
+/**
+ * Course already owned error (Codex-2pryk WP-6)
+ * Thrown when a user starts a course checkout while already holding a live
+ * entitlement over that course (purchase, subscription, tier, or grant).
+ */
+export class CourseAlreadyOwnedError extends ConflictError {
+  constructor(courseId: string, customerId: string) {
+    super('Course already owned', {
+      courseId,
+      customerId,
+      code: 'COURSE_ALREADY_OWNED',
+    });
+  }
+}
+
+/**
  * Payment processing error
  * Thrown when Stripe checkout session creation or payment processing fails
  */

--- a/packages/purchase/src/index.ts
+++ b/packages/purchase/src/index.ts
@@ -35,7 +35,9 @@
 // Re-export validation schemas for convenience
 export {
   type CreateCheckoutInput,
+  type CreateCourseCheckoutInput,
   createCheckoutSchema,
+  createCourseCheckoutSchema,
   type GetPurchaseInput,
   getPurchaseSchema,
   type PurchaseQueryInput,
@@ -53,6 +55,8 @@ export {
   BusinessLogicError,
   ConflictError,
   ContentNotPurchasableError,
+  CourseAlreadyOwnedError,
+  CourseNotPurchasableError,
   ForbiddenError,
   InternalServiceError,
   isPurchaseServiceError,
@@ -64,6 +68,21 @@ export {
   ValidationError,
   wrapError,
 } from './errors';
+// Creator agreement-share resolver (Codex-nk4km WP-4, shared with WP-6)
+export {
+  type AgreementRevenueType,
+  findActiveCreatorAgreementShare,
+} from './services/agreement-share';
+// Entitlement + auto-enrollment write seam (Codex-2pryk WP-6)
+export {
+  autoEnroll,
+  type EntitlementWriteClient,
+  refreshCourseSubscriptionEntitlementExpiry,
+  revokeCourseSubscriptionEntitlement,
+  writeContentPurchaseEntitlement,
+  writeCoursePurchaseEntitlement,
+  writeCourseSubscriptionEntitlement,
+} from './services/entitlement-writer';
 // Fee configuration service (Codex-m644n)
 export {
   type AuditLogEntry,
@@ -115,6 +134,7 @@ export {
 export type {
   CheckoutSessionResult,
   CheckoutSessionVerifyResult,
+  CompleteCoursePurchaseMetadata,
   CompletePurchaseMetadata,
   NewPurchaseInput,
   Purchase,

--- a/packages/purchase/src/services/agreement-share.ts
+++ b/packages/purchase/src/services/agreement-share.ts
@@ -1,0 +1,82 @@
+/**
+ * Creator revenue-share agreement lookup (Codex-nk4km WP-4, extracted for reuse
+ * by Codex-2pryk WP-6).
+ *
+ * Resolves the creator's slice of the post-platform pool from their ACTIVE
+ * `creator_organization_agreements` row (via the accepted proposal it points
+ * at). Returns the share in basis points, or `null` when no agreement applies
+ * (caller falls back to the FeeConfigService-resolved org fee).
+ *
+ * This is the exact query `PurchaseService.completePurchase` ran inline for
+ * content purchases; hoisted so the one-off COURSE purchase (which reuses
+ * `content_purchase` share terms per HARDENING §H4(a)) and the course-
+ * subscription payout (`subscription` terms) apply IDENTICAL agreement math
+ * without duplicating the subtle Decision-Q3 date predicates.
+ *
+ * Decision Q3 (active-as-of-`at`): an agreement counts when it is `active`, OR
+ * `terminated` after `at`; and its effective window brackets `at`. `at` is the
+ * pinned purchase/invoice timestamp so a webhook replay lands on the same side
+ * of any agreement boundary.
+ */
+
+import type { DatabaseClient } from '@codex/database';
+import {
+  agreementProposals,
+  creatorOrganizationAgreements,
+} from '@codex/database/schema';
+import { and, eq, gt, isNull, lte, or } from 'drizzle-orm';
+
+type Tx = Parameters<Parameters<DatabaseClient['transaction']>[0]>[0];
+type QueryClient = DatabaseClient | Tx;
+
+/** Revenue types an agreement can be scoped to (`creator_organization_agreements`). */
+export type AgreementRevenueType = 'subscription' | 'content_purchase';
+
+/**
+ * The creator's agreed share of the post-platform pool in basis points, or
+ * `null` when no active agreement brackets `at`.
+ */
+export async function findActiveCreatorAgreementShare(
+  client: QueryClient,
+  params: {
+    organizationId: string;
+    creatorId: string;
+    revenueType: AgreementRevenueType;
+    at: Date;
+  }
+): Promise<number | null> {
+  const [row] = await client
+    .select({
+      sharePercent: agreementProposals.proposedCreatorSharePercent,
+    })
+    .from(creatorOrganizationAgreements)
+    .innerJoin(
+      agreementProposals,
+      eq(agreementProposals.id, creatorOrganizationAgreements.currentProposalId)
+    )
+    .where(
+      and(
+        eq(creatorOrganizationAgreements.organizationId, params.organizationId),
+        eq(creatorOrganizationAgreements.creatorId, params.creatorId),
+        eq(creatorOrganizationAgreements.revenueType, params.revenueType),
+        // Q3: active, or terminated after `at`. The schema CHECK enforces
+        // status='terminated' ⇔ terminatedAt IS NOT NULL, so status='active'
+        // implies terminatedAt IS NULL.
+        or(
+          eq(creatorOrganizationAgreements.status, 'active'),
+          and(
+            eq(creatorOrganizationAgreements.status, 'terminated'),
+            gt(creatorOrganizationAgreements.terminatedAt, params.at)
+          )
+        ),
+        lte(creatorOrganizationAgreements.effectiveFrom, params.at),
+        or(
+          isNull(creatorOrganizationAgreements.effectiveUntil),
+          gt(creatorOrganizationAgreements.effectiveUntil, params.at)
+        )
+      )
+    )
+    .limit(1);
+
+  return row?.sharePercent ?? null;
+}

--- a/packages/purchase/src/services/entitlement-writer.ts
+++ b/packages/purchase/src/services/entitlement-writer.ts
@@ -1,0 +1,208 @@
+/**
+ * Entitlement + enrollment WRITE seam (Codex-2pryk · WP-6).
+ *
+ * The write side of the greenfield access core: on a completed course/content
+ * acquisition these functions INSERT the `entitlements` grant row that the WP-2
+ * resolver (`@codex/access` `entitlements-resolver.ts`) READS, closing the
+ * buy → grant-written → resolver-grants round-trip.
+ *
+ * Placement: `@codex/purchase` is upstream of `@codex/subscription` (which
+ * depends on it) and of `@codex/access`, so BOTH the one-off purchase path
+ * (`PurchaseService`) and the course-subscription path (`CourseSubscriptionService`)
+ * reuse ONE grant writer without a dependency cycle — `PurchaseService` cannot
+ * import `@codex/access`, and duplicating money-adjacent inserts would drift.
+ *
+ * ## Idempotency
+ * Every INSERT is `ON CONFLICT DO NOTHING` against the partial unique indexes
+ * `uq_entitlement_live_content` / `uq_entitlement_live_course` (one LIVE grant
+ * per user × resource × source). A Stripe webhook redelivery is therefore a
+ * no-op, never a duplicate grant. The indexes are scoped to `revokedAt IS NULL`,
+ * so a lawful re-purchase AFTER revocation still writes a fresh grant.
+ *
+ * ## Auto-enrollment (D-G)
+ * A course grant also creates a `course_enrollments` side-record (idempotent via
+ * `uq_course_enrollment_user_course`). Enrollment is NOT a gate — `canEnterCourse`
+ * gates on the entitlement — it is the library/progress shelf, so it is written
+ * best-effort alongside the grant, in the SAME transaction where one is passed.
+ */
+
+import type { DatabaseClient } from '@codex/database';
+import { courseEnrollments, entitlements } from '@codex/database/schema';
+import type { StoredEntitlementSource } from '@codex/shared-types';
+import { and, eq, isNull } from 'drizzle-orm';
+
+/**
+ * A write-capable query client. Both the base `DatabaseClient` and a transaction
+ * client expose `.insert` / `.update`, so a grant write runs identically under
+ * either without an `as any` cast (mirrors the resolver's `AccessQueryClient`).
+ */
+type Tx = Parameters<Parameters<DatabaseClient['transaction']>[0]>[0];
+export type EntitlementWriteClient = DatabaseClient | Tx;
+
+/**
+ * Grant a CONTENT entitlement for a completed one-off purchase (SPEC §6.2,
+ * `source='content_purchase'`). Additive to the authoritative `contentAccess`
+ * row + `verifyPurchase` — the resolver unions the two, so this is the
+ * forward-compatible grant the resolver reads directly.
+ *
+ * `organizationId` is REQUIRED (the `entitlements` table's org FK is NOT NULL,
+ * and the frozen `Entitlement.organizationId` is non-nullable). Orgless
+ * (bi-party) content purchases therefore write NO entitlement row and rely on
+ * `verifyPurchase` alone — the caller must skip this write when org is null.
+ */
+export async function writeContentPurchaseEntitlement(
+  client: EntitlementWriteClient,
+  params: {
+    userId: string;
+    organizationId: string;
+    contentId: string;
+    purchaseId: string;
+  }
+): Promise<void> {
+  await client
+    .insert(entitlements)
+    .values({
+      userId: params.userId,
+      organizationId: params.organizationId,
+      contentId: params.contentId,
+      source: 'content_purchase',
+      sourceRef: params.purchaseId,
+    })
+    .onConflictDoNothing();
+}
+
+/**
+ * Grant a COURSE entitlement for a completed one-off course purchase (permanent,
+ * `source='course_purchase'`) and auto-enroll (D-G).
+ */
+export async function writeCoursePurchaseEntitlement(
+  client: EntitlementWriteClient,
+  params: {
+    userId: string;
+    organizationId: string;
+    courseId: string;
+    purchaseId: string;
+  }
+): Promise<void> {
+  await client
+    .insert(entitlements)
+    .values({
+      userId: params.userId,
+      organizationId: params.organizationId,
+      courseId: params.courseId,
+      source: 'course_purchase',
+      sourceRef: params.purchaseId,
+    })
+    .onConflictDoNothing();
+  await autoEnroll(client, {
+    userId: params.userId,
+    courseId: params.courseId,
+    source: 'course_purchase',
+  });
+}
+
+/**
+ * Grant a COURSE entitlement for an active course-specific subscription
+ * (`source='course_subscription'`) and auto-enroll (D-G).
+ *
+ * `expiresAt` is the subscription's `currentPeriodEnd`: the stored grant is
+ * fail-closed — if a renewal is missed the grant lapses on its own (the resolver
+ * filters `expiresAt > now`), even before a `customer.subscription.deleted`
+ * webhook lands. Renewals bump it via {@link refreshCourseSubscriptionEntitlementExpiry}.
+ */
+export async function writeCourseSubscriptionEntitlement(
+  client: EntitlementWriteClient,
+  params: {
+    userId: string;
+    organizationId: string;
+    courseId: string;
+    courseSubscriptionId: string;
+    expiresAt: Date;
+  }
+): Promise<void> {
+  await client
+    .insert(entitlements)
+    .values({
+      userId: params.userId,
+      organizationId: params.organizationId,
+      courseId: params.courseId,
+      source: 'course_subscription',
+      sourceRef: params.courseSubscriptionId,
+      expiresAt: params.expiresAt,
+    })
+    .onConflictDoNothing();
+  await autoEnroll(client, {
+    userId: params.userId,
+    courseId: params.courseId,
+    source: 'course_subscription',
+  });
+}
+
+/**
+ * Extend the live course-subscription grant's `expiresAt` on a renewal
+ * (`invoice.payment_succeeded`). No-op when no live grant exists (self-heal
+ * writes it first). Idempotent — replaying the same invoice just re-sets the
+ * same period end.
+ */
+export async function refreshCourseSubscriptionEntitlementExpiry(
+  client: EntitlementWriteClient,
+  params: { userId: string; courseId: string; expiresAt: Date }
+): Promise<void> {
+  await client
+    .update(entitlements)
+    .set({ expiresAt: params.expiresAt })
+    .where(
+      and(
+        eq(entitlements.userId, params.userId),
+        eq(entitlements.courseId, params.courseId),
+        eq(entitlements.source, 'course_subscription'),
+        isNull(entitlements.revokedAt)
+      )
+    );
+}
+
+/**
+ * Revoke the live course-subscription grant immediately (subscription deleted /
+ * unpaid). Sets `revokedAt` so the resolver stops granting on the next read —
+ * this is the hard cut-off for an access-reducing lifecycle event, distinct from
+ * the soft `expiresAt` lapse used for missed renewals. Idempotent.
+ */
+export async function revokeCourseSubscriptionEntitlement(
+  client: EntitlementWriteClient,
+  params: { userId: string; courseId: string }
+): Promise<void> {
+  await client
+    .update(entitlements)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(entitlements.userId, params.userId),
+        eq(entitlements.courseId, params.courseId),
+        eq(entitlements.source, 'course_subscription'),
+        isNull(entitlements.revokedAt)
+      )
+    );
+}
+
+/**
+ * Auto-create the `course_enrollments` side-record for a course grant (D-G).
+ * Idempotent via `uq_course_enrollment_user_course`. Enrollment is the
+ * library/progress shelf, NOT the access gate.
+ */
+export async function autoEnroll(
+  client: EntitlementWriteClient,
+  params: {
+    userId: string;
+    courseId: string;
+    source: StoredEntitlementSource | 'tier_subscription' | 'first_access';
+  }
+): Promise<void> {
+  await client
+    .insert(courseEnrollments)
+    .values({
+      userId: params.userId,
+      courseId: params.courseId,
+      source: params.source,
+    })
+    .onConflictDoNothing();
+}

--- a/packages/purchase/src/services/purchase-service.ts
+++ b/packages/purchase/src/services/purchase-service.ts
@@ -29,10 +29,10 @@ import {
 } from '@codex/constants';
 import { getConstraintName, isUniqueViolation, toIso } from '@codex/database';
 import {
-  agreementProposals,
   content,
   contentAccess,
-  creatorOrganizationAgreements,
+  courses,
+  entitlements,
   organizationMemberships,
   payouts,
   purchases,
@@ -43,6 +43,7 @@ import {
 import { BaseService, type ServiceConfig } from '@codex/service-errors';
 import type {
   CreateCheckoutInput,
+  CreateCourseCheckoutInput,
   PurchaseQueryInput,
   SalesQueryInput,
   SalesStatsQueryInput,
@@ -50,6 +51,7 @@ import type {
 import {
   checkoutSessionMetadataSchema,
   createCheckoutSchema,
+  createCourseCheckoutSchema,
   createPortalSessionSchema,
   extractPlainText,
   getPurchaseSchema,
@@ -62,7 +64,6 @@ import {
   count,
   desc,
   eq,
-  gt,
   gte,
   isNotNull,
   isNull,
@@ -75,12 +76,19 @@ import type Stripe from 'stripe';
 import {
   AlreadyPurchasedError,
   ContentNotPurchasableError,
+  CourseAlreadyOwnedError,
+  CourseNotPurchasableError,
   ForbiddenError,
   NotFoundError,
   PaymentProcessingError,
   PurchaseNotFoundError,
 } from '../errors';
 import { resolvePrimaryConnect } from '../utils/resolve-primary-connect';
+import { findActiveCreatorAgreementShare } from './agreement-share';
+import {
+  writeContentPurchaseEntitlement,
+  writeCoursePurchaseEntitlement,
+} from './entitlement-writer';
 import { withStaleCustomerRecovery } from './resolve-customer';
 
 /**
@@ -100,6 +108,7 @@ import type { PaginatedListResponse } from '@codex/shared-types';
 import type {
   CheckoutSessionResult,
   CheckoutSessionVerifyResult,
+  CompleteCoursePurchaseMetadata,
   CompletePurchaseMetadata,
   Purchase,
   PurchaseListItem,
@@ -613,58 +622,19 @@ export class PurchaseService extends BaseService {
         // row — skip the query entirely (it would also fail to typecheck
         // against the nullable `organizationId`).
         const purchasedAt = new Date();
-        const [agreementRow] = organizationId
-          ? await tx
-              .select({
-                sharePercent: agreementProposals.proposedCreatorSharePercent,
-              })
-              .from(creatorOrganizationAgreements)
-              .innerJoin(
-                agreementProposals,
-                eq(
-                  agreementProposals.id,
-                  creatorOrganizationAgreements.currentProposalId
-                )
-              )
-              .where(
-                and(
-                  eq(
-                    creatorOrganizationAgreements.organizationId,
-                    organizationId
-                  ),
-                  eq(
-                    creatorOrganizationAgreements.creatorId,
-                    contentRecord.creatorId
-                  ),
-                  eq(
-                    creatorOrganizationAgreements.revenueType,
-                    'content_purchase'
-                  ),
-                  // Per Decision Q3: active-as-of-purchase-date. The schema
-                  // check enforces (status='terminated') = (terminatedAt IS
-                  // NOT NULL) — status='active' implies terminatedAt is NULL.
-                  or(
-                    eq(creatorOrganizationAgreements.status, 'active'),
-                    and(
-                      eq(creatorOrganizationAgreements.status, 'terminated'),
-                      gt(
-                        creatorOrganizationAgreements.terminatedAt,
-                        purchasedAt
-                      )
-                    )
-                  ),
-                  lte(creatorOrganizationAgreements.effectiveFrom, purchasedAt),
-                  or(
-                    isNull(creatorOrganizationAgreements.effectiveUntil),
-                    gt(
-                      creatorOrganizationAgreements.effectiveUntil,
-                      purchasedAt
-                    )
-                  )
-                )
-              )
-              .limit(1)
-          : [undefined];
+        // Codex-2pryk WP-6: agreement lookup hoisted to the shared
+        // `findActiveCreatorAgreementShare` (reused by the course-purchase +
+        // course-subscription payout paths so all three apply IDENTICAL
+        // Decision-Q3 agreement math). Returns the creator's share in basis
+        // points, or null when no active agreement brackets `purchasedAt`.
+        const agreementSharePercent = organizationId
+          ? await findActiveCreatorAgreementShare(tx, {
+              organizationId,
+              creatorId: contentRecord.creatorId,
+              revenueType: 'content_purchase',
+              at: purchasedAt,
+            })
+          : null;
 
         // Codex-69t7c WP5: for orgless (bi-party) purchases the org leg is
         // ALWAYS zero — there is no organization to pay, so the creator keeps
@@ -677,8 +647,8 @@ export class PurchaseService extends BaseService {
         // "org keeps 100% of post-platform" unless an admin overrode it).
         const effectiveOrgFeePercent = !organizationId
           ? 0
-          : agreementRow
-            ? 10_000 - agreementRow.sharePercent
+          : agreementSharePercent != null
+            ? 10_000 - agreementSharePercent
             : fees.orgFeePercent;
 
         // Codex-69t7c WP5 hardening (d): record the orgless org-fee-zero
@@ -726,7 +696,7 @@ export class PurchaseService extends BaseService {
           platformFeeCents: revenueSplit.platformFeeCents,
           organizationFeeCents: revenueSplit.organizationFeeCents,
           creatorPayoutCents: revenueSplit.creatorPayoutCents,
-          agreementApplied: Boolean(agreementRow),
+          agreementApplied: agreementSharePercent != null,
           source: 'content_purchase',
         });
 
@@ -795,6 +765,20 @@ export class PurchaseService extends BaseService {
             },
           });
 
+        // Step 5a (Codex-2pryk WP-6): write the greenfield `entitlements` grant
+        // the resolver reads. Additive to `contentAccess` + `verifyPurchase`
+        // (the resolver unions all three). Org-scoped ONLY — `entitlements`
+        // requires a non-null org, so orgless (bi-party) content writes no grant
+        // row and stays covered by `verifyPurchase` alone. Idempotent on replay.
+        if (organizationId) {
+          await writeContentPurchaseEntitlement(tx, {
+            userId: metadata.customerId,
+            organizationId,
+            contentId: metadata.contentId,
+            purchaseId: purchase.id,
+          });
+        }
+
         return {
           purchase,
           isNew: true,
@@ -847,6 +831,347 @@ export class PurchaseService extends BaseService {
         amountPaidCents: metadata.amountPaidCents,
       });
       this.handleError(error, 'completePurchase');
+    }
+  }
+
+  // ─── Course purchase (Codex-2pryk WP-6 · SPEC §7 path 1) ─────────────────────
+
+  /**
+   * Create a Stripe Checkout session for a one-off COURSE purchase.
+   *
+   * The course analogue of {@link createCheckoutSession}: `mode: 'payment'`,
+   * platform-charge (Option B) so the SAME `writePurchasePayouts` fan-out splits
+   * the charge post-webhook. The session metadata is tagged `kind: 'course'` so
+   * the `checkout.session.completed` handler routes to
+   * {@link completeCoursePurchase}. Org + creator are NOT in metadata — they are
+   * re-derived from the `courses` row at completion (courses are always
+   * org-owned), so a tampered session can never redirect the payout.
+   */
+  async createCourseCheckoutSession(
+    input: CreateCourseCheckoutInput,
+    customerId: string
+  ): Promise<CheckoutSessionResult> {
+    const validated = createCourseCheckoutSchema.parse(input);
+
+    try {
+      const course = await this.db.query.courses.findFirst({
+        where: and(
+          eq(courses.id, validated.courseId),
+          isNull(courses.deletedAt)
+        ),
+      });
+
+      if (!course) {
+        throw new CourseNotPurchasableError(validated.courseId, 'deleted');
+      }
+      if (course.status !== CONTENT_STATUS.PUBLISHED) {
+        throw new CourseNotPurchasableError(
+          validated.courseId,
+          'not_published',
+          {
+            status: course.status,
+          }
+        );
+      }
+      if (course.priceCents === null || course.priceCents <= 0) {
+        throw new CourseNotPurchasableError(validated.courseId, 'no_price', {
+          priceCents: course.priceCents,
+        });
+      }
+
+      // Double-purchase guard: a completed course purchase already grants a
+      // permanent entitlement, so block a second checkout (mirrors the content
+      // path's AlreadyPurchasedError guard).
+      const existing = await this.db.query.purchases.findFirst({
+        where: and(
+          eq(purchases.customerId, customerId),
+          eq(purchases.courseId, validated.courseId),
+          eq(purchases.status, PURCHASE_STATUS.COMPLETED)
+        ),
+      });
+      if (existing) {
+        throw new CourseAlreadyOwnedError(validated.courseId, customerId);
+      }
+
+      const [user] = await this.db
+        .select({ email: users.email })
+        .from(users)
+        .where(eq(users.id, customerId))
+        .limit(1);
+      if (!user?.email) {
+        throw new NotFoundError('User email not found for checkout', {
+          customerId,
+          courseId: validated.courseId,
+        });
+      }
+
+      // Hoist the narrowed price across the closure boundary (TS drops the
+      // property narrowing inside the callback — same reason as the content path).
+      const priceCents = course.priceCents;
+
+      const session = await withStaleCustomerRecovery(
+        { db: this.db, stripe: this.stripe },
+        { userId: customerId, email: user.email },
+        (resolvedCustomerId) =>
+          this.stripe.checkout.sessions.create({
+            mode: 'payment',
+            payment_method_types: ['card'],
+            customer: resolvedCustomerId,
+            line_items: [
+              {
+                price_data: {
+                  currency: CURRENCY.GBP,
+                  unit_amount: priceCents,
+                  product_data: {
+                    name: course.title,
+                    description: course.lede
+                      ? course.lede.slice(0, 500)
+                      : undefined,
+                  },
+                },
+                quantity: 1,
+              },
+            ],
+            success_url: validated.successUrl,
+            cancel_url: validated.cancelUrl,
+            // `kind: 'course'` discriminates this from a content purchase at the
+            // webhook. organizationId is deliberately omitted (re-derived server
+            // side from the course row).
+            metadata: {
+              kind: 'course',
+              courseId: validated.courseId,
+              customerId,
+              courseTitle: course.title,
+            },
+            client_reference_id: customerId,
+          }),
+        {
+          onStaleRecovery: (info) =>
+            this.obs.warn(
+              'Stale users.stripe_customer_id detected; clearing and retrying',
+              { ...info, courseId: validated.courseId }
+            ),
+        }
+      );
+
+      if (!session.url) {
+        throw new PaymentProcessingError('Checkout session URL not generated', {
+          sessionId: session.id,
+        });
+      }
+
+      return { sessionUrl: session.url, sessionId: session.id };
+    } catch (error) {
+      if (
+        error instanceof CourseNotPurchasableError ||
+        error instanceof CourseAlreadyOwnedError ||
+        error instanceof NotFoundError ||
+        error instanceof PaymentProcessingError
+      ) {
+        throw error;
+      }
+      if (isStripeError(error)) {
+        throw new PaymentProcessingError(
+          'Failed to create course checkout session',
+          { stripeError: error.message, courseId: validated.courseId }
+        );
+      }
+      this.handleError(error, 'createCourseCheckoutSession');
+    }
+  }
+
+  /**
+   * Complete a one-off COURSE purchase after Stripe payment confirmation.
+   *
+   * The course analogue of {@link completePurchase}: same immutable revenue-split
+   * snapshot, same idempotency (by `stripePaymentIntentId`), and the SAME
+   * `writePurchasePayouts` Option-B fan-out (keyed on the purchase id, so a
+   * `purchases` row with a `courseId` target flows through unchanged). Differs
+   * only in the resource: it writes a `course_purchase` entitlement + auto-enrolls
+   * (via {@link writeCoursePurchaseEntitlement}) instead of a `contentAccess` row.
+   *
+   * Per HARDENING §H4(a) course purchases REUSE `content_purchase` agreement
+   * share terms — the agreement lookup uses `revenueType: 'content_purchase'`.
+   */
+  async completeCoursePurchase(
+    stripePaymentIntentId: string,
+    metadata: CompleteCoursePurchaseMetadata
+  ): Promise<Purchase> {
+    try {
+      const txResult = await this.db.transaction(async (tx) => {
+        // Idempotency — a webhook replay returns the existing purchase and skips
+        // payouts (the first-write path already ran; transfer idempotency keys
+        // protect the money side either way).
+        const existing = await tx.query.purchases.findFirst({
+          where: eq(purchases.stripePaymentIntentId, stripePaymentIntentId),
+        });
+        if (existing) {
+          return { purchase: existing, isNew: false } as const;
+        }
+
+        const course = await tx.query.courses.findFirst({
+          where: eq(courses.id, metadata.courseId),
+          columns: { organizationId: true, creatorId: true },
+        });
+        if (!course) {
+          throw new PaymentProcessingError(
+            'Course not found during purchase completion',
+            { courseId: metadata.courseId, stripePaymentIntentId }
+          );
+        }
+
+        // Courses are ALWAYS org-owned — the org is authoritative from the row.
+        const organizationId = course.organizationId;
+
+        const fees = this.feeConfig
+          ? await this.feeConfig.getFeesForCreator(
+              organizationId,
+              course.creatorId,
+              'one_off'
+            )
+          : {
+              platformFeePercent: DEFAULT_PLATFORM_FEE_PERCENTAGE,
+              orgFeePercent: DEFAULT_ORG_FEE_PERCENTAGE,
+              minPlatformFeeCents: 0,
+              minTransferCents: 0,
+            };
+
+        // HARDENING §H4(a): course purchases reuse the creator's
+        // `content_purchase` revenue-share agreement terms.
+        const purchasedAt = new Date();
+        const agreementSharePercent = await findActiveCreatorAgreementShare(
+          tx,
+          {
+            organizationId,
+            creatorId: course.creatorId,
+            revenueType: 'content_purchase',
+            at: purchasedAt,
+          }
+        );
+        const effectiveOrgFeePercent =
+          agreementSharePercent != null
+            ? 10_000 - agreementSharePercent
+            : fees.orgFeePercent;
+
+        const rawSplit = calculateRevenueSplit(
+          metadata.amountPaidCents,
+          fees.platformFeePercent,
+          effectiveOrgFeePercent
+        );
+        const revenueSplit = applyMinPlatformFeeFloor(
+          metadata.amountPaidCents,
+          rawSplit,
+          fees.minPlatformFeeCents
+        );
+
+        this.obs.info('payout_split_computed', {
+          purchaseId: undefined,
+          courseId: metadata.courseId,
+          organizationId,
+          creatorId: course.creatorId,
+          amountPaidCents: metadata.amountPaidCents,
+          platformFeeCents: revenueSplit.platformFeeCents,
+          organizationFeeCents: revenueSplit.organizationFeeCents,
+          creatorPayoutCents: revenueSplit.creatorPayoutCents,
+          agreementApplied: agreementSharePercent != null,
+          source: 'course_purchase',
+        });
+
+        if (
+          metadata.stripeApplicationFeeCents != null &&
+          metadata.stripeApplicationFeeCents !== revenueSplit.platformFeeCents
+        ) {
+          this.obs.warn(
+            'Platform fee mismatch: Stripe-collected application fee differs from calculated split',
+            {
+              stripeApplicationFeeCents: metadata.stripeApplicationFeeCents,
+              calculatedPlatformFeeCents: revenueSplit.platformFeeCents,
+              amountPaidCents: metadata.amountPaidCents,
+              stripePaymentIntentId,
+              courseId: metadata.courseId,
+            }
+          );
+        }
+
+        const [purchase] = await tx
+          .insert(purchases)
+          .values({
+            customerId: metadata.customerId,
+            // Split target — course, not content (CHECK enforces exactly one).
+            courseId: metadata.courseId,
+            organizationId,
+            amountPaidCents: metadata.amountPaidCents,
+            currency: metadata.currency || CURRENCY.GBP,
+            stripePaymentIntentId,
+            status: PURCHASE_STATUS.COMPLETED,
+            purchasedAt,
+            platformFeeCents: revenueSplit.platformFeeCents,
+            organizationFeeCents: revenueSplit.organizationFeeCents,
+            creatorPayoutCents: revenueSplit.creatorPayoutCents,
+            platformAgreementId: null,
+            creatorOrgAgreementId: null,
+          })
+          .returning();
+
+        if (!purchase) {
+          throw new PaymentProcessingError('Failed to create purchase record', {
+            stripePaymentIntentId,
+          });
+        }
+
+        // Grant the course entitlement (the resolver's READ target) + auto-enroll,
+        // atomically with the purchase row. Idempotent on replay.
+        await writeCoursePurchaseEntitlement(tx, {
+          userId: metadata.customerId,
+          organizationId,
+          courseId: metadata.courseId,
+          purchaseId: purchase.id,
+        });
+
+        return {
+          purchase,
+          isNew: true,
+          revenueSplit,
+          creatorId: course.creatorId,
+          organizationId,
+        } as const;
+      });
+
+      // Post-commit payouts — REUSE the Option-B fan-out verbatim. A course
+      // purchase row carries a `courseId` target; `writePurchasePayouts` only
+      // reads `purchase.id` + the split, so it splits the charge identically.
+      if (txResult.isNew && metadata.stripeChargeId) {
+        await this.writePurchasePayouts({
+          purchase: txResult.purchase,
+          revenueSplit: txResult.revenueSplit,
+          creatorId: txResult.creatorId,
+          organizationId: txResult.organizationId,
+          stripeChargeId: metadata.stripeChargeId,
+        });
+      } else if (txResult.isNew && !metadata.stripeChargeId) {
+        const errorId = crypto.randomUUID();
+        this.obs.error(
+          'Course purchase completed without stripeChargeId — payouts ledger entries skipped; creator will NOT be paid',
+          {
+            errorId,
+            purchaseId: txResult.purchase.id,
+            creatorId: txResult.creatorId,
+            organizationId: txResult.organizationId,
+            stripePaymentIntentId,
+          }
+        );
+      }
+
+      return txResult.purchase;
+    } catch (error) {
+      this.obs.error('Failed to complete course purchase', {
+        error: error instanceof Error ? error.message : String(error),
+        stripePaymentIntentId,
+        customerId: metadata.customerId,
+        courseId: metadata.courseId,
+        amountPaidCents: metadata.amountPaidCents,
+      });
+      this.handleError(error, 'completeCoursePurchase');
     }
   }
 
@@ -1371,8 +1696,14 @@ export class PurchaseService extends BaseService {
     const validated = purchaseQuerySchema.parse(filters);
 
     try {
-      // Build WHERE conditions
-      const conditions = [eq(purchases.customerId, customerId)];
+      // Build WHERE conditions. Codex-2pryk WP-6: this is the CONTENT purchase
+      // history (joins + returns content). Course purchases (contentId NULL) are
+      // a distinct shape surfaced via the library/enrollments shelf, not here —
+      // scope them out so the `content` join is always present.
+      const conditions = [
+        eq(purchases.customerId, customerId),
+        isNotNull(purchases.contentId),
+      ];
 
       if (validated.status) {
         conditions.push(eq(purchases.status, validated.status));
@@ -1443,7 +1774,9 @@ export class PurchaseService extends BaseService {
           id: p.id,
           customerId: p.customerId,
           createdAt: toIso(p.createdAt),
-          contentId: p.contentId,
+          // `content` is guaranteed present — getPurchaseHistory scopes to
+          // content purchases (contentId NOT NULL) — so its id is the target.
+          contentId: p.content.id,
           contentTitle: p.content.title,
           amountCents: p.amountPaidCents,
           status: coercePurchaseStatus(p.status),
@@ -1663,15 +1996,33 @@ export class PurchaseService extends BaseService {
           })
           .where(eq(purchases.id, purchase.id));
 
-        // Revoke content access (soft delete)
+        // Revoke content access (soft delete) — content purchases only. Course
+        // purchases grant no contentAccess row (they use entitlements).
+        if (purchase.contentId) {
+          await tx
+            .update(contentAccess)
+            .set({ deletedAt: new Date() })
+            .where(
+              and(
+                eq(contentAccess.userId, purchase.customerId),
+                eq(contentAccess.contentId, purchase.contentId),
+                isNull(contentAccess.deletedAt)
+              )
+            );
+        }
+
+        // Codex-2pryk WP-6: revoke the entitlement this purchase granted
+        // (content_purchase OR course_purchase — both carry sourceRef=purchase.id).
+        // Without this a refund would leave a LIVE grant the resolver still
+        // honours (access-integrity bug). Keyed on sourceRef so one statement
+        // covers either target. Idempotent (no-op if already revoked / absent).
         await tx
-          .update(contentAccess)
-          .set({ deletedAt: new Date() })
+          .update(entitlements)
+          .set({ revokedAt: new Date() })
           .where(
             and(
-              eq(contentAccess.userId, purchase.customerId),
-              eq(contentAccess.contentId, purchase.contentId),
-              isNull(contentAccess.deletedAt)
+              eq(entitlements.sourceRef, purchase.id),
+              isNull(entitlements.revokedAt)
             )
           );
       });
@@ -1999,14 +2350,30 @@ export class PurchaseService extends BaseService {
           })
           .where(eq(purchases.id, purchase.id));
 
+        // Content purchases only — course purchases grant no contentAccess row.
+        if (purchase.contentId) {
+          await tx
+            .update(contentAccess)
+            .set({ deletedAt: new Date() })
+            .where(
+              and(
+                eq(contentAccess.userId, purchase.customerId),
+                eq(contentAccess.contentId, purchase.contentId),
+                isNull(contentAccess.deletedAt)
+              )
+            );
+        }
+
+        // Codex-2pryk WP-6: a dispute is access-reducing like a refund — revoke
+        // the entitlement this purchase granted (content_purchase / course_purchase)
+        // by sourceRef so the resolver stops honouring it. Idempotent.
         await tx
-          .update(contentAccess)
-          .set({ deletedAt: new Date() })
+          .update(entitlements)
+          .set({ revokedAt: new Date() })
           .where(
             and(
-              eq(contentAccess.userId, purchase.customerId),
-              eq(contentAccess.contentId, purchase.contentId),
-              isNull(contentAccess.deletedAt)
+              eq(entitlements.sourceRef, purchase.id),
+              isNull(entitlements.revokedAt)
             )
           );
       });
@@ -2101,10 +2468,13 @@ export class PurchaseService extends BaseService {
           },
         });
 
-        if (purchase?.purchasedAt) {
+        // Content-purchase sessions populate the purchase + content blocks.
+        // Course-purchase sessions (content join null) return sessionStatus only
+        // — the course success surface reads its own offer, not this shape.
+        if (purchase?.purchasedAt && purchase.content) {
           result.purchase = {
             id: purchase.id,
-            contentId: purchase.contentId,
+            contentId: purchase.content.id,
             amountPaidCents: purchase.amountPaidCents,
             purchasedAt: purchase.purchasedAt.toISOString(),
           };
@@ -2255,7 +2625,14 @@ export class PurchaseService extends BaseService {
     const validated = salesQuerySchema.parse(filters);
 
     try {
-      const conditions = [eq(purchases.organizationId, orgId)];
+      // Codex-2pryk WP-6: the Sales ledger's SaleListItem shape is content-
+      // shaped (contentTitle/contentSlug). Scope to content purchases so the
+      // `content` join is always present; course sales get their own reporting
+      // surface (WP-7) rather than being force-fit into the content columns.
+      const conditions = [
+        eq(purchases.organizationId, orgId),
+        isNotNull(purchases.contentId),
+      ];
 
       if (validated.status === 'disputed') {
         conditions.push(isNotNull(purchases.disputedAt));
@@ -2308,29 +2685,36 @@ export class PurchaseService extends BaseService {
       ]);
       const total = countResult[0]?.total ?? 0;
 
-      const formatted: SaleListItem[] = items.map((p) => ({
-        id: p.id,
-        purchasedAt: toIso(p.purchasedAt),
-        createdAt: toIso(p.createdAt),
-        customerId: p.customerId,
-        customerName: p.customer.name,
-        customerEmail: p.customer.email,
-        contentId: p.contentId,
-        contentTitle: p.content.title,
-        contentSlug: p.content.slug,
-        amountPaidCents: p.amountPaidCents,
-        currency: p.currency,
-        status: coercePurchaseStatus(p.status) as SaleListItem['status'],
-        platformFeeCents: p.platformFeeCents,
-        organizationFeeCents: p.organizationFeeCents,
-        creatorPayoutCents: p.creatorPayoutCents,
-        refundedAt: toIso(p.refundedAt),
-        refundAmountCents: p.refundAmountCents,
-        refundReason: p.refundReason,
-        disputedAt: toIso(p.disputedAt),
-        disputeReason: p.disputeReason,
-        stripePaymentIntentId: p.stripePaymentIntentId,
-      }));
+      // `content` is guaranteed present (conditions filter contentId NOT NULL);
+      // the type predicate narrows the relation to non-null without an `as` cast.
+      const formatted: SaleListItem[] = items
+        .filter(
+          (p): p is typeof p & { content: NonNullable<typeof p.content> } =>
+            p.content !== null
+        )
+        .map((p) => ({
+          id: p.id,
+          purchasedAt: toIso(p.purchasedAt),
+          createdAt: toIso(p.createdAt),
+          customerId: p.customerId,
+          customerName: p.customer.name,
+          customerEmail: p.customer.email,
+          contentId: p.content.id,
+          contentTitle: p.content.title,
+          contentSlug: p.content.slug,
+          amountPaidCents: p.amountPaidCents,
+          currency: p.currency,
+          status: coercePurchaseStatus(p.status) as SaleListItem['status'],
+          platformFeeCents: p.platformFeeCents,
+          organizationFeeCents: p.organizationFeeCents,
+          creatorPayoutCents: p.creatorPayoutCents,
+          refundedAt: toIso(p.refundedAt),
+          refundAmountCents: p.refundAmountCents,
+          refundReason: p.refundReason,
+          disputedAt: toIso(p.disputedAt),
+          disputeReason: p.disputeReason,
+          stripePaymentIntentId: p.stripePaymentIntentId,
+        }));
 
       return {
         items: formatted,
@@ -2365,7 +2749,12 @@ export class PurchaseService extends BaseService {
     const validated = salesStatsQuerySchema.parse(filters);
 
     try {
-      const conditions = [eq(purchases.organizationId, orgId)];
+      // Content-only, to match `listSales` (course sales report separately, WP-7)
+      // so the header tiles and the table below them agree.
+      const conditions = [
+        eq(purchases.organizationId, orgId),
+        isNotNull(purchases.contentId),
+      ];
 
       conditions.push(
         ...purchaseDateWindow(validated.fromDate, validated.toDate)

--- a/packages/purchase/src/types.ts
+++ b/packages/purchase/src/types.ts
@@ -64,6 +64,29 @@ export interface CompletePurchaseMetadata {
 }
 
 /**
+ * Metadata for completing a one-off COURSE purchase (Codex-2pryk WP-6).
+ *
+ * Mirrors {@link CompletePurchaseMetadata} but targets a course. There is no
+ * `organizationId` field: courses are ALWAYS org-owned, so the org (and the
+ * creator to pay) is resolved authoritatively from the `courses` row, never
+ * trusted from Stripe metadata.
+ */
+export interface CompleteCoursePurchaseMetadata {
+  /** Course ID being purchased */
+  courseId: string;
+  /** Customer ID making purchase */
+  customerId: string;
+  /** Amount paid in cents */
+  amountPaidCents: number;
+  /** Currency code (default: 'gbp') */
+  currency?: string;
+  /** Application fee Stripe actually collected (from PaymentIntent), for reconciliation */
+  stripeApplicationFeeCents?: number | null;
+  /** Stripe charge id (PaymentIntent.latest_charge) — required for payouts ledger + source_transaction. */
+  stripeChargeId?: string | null;
+}
+
+/**
  * Purchase list item for account payment history
  */
 export interface PurchaseListItem {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -41,7 +41,10 @@ export type { RevenueSplit } from './financial';
 export type {
   BrandTokenOverrides,
   ContentAccessPolicy,
+  CourseAccessPath,
+  CourseOffer,
   CourseSectionType,
+  CourseTierOffer,
   Entitlement,
   EntitlementResolver,
   EntitlementSource,

--- a/packages/shared-types/src/journeys.ts
+++ b/packages/shared-types/src/journeys.ts
@@ -252,3 +252,57 @@ export interface EntitlementResolver {
     courseIds: readonly string[]
   ): Promise<ReadonlyMap<string, boolean>>;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Monetization — the course offer (SPEC §7, owned by WP-6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * One of the three ways a course can be acquired (SPEC §7). Discriminates the
+ * pricing panel on the sales-page builder and the offer surface on the course
+ * landing page.
+ *
+ *   - `purchase`       — one-off, permanent (`courses.priceCents`).
+ *   - `subscription`   — course-specific recurring (`course_subscription_plans`).
+ *   - `tier`           — included in one or more org subscription tiers
+ *                        (`course_tier_access`, exact tier match, not min-tier).
+ */
+export type CourseAccessPath = 'purchase' | 'subscription' | 'tier';
+
+/** One org tier that unlocks a course (SPEC §7 tier-access path). */
+export interface CourseTierOffer {
+  tierId: string;
+  tierName: string;
+  /** Lowest active price across intervals, in GBP pence — for "from £X" copy. */
+  priceMonthly: number;
+  priceAnnual: number;
+}
+
+/**
+ * The complete monetization offer for one course (SPEC §7) — every acquisition
+ * path a viewer can take, plus whether they ALREADY hold access. Returned by the
+ * offer read (WP-6), consumed by the sales page + course landing.
+ *
+ * A path is present in `paths` only when it is actually purchasable/enterable
+ * (published course + configured price/plan/tier). `entitled=true` means the
+ * viewer already holds a live entitlement (any source) and should see "enter"
+ * rather than "buy". Amounts are GBP integer pence.
+ */
+export interface CourseOffer {
+  courseId: string;
+  organizationId: string;
+  /** Ordered subset of the three paths, only those currently available. */
+  paths: CourseAccessPath[];
+  /** One-off purchase, when `courses.priceCents` is set. */
+  purchase: { priceCents: number } | null;
+  /** Course-specific subscription, when an active plan exists. */
+  subscription: {
+    planId: string;
+    priceMonthly: number;
+    priceAnnual: number;
+  } | null;
+  /** Org tiers that include this course (exact grants). */
+  tiers: CourseTierOffer[];
+  /** True when the viewer already holds a live entitlement over the course. */
+  entitled: boolean;
+}

--- a/packages/subscription/src/errors.ts
+++ b/packages/subscription/src/errors.ts
@@ -136,6 +136,39 @@ export class SubscriptionPaymentRequiredError extends ServiceError {
 }
 
 // ============================================================================
+// Course Subscription Errors (Codex-2pryk WP-6 · SPEC §7)
+// ============================================================================
+
+export class CourseSubscriptionPlanNotFoundError extends NotFoundError {
+  constructor(courseId: string, context?: Record<string, unknown>) {
+    super('No course subscription plan configured for this course', {
+      courseId,
+      code: 'COURSE_SUBSCRIPTION_PLAN_NOT_FOUND',
+      ...context,
+    });
+  }
+}
+
+export class CourseSubscriptionPlanExistsError extends ConflictError {
+  constructor(courseId: string) {
+    super('A subscription plan already exists for this course', {
+      courseId,
+      code: 'COURSE_SUBSCRIPTION_PLAN_EXISTS',
+    });
+  }
+}
+
+export class AlreadyCourseSubscribedError extends ConflictError {
+  constructor(userId: string, courseId: string) {
+    super('User already has an active subscription to this course', {
+      userId,
+      courseId,
+      code: 'ALREADY_COURSE_SUBSCRIBED',
+    });
+  }
+}
+
+// ============================================================================
 // Connect Account Errors
 // ============================================================================
 

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -18,6 +18,7 @@ export {
   type ChangeTierInput,
   type ConnectAccountStatus,
   type ConnectOnboardInput,
+  type CreateCourseSubscriptionCheckoutInput,
   type CreateSubscriptionCheckoutInput,
   type CreateTierInput,
   cancelSubscriptionSchema,
@@ -26,6 +27,7 @@ export {
   connectDashboardSchema,
   connectOnboardSchema,
   connectStatusQuerySchema,
+  createCourseSubscriptionCheckoutSchema,
   createSubscriptionCheckoutSchema,
   createTierSchema,
   getCurrentSubscriptionQuerySchema,
@@ -40,16 +42,23 @@ export {
   payoutStatusFilterEnum,
   type ReorderTiersInput,
   reorderTiersSchema,
+  type SetCourseTierAccessInput,
   type SubscriptionStatus,
+  setCourseTierAccessSchema,
   subscriptionStatusEnum,
   type UpdateTierInput,
+  type UpsertCourseSubscriptionPlanInput,
   updateTierSchema,
+  upsertCourseSubscriptionPlanSchema,
 } from '@codex/validation';
 // Error classes
 export {
+  AlreadyCourseSubscribedError,
   AlreadySubscribedError,
   ConnectAccountNotFoundError,
   ConnectAccountNotReadyError,
+  CourseSubscriptionPlanExistsError,
+  CourseSubscriptionPlanNotFoundError,
   CreatorConnectRequiredError,
   isSubscriptionServiceError,
   SubscriptionCheckoutError,
@@ -63,6 +72,11 @@ export {
 
 // Services
 export { ConnectAccountService } from './services/connect-account-service';
+export {
+  COURSE_SUBSCRIPTION_METADATA_TYPE,
+  CourseSubscriptionService,
+  type CourseSubscriptionWebhookResult,
+} from './services/course-subscription-service';
 export {
   calculateRevenueSplit,
   type RevenueSplit,

--- a/packages/subscription/src/services/__tests__/course-subscription-service.integration.test.ts
+++ b/packages/subscription/src/services/__tests__/course-subscription-service.integration.test.ts
@@ -1,0 +1,270 @@
+/**
+ * CourseSubscriptionService lifecycle (Codex-2pryk · WP-6 · SPEC §7 path 3).
+ *
+ * Real DB, mocked Stripe (same shape as the parent subscription suite). Proves:
+ *   1. activation writes the course_subscriptions row + the course_subscription
+ *      entitlement (the WP-2 resolver's READ target) + the auto-enrollment.
+ *   2. an invoice.paid fan-out writes each payout ledger row (attributed by
+ *      courseSubscriptionId) exactly once — a redelivered invoice is idempotent.
+ *   3. the `isCourseSubscription` discriminator the webhook dispatcher relies on.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  type CourseSubscriptionPlan,
+  courseEnrollments,
+  courseSubscriptionPlans,
+  courseSubscriptions,
+  courses,
+  entitlements,
+  organizationMemberships,
+  organizations,
+  payouts,
+  stripeConnectAccounts,
+} from '@codex/database/schema';
+import {
+  createMockStripe,
+  createMockStripeInvoice,
+  createMockStripeSubscription,
+  createTestConnectAccountInput,
+  createUniqueSlug,
+  type Database,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from '@codex/test-utils';
+import { and, eq } from 'drizzle-orm';
+import type Stripe from 'stripe';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  COURSE_SUBSCRIPTION_METADATA_TYPE,
+  CourseSubscriptionService,
+} from '../course-subscription-service';
+
+describe('CourseSubscriptionService lifecycle (WP-6)', () => {
+  let db: Database;
+  let subscriberId: string;
+  let creatorId: string;
+  let orgId: string;
+  let courseId: string;
+  let plan: CourseSubscriptionPlan;
+  let service: CourseSubscriptionService;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    [subscriberId, creatorId] = await seedTestUsers(db, 2);
+
+    await db
+      .insert(stripeConnectAccounts)
+      .values(createTestConnectAccountInput(null, creatorId))
+      .onConflictDoNothing();
+
+    const [org] = await db
+      .insert(organizations)
+      .values({ name: 'Course Sub Org', slug: createUniqueSlug('cs-org') })
+      .returning({ id: organizations.id });
+    if (!org) throw new Error('failed org');
+    orgId = org.id;
+    await db.insert(organizationMemberships).values({
+      organizationId: orgId,
+      userId: creatorId,
+      role: 'owner',
+      status: 'active',
+    });
+
+    const [course] = await db
+      .insert(courses)
+      .values({
+        organizationId: orgId,
+        creatorId,
+        slug: createUniqueSlug('cs-course'),
+        title: 'Subscribable Course',
+        status: 'published',
+        priceCents: null,
+      })
+      .returning({ id: courses.id });
+    if (!course) throw new Error('failed course');
+    courseId = course.id;
+
+    const [planRow] = await db
+      .insert(courseSubscriptionPlans)
+      .values({
+        courseId,
+        priceMonthly: 5000,
+        priceAnnual: 50000,
+        stripeProductId: `prod_${randomUUID().slice(0, 8)}`,
+        stripePriceMonthlyId: `price_m_${randomUUID().slice(0, 8)}`,
+        stripePriceAnnualId: `price_a_${randomUUID().slice(0, 8)}`,
+      })
+      .returning();
+    if (!planRow) throw new Error('failed plan');
+    plan = planRow;
+
+    service = new CourseSubscriptionService(
+      { db, environment: 'test' },
+      createMockStripe()
+    );
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  function courseSubStripeObject(
+    id: string,
+    cId: string = courseId,
+    pId: string = plan.id
+  ): Stripe.Subscription {
+    return createMockStripeSubscription({
+      id,
+      customer: `cus_${randomUUID().slice(0, 8)}`,
+      metadata: {
+        type: COURSE_SUBSCRIPTION_METADATA_TYPE,
+        codex_user_id: subscriberId,
+        codex_course_id: cId,
+        codex_plan_id: pId,
+        codex_organization_id: orgId,
+      },
+    }) as unknown as Stripe.Subscription;
+  }
+
+  /** A fresh course + plan so per-(user,course) unique constraints don't collide. */
+  async function makeCourseWithPlan(): Promise<{ cId: string; pId: string }> {
+    const [c] = await db
+      .insert(courses)
+      .values({
+        organizationId: orgId,
+        creatorId,
+        slug: createUniqueSlug('cs-course'),
+        title: 'Subscribable Course',
+        status: 'published',
+        priceCents: null,
+      })
+      .returning({ id: courses.id });
+    if (!c) throw new Error('failed course');
+    const [p] = await db
+      .insert(courseSubscriptionPlans)
+      .values({
+        courseId: c.id,
+        priceMonthly: 5000,
+        priceAnnual: 50000,
+        stripeProductId: `prod_${randomUUID().slice(0, 8)}`,
+        stripePriceMonthlyId: `price_m_${randomUUID().slice(0, 8)}`,
+        stripePriceAnnualId: `price_a_${randomUUID().slice(0, 8)}`,
+      })
+      .returning({ id: courseSubscriptionPlans.id });
+    if (!p) throw new Error('failed plan');
+    return { cId: c.id, pId: p.id };
+  }
+
+  it('isCourseSubscription discriminates course subs from org subs', () => {
+    expect(
+      CourseSubscriptionService.isCourseSubscription(
+        courseSubStripeObject('sub_x')
+      )
+    ).toBe(true);
+    expect(
+      CourseSubscriptionService.isCourseSubscription(
+        createMockStripeSubscription() as unknown as Stripe.Subscription
+      )
+    ).toBe(false);
+  });
+
+  it('activation writes course_subscriptions row + entitlement + enrollment', async () => {
+    const stripeSubId = `sub_${randomUUID().slice(0, 8)}`;
+    await service.handleCourseSubscriptionCreated(
+      courseSubStripeObject(stripeSubId)
+    );
+
+    const [row] = await db
+      .select()
+      .from(courseSubscriptions)
+      .where(eq(courseSubscriptions.stripeSubscriptionId, stripeSubId));
+    expect(row).toBeDefined();
+    expect(row?.status).toBe('active');
+    expect(row?.courseId).toBe(courseId);
+    expect(row?.planId).toBe(plan.id);
+
+    const grants = await db
+      .select()
+      .from(entitlements)
+      .where(
+        and(
+          eq(entitlements.userId, subscriberId),
+          eq(entitlements.courseId, courseId),
+          eq(entitlements.source, 'course_subscription')
+        )
+      );
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.revokedAt).toBeNull();
+    expect(grants[0]?.expiresAt).not.toBeNull();
+    expect(grants[0]?.sourceRef).toBe(row?.id);
+
+    const enrolls = await db
+      .select()
+      .from(courseEnrollments)
+      .where(
+        and(
+          eq(courseEnrollments.userId, subscriberId),
+          eq(courseEnrollments.courseId, courseId)
+        )
+      );
+    expect(enrolls).toHaveLength(1);
+  });
+
+  it('invoice payment fans out payouts once; redelivery is idempotent', async () => {
+    const { cId, pId } = await makeCourseWithPlan();
+    const stripeSubId = `sub_${randomUUID().slice(0, 8)}`;
+    const sub = courseSubStripeObject(stripeSubId, cId, pId);
+    await service.handleCourseSubscriptionCreated(sub);
+    const [row] = await db
+      .select({ id: courseSubscriptions.id })
+      .from(courseSubscriptions)
+      .where(eq(courseSubscriptions.stripeSubscriptionId, stripeSubId));
+    const courseSubscriptionId = row?.id;
+    expect(courseSubscriptionId).toBeDefined();
+
+    const chargeId = `ch_${randomUUID().slice(0, 8)}`;
+    const invoice = createMockStripeInvoice({
+      amount_paid: 5000,
+      currency: 'gbp',
+      parent: {
+        subscription_details: {
+          subscription: stripeSubId,
+          metadata: { type: COURSE_SUBSCRIPTION_METADATA_TYPE },
+        },
+      },
+      payments: {
+        data: [
+          { payment: { payment_intent: `pi_${chargeId}`, charge: chargeId } },
+        ],
+      },
+    }) as unknown as Stripe.Invoice;
+
+    await service.handleCourseInvoicePaymentSucceeded(invoice, sub);
+
+    const payoutRows = await db
+      .select()
+      .from(payouts)
+      .where(eq(payouts.courseSubscriptionId, courseSubscriptionId as string));
+    const byType = payoutRows.reduce<Record<string, number>>((acc, r) => {
+      acc[r.payoutType] = (acc[r.payoutType] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(byType.platform_fee).toBe(1);
+    expect(byType.creator_payout).toBe(1);
+    expect(byType.organization_fee).toBe(1);
+    // Every row is attributed by courseSubscriptionId + sourceType='subscription'.
+    expect(payoutRows.every((r) => r.sourceType === 'subscription')).toBe(true);
+    // Split sums exactly to the charge amount.
+    expect(payoutRows.reduce((s, r) => s + r.amountCents, 0)).toBe(5000);
+
+    // Redeliver the SAME invoice → the per-charge guard skips the fan-out.
+    await service.handleCourseInvoicePaymentSucceeded(invoice, sub);
+    const payoutRowsAfter = await db
+      .select()
+      .from(payouts)
+      .where(eq(payouts.courseSubscriptionId, courseSubscriptionId as string));
+    expect(payoutRowsAfter).toHaveLength(payoutRows.length);
+  });
+});

--- a/packages/subscription/src/services/course-subscription-service.ts
+++ b/packages/subscription/src/services/course-subscription-service.ts
@@ -1,0 +1,954 @@
+/**
+ * CourseSubscriptionService (Codex-2pryk · WP-6 · SPEC §7 path 3).
+ *
+ * A course-SPECIFIC recurring subscription — "a low-friction entry into one
+ * course" (SPEC §7). Decision D-C (HARDENING §H3): each course gets a SEPARATE
+ * Stripe Product per plan (reusing the `TierService` product/price-sync shape),
+ * recorded on `course_subscription_plans`, with `course_subscriptions.planId`
+ * FK. Distinct from the ORG tier subscription (`SubscriptionService`): a course
+ * sub is not an org `subscriptions` row and never grants org membership.
+ *
+ * Lifecycle (all events flow through the SAME `/webhooks/stripe/subscription`
+ * endpoint as org subs — the handler discriminates by the Stripe subscription's
+ * `type: 'course_subscription'` metadata and routes here):
+ *   - checkout.session.completed → {@link handleCourseSubscriptionCreated}
+ *   - invoice.payment_succeeded  → {@link handleCourseInvoicePaymentSucceeded}
+ *   - customer.subscription.updated → {@link handleCourseSubscriptionUpdated}
+ *   - customer.subscription.deleted → {@link handleCourseSubscriptionDeleted}
+ *
+ * Entitlement seam: activation writes a `course_subscription` entitlement (the
+ * READ target of the WP-2 resolver) with `expiresAt = currentPeriodEnd`, so a
+ * missed renewal fails closed even before a delete webhook lands; renewals bump
+ * it, a delete/unpaid revokes it. Auto-enrollment (D-G) rides along.
+ *
+ * Payouts: recurring-invoice revenue REUSES the h69cg payout LEDGER (`payouts`)
+ * — Option B platform-charge fan-out (creator + org secondary transfers linked
+ * by `source_transaction`), attributed via the new `payouts.courseSubscriptionId`
+ * FK (§H3). Idempotent by Stripe charge id + deterministic transfer idempotency
+ * keys, mirroring `PurchaseService.writePurchasePayouts`.
+ */
+
+import { BILLING_INTERVAL, CONTENT_STATUS, CURRENCY } from '@codex/constants';
+import { getConstraintName, isUniqueViolation } from '@codex/database';
+import {
+  type CourseSubscription,
+  courseSubscriptionPlans,
+  courseSubscriptions,
+  courses,
+  payouts,
+  stripeConnectAccounts,
+  users,
+} from '@codex/database/schema';
+import {
+  applyMinPlatformFeeFloor,
+  calculateRevenueSplit,
+  DEFAULT_ORG_FEE_PERCENTAGE,
+  DEFAULT_PLATFORM_FEE_PERCENTAGE,
+  type FeeConfigService,
+  findActiveCreatorAgreementShare,
+  refreshCourseSubscriptionEntitlementExpiry,
+  resolvePrimaryConnect,
+  revokeCourseSubscriptionEntitlement,
+  withStaleCustomerRecovery,
+  writeCourseSubscriptionEntitlement,
+} from '@codex/purchase';
+import {
+  BaseService,
+  InternalServiceError,
+  NotFoundError,
+  type ServiceConfig,
+} from '@codex/service-errors';
+import type { CreateCourseSubscriptionCheckoutInput } from '@codex/validation';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import type Stripe from 'stripe';
+import {
+  AlreadyCourseSubscribedError,
+  ConnectAccountNotReadyError,
+  CourseSubscriptionPlanExistsError,
+  CourseSubscriptionPlanNotFoundError,
+  SubscriptionCheckoutError,
+} from '../errors';
+import { resolveStatus } from './stripe-status-mapper';
+
+/** Marks a Stripe subscription as a course sub (vs. an org tier sub). */
+export const COURSE_SUBSCRIPTION_METADATA_TYPE = 'course_subscription';
+
+/** Statuses under which a course subscription's stored grant stays live. */
+const GRANTING_STATUSES = ['active', 'cancelling', 'past_due'];
+
+interface CourseSubscriptionServiceConfig extends ServiceConfig {
+  /** Injected so invoice payouts resolve fees via the 3-tier fallback chain. */
+  feeConfig?: FeeConfigService;
+}
+
+/** Minimal per-event result so the webhook can bump the buyer's caches. */
+export interface CourseSubscriptionWebhookResult {
+  userId: string;
+  organizationId: string;
+}
+
+export class CourseSubscriptionService extends BaseService {
+  private readonly stripe: Stripe;
+  private readonly feeConfig: FeeConfigService | undefined;
+
+  constructor(config: CourseSubscriptionServiceConfig, stripe: Stripe) {
+    super(config);
+    this.stripe = stripe;
+    this.feeConfig = config.feeConfig;
+  }
+
+  // ─── Plan management (Stripe Product + 2 Prices, per course) ─────────────────
+
+  /**
+   * Create the course's subscription plan: a Stripe Product + monthly/annual
+   * Prices (on the PLATFORM account — the platform-charge model, same as tiers)
+   * plus the `course_subscription_plans` row. One live plan per course.
+   */
+  async createPlan(
+    courseId: string,
+    input: { priceMonthly: number; priceAnnual: number }
+  ): Promise<typeof courseSubscriptionPlans.$inferSelect> {
+    try {
+      const course = await this.db.query.courses.findFirst({
+        where: and(eq(courses.id, courseId), isNull(courses.deletedAt)),
+        columns: { id: true, title: true, organizationId: true },
+      });
+      if (!course) {
+        throw new NotFoundError('Course not found', { courseId });
+      }
+
+      // A course sub pays out to the org/creator, so the org Connect account
+      // must be ready before a plan can be sold (mirrors TierService).
+      const connect = await resolvePrimaryConnect(
+        this.db,
+        course.organizationId
+      );
+      if (!connect?.chargesEnabled || !connect?.payoutsEnabled) {
+        throw new ConnectAccountNotReadyError(course.organizationId);
+      }
+
+      const existing = await this.db.query.courseSubscriptionPlans.findFirst({
+        where: and(
+          eq(courseSubscriptionPlans.courseId, courseId),
+          isNull(courseSubscriptionPlans.deletedAt)
+        ),
+      });
+      if (existing) {
+        throw new CourseSubscriptionPlanExistsError(courseId);
+      }
+
+      const idempotencyBase = crypto.randomUUID();
+      const product = await this.stripe.products.create(
+        {
+          name: `${course.title} — Subscription`,
+          metadata: {
+            codex_organization_id: course.organizationId,
+            codex_course_id: courseId,
+            codex_type: COURSE_SUBSCRIPTION_METADATA_TYPE,
+          },
+        },
+        { idempotencyKey: `course-plan-product-${idempotencyBase}` }
+      );
+
+      const [monthlyPrice, annualPrice] = await Promise.all([
+        this.stripe.prices.create(
+          {
+            product: product.id,
+            unit_amount: input.priceMonthly,
+            currency: CURRENCY.GBP,
+            recurring: { interval: 'month' },
+            metadata: { codex_course_id: courseId, interval: 'month' },
+          },
+          { idempotencyKey: `course-plan-price-monthly-${idempotencyBase}` }
+        ),
+        this.stripe.prices.create(
+          {
+            product: product.id,
+            unit_amount: input.priceAnnual,
+            currency: CURRENCY.GBP,
+            recurring: { interval: 'year' },
+            metadata: { codex_course_id: courseId, interval: 'year' },
+          },
+          { idempotencyKey: `course-plan-price-annual-${idempotencyBase}` }
+        ),
+      ]);
+
+      try {
+        const [plan] = await this.db
+          .insert(courseSubscriptionPlans)
+          .values({
+            courseId,
+            priceMonthly: input.priceMonthly,
+            priceAnnual: input.priceAnnual,
+            stripeProductId: product.id,
+            stripePriceMonthlyId: monthlyPrice.id,
+            stripePriceAnnualId: annualPrice.id,
+          })
+          .returning();
+        if (!plan) {
+          throw new InternalServiceError('Failed to insert course plan', {
+            courseId,
+          });
+        }
+        return plan;
+      } catch (dbError) {
+        // Archive the Stripe Product so a failed DB insert leaves no orphan.
+        await this.stripe.products
+          .update(product.id, { active: false })
+          .catch((cleanupErr) =>
+            this.obs.error('Failed to archive orphaned course plan product', {
+              stripeProductId: product.id,
+              courseId,
+              error:
+                cleanupErr instanceof Error
+                  ? cleanupErr.message
+                  : String(cleanupErr),
+            })
+          );
+        throw dbError;
+      }
+    } catch (error) {
+      this.handleError(error, 'createPlan');
+    }
+  }
+
+  /** The live plan for a course, or null. */
+  async getPlanForCourse(
+    courseId: string
+  ): Promise<typeof courseSubscriptionPlans.$inferSelect | null> {
+    const plan = await this.db.query.courseSubscriptionPlans.findFirst({
+      where: and(
+        eq(courseSubscriptionPlans.courseId, courseId),
+        eq(courseSubscriptionPlans.isActive, true),
+        isNull(courseSubscriptionPlans.deletedAt)
+      ),
+    });
+    return plan ?? null;
+  }
+
+  // ─── Checkout ────────────────────────────────────────────────────────────────
+
+  /**
+   * Create a Stripe Checkout session (`mode: 'subscription'`) for a course sub.
+   * Platform-charge model (no `transfer_data`) so `invoice.payment_succeeded`
+   * fans out the split via `source_transaction`, exactly like org subs.
+   */
+  async createCheckoutSession(
+    userId: string,
+    input: CreateCourseSubscriptionCheckoutInput
+  ): Promise<{ sessionUrl: string; sessionId: string }> {
+    try {
+      const course = await this.db.query.courses.findFirst({
+        where: and(eq(courses.id, input.courseId), isNull(courses.deletedAt)),
+        columns: { id: true, organizationId: true, status: true },
+      });
+      if (!course) {
+        throw new NotFoundError('Course not found', {
+          courseId: input.courseId,
+        });
+      }
+      if (course.status !== CONTENT_STATUS.PUBLISHED) {
+        throw new SubscriptionCheckoutError('Course is not published', {
+          courseId: input.courseId,
+        });
+      }
+
+      const plan = await this.getPlanForCourse(input.courseId);
+      if (!plan) {
+        throw new CourseSubscriptionPlanNotFoundError(input.courseId);
+      }
+
+      // Block a second active sub to the same course (the partial unique index
+      // also enforces this at the DB, but fail early with a clean 409).
+      const [existing] = await this.db
+        .select({ id: courseSubscriptions.id })
+        .from(courseSubscriptions)
+        .where(
+          and(
+            eq(courseSubscriptions.userId, userId),
+            eq(courseSubscriptions.courseId, input.courseId),
+            inArray(courseSubscriptions.status, GRANTING_STATUSES)
+          )
+        )
+        .limit(1);
+      if (existing) {
+        throw new AlreadyCourseSubscribedError(userId, input.courseId);
+      }
+
+      const stripePriceId =
+        input.billingInterval === BILLING_INTERVAL.MONTH
+          ? plan.stripePriceMonthlyId
+          : plan.stripePriceAnnualId;
+      if (!stripePriceId) {
+        throw new SubscriptionCheckoutError(
+          'Stripe Price not configured for this plan and interval',
+          { courseId: input.courseId, billingInterval: input.billingInterval }
+        );
+      }
+
+      const [user] = await this.db
+        .select({ email: users.email })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
+      if (!user?.email) {
+        throw new NotFoundError('User email not found for checkout', {
+          userId,
+        });
+      }
+
+      const metadata = {
+        type: COURSE_SUBSCRIPTION_METADATA_TYPE,
+        codex_user_id: userId,
+        codex_course_id: input.courseId,
+        codex_plan_id: plan.id,
+        codex_organization_id: course.organizationId,
+      };
+
+      const session = await withStaleCustomerRecovery(
+        { db: this.db, stripe: this.stripe },
+        { userId, email: user.email },
+        (stripeCustomerId) =>
+          this.stripe.checkout.sessions.create({
+            mode: 'subscription',
+            customer: stripeCustomerId,
+            line_items: [{ price: stripePriceId, quantity: 1 }],
+            success_url: input.successUrl,
+            cancel_url: input.cancelUrl,
+            metadata,
+            subscription_data: { metadata },
+          }),
+        {
+          onStaleRecovery: (info) =>
+            this.obs.warn(
+              'Stale users.stripe_customer_id detected; clearing and retrying',
+              { ...info, courseId: input.courseId }
+            ),
+        }
+      );
+
+      if (!session.url) {
+        throw new SubscriptionCheckoutError(
+          'Failed to create checkout session URL'
+        );
+      }
+      return { sessionUrl: session.url, sessionId: session.id };
+    } catch (error) {
+      this.handleError(error, 'createCheckoutSession');
+    }
+  }
+
+  // ─── Webhook handlers ──────────────────────────────────────────────────────
+
+  /**
+   * Discriminator: does this Stripe subscription belong to a course sub? Read by
+   * the webhook dispatcher to route between org- and course-subscription paths.
+   */
+  static isCourseSubscription(stripeSub: Stripe.Subscription): boolean {
+    return (
+      (stripeSub.metadata?.type ?? null) === COURSE_SUBSCRIPTION_METADATA_TYPE
+    );
+  }
+
+  /**
+   * Ensure the `course_subscriptions` row exists (self-heal on webhook-ordering
+   * races, mirroring `ensureSubscriptionDataPresent`). Returns null when the
+   * subscription lacks course metadata or Stripe reports it not-found.
+   */
+  private async ensureDataPresent(
+    stripeSub: Stripe.Subscription
+  ): Promise<{ row: CourseSubscription; justInserted: boolean } | null> {
+    const [existing] = await this.db
+      .select()
+      .from(courseSubscriptions)
+      .where(eq(courseSubscriptions.stripeSubscriptionId, stripeSub.id))
+      .limit(1);
+    if (existing) return { row: existing, justInserted: false };
+
+    const metadata = stripeSub.metadata ?? {};
+    const userId = metadata.codex_user_id;
+    const courseId = metadata.codex_course_id;
+    const planId = metadata.codex_plan_id;
+    const organizationId = metadata.codex_organization_id;
+    if (!userId || !courseId || !planId || !organizationId) {
+      this.obs.warn('Course subscription webhook missing metadata', {
+        stripeSubscriptionId: stripeSub.id,
+        metadata,
+      });
+      return null;
+    }
+
+    const item = stripeSub.items.data[0];
+    const billingInterval =
+      item?.price?.recurring?.interval === 'year'
+        ? BILLING_INTERVAL.YEAR
+        : BILLING_INTERVAL.MONTH;
+    const periodStart = item?.current_period_start ?? 0;
+    const periodEnd = item?.current_period_end ?? 0;
+    const status = resolveStatus(
+      stripeSub.status,
+      stripeSub.cancel_at_period_end ?? false,
+      'active'
+    );
+
+    try {
+      await this.db.insert(courseSubscriptions).values({
+        userId,
+        courseId,
+        planId,
+        organizationId,
+        stripeSubscriptionId: stripeSub.id,
+        stripeCustomerId:
+          typeof stripeSub.customer === 'string'
+            ? stripeSub.customer
+            : stripeSub.customer.id,
+        status,
+        billingInterval,
+        currentPeriodStart: new Date(periodStart * 1000),
+        currentPeriodEnd: new Date(periodEnd * 1000),
+        cancelAtPeriodEnd: stripeSub.cancel_at_period_end ?? false,
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        const [raced] = await this.db
+          .select()
+          .from(courseSubscriptions)
+          .where(eq(courseSubscriptions.stripeSubscriptionId, stripeSub.id))
+          .limit(1);
+        if (raced) return { row: raced, justInserted: false };
+      }
+      throw error;
+    }
+
+    const [inserted] = await this.db
+      .select()
+      .from(courseSubscriptions)
+      .where(eq(courseSubscriptions.stripeSubscriptionId, stripeSub.id))
+      .limit(1);
+    if (!inserted) {
+      throw new InternalServiceError(
+        'course subscription row missing after insert',
+        { stripeSubscriptionId: stripeSub.id }
+      );
+    }
+    return { row: inserted, justInserted: true };
+  }
+
+  /**
+   * customer.subscription.created (course sub): ensure the row + write the
+   * `course_subscription` entitlement (expiresAt = currentPeriodEnd) + auto-enroll.
+   */
+  async handleCourseSubscriptionCreated(
+    stripeSub: Stripe.Subscription
+  ): Promise<CourseSubscriptionWebhookResult | void> {
+    const presence = await this.ensureDataPresent(stripeSub);
+    if (!presence) return;
+    const { row } = presence;
+
+    await writeCourseSubscriptionEntitlement(this.db, {
+      userId: row.userId,
+      organizationId: row.organizationId ?? '',
+      courseId: row.courseId,
+      courseSubscriptionId: row.id,
+      expiresAt: row.currentPeriodEnd,
+    });
+
+    this.obs.info('Course subscription activated', {
+      courseSubscriptionId: row.id,
+      courseId: row.courseId,
+      userId: row.userId,
+    });
+    return { userId: row.userId, organizationId: row.organizationId ?? '' };
+  }
+
+  /**
+   * invoice.payment_succeeded (course sub): refresh the period + entitlement
+   * expiry, then fan out the recurring-revenue payout for the invoice charge.
+   */
+  async handleCourseInvoicePaymentSucceeded(
+    stripeInvoice: Stripe.Invoice,
+    stripeSub: Stripe.Subscription
+  ): Promise<CourseSubscriptionWebhookResult | void> {
+    const presence = await this.ensureDataPresent(stripeSub);
+    if (!presence) return;
+    const { row } = presence;
+
+    const item = stripeSub.items.data[0];
+    const periodStart = item?.current_period_start ?? 0;
+    const periodEnd = item?.current_period_end ?? 0;
+    const newPeriodEnd = new Date(periodEnd * 1000);
+
+    await this.db
+      .update(courseSubscriptions)
+      .set({
+        currentPeriodStart: new Date(periodStart * 1000),
+        currentPeriodEnd: newPeriodEnd,
+        status: resolveStatus(
+          stripeSub.status,
+          stripeSub.cancel_at_period_end ?? false,
+          'active'
+        ),
+        updatedAt: new Date(),
+      })
+      .where(eq(courseSubscriptions.id, row.id));
+
+    // Extend the stored grant to the new period end (fail-closed between renewals).
+    await refreshCourseSubscriptionEntitlementExpiry(this.db, {
+      userId: row.userId,
+      courseId: row.courseId,
+      expiresAt: newPeriodEnd,
+    });
+
+    // GBP-only: the fan-out is hardcoded to GBP transfers (same invariant as
+    // the org-subscription pipeline). Reject a non-GBP invoice loudly.
+    if (stripeInvoice.currency && stripeInvoice.currency !== CURRENCY.GBP) {
+      this.obs.error('Non-GBP course subscription invoice — skipping payouts', {
+        courseSubscriptionId: row.id,
+        invoiceId: stripeInvoice.id,
+        currency: stripeInvoice.currency,
+      });
+      return { userId: row.userId, organizationId: row.organizationId ?? '' };
+    }
+
+    const chargeId = await this.resolveInvoiceCharge(stripeInvoice);
+    if (!chargeId) {
+      this.obs.warn(
+        'Course subscription invoice has no charge — skipping payouts',
+        { courseSubscriptionId: row.id, invoiceId: stripeInvoice.id }
+      );
+      return { userId: row.userId, organizationId: row.organizationId ?? '' };
+    }
+
+    await this.writeCoursePayouts(row, stripeInvoice.amount_paid, chargeId);
+
+    return { userId: row.userId, organizationId: row.organizationId ?? '' };
+  }
+
+  /**
+   * customer.subscription.updated (course sub): mirror status/period. `unpaid`
+   * is access-reducing → revoke the grant immediately.
+   */
+  async handleCourseSubscriptionUpdated(
+    stripeSub: Stripe.Subscription
+  ): Promise<CourseSubscriptionWebhookResult | void> {
+    const presence = await this.ensureDataPresent(stripeSub);
+    if (!presence) return;
+    const { row } = presence;
+
+    const item = stripeSub.items.data[0];
+    const status = resolveStatus(
+      stripeSub.status,
+      stripeSub.cancel_at_period_end ?? false,
+      row.status as Parameters<typeof resolveStatus>[2]
+    );
+    await this.db
+      .update(courseSubscriptions)
+      .set({
+        status,
+        cancelAtPeriodEnd: stripeSub.cancel_at_period_end ?? false,
+        currentPeriodEnd: item?.current_period_end
+          ? new Date(item.current_period_end * 1000)
+          : row.currentPeriodEnd,
+        updatedAt: new Date(),
+      })
+      .where(eq(courseSubscriptions.id, row.id));
+
+    if (stripeSub.status === 'unpaid') {
+      await revokeCourseSubscriptionEntitlement(this.db, {
+        userId: row.userId,
+        courseId: row.courseId,
+      });
+    }
+    return { userId: row.userId, organizationId: row.organizationId ?? '' };
+  }
+
+  /**
+   * customer.subscription.deleted (course sub): mark cancelled + REVOKE the
+   * stored grant so the resolver stops granting immediately.
+   */
+  async handleCourseSubscriptionDeleted(
+    stripeSub: Stripe.Subscription
+  ): Promise<CourseSubscriptionWebhookResult | void> {
+    const [row] = await this.db
+      .select()
+      .from(courseSubscriptions)
+      .where(eq(courseSubscriptions.stripeSubscriptionId, stripeSub.id))
+      .limit(1);
+    if (!row) return;
+
+    await this.db
+      .update(courseSubscriptions)
+      .set({
+        status: 'cancelled',
+        cancelledAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(courseSubscriptions.id, row.id));
+
+    await revokeCourseSubscriptionEntitlement(this.db, {
+      userId: row.userId,
+      courseId: row.courseId,
+    });
+
+    this.obs.info('Course subscription cancelled', {
+      courseSubscriptionId: row.id,
+      courseId: row.courseId,
+      userId: row.userId,
+    });
+    return { userId: row.userId, organizationId: row.organizationId ?? '' };
+  }
+
+  // ─── Payout fan-out (Option B platform charge — mirrors writePurchasePayouts) ─
+
+  /**
+   * Split a course-subscription invoice charge and fan out the creator + org
+   * secondary transfers, writing `payouts` rows attributed by
+   * `courseSubscriptionId` (§H3). ctx='subscription' (recurring), and per
+   * HARDENING §H4 the creator's `subscription` revenue-share agreement applies.
+   */
+  private async writeCoursePayouts(
+    sub: CourseSubscription,
+    amountCents: number,
+    stripeChargeId: string
+  ): Promise<void> {
+    const [course] = await this.db
+      .select({
+        creatorId: courses.creatorId,
+        organizationId: courses.organizationId,
+      })
+      .from(courses)
+      .where(eq(courses.id, sub.courseId))
+      .limit(1);
+    if (!course) {
+      this.obs.error('Course missing during course-sub payout', {
+        courseSubscriptionId: sub.id,
+        courseId: sub.courseId,
+      });
+      return;
+    }
+    const { creatorId, organizationId } = course;
+
+    // Idempotency: `invoice.payment_succeeded` can redeliver. Only platform_fee
+    // has a per-charge unique index, so guard the WHOLE fan-out with a per-charge
+    // SELECT pre-check (mirrors executeTransfers) — if any payout row already
+    // exists for this (charge, course-sub), the fan-out ran; skip re-inserting
+    // the creator/org rows. The transfer idempotency keys are the second line of
+    // defence against double-paying if two redeliveries race past this check.
+    const [already] = await this.db
+      .select({ id: payouts.id })
+      .from(payouts)
+      .where(
+        and(
+          eq(payouts.stripeChargeId, stripeChargeId),
+          eq(payouts.courseSubscriptionId, sub.id)
+        )
+      )
+      .limit(1);
+    if (already) {
+      this.obs.info(
+        'Course-sub payouts already recorded for charge — skipping',
+        {
+          courseSubscriptionId: sub.id,
+          stripeChargeId,
+        }
+      );
+      return;
+    }
+
+    const fees = this.feeConfig
+      ? await this.feeConfig.getFeesForCreator(
+          organizationId,
+          creatorId,
+          'subscription'
+        )
+      : {
+          platformFeePercent: DEFAULT_PLATFORM_FEE_PERCENTAGE,
+          orgFeePercent: DEFAULT_ORG_FEE_PERCENTAGE,
+          minPlatformFeeCents: 0,
+          minTransferCents: 0,
+        };
+
+    const agreementSharePercent = await findActiveCreatorAgreementShare(
+      this.db,
+      {
+        organizationId,
+        creatorId,
+        revenueType: 'subscription',
+        at: new Date(),
+      }
+    );
+    const effectiveOrgFeePercent =
+      agreementSharePercent != null
+        ? 10_000 - agreementSharePercent
+        : fees.orgFeePercent;
+
+    const split = applyMinPlatformFeeFloor(
+      amountCents,
+      calculateRevenueSplit(
+        amountCents,
+        fees.platformFeePercent,
+        effectiveOrgFeePercent
+      ),
+      fees.minPlatformFeeCents
+    );
+
+    this.obs.info('payout_split_computed', {
+      courseSubscriptionId: sub.id,
+      courseId: sub.courseId,
+      organizationId,
+      creatorId,
+      amountPaidCents: amountCents,
+      platformFeeCents: split.platformFeeCents,
+      organizationFeeCents: split.organizationFeeCents,
+      creatorPayoutCents: split.creatorPayoutCents,
+      agreementApplied: agreementSharePercent != null,
+      source: 'course_subscription',
+    });
+
+    const transferGroup = `course_sub_${sub.id}`;
+    const now = new Date();
+
+    // 1. Platform fee — retained on platform balance (no transfer). Idempotent
+    // per charge via uq_payouts_platform_fee_per_charge.
+    if (split.platformFeeCents > 0) {
+      try {
+        await this.db
+          .insert(payouts)
+          .values({
+            userId: null,
+            organizationId,
+            courseSubscriptionId: sub.id,
+            amountCents: split.platformFeeCents,
+            payoutType: 'platform_fee',
+            status: 'paid',
+            sourceType: 'subscription',
+            stripeChargeId,
+            transferGroup,
+            resolvedAt: now,
+          })
+          .onConflictDoNothing({
+            target: payouts.stripeChargeId,
+            where: sql`${payouts.payoutType} = 'platform_fee'`,
+          });
+      } catch (err) {
+        this.obs.error('Failed to insert course-sub platform_fee payout', {
+          courseSubscriptionId: sub.id,
+          stripeChargeId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // 2. Creator payout — secondary transfer to the course creator's account.
+    if (split.creatorPayoutCents > 0) {
+      const [creatorConnect] = await this.db
+        .select()
+        .from(stripeConnectAccounts)
+        .where(eq(stripeConnectAccounts.userId, creatorId))
+        .limit(1);
+      await this.executeCourseTransfer({
+        sub,
+        organizationId,
+        amountCents: split.creatorPayoutCents,
+        payoutType: 'creator_payout',
+        rowUserId: creatorId,
+        connect: creatorConnect,
+        stripeChargeId,
+        transferGroup,
+        idempotencyKey: `${stripeChargeId}_creator`,
+        now,
+      });
+    }
+
+    // 3. Organization fee — secondary transfer to the org's Connect account.
+    if (split.organizationFeeCents > 0) {
+      const orgConnect = await resolvePrimaryConnect(this.db, organizationId);
+      const rowUserId = orgConnect?.userId ?? null;
+      if (rowUserId) {
+        await this.executeCourseTransfer({
+          sub,
+          organizationId,
+          amountCents: split.organizationFeeCents,
+          payoutType: 'organization_fee',
+          rowUserId,
+          connect: orgConnect,
+          stripeChargeId,
+          transferGroup,
+          idempotencyKey: `${stripeChargeId}_org_fee`,
+          now,
+        });
+      } else {
+        this.obs.error(
+          'Cannot record course-sub organization_fee payout: no org Connect/owner',
+          { courseSubscriptionId: sub.id, organizationId }
+        );
+      }
+    }
+  }
+
+  /**
+   * Execute one secondary transfer (creator or org) for a course sub + write its
+   * `payouts` ledger row. Per-row error isolation, NEVER throws — mirrors
+   * `PurchaseService.executePurchaseTransfer`. success → paid+transferId,
+   * connect-not-ready → pending, Stripe failure → failed.
+   */
+  private async executeCourseTransfer(params: {
+    sub: CourseSubscription;
+    organizationId: string;
+    amountCents: number;
+    payoutType: 'creator_payout' | 'organization_fee';
+    rowUserId: string;
+    connect: { stripeAccountId: string; chargesEnabled: boolean } | undefined;
+    stripeChargeId: string;
+    transferGroup: string;
+    idempotencyKey: string;
+    now: Date;
+  }): Promise<void> {
+    const {
+      sub,
+      organizationId,
+      amountCents,
+      payoutType,
+      rowUserId,
+      connect,
+      stripeChargeId,
+      transferGroup,
+      idempotencyKey,
+      now,
+    } = params;
+
+    if (!connect?.chargesEnabled) {
+      try {
+        await this.db.insert(payouts).values({
+          userId: rowUserId,
+          organizationId,
+          courseSubscriptionId: sub.id,
+          amountCents,
+          payoutType,
+          status: 'pending',
+          sourceType: 'subscription',
+          reason: 'connect_not_ready',
+          stripeChargeId,
+          transferGroup,
+        });
+      } catch (err) {
+        if (!isUniqueViolation(err)) {
+          this.obs.error(
+            `Failed to record pending ${payoutType} (course sub)`,
+            {
+              courseSubscriptionId: sub.id,
+              constraint: getConstraintName(err),
+              error: err instanceof Error ? err.message : String(err),
+            }
+          );
+        }
+      }
+      return;
+    }
+
+    try {
+      const transfer = await this.stripe.transfers.create(
+        {
+          amount: amountCents,
+          currency: CURRENCY.GBP,
+          destination: connect.stripeAccountId,
+          source_transaction: stripeChargeId,
+          metadata: {
+            course_subscription_id: sub.id,
+            type: payoutType,
+            stripe_charge_id: stripeChargeId,
+          },
+        },
+        { idempotencyKey }
+      );
+      try {
+        await this.db.insert(payouts).values({
+          userId: rowUserId,
+          organizationId,
+          courseSubscriptionId: sub.id,
+          amountCents,
+          payoutType,
+          status: 'paid',
+          sourceType: 'subscription',
+          stripeTransferId: transfer.id,
+          stripeChargeId,
+          transferGroup,
+          resolvedAt: now,
+        });
+      } catch (insertErr) {
+        if (!isUniqueViolation(insertErr)) {
+          const errorId = crypto.randomUUID();
+          this.obs.error(
+            `${payoutType} transfer succeeded but course-sub ledger insert failed`,
+            {
+              errorId,
+              courseSubscriptionId: sub.id,
+              stripeTransferId: transfer.id,
+              idempotencyKey,
+              constraint: getConstraintName(insertErr),
+              error:
+                insertErr instanceof Error
+                  ? insertErr.message
+                  : String(insertErr),
+            }
+          );
+        }
+      }
+    } catch (transferErr) {
+      this.obs.error(`${payoutType} transfer failed (course sub)`, {
+        courseSubscriptionId: sub.id,
+        amountCents,
+        idempotencyKey,
+        destination: connect.stripeAccountId,
+        error:
+          transferErr instanceof Error
+            ? transferErr.message
+            : String(transferErr),
+      });
+      try {
+        await this.db.insert(payouts).values({
+          userId: rowUserId,
+          organizationId,
+          courseSubscriptionId: sub.id,
+          amountCents,
+          payoutType,
+          status: 'failed',
+          sourceType: 'subscription',
+          reason: 'transfer_failed',
+        });
+      } catch (insertErr) {
+        if (!isUniqueViolation(insertErr)) {
+          this.obs.error(`Failed to record failed ${payoutType} (course sub)`, {
+            courseSubscriptionId: sub.id,
+            error:
+              insertErr instanceof Error
+                ? insertErr.message
+                : String(insertErr),
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Resolve the source charge id for an invoice's transfers. Webhook payloads
+   * omit expanded `payments` by default, so fall back through expand →
+   * payment_intent → charges.list (mirrors SubscriptionService.resolveInvoiceCharge).
+   */
+  private async resolveInvoiceCharge(
+    invoice: Stripe.Invoice
+  ): Promise<string | null> {
+    const payment = invoice.payments?.data?.[0];
+    const paymentCharge = payment?.payment?.charge;
+    if (typeof paymentCharge === 'string') return paymentCharge;
+
+    if (invoice.id) {
+      const expanded = await this.stripe.invoices.retrieve(invoice.id, {
+        expand: ['payments'],
+      });
+      const expandedCharge = expanded.payments?.data?.[0]?.payment?.charge;
+      if (typeof expandedCharge === 'string') return expandedCharge;
+    }
+    return null;
+  }
+}

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -25,6 +25,8 @@ export * from './primitives';
 export * from './schemas/access';
 // Agreements schemas (Codex-hqke2 — WP-3 of Codex-nk4km)
 export * from './schemas/agreements';
+// Course monetization schemas (Codex-2pryk WP-6 · SPEC §7)
+export * from './schemas/course-commerce';
 // Fee configuration schemas (Codex-m644n)
 export * from './schemas/fee-config';
 // File upload schemas

--- a/packages/validation/src/schemas/course-commerce.ts
+++ b/packages/validation/src/schemas/course-commerce.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { uuidSchema } from '../primitives';
+import { checkoutRedirectUrlSchema } from './purchase';
+import { billingIntervalEnum } from './subscription';
+
+/**
+ * Course monetization validation (Codex-2pryk WP-6 · SPEC §7).
+ *
+ * The three course-access paths' write inputs:
+ *   - one-off course purchase checkout   → see `createCourseCheckoutSchema` (purchase.ts)
+ *   - course-specific subscription        → `createCourseSubscriptionCheckoutSchema` + plan CRUD here
+ *   - org tier → course grant             → `setCourseTierAccessSchema` here
+ *
+ * Prices are GBP integer pence. Redirect URLs reuse the host-allowlisted
+ * checkout schema (open-redirect prevention).
+ */
+
+/**
+ * Create/replace the course-specific subscription PLAN (one live plan per
+ * course). Drives the Stripe Product + monthly/annual Price sync.
+ */
+export const upsertCourseSubscriptionPlanSchema = z
+  .object({
+    courseId: uuidSchema,
+    priceMonthly: z
+      .number()
+      .int('Price must be a whole number (pence)')
+      .min(100, 'Minimum price is £1.00 (100 pence)')
+      .max(10000000, 'Maximum price is £100,000'),
+    priceAnnual: z
+      .number()
+      .int('Price must be a whole number (pence)')
+      .min(100, 'Minimum price is £1.00 (100 pence)')
+      .max(10000000, 'Maximum price is £100,000'),
+  })
+  .refine((data) => data.priceAnnual <= data.priceMonthly * 12, {
+    message: 'Annual price must offer equal or better value than monthly',
+    path: ['priceAnnual'],
+  });
+
+/**
+ * Start a course-specific subscription checkout. `courseId` + interval are the
+ * inputs; the plan + its Stripe Price are resolved server-side.
+ */
+export const createCourseSubscriptionCheckoutSchema = z.object({
+  courseId: uuidSchema,
+  billingInterval: billingIntervalEnum,
+  successUrl: checkoutRedirectUrlSchema,
+  cancelUrl: checkoutRedirectUrlSchema,
+});
+
+/** Path params for the public course-offer read (`GET /courses/:courseId/offer`). */
+export const courseOfferParamsSchema = z.object({
+  courseId: uuidSchema,
+});
+
+/**
+ * Set the EXACT set of org tiers that unlock a course (SPEC §7 tier-access:
+ * "not just min-tier"). Replaces the course's tier-access rows with `tierIds`.
+ * The N1 guarantee (every tier must belong to the course's org) is enforced by
+ * the service write-path guard AND the `course_tier_access` composite FKs.
+ */
+export const setCourseTierAccessSchema = z.object({
+  courseId: uuidSchema,
+  tierIds: z
+    .array(uuidSchema)
+    .max(50, 'Cannot grant more than 50 tiers to one course'),
+});
+
+export type CourseOfferParams = z.infer<typeof courseOfferParamsSchema>;
+export type UpsertCourseSubscriptionPlanInput = z.infer<
+  typeof upsertCourseSubscriptionPlanSchema
+>;
+export type CreateCourseSubscriptionCheckoutInput = z.infer<
+  typeof createCourseSubscriptionCheckoutSchema
+>;
+export type SetCourseTierAccessInput = z.infer<
+  typeof setCourseTierAccessSchema
+>;

--- a/packages/validation/src/schemas/purchase.ts
+++ b/packages/validation/src/schemas/purchase.ts
@@ -105,6 +105,19 @@ export const createCheckoutSchema = z.object({
 });
 
 /**
+ * Create Course Checkout Session Schema (Codex-2pryk WP-6)
+ *
+ * One-off COURSE purchase checkout. Same shape as {@link createCheckoutSchema}
+ * but targets a course. The org + creator (payout recipient) are resolved
+ * server-side from the `courses` row, never accepted from the client.
+ */
+export const createCourseCheckoutSchema = z.object({
+  courseId: uuidSchema,
+  successUrl: checkoutRedirectUrlSchema,
+  cancelUrl: checkoutRedirectUrlSchema,
+});
+
+/**
  * Purchase Query Schema
  *
  * Used for GET /api/purchases with filters
@@ -155,6 +168,21 @@ export const checkoutSessionMetadataSchema = z.object({
 });
 
 /**
+ * Course Checkout Session Metadata Schema (Codex-2pryk WP-6)
+ *
+ * Validates metadata on a one-off COURSE checkout session. `kind: 'course'`
+ * discriminates it from the content metadata at the webhook so the handler
+ * routes to `completeCoursePurchase`. `organizationId` is NOT carried — it is
+ * re-derived from the course row server-side (courses are always org-owned).
+ */
+export const courseCheckoutSessionMetadataSchema = z.object({
+  kind: z.literal('course'),
+  customerId: userIdSchema,
+  courseId: uuidSchema,
+  courseTitle: z.string().optional(),
+});
+
+/**
  * Create Portal Session Schema
  *
  * Used for POST /checkout/portal-session to create a Stripe billing portal session
@@ -179,6 +207,12 @@ export const createPortalSessionSchema = z.object({
  */
 export type PurchaseStatus = z.infer<typeof purchaseStatusEnum>;
 export type CreateCheckoutInput = z.infer<typeof createCheckoutSchema>;
+export type CreateCourseCheckoutInput = z.infer<
+  typeof createCourseCheckoutSchema
+>;
+export type CourseCheckoutSessionMetadata = z.infer<
+  typeof courseCheckoutSessionMetadataSchema
+>;
 export type PurchaseQueryInput = z.infer<typeof purchaseQuerySchema>;
 export type GetPurchaseInput = z.infer<typeof getPurchaseSchema>;
 export type CheckoutSessionMetadata = z.infer<

--- a/packages/worker-utils/src/procedure/service-registry.ts
+++ b/packages/worker-utils/src/procedure/service-registry.ts
@@ -9,6 +9,7 @@
 import {
   AccessRevocation,
   ContentAccessService,
+  CourseAccessService,
   EntitlementsService,
 } from '@codex/access';
 import {
@@ -49,6 +50,7 @@ import {
 import type { Bindings } from '@codex/shared-types';
 import {
   ConnectAccountService,
+  CourseSubscriptionService,
   SubscriptionService,
   TierService,
 } from '@codex/subscription';
@@ -158,6 +160,8 @@ export function createServiceRegistry(
   let _subscription: SubscriptionService | undefined;
   let _tier: TierService | undefined;
   let _connectAccount: ConnectAccountService | undefined;
+  let _courseSubscription: CourseSubscriptionService | undefined;
+  let _courseAccess: CourseAccessService | undefined;
   let _agreements: AgreementService | undefined;
 
   // Shared per-request DB client (for services needing transactions)
@@ -816,6 +820,35 @@ export function createServiceRegistry(
         }
       }
       return _connectAccount;
+    },
+
+    get courseSubscription() {
+      if (!_courseSubscription) {
+        // Course-sub payouts resolve fees via the same 3-tier fallback chain as
+        // purchases/subscriptions; Stripe client is deferred (read-only course
+        // pages never construct it) — same pattern as `subscription`/`tier`.
+        _courseSubscription = new CourseSubscriptionService(
+          {
+            db: getSharedDb(),
+            environment: getEnvironment(),
+            feeConfig: registry.feeConfig,
+          },
+          getLazyStripeClient()
+        );
+      }
+      return _courseSubscription;
+    },
+
+    get courseAccess() {
+      if (!_courseAccess) {
+        // Pure DB (no Stripe). Uses the shared WS client because `setTierAccess`
+        // replaces a course's tier-access rows inside a transaction.
+        _courseAccess = new CourseAccessService({
+          db: getSharedDb(),
+          environment: getEnvironment(),
+        });
+      }
+      return _courseAccess;
     },
 
     // ========================================================================

--- a/packages/worker-utils/src/procedure/types.ts
+++ b/packages/worker-utils/src/procedure/types.ts
@@ -8,7 +8,11 @@
  * - Procedure context with full typing
  */
 
-import type { ContentAccessService, EntitlementsService } from '@codex/access';
+import type {
+  ContentAccessService,
+  CourseAccessService,
+  EntitlementsService,
+} from '@codex/access';
 import type {
   AdminAnalyticsService,
   AdminContentManagementService,
@@ -43,6 +47,7 @@ import type {
 } from '@codex/shared-types';
 import type {
   ConnectAccountService,
+  CourseSubscriptionService,
   SubscriptionService,
   TierService,
 } from '@codex/subscription';
@@ -170,6 +175,18 @@ export interface ServiceRegistry {
   subscription: SubscriptionService;
   tier: TierService;
   connect: ConnectAccountService;
+  /**
+   * Course-specific subscriptions (Codex-2pryk WP-6 · SPEC §7): plan Stripe
+   * sync, checkout, and the course-sub webhook lifecycle + payout fan-out.
+   * Stripe-backed, so lazily constructed with the deferred Stripe client.
+   */
+  courseSubscription: CourseSubscriptionService;
+  /**
+   * Course monetization access surface (Codex-2pryk WP-6): tier→course grant
+   * management (N1 guard) + the `getCourseOffer` read composing all three §7
+   * paths. Pure DB — no Stripe.
+   */
+  courseAccess: CourseAccessService;
 
   // Media & Processing domain
   transcoding: TranscodingService;

--- a/workers/ecom-api/src/handlers/checkout.ts
+++ b/workers/ecom-api/src/handlers/checkout.ts
@@ -18,12 +18,48 @@
 
 import { invalidateUserLibrary } from '@codex/cache';
 import { CURRENCY } from '@codex/constants';
+import type { ObservabilityClient } from '@codex/observability';
 import { PurchaseService } from '@codex/purchase';
-import { checkoutSessionMetadataSchema } from '@codex/validation';
+import {
+  checkoutSessionMetadataSchema,
+  courseCheckoutSessionMetadataSchema,
+} from '@codex/validation';
 import { createWebhookDbClient, sendEmailToWorker } from '@codex/worker-utils';
 import type { Context } from 'hono';
 import type Stripe from 'stripe';
 import type { StripeWebhookEnv } from '../types';
+
+/**
+ * Retrieve the charge id + Stripe-collected application fee for a PaymentIntent.
+ * The payouts pipeline uses the charge as `source_transaction`; the app fee is
+ * reconciled against the calculated split. Best-effort — a miss degrades the
+ * payouts write to a no-op but the purchase + grant still complete.
+ */
+async function resolvePaymentIntentCharge(
+  stripe: Stripe,
+  paymentIntentId: string,
+  obs: ObservabilityClient | undefined
+): Promise<{
+  stripeChargeId: string | null;
+  stripeApplicationFeeCents: number | null;
+}> {
+  try {
+    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+    return {
+      stripeApplicationFeeCents: paymentIntent.application_fee_amount ?? null,
+      stripeChargeId:
+        typeof paymentIntent.latest_charge === 'string'
+          ? paymentIntent.latest_charge
+          : (paymentIntent.latest_charge?.id ?? null),
+    };
+  } catch (piError) {
+    obs?.warn('Could not retrieve PaymentIntent for fee reconciliation', {
+      paymentIntentId,
+      error: piError instanceof Error ? piError.message : String(piError),
+    });
+    return { stripeChargeId: null, stripeApplicationFeeCents: null };
+  }
+}
 
 /**
  * Handle checkout.session.completed event
@@ -83,6 +119,14 @@ export async function handleCheckoutCompleted(
 
   if (!paymentIntentId) {
     obs?.error('Missing payment intent ID', { sessionId: session.id });
+    return;
+  }
+
+  // Codex-2pryk WP-6: a `kind: 'course'` session targets a COURSE, not content.
+  // Route to the course completion path and return — the content metadata schema
+  // below does not apply to it.
+  if (session.metadata?.kind === 'course') {
+    await handleCourseCheckoutCompleted(session, paymentIntentId, stripe, c);
     return;
   }
 
@@ -200,6 +244,109 @@ export async function handleCheckoutCompleted(
           priceFormatted: formatted,
           purchaseDate: new Date().toLocaleDateString('en-GB'),
           contentUrl: `${c.env.WEB_APP_URL || ''}/content/${validatedMetadata.contentId}`,
+        },
+      });
+    }
+  } finally {
+    await cleanup();
+  }
+}
+
+/**
+ * Complete a one-off COURSE purchase from a `kind: 'course'` checkout session
+ * (Codex-2pryk WP-6). Mirrors the content path but calls
+ * `PurchaseService.completeCoursePurchase`, which writes a `course_purchase`
+ * entitlement + auto-enrolls and reuses the Option-B payout fan-out.
+ * Idempotent by `stripePaymentIntentId`; returns 200 even on failure so Stripe
+ * does not retry a poisoned event (failures are logged for manual triage).
+ */
+async function handleCourseCheckoutCompleted(
+  session: Stripe.Checkout.Session,
+  paymentIntentId: string,
+  stripe: Stripe,
+  c: Context<StripeWebhookEnv>
+): Promise<void> {
+  const obs = c.get('obs');
+
+  let metadata: ReturnType<typeof courseCheckoutSessionMetadataSchema.parse>;
+  try {
+    metadata = courseCheckoutSessionMetadataSchema.parse(session.metadata);
+  } catch (validationError) {
+    obs?.error('Invalid course checkout session metadata', {
+      sessionId: session.id,
+      error:
+        validationError instanceof Error
+          ? validationError.message
+          : 'Unknown validation error',
+    });
+    return;
+  }
+
+  const amountTotal = session.amount_total;
+  if (typeof amountTotal !== 'number') {
+    obs?.error('Invalid amount_total on course checkout', {
+      sessionId: session.id,
+      amountTotal,
+    });
+    return;
+  }
+
+  const { stripeChargeId, stripeApplicationFeeCents } =
+    await resolvePaymentIntentCharge(stripe, paymentIntentId, obs);
+
+  const { db, cleanup } = createWebhookDbClient(c.env);
+  try {
+    const purchaseService = new PurchaseService(
+      { db, environment: c.env.ENVIRONMENT || 'development' },
+      stripe
+    );
+
+    const purchase = await purchaseService.completeCoursePurchase(
+      paymentIntentId,
+      {
+        customerId: metadata.customerId,
+        courseId: metadata.courseId,
+        amountPaidCents: amountTotal,
+        currency: CURRENCY.GBP,
+        stripeApplicationFeeCents,
+        stripeChargeId,
+      }
+    );
+
+    obs?.info('Course purchase completed successfully', {
+      purchaseId: purchase.id,
+      customerId: metadata.customerId,
+      courseId: metadata.courseId,
+      amountCents: amountTotal,
+    });
+
+    // Bump the buyer's library version so the new course entitlement + enrollment
+    // surface on their other devices.
+    if (c.executionCtx) {
+      invalidateUserLibrary({
+        kv: c.env.CACHE_KV,
+        waitUntil: c.executionCtx.waitUntil.bind(c.executionCtx),
+        userId: metadata.customerId,
+        logger: obs,
+      });
+    }
+
+    const customerEmail = session.customer_details?.email;
+    const customerName = session.customer_details?.name || 'there';
+    if (customerEmail) {
+      const formatted = `£${(amountTotal / 100).toFixed(2)}`;
+      sendEmailToWorker(c.env, c.executionCtx, {
+        to: customerEmail,
+        toName: customerName,
+        templateName: 'purchase-receipt',
+        category: 'transactional',
+        userId: metadata.customerId,
+        data: {
+          userName: customerName,
+          contentTitle: metadata.courseTitle || 'Course purchase',
+          priceFormatted: formatted,
+          purchaseDate: new Date().toLocaleDateString('en-GB'),
+          contentUrl: `${c.env.WEB_APP_URL || ''}/courses/${metadata.courseId}`,
         },
       });
     }

--- a/workers/ecom-api/src/handlers/subscription-webhook.ts
+++ b/workers/ecom-api/src/handlers/subscription-webhook.ts
@@ -28,10 +28,18 @@
  */
 
 import { AccessRevocation, type RevocationReason } from '@codex/access';
-import { VersionedCache } from '@codex/cache';
+import { invalidateUserLibrary, VersionedCache } from '@codex/cache';
 import { STRIPE_EVENTS } from '@codex/constants';
-import type { WebhookHandlerResult } from '@codex/subscription';
-import { SubscriptionService, TierService } from '@codex/subscription';
+import { FeeConfigService } from '@codex/purchase';
+import type {
+  CourseSubscriptionWebhookResult,
+  WebhookHandlerResult,
+} from '@codex/subscription';
+import {
+  CourseSubscriptionService,
+  SubscriptionService,
+  TierService,
+} from '@codex/subscription';
 import { createWebhookDbClient, sendEmailToWorker } from '@codex/worker-utils';
 import type { Context } from 'hono';
 import type Stripe from 'stripe';
@@ -261,6 +269,41 @@ export async function handleSubscriptionWebhook(
       stripe
     );
 
+    // Codex-2pryk WP-6: course-specific subscriptions flow through this SAME
+    // webhook (they are mode=subscription). They are discriminated by the Stripe
+    // subscription's `type: 'course_subscription'` metadata and routed to
+    // CourseSubscriptionService so the org SubscriptionService never records a
+    // course sub as an org subscription.
+    const courseSubService = new CourseSubscriptionService(
+      {
+        db,
+        environment: c.env.ENVIRONMENT || 'development',
+        feeConfig: new FeeConfigService({
+          db,
+          environment: c.env.ENVIRONMENT || 'development',
+          cache,
+          waitUntil,
+        }),
+      },
+      stripe
+    );
+
+    /**
+     * Bump a course-sub buyer's library version (their entitlement + enrollment
+     * just changed). Fire-and-forget, mirrors the content checkout handler.
+     */
+    const invalidateCourseBuyer = (
+      result: CourseSubscriptionWebhookResult | void
+    ): void => {
+      if (!result?.userId) return;
+      invalidateUserLibrary({
+        kv: c.env.CACHE_KV,
+        waitUntil,
+        userId: result.userId,
+        logger: obs,
+      });
+    };
+
     /**
      * Fire-and-forget org-level cache invalidation after a Stripe
      * Dashboard sync-back write. Bumps the org's version key which
@@ -322,6 +365,22 @@ export async function handleSubscriptionWebhook(
         // Retrieve the full subscription object for period dates + metadata
         const subscription =
           await stripe.subscriptions.retrieve(subscriptionId);
+
+        // Course-sub branch (Codex-2pryk WP-6): write the course_subscription
+        // entitlement + auto-enroll; never a org subscription row.
+        if (CourseSubscriptionService.isCourseSubscription(subscription)) {
+          const courseResult =
+            await courseSubService.handleCourseSubscriptionCreated(
+              subscription
+            );
+          invalidateCourseBuyer(courseResult);
+          obs?.info('Course subscription created from checkout', {
+            sessionId: session.id,
+            subscriptionId,
+          });
+          break;
+        }
+
         // `handleSubscriptionCreated` owns its own cache invalidation via
         // the orchestrator hook inside SubscriptionService.
         const result = await service.handleSubscriptionCreated(
@@ -340,6 +399,21 @@ export async function handleSubscriptionWebhook(
 
       case STRIPE_EVENTS.SUBSCRIPTION_UPDATED: {
         const subscription = event.data.object as Stripe.Subscription;
+
+        // Course-sub branch (Codex-2pryk WP-6): mirror status/period; `unpaid`
+        // revokes the grant inside the service.
+        if (CourseSubscriptionService.isCourseSubscription(subscription)) {
+          const courseResult =
+            await courseSubService.handleCourseSubscriptionUpdated(
+              subscription
+            );
+          invalidateCourseBuyer(courseResult);
+          obs?.info('Course subscription updated', {
+            subscriptionId: subscription.id,
+          });
+          break;
+        }
+
         // `handleSubscriptionUpdated` owns its own cache invalidation via
         // the orchestrator hook inside SubscriptionService. Tier changes
         // and status flips (active ↔ cancelling ↔ past_due) all bump
@@ -388,6 +462,21 @@ export async function handleSubscriptionWebhook(
 
       case STRIPE_EVENTS.SUBSCRIPTION_DELETED: {
         const subscription = event.data.object as Stripe.Subscription;
+
+        // Course-sub branch (Codex-2pryk WP-6): mark cancelled + REVOKE the
+        // stored grant so the resolver stops granting immediately.
+        if (CourseSubscriptionService.isCourseSubscription(subscription)) {
+          const courseResult =
+            await courseSubService.handleCourseSubscriptionDeleted(
+              subscription
+            );
+          invalidateCourseBuyer(courseResult);
+          obs?.info('Course subscription deleted', {
+            subscriptionId: subscription.id,
+          });
+          break;
+        }
+
         // `handleSubscriptionDeleted` owns its own cache invalidation via
         // the orchestrator hook inside SubscriptionService.
         const result = await service.handleSubscriptionDeleted(
@@ -457,6 +546,33 @@ export async function handleSubscriptionWebhook(
 
       case STRIPE_EVENTS.INVOICE_PAYMENT_SUCCEEDED: {
         const invoice = event.data.object as Stripe.Invoice;
+
+        // Course-sub branch (Codex-2pryk WP-6): discriminate via the invoice's
+        // subscription_details metadata (Stripe copies the subscription's
+        // metadata onto the invoice) so org invoices pay NO extra retrieve. Only
+        // the course path retrieves the full subscription (for period + items).
+        const subDetails = invoice.parent?.subscription_details;
+        const subMetaType = subDetails?.metadata?.type ?? null;
+        if (subMetaType === 'course_subscription') {
+          const stripeSubId =
+            typeof subDetails?.subscription === 'string'
+              ? subDetails.subscription
+              : (subDetails?.subscription?.id ?? null);
+          if (stripeSubId) {
+            const courseSub = await stripe.subscriptions.retrieve(stripeSubId);
+            const courseResult =
+              await courseSubService.handleCourseInvoicePaymentSucceeded(
+                invoice,
+                courseSub
+              );
+            invalidateCourseBuyer(courseResult);
+            obs?.info('Course subscription invoice payment succeeded', {
+              invoiceId: invoice.id,
+            });
+          }
+          break;
+        }
+
         // `handleInvoicePaymentSucceeded` owns its own cache invalidation
         // via the orchestrator hook inside SubscriptionService. Renewal
         // continues access — both per-user version keys are bumped from

--- a/workers/ecom-api/src/index.ts
+++ b/workers/ecom-api/src/index.ts
@@ -31,6 +31,7 @@ import { verifyStripeSignature } from './middleware/verify-signature';
 import agreements from './routes/agreements';
 import checkout from './routes/checkout';
 import connect from './routes/connect';
+import courses from './routes/courses';
 import purchases from './routes/purchases';
 import sales from './routes/sales';
 import subscriptions from './routes/subscriptions';
@@ -133,6 +134,12 @@ app.route('/sales', sales);
  * Handles subscription checkout, management, and queries
  */
 app.route('/subscriptions', subscriptions);
+
+/**
+ * Course monetization routes (Codex-2pryk WP-6)
+ * Public course offer read (three §7 access paths + viewer entitlement).
+ */
+app.route('/courses', courses);
 
 /**
  * Connect routes

--- a/workers/ecom-api/src/routes/checkout.ts
+++ b/workers/ecom-api/src/routes/checkout.ts
@@ -20,6 +20,8 @@
 import type { HonoEnv } from '@codex/shared-types';
 import {
   createCheckoutSchema,
+  createCourseCheckoutSchema,
+  createCourseSubscriptionCheckoutSchema,
   createPortalSessionSchema,
   verifyCheckoutSessionSchema,
 } from '@codex/validation';
@@ -111,6 +113,51 @@ checkout.post(
         sessionUrl: session.sessionUrl,
         sessionId: session.sessionId,
       };
+    },
+  })
+);
+
+/**
+ * POST /checkout/course
+ *
+ * Create a Stripe Checkout session for a one-off COURSE purchase (Codex-2pryk
+ * WP-6 · SPEC §7). The org + creator (payout recipient) are resolved server-side
+ * from the course row; the client supplies only the courseId + redirect URLs.
+ */
+checkout.post(
+  '/course',
+  procedure({
+    policy: { auth: 'required', rateLimit: 'strict' },
+    input: { body: createCourseCheckoutSchema },
+    handler: async (ctx): Promise<CheckoutSessionResponse> => {
+      const { courseId, successUrl, cancelUrl } = ctx.input.body;
+      const session = await ctx.services.purchase.createCourseCheckoutSession(
+        { courseId, successUrl, cancelUrl },
+        ctx.user.id
+      );
+      return { sessionUrl: session.sessionUrl, sessionId: session.sessionId };
+    },
+  })
+);
+
+/**
+ * POST /checkout/course-subscription
+ *
+ * Create a Stripe Checkout session for a course-specific SUBSCRIPTION (SPEC §7
+ * path 3). The plan + Stripe Price are resolved server-side from the courseId.
+ */
+checkout.post(
+  '/course-subscription',
+  procedure({
+    policy: { auth: 'required', rateLimit: 'strict' },
+    input: { body: createCourseSubscriptionCheckoutSchema },
+    handler: async (ctx): Promise<CheckoutSessionResponse> => {
+      const session =
+        await ctx.services.courseSubscription.createCheckoutSession(
+          ctx.user.id,
+          ctx.input.body
+        );
+      return { sessionUrl: session.sessionUrl, sessionId: session.sessionId };
     },
   })
 );

--- a/workers/ecom-api/src/routes/courses.ts
+++ b/workers/ecom-api/src/routes/courses.ts
@@ -1,0 +1,42 @@
+/**
+ * Course monetization routes (Codex-2pryk WP-6 · SPEC §7).
+ *
+ * GET /courses/:courseId/offer — the public read composing all three §7
+ * acquisition paths (one-off purchase, course subscription, org-tier access)
+ * plus, for an authenticated viewer, whether they already hold access. Backs
+ * the sales-page + course-landing pricing surfaces.
+ *
+ * The management mutations (create subscription plan, set tier access) live on
+ * `ctx.services.courseSubscription` / `ctx.services.courseAccess` and are wired
+ * into the studio builder surface (WP-5) with its org-management auth context —
+ * they are intentionally not exposed here, where there is no org guard.
+ */
+
+import type { CourseOffer, HonoEnv } from '@codex/shared-types';
+import { courseOfferParamsSchema } from '@codex/validation';
+import { procedure } from '@codex/worker-utils';
+import { Hono } from 'hono';
+
+const courses = new Hono<HonoEnv>();
+
+/**
+ * GET /courses/:courseId/offer
+ *
+ * Optional auth: anonymous callers get the offer with `entitled: false`; an
+ * authenticated caller additionally learns whether they already hold access.
+ */
+courses.get(
+  '/:courseId/offer',
+  procedure({
+    policy: { auth: 'optional', rateLimit: 'api' },
+    input: { params: courseOfferParamsSchema },
+    handler: async (ctx): Promise<CourseOffer> => {
+      return ctx.services.courseAccess.getCourseOffer(
+        ctx.input.params.courseId,
+        ctx.user?.id ?? null
+      );
+    },
+  })
+);
+
+export default courses;


### PR DESCRIPTION
## WP-6 — Course monetization (Epic 1, Codex-2pryk.2.4) — STACKED on WP-2 (#412) — MONEY-CRITICAL

**Base is WP-2's branch** (needs WP-1 schema + WP-2 resolver + dev's h69cg payout pipeline). Merge LAST in the BE spine: #411→#412→this. 37 files; migration **0080_clumsy_forge** (applied+backfilled on local Neon).

### 3 course-access paths (SPEC §7)
- **One-off course purchase**: nullable purchase target — `purchases.contentId` now nullable + new `purchases.courseId` + CHECK exactly-one. `createCourseCheckoutSession`/`completeCoursePurchase` REUSE `writePurchasePayouts`/`executePurchaseTransfer` VERBATIM (h69cg Option-B platform charge). Agreement revenueType=content_purchase (H4a).
- **Course subscription (D-C)**: new `CourseSubscriptionService` — separate Stripe product + 2 prices (mirrors TierService), `mode:subscription` checkout, self-heal + webhook lifecycle; payout fan-out mirrors the purchase Option-B pattern.
- **Tier access**: `CourseAccessService.setTierAccess` writes exact tier→course grants; resolver grants derived (WP-2).

### Entitlement-WRITE seam (the write side WP-2 reads)
`entitlement-writer.ts` (shared purchase + course-sub): writes content_purchase/course_purchase/course_subscription grants. content_purchase org-scoped (orgless stays on verifyPurchase). course_subscription grant carries `expiresAt=currentPeriodEnd` (fail-closed between renewals; renewals bump, delete/unpaid revokes). **Refund/dispute REVOKE the grant by sourceRef=purchase.id** (else resolver grants post-refund). Idempotent via partial-unique `uq_entitlement_live_{content,course}`.

### Payout reuse (§H3) + offers (§7)
`payouts.courseSubscriptionId` (3rd nullable source-FK) + CHECK ≤1 source; per-charge SELECT pre-check on the course-sub fan-out (invoice.paid redelivery guard). `CourseOffer`/`CourseAccessPath`/`CourseTierOffer` + `getCourseOffer` + public `GET /courses/:id/offer`.

### N1 guard (from WP-2 review — CLOSED both layers)
Write-path: `setTierAccess` rejects cross-org tier (ForbiddenError). DURABLE DB backstop: `course_tier_access.organization_id` + composite FKs → courses(id,org) + subscription_tiers(id,org) (+ parent unique indexes). Cross-org grant impossible at DB level.

### Auto-enroll (D-G)
Entitlement writers insert a `course_enrollments` side-record (onConflictDoNothing) — library/progress shelf, NOT the gate.

### Scope deferred to Round-D (documented, deliberate)
- `plan-create` + `tier-access-set` are complete/tested SERVICE methods but NOT exposed as HTTP routes (need org-management auth context — shipping under-authorized money mutations judged worse than deferring). Reachable money paths (both checkouts + webhooks + public offer read) ARE wired.
- Content read-views scoped `contentId IS NOT NULL` (course purchases don't leak into content columns). Course-sub plan price-edit is create-only (Stripe price-immutability follow-up).

### Verification (local, warm — money round-trips on live Neon)
Round-trip (buy→entitlement→resolver GRANTS, resolver imported+asserted): access 7/7 (purchase/course-sub/tier canEnterCourse + idempotent replay + expiry-fail-closed + revoke + **N1 rejected service+DB** + payout idempotency [3 rows platform/creator/org, split sums, replay adds 0]); subscription 3/3. **No regression: purchase 247/247, subscription 427, access 205** (incl h69cg payout + WP-2 resolver; fixed 2 drifted WP-2 tests for the new org column). typecheck 57/57, build 32/32, biome exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)