### PR TITLE
feat(journeys): draft live-preview in the builder iframe (Codex-isr02 P0b-2)

### DIFF
--- a/apps/web/src/lib/remote/journeys.remote.ts
+++ b/apps/web/src/lib/remote/journeys.remote.ts
@@ -22,6 +22,7 @@ import { error } from '@sveltejs/kit';
 import { z } from 'zod';
 import { command, getRequestEvent, query } from '$app/server';
 import type { PracticeCompletionRecord } from '$lib/journeys/types';
+import { logger } from '$lib/observability';
 import type {
   EnrolledJourneyCard,
   JourneyCardView,
@@ -280,9 +281,18 @@ export const getCoursePagePreview = query(
     if (!ctx) return null;
     try {
       return await ctx.api.access.coursePagePreview(ctx.orgId, slug);
-    } catch {
-      // A non-manager's session → the worker's requireOrgManagement denies;
-      // treat ANY failure as "no preview" so the caller 404s (fail-closed).
+    } catch (err) {
+      // Fail-closed: ANY failure → no preview → the caller 404s. A 403 is the
+      // EXPECTED non-manager denial (the worker's requireOrgManagement), so it
+      // stays silent; log only UNEXPECTED failures (5xx / timeout) so a transient
+      // worker outage degrading a real manager's preview to a 404 isn't invisible.
+      const status = (err as { status?: number } | null)?.status;
+      if (status !== 403) {
+        logger.error('journey draft preview read failed', {
+          error: err instanceof Error ? err.message : String(err),
+          status,
+        });
+      }
       return null;
     }
   }

--- a/apps/web/src/lib/remote/journeys.remote.ts
+++ b/apps/web/src/lib/remote/journeys.remote.ts
@@ -263,3 +263,27 @@ export const saveJourneyPage = command(
     await ctx.api.access.saveJourneyPage(ctx.orgId, record);
   }
 );
