### PR TITLE
refactor(journeys): relabel user-facing "Journeys" → "Portals" (Codex-2pryk)

### DIFF
--- a/apps/web/src/lib/components/journeys/JourneyCard.svelte
+++ b/apps/web/src/lib/components/journeys/JourneyCard.svelte
@@ -27,7 +27,7 @@
     /**
      * Enrolled progress rollup. When set, the foot renders a progress ring +
      * status line ("N of M practices" / "Completed" / "Not started yet")
-     * instead of the price + "View journey" affordance.
+     * instead of the price + "View portal" affordance.
      */
     progress?: {
       percent: number;
@@ -68,7 +68,7 @@
 
 <a class="journey-card" {href} class:journey-card--enrolled={Boolean(progress)}>
   <div class="journey-card__head">
-    <span class="journey-card__badge">Journey</span>
+    <span class="journey-card__badge">Portal</span>
     {#if journey.kicker}
       <span class="journey-card__kicker">{journey.kicker}</span>
     {/if}
@@ -102,7 +102,7 @@
           {/if}
         </span>
         <span class="journey-card__go">
-          View journey
+          View portal
           <span class="journey-card__arrow" aria-hidden="true">&rarr;</span>
         </span>
       </div>

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -67,7 +67,7 @@ export const SIDEBAR_BASE_LINKS: SidebarLink[] = [
 
 /** Studio sidebar — admin-only links */
 export const SIDEBAR_ADMIN_LINKS: SidebarLink[] = [
-  { href: '/studio/journeys', label: 'Journeys', icon: 'journeys' },
+  { href: '/studio/journeys', label: 'Portals', icon: 'journeys' },
   { href: '/studio/brand', label: 'Brand', icon: 'brand' },
   { href: '/studio/categories', label: 'Categories', icon: 'categories' },
   { href: '/studio/team', label: 'Team', icon: 'team' },

--- a/apps/web/src/routes/_org/[slug]/(space)/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/+page.svelte
@@ -589,7 +589,7 @@
     {/if}
   {/await}
 
-  <!-- Guided journeys — published course-journeys for this org (Codex-oi2w4),
+  <!-- Guided portals — published course-journeys for this org (Codex-oi2w4),
        featured-first. Streamed; hidden when the org has none. -->
   {#await data.journeys then journeys}
     {#if journeys.length > 0}
@@ -597,7 +597,7 @@
         <header class="lede">
           <p class="lede__eyebrow">Go deeper</p>
           <div class="lede__title-row">
-            <h2 class="lede__title">Guided journeys</h2>
+            <h2 class="lede__title">Guided portals</h2>
             <a href="/explore" class="lede__view-all">
               Explore all
               <span aria-hidden="true">→</span>
@@ -608,7 +608,7 @@
           items={journeys}
           itemMinWidth="20rem"
           gap="var(--space-4)"
-          ariaLabel="Guided journeys"
+          ariaLabel="Guided portals"
         >
           {#snippet renderItem(journey)}
             <JourneyCard

--- a/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/explore/+page.svelte
@@ -419,18 +419,18 @@
     {/if}
   </header>
 
-  <!-- Guided journeys rail (Codex-oi2w4) — shown only on the default browse view
+  <!-- Guided portals rail (Codex-oi2w4) — shown only on the default browse view
        (the server omits it under any active filter/search). Journeys read
        differently from content (SPEC §8.5): a distinct discovery affordance
        above the content grid. -->
   {#if data.journeys.length > 0}
     <section class="explore__journeys">
       <Carousel
-        title="Guided journeys"
+        title="Guided portals"
         items={data.journeys}
         itemMinWidth="20rem"
         gap="var(--space-4)"
-        ariaLabel="Guided journeys"
+        ariaLabel="Guided portals"
       >
         {#snippet renderItem(journey)}
           <JourneyCard

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/+page.server.ts
@@ -53,7 +53,7 @@ export const load: PageServerLoad = async ({
   }
 
   if (!coursePage) {
-    throw error(404, 'This journey could not be found.');
+    throw error(404, 'This portal could not be found.');
   }
 
   // Version-keyed invalidation dependency. NOTE (flagged for the conductor):

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/+page.server.ts
@@ -29,7 +29,7 @@ export const load: PageServerLoad = async ({
 
   const coursePage = await getCoursePage({ slug: params.journeySlug });
   if (!coursePage) {
-    throw error(404, 'This journey could not be found.');
+    throw error(404, 'This portal could not be found.');
   }
 
   // Prices are server-authoritative and the pay step is per-user — a checkout

--- a/apps/web/src/routes/_org/[slug]/(space)/library/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/library/+page.svelte
@@ -46,7 +46,7 @@
   let isLoadingFromServer = $state(false);
   let loadError = $state(false);
 
-  // Enrolled journeys — the "Your journeys" shelf (Codex-oi2w4). Fetched
+  // Enrolled journeys — the "Your portals" shelf (Codex-oi2w4). Fetched
   // client-side via the remote (self-scoped to the session user + this org);
   // guests / errors resolve to an empty shelf (hidden). Independent of the
   // owned-content load so one failing never blanks the other.
@@ -278,11 +278,11 @@
     {#if enrolledJourneys.length > 0}
       <section class="library-journeys">
         <Carousel
-          title="Your journeys"
+          title="Your portals"
           items={enrolledJourneys}
           itemMinWidth="20rem"
           gap="var(--space-4)"
-          ariaLabel="Your journeys"
+          ariaLabel="Your portals"
         >
           {#snippet renderItem(journey)}
             <JourneyCard

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
@@ -76,14 +76,14 @@
 </script>
 
 <svelte:head>
-  <title>Journeys | {data.org.name}</title>
+  <title>Portals | {data.org.name}</title>
   <meta name="robots" content="noindex" />
 </svelte:head>
 
 <div class="journeys">
   <header class="journeys__bar">
     <div class="journeys__heading">
-      <h1 class="journeys__title">Journeys</h1>
+      <h1 class="journeys__title">Portals</h1>
       <p class="journeys__count" aria-live="polite">
         {loading ? 'Loading…' : `${items.length} ${items.length === 1 ? 'page' : 'pages'}`}
       </p>
@@ -104,7 +104,7 @@
 
     <a href="/studio/journeys/new" class="journeys__create">
       <PlusIcon size={16} />
-      New journey
+      New portal
     </a>
   </header>
 
@@ -163,12 +163,12 @@
     {:else}
       <div class="journeys__empty">
         <EmptyState
-          title="No journeys yet"
+          title="No portals yet"
           description="Create a course landing page and start shaping its curriculum."
           icon={CompassIcon}
         >
           {#snippet action()}
-            <a href="/studio/journeys/new" class="journeys__empty-cta">New journey</a>
+            <a href="/studio/journeys/new" class="journeys__empty-cta">New portal</a>
           {/snippet}
         </EmptyState>
       </div>

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/new/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/new/+page.svelte
@@ -44,18 +44,18 @@
 </script>
 
 <svelte:head>
-  <title>New journey | {data.org.name}</title>
+  <title>New portal | {data.org.name}</title>
   <meta name="robots" content="noindex" />
 </svelte:head>
 
 <div class="new-journey">
   <nav class="new-journey__crumbs" aria-label="Breadcrumb">
-    <a href="/studio/journeys">Journeys</a>
+    <a href="/studio/journeys">Portals</a>
     <span aria-hidden="true">/</span>
     <span aria-current="page">New</span>
   </nav>
 
-  <h1 class="new-journey__title">Create a journey</h1>
+  <h1 class="new-journey__title">Create a portal</h1>
 
   <form class="new-journey__form" onsubmit={handleSubmit}>
     <label class="new-journey__field">


### PR DESCRIPTION
## User-facing relabel: "Journeys" → "Portals"

You confirmed the product noun should be **Portals**. This is a **display-text-only** pass — routes (`/studio/journeys`, `/journeys/:slug`), identifiers, component names, CSS classes, icons, bead ids, and code comments stay `journeys` internally.

> **Stacked** on `feat/journeys-draft-preview` (#420) → #419 → #418 → `dev`. Top of the journeys stack; merge last.

### Scope (feature-label strings only; course/descriptive copy left as-is)
- **Studio**: sidebar nav label; index `<title>`/`<h1>`/empty-state + "New portal"; new-portal page title, breadcrumb, "Create a portal".
- **Member**: "Guided portals" rail (home + explore), "Your portals" shelf (library).
- **Card**: "Portal" badge + "View portal" CTA.
- **404 copy**: "This portal could not be found." (sell + checkout).

Deliberately **not** relabelled: a course's own title (e.g. "…A Somatic Journey Home"), the "a guided journey with stages…" pageType descriptor — those are content/experiential prose, not the feature label.

### Why display-only is safe here
The journeys UI strings are **hardcoded in components, not Paraglide message keys** (verified — the only journey-ish `en.json` value is an unrelated landing hero), so there's no i18n two-file churn and no route/type impact.

### Gates
svelte-check = baseline (0 net-new) · biome clean. Display-only change over surfaces already live-verified this session (home/explore/library rails, studio index, builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)