### PR TITLE
feat(web): Journeys entry point in studio sidebar (Codex-f53c6)

### DIFF
--- a/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
+++ b/apps/web/src/lib/components/layout/StudioSidebar/StudioSidebar.svelte
@@ -26,6 +26,7 @@
     LayoutDashboardIcon,
     FileIcon,
     FileTextIcon,
+    CompassIcon,
     VideoIcon,
     TagIcon,
     TrendingUpIcon,
@@ -60,6 +61,7 @@
   const ICON_MAP: Record<SidebarIcon, Component<Record<string, unknown>>> = {
     dashboard: LayoutDashboardIcon,
     content: FileIcon,
+    journeys: CompassIcon,
     media: VideoIcon,
     categories: TagIcon,
     analytics: TrendingUpIcon,

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -13,6 +13,7 @@ interface NavLink {
 export type SidebarIcon =
   | 'dashboard'
   | 'content'
+  | 'journeys'
   | 'media'
   | 'categories'
   | 'analytics'
@@ -66,6 +67,7 @@ export const SIDEBAR_BASE_LINKS: SidebarLink[] = [
 
 /** Studio sidebar — admin-only links */
 export const SIDEBAR_ADMIN_LINKS: SidebarLink[] = [
+  { href: '/studio/journeys', label: 'Journeys', icon: 'journeys' },
   { href: '/studio/brand', label: 'Brand', icon: 'brand' },
   { href: '/studio/categories', label: 'Categories', icon: 'categories' },
   { href: '/studio/team', label: 'Team', icon: 'team' },


### PR DESCRIPTION
## What
Adds a **Journeys** link to the Creator Studio sidebar (`SIDEBAR_ADMIN_LINKS`, CompassIcon) → `/studio/journeys`.

## Why
Journey routes shipped orphaned — the sidebar had **no** link to `/studio/journeys`, so the entire creator journey loop (index → new → builder → curriculum → insights) was reachable only by typing the URL. This is the first slice of the Journeys reconciliation (conforming the shipped FE to the mockups): **reachability**.

## Placement rationale
Admin section = renders only in **org** context for **admin/owner** — mirrors the builder's own `+page.server.ts` admin/owner gate, and avoids showing an org-scoped feature in a personal studio.

## Verification (CI is down — gated locally)
- svelte-check: 0 new errors in changed files (total == pre-existing baseline 86/45).
- biome: clean on `navigation.ts` (warnings are pre-existing unused `STUDIO_NAV`).
- `Record<SidebarIcon>` type enforces the icon binding (typecheck-verified).
- **Live (dev stack):** link present in both rails w/ correct href + Compass icon; navigates to `/studio/journeys`; page renders; **0 console errors**.

## Follow-ups (tracked)
- P0b: wire the creator loop to real `landing_pages` (list/create/get/save) + fix builder iframe 404 (previews mock slug today).
- P1: surface journeys in Explore / Library / Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)