+
+/**
+ * Studio LIVE-PREVIEW read (Codex-isr02 P0b-2). Resolves the sell-page envelope
+ * for ANY status (drafts included) so the builder iframe can render an
+ * unpublished draft. Management-gated by the worker (`requireOrgManagement`); the
+ * org is resolved from the request HOST. Returns null off a non-org host, for a
+ * non-manager (the worker denies → caught here), or when no such page exists —
+ * so the public sell load's fallback fail-closes to a 404. Reuses the public
+ * `coursePageSchema` (`{ slug }`).
+ */
+export const getCoursePagePreview = query(
+  coursePageSchema,
+  async ({ slug }): Promise<JourneyCoursePage | null> => {
+    const ctx = await resolveStudioOrg();
+    if (!ctx) return null;
+    try {
+      return await ctx.api.access.coursePagePreview(ctx.orgId, slug);
+    } catch {
+      // A non-manager's session → the worker's requireOrgManagement denies;
+      // treat ANY failure as "no preview" so the caller 404s (fail-closed).
+      return null;
+    }
+  }
+);

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1241,6 +1241,21 @@ export function createServerApi(
         ),
 
       /**
+       * Studio LIVE-PREVIEW read (Codex-isr02 P0b-2) — the sell-page envelope
+       * for ANY status (drafts included), management-gated (owner/admin; the
+       * worker re-derives org from the session). Powers the builder iframe
+       * rendering an unpublished draft; null for a foreign/missing/non-managed
+       * page so the public load fail-closes to 404.
+       */
+      coursePagePreview: (organizationId: string, slug: string) =>
+        request<JourneyCoursePage | null>(
+          'access',
+          `/api/journeys/studio/journeys/preview/by-slug?organizationId=${encodeURIComponent(
+            organizationId
+          )}&slug=${encodeURIComponent(slug)}`
+        ),
+
+      /**
        * Persist the builder's draft (sections/brand/title/slug/status). The param
        * is the editable subset the save touches; `brandOverrides` is optional to
        * stay assignable from SvelteKit's `command()`-inferred record (which infers

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1243,9 +1243,10 @@ export function createServerApi(
       /**
        * Studio LIVE-PREVIEW read (Codex-isr02 P0b-2) — the sell-page envelope
        * for ANY status (drafts included), management-gated (owner/admin; the
-       * worker re-derives org from the session). Powers the builder iframe
-       * rendering an unpublished draft; null for a foreign/missing/non-managed
-       * page so the public load fail-closes to 404.
+       * worker authorizes the client-supplied org against the session's
+       * membership). Powers the builder iframe rendering an unpublished draft;
+       * null for a foreign/missing/non-managed page so the public load
+       * fail-closes to 404.
        */
       coursePagePreview: (organizationId: string, slug: string) =>
         request<JourneyCoursePage | null>(

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/+page.server.ts
@@ -21,20 +21,37 @@
 import { error } from '@sveltejs/kit';
 import { CACHE_HEADERS } from '$lib/server/cache';
 import type { PageServerLoad } from './$types';
-import { getCoursePage, resolveSellPreview } from './journey-data';
+import {
+  getCoursePage,
+  getCoursePagePreview,
+  resolveSellPreview,
+} from './journey-data';
 
 export const load: PageServerLoad = async ({
   params,
   parent,
   setHeaders,
   depends,
+  locals,
 }) => {
   // Ensure the org layout (auth + branding + org resolution) has resolved before
   // we commit cache headers — mirrors the org-landing precedent.
   await parent();
 
-  // AWAIT: the SEO-critical, first-paint envelope. Null → no published page.
-  const coursePage = await getCoursePage({ slug: params.journeySlug });
+  // AWAIT: the SEO-critical, first-paint envelope. Null → no PUBLISHED page.
+  let coursePage = await getCoursePage({ slug: params.journeySlug });
+
+  // Draft live-preview (Codex-isr02 P0b-2): when there's no published page but a
+  // user IS signed in, try the management-gated preview read so an org manager
+  // can preview an UNPUBLISHED draft in the builder iframe. The worker's
+  // requireOrgManagement is the sole authority — a non-manager (or anon, who
+  // never reaches this branch) gets null → 404 (fail-closed). This shell is
+  // minimal for a fresh draft; the builder streams live sections/brand over the
+  // page-preview bridge, which +page.svelte overlays on top.
+  if (!coursePage && locals.user) {
+    coursePage = await getCoursePagePreview({ slug: params.journeySlug });
+  }
+
   if (!coursePage) {
     throw error(404, 'This journey could not be found.');
   }

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/+page.svelte
@@ -8,12 +8,39 @@
   where the intro/reel sections `{#await}` it behind poster skeletons.
 -->
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { extractPlainText } from '@codex/validation';
   import { StructuredData } from '$lib/components/seo';
+  import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
+  import { initPagePreviewBridge } from '$lib/page-builder/page-preview-bridge';
   import { JourneyRenderer } from '$lib/page-builder/render';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
+
+  // Live-preview receiver (Codex-isr02 P0b-2). INERT for real visitors — the
+  // bridge attaches no listener unless this page is embedded in the studio
+  // builder iframe (window.parent !== window). When embedded, builder edits
+  // arrive as `codex:page-preview:v1` messages → pageBuilder.applyPreviewState.
+  onMount(() => initPagePreviewBridge());
+
+  // The envelope the renderer draws. Standalone → the SSR `coursePage` as-is.
+  // Embedded + a preview message has landed (`pageBuilder.isOpen`) → overlay the
+  // builder's live pending sections + brand overrides so edits re-render live.
+  const renderCoursePage = $derived(
+    pageBuilder.isOpen
+      ? {
+          ...data.coursePage,
+          page: {
+            ...data.coursePage.page,
+            sections: pageBuilder.sections,
+            brandOverrides:
+              pageBuilder.pending?.brandOverrides ??
+              data.coursePage.page.brandOverrides,
+          },
+        }
+      : data.coursePage
+  );
 
   const course = $derived(data.coursePage.course);
 
@@ -52,4 +79,4 @@
 
 <StructuredData data={structuredData} />
 
-<JourneyRenderer coursePage={data.coursePage} sellPreview={data.sellPreview} />
+<JourneyRenderer coursePage={renderCoursePage} sellPreview={data.sellPreview} />

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/journey-data.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/journey-data.ts
@@ -16,8 +16,18 @@
  *      clips for the intro/reel media (SPEC §10), reusing the SAME public preview
  *      path (`hlsPreviewKey` → CDN URL, no signing) the org-landing hero uses.
  *
+ *   - `getCoursePagePreview` → `query()` for the STUDIO live-preview iframe only
+ *      (Codex-isr02 P0b-2): the SAME envelope for ANY status (drafts included),
+ *      management-gated by the worker. The public load falls back to it (only for
+ *      a signed-in user) when `getCoursePage` returns null, so a manager can
+ *      preview an unpublished draft; a non-manager / anon still 404s (fail-closed).
+ *
  * Kept as a thin re-export (rather than importing the remote directly in the
  * loads) so the seam's single-module contract — and the tests that mock it —
  * stay stable.
  */
-export { getCoursePage, resolveSellPreview } from '$lib/remote/journeys.remote';
+export {
+  getCoursePage,
+  getCoursePagePreview,
+  resolveSellPreview,
+} from '$lib/remote/journeys.remote';

--- a/packages/access/src/services/__tests__/course-studio-management.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-studio-management.integration.test.ts
@@ -315,4 +315,63 @@ describe('Studio journey management (Codex-isr02)', () => {
       expect(row?.enrolledCount).toBe(1);
     });
   });
+
+  describe('getCoursePagePreview (Codex-isr02 P0b-2)', () => {
+    it('resolves a DRAFT journey the published read cannot (status-agnostic)', async () => {
+      const { id: pageId, slug } = await service.createJourney(
+        orgAId,
+        creatorId,
+        { title: uniqueTitle('DraftPreview'), pageType: 'course' }
+      );
+
+      // The public, published-only read cannot see an unpublished draft…
+      expect(await service.getCoursePage(orgAId, slug)).toBeNull();
+
+      // …but the management-gated preview read resolves the full envelope so the
+      // builder iframe can render it.
+      const preview = await service.getCoursePagePreview(orgAId, slug);
+      expect(preview).not.toBeNull();
+      expect(preview?.page.id).toBe(pageId);
+      expect(preview?.page.slug).toBe(slug);
+      expect(preview?.page.status).toBe('draft');
+      expect(preview?.course.slug).toBe(slug);
+      // A fresh draft has no curriculum yet — the builder streams sections live.
+      expect(preview?.stages).toEqual([]);
+      expect(preview?.testimonials).toEqual([]);
+    });
+
+    it('is org-scoped — a foreign org never resolves the page (defence-in-depth)', async () => {
+      const { slug } = await service.createJourney(orgAId, creatorId, {
+        title: uniqueTitle('ForeignPreview'),
+        pageType: 'course',
+      });
+      // Org B must never resolve org A's draft, even via the preview read (the
+      // content-api route ALSO gates with requireOrgManagement upstream).
+      expect(await service.getCoursePagePreview(orgBId, slug)).toBeNull();
+    });
+
+    it('also resolves a PUBLISHED journey (both reads agree once live)', async () => {
+      const { id: pageId, slug } = await service.createJourney(
+        orgAId,
+        creatorId,
+        { title: uniqueTitle('PubPreview'), pageType: 'course' }
+      );
+      const loaded = await service.getJourneyForBuilder(orgAId, pageId);
+      if (!loaded) throw new Error('page not found after create');
+      await service.saveJourneyPage(orgAId, {
+        id: pageId,
+        title: loaded.title,
+        slug: loaded.slug,
+        status: 'published',
+        sections: [],
+        brandOverrides: null,
+      });
+
+      expect(
+        (await service.getCoursePagePreview(orgAId, slug))?.page.status
+      ).toBe('published');
+      // Once published, the public read sees it too.
+      expect(await service.getCoursePage(orgAId, slug)).not.toBeNull();
+    });
+  });
 });

--- a/packages/access/src/services/course-journey-service.ts
+++ b/packages/access/src/services/course-journey-service.ts
@@ -253,6 +253,120 @@ export class CourseJourneyService extends BaseService {
   }
 
   /**
+   * Resolve a course sales page for the STUDIO LIVE-PREVIEW iframe (Codex-isr02
+   * P0b-2). Structurally identical to {@link getCoursePage} but ANY status
+   * (draft / published / archived), so a creator can preview an UNPUBLISHED
+   * draft in the builder before it goes live. This is NEVER a public read: the
+   * content-api route gates it with `requireOrgManagement` (owner/admin of THIS
+   * org), and this method still scopes every query to `organizationId` as
+   * defence-in-depth. {@link getCoursePage} remains the only unauthenticated
+   * by-slug read and stays published-only.
+   *
+   * The initial payload can be minimal for a brand-new draft (empty
+   * sections/stages) — the builder streams live sections + brand overrides over
+   * the page-preview bridge, which the public sell page overlays on top.
+   */
+  async getCoursePagePreview(
+    organizationId: string,
+    slug: string
+  ): Promise<JourneyCoursePage | null> {
+    try {
+      // The landing page by org-scoped slug — ANY status (draft included).
+      const [pageRow] = await this.db
+        .select({
+          id: landingPages.id,
+          organizationId: landingPages.organizationId,
+          publishedAt: landingPages.publishedAt,
+          pageType: landingPages.pageType,
+          slug: landingPages.slug,
+          title: landingPages.title,
+          status: landingPages.status,
+          subjectType: landingPages.subjectType,
+          subjectId: landingPages.subjectId,
+          brandOverrides: landingPages.brandOverrides,
+          sections: landingPages.sections,
+        })
+        .from(landingPages)
+        .where(
+          and(
+            eq(landingPages.organizationId, organizationId),
+            eq(landingPages.slug, slug),
+            isNull(landingPages.deletedAt)
+          )
+        )
+        .limit(1);
+
+      if (!pageRow) return null;
+      if (pageRow.subjectType !== 'course' || !pageRow.subjectId) return null;
+
+      // The subject course — ANY status, org-scoped (guards a cross-org subjectId).
+      const [courseRow] = await this.db
+        .select({
+          id: courses.id,
+          slug: courses.slug,
+          title: courses.title,
+          kicker: courses.kicker,
+          lede: courses.lede,
+          status: courses.status,
+          priceCents: courses.priceCents,
+        })
+        .from(courses)
+        .where(
+          and(
+            eq(courses.id, pageRow.subjectId),
+            eq(courses.organizationId, organizationId),
+            isNull(courses.deletedAt)
+          )
+        )
+        .limit(1);
+
+      if (!courseRow) return null;
+
+      const [stages, testimonials] = await Promise.all([
+        this.loadPublicStages(courseRow.id),
+        this.loadTestimonials(courseRow.id),
+      ]);
+
+      const practiceCount = stages.reduce(
+        (total, stage) => total + stage.practices.length,
+        0
+      );
+
+      return {
+        page: {
+          id: pageRow.id,
+          organizationId: pageRow.organizationId,
+          publishedAt: pageRow.publishedAt?.toISOString() ?? null,
+          pageType: pageRow.pageType,
+          slug: pageRow.slug,
+          title: pageRow.title,
+          status: pageRow.status as PageStatus,
+          subjectType: pageRow.subjectType,
+          subjectId: pageRow.subjectId,
+          brandOverrides:
+            (pageRow.brandOverrides as BrandTokenOverrides) ?? null,
+          sections: (pageRow.sections as PageSection[]) ?? [],
+        },
+        course: {
+          id: courseRow.id,
+          slug: courseRow.slug,
+          title: courseRow.title,
+          kicker: courseRow.kicker,
+          lede: courseRow.lede,
+          status: courseRow.status as PageStatus,
+          priceCents: courseRow.priceCents,
+          stageCount: stages.length,
+          practiceCount,
+        },
+        stages,
+        testimonials,
+      };
+    } catch (error) {
+      this.handleError(error, 'getCoursePagePreview');
+    }
+  }
+
+  /**
    * Resolve the PUBLIC 30s sell-preview clips for a course's intro-film +
    * practice reel (SPEC §10) — the streamed, off-critical-path payload of the
    * sales page. PUBLIC: NO auth, NO `canView` (HARDENING §E). The clips reuse the

--- a/workers/content-api/src/routes/journeys.ts
+++ b/workers/content-api/src/routes/journeys.ts
@@ -397,6 +397,38 @@ app.post(
 );
 
 /**
+ * GET /api/journeys/studio/journeys/preview/by-slug?organizationId=&slug=
+ *
+ * The STUDIO live-preview read (Codex-isr02 P0b-2): the same `JourneyCoursePage`
+ * envelope as the public sell page but for ANY status, so the builder iframe can
+ * render an UNPUBLISHED draft. `requireOrgManagement` (owner/admin) re-derives
+ * the org from the session and sets `ctx.organizationId`; a non-manager / foreign
+ * caller is denied here, so the public sell load's preview fallback fail-closes
+ * to 404. The 4-segment path cannot collide with `:pageId` (3 segments), and is
+ * registered before it regardless.
+ * @returns {JourneyCoursePage | null}
+ */
+app.get(
+  '/studio/journeys/preview/by-slug',
+  procedure({
+    policy: {
+      auth: 'required',
+      requireOrgManagement: true,
+      rateLimit: 'api',
+    },
+    input: {
+      query: courseBySlugQuerySchema,
+    },
+    handler: async (ctx): Promise<JourneyCoursePage | null> => {
+      return ctx.services.courseJourney.getCoursePagePreview(
+        ctx.organizationId,
+        ctx.input.query.slug
+      );
+    },
+  })
+);
+
+/**
  * GET /api/journeys/studio/journeys/:pageId?organizationId=
  * Load a page draft into the builder (any status; org-scoped → null if foreign).
  * @returns {JourneyPageRecord | null}

--- a/workers/content-api/src/routes/journeys.ts
+++ b/workers/content-api/src/routes/journeys.ts
@@ -401,10 +401,12 @@ app.post(
  *
  * The STUDIO live-preview read (Codex-isr02 P0b-2): the same `JourneyCoursePage`
  * envelope as the public sell page but for ANY status, so the builder iframe can
- * render an UNPUBLISHED draft. `requireOrgManagement` (owner/admin) re-derives
- * the org from the session and sets `ctx.organizationId`; a non-manager / foreign
- * caller is denied here, so the public sell load's preview fallback fail-closes
- * to 404. The 4-segment path cannot collide with `:pageId` (3 segments), and is
+ * render an UNPUBLISHED draft. `requireOrgManagement` AUTHORIZES the
+ * client-supplied `organizationId` against the session user's owner/admin
+ * membership before using it as `ctx.organizationId` (the handler forwards that
+ * verified value, never the raw client one); a non-manager / foreign caller is
+ * denied here, so the public sell load's preview fallback fail-closes to 404.
+ * The 4-segment path cannot collide with `:pageId` (3 segments), and is
  * registered before it regardless.
  * @returns {JourneyCoursePage | null}
  */


### PR DESCRIPTION
## P0b-2 — draft live-preview (Codex-isr02 remainder)

Closes the two remaining gaps in the creator builder loop:
1. A brand-new **DRAFT** journey **404'd** in the builder's preview iframe (the public sell read `getCoursePage` is published-only).
2. The public sell page never mounted the **live-edit receiver**, so builder edits didn't stream.

> **Stacked** on `feat/journeys-discovery-surfaces` (P1 / PR #419) → `feat/journeys-creator-wiring` (P0b-1 / PR #418) → `dev`. Merge in order.

### Approach — Option B (public route renders drafts for org-managers, fail-closed)
Chosen over an authed `/studio/.../preview` route + layout reset because the builder iframe **already** loads `/journeys/[slug]` (the org-layout sell page — no studio sidebar) and the postMessage **sender** was already wired. The only gaps were the draft read + the receiver.

- **`@codex/access`** `getCoursePagePreview(orgId, slug)` — status-agnostic sibling of `getCoursePage` (drafts included), still org-scoped (defence-in-depth).
- **content-api** `GET /studio/journeys/preview/by-slug` (`requireOrgManagement`) — the worker authorizes the client org against session owner/admin membership; 4-segment path can't collide with `:pageId`.
- **api client + remote** (`getCoursePagePreview`) — fail-closed: catches the worker denial → null; logs only unexpected (non-403) failures.
- **Public sell load** — when `getCoursePage` is null **and** a user is signed in, fall back to the preview read; still null → 404. Anon / non-manager never see drafts.
- **Public sell `+page.svelte`** — `initPagePreviewBridge()` on mount (INERT unless embedded; safe in the public bundle) + a reactive overlay that swaps in the builder's live `sections`/`brandOverrides` when `pageBuilder.isOpen`.

### Gates (local) + review
- 11/11 access tests (3 new preview tests: draft resolves via preview not the public read; org-scoped; published resolves via both) · typecheck clean · svelte-check = baseline · biome clean
- Security-focused code review: **no CRITICAL/HIGH** (fail-closed confirmed at 4 layers; bridge inert for public visitors; import boundary holds). LOW-1 (docstring precision) + LOW-2 (observability crumb) applied.

### Live-verified (Studio Alpha)
Created a real draft → builder iframe **renders it (no 404)** → added a Hero + typed a headline → **streamed into the preview live**. 0 console errors. Throwaway draft soft-deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)