### PR TITLE
feat(journeys): studio-index revenue (batch read) + P2 audit/curriculum docs (Codex-9p47t)

### DIFF
--- a/apps/web/src/lib/remote/journeys.remote.ts
+++ b/apps/web/src/lib/remote/journeys.remote.ts
@@ -223,6 +223,28 @@ export const listJourneys = query(
   }
 );
 
+const listJourneyRevenueSchema = z
+  .object({ organizationId: z.string().uuid() })
+  .optional();
+
+/**
+ * Studio index BATCH revenue (Codex-9p47t) — authoritative gross 30d revenue per
+ * journey, keyed by landing-page id (the figure `listJourneys` omits to avoid
+ * drift from the per-journey Insights read). Runs as a SEPARATE query from
+ * `listJourneys` so the row list paints immediately and the badge streams in
+ * (SPA-native "await critical, stream secondary"). Org from the request HOST via
+ * `resolveStudioOrg`; the input org is not trusted (the worker's
+ * `requireOrgManagement` is the authority). `{}` off a non-org host.
+ */
+export const listJourneyRevenue = query(
+  listJourneyRevenueSchema,
+  async (): Promise<Record<string, number>> => {
+    const ctx = await resolveStudioOrg();
+    if (!ctx) return {};
+    return ctx.api.access.listJourneyRevenue(ctx.orgId, '30d');
+  }
+);
+
 const journeyIdSchema = z.object({ id: z.string().uuid() });
 
 /**

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1204,6 +1204,21 @@ export function createServerApi(
           )}`
         ),
 
+      /**
+       * Studio index BATCH revenue (Codex-9p47t): authoritative gross revenue
+       * per journey (30d default), keyed by landing-page id — the figure
+       * `listJourneys` omits (revenueCents null) to avoid drift. Owner/admin
+       * only; `organizationId` is for org resolution only. Money is GBP pence;
+       * journeys with no revenue are omitted from the map.
+       */
+      listJourneyRevenue: (organizationId: string, period?: string) =>
+        request<Record<string, number>>(
+          'access',
+          `/api/journeys/insights/org-revenue?organizationId=${encodeURIComponent(
+            organizationId
+          )}${period ? `&period=${encodeURIComponent(period)}` : ''}`
+        ),
+
       // ── Studio journey MANAGEMENT (Codex-isr02 · page-builder write path) ──
       // Owner/admin only — the content-api routes enforce `requireOrgManagement`
       // and re-derive scope from the session; `organizationId` here is used ONLY

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
@@ -16,7 +16,7 @@
   import type { PageStatus } from '@codex/shared-types';
   import EmptyState from '$lib/components/ui/EmptyState/EmptyState.svelte';
   import { CompassIcon, PlusIcon } from '$lib/components/ui/Icon';
-  import { listJourneys } from '$lib/remote/journeys.remote';
+  import { listJourneys, listJourneyRevenue } from '$lib/remote/journeys.remote';
 
   const { data } = $props();
 
@@ -43,6 +43,14 @@
 
   const items = $derived(journeysQuery.current ?? []);
   const loading = $derived(journeysQuery.loading);
+
+  // Authoritative per-journey revenue, keyed by landing-page id. A SEPARATE
+  // query (independent of the status filter) so the row list paints immediately
+  // and the badge streams in — the figure `listJourneys` omits by design.
+  const revenueQuery = $derived(
+    listJourneyRevenue({ organizationId: data.org.id })
+  );
+  const revenue = $derived(revenueQuery.current ?? {});
 
   const gbp = new Intl.NumberFormat('en-GB', {
     style: 'currency',
@@ -118,6 +126,7 @@
     {:else if items.length > 0}
       <ol class="journeys__rows" role="list">
         {#each items as j (j.id)}
+          {@const rev = money(revenue[j.id] ?? null)}
           <li class="journey-row">
             <div class="journey-row__main">
               <div class="journey-row__title-line">
@@ -140,8 +149,8 @@
                   <span>{j.enrolledCount} enrolled</span>
                   <span aria-hidden="true">·</span>
                 {/if}
-                {#if money(j.revenueCents)}
-                  <span>{money(j.revenueCents)}</span>
+                {#if rev}
+                  <span>{rev} · 30d</span>
                   <span aria-hidden="true">·</span>
                 {/if}
                 <span class="journey-row__updated">Updated {when(j.updatedAt)}</span>

--- a/docs/design/course-journeys/conformance-audit-2026-07-24.md
+++ b/docs/design/course-journeys/conformance-audit-2026-07-24.md
@@ -1,0 +1,65 @@
+# Journeys/Portals Conformance Audit — 2026-07-24
+
+**Bead:** `Codex-a1tz6` (P2 conformance). **Method:** live Playwright walk of all 8 shipped
+surfaces (authed as owner `creator@test.com`) vs `docs/design/course-journeys/prototype/*.html`.
+Demo: Studio Alpha, Rootwork journey (landing-page id `68479fa3-0ec5-426c-b8ee-eed9249773ca`).
+Every surface passed the **390px** overflow check (zero horizontal overflow). "Portals" display
+label correctly applied in studio (titles/h1/"New portal"); routes + ids stay `journeys`.
+Screenshots/snapshots: `01-sell.png … 08-insights.png` (+ `*.snapshot.md`) in the main worktree root.
+
+## Matrix (conformance per surface)
+
+| # | Surface | Route | Prototype | Conformance |
+|---|---|---|---|---|
+| 1 | Sell / landing | `/journeys/rootwork` | `course-sell.html` | CLOSE |
+| 2 | Checkout | `/journeys/rootwork/checkout` | `checkout.html` | MODERATE-GAP (partly by-design) |
+| 3 | Member dashboard | `/journeys/rootwork/dashboard` | `course-dashboard.html` | CLOSE |
+| 4 | In-course | `/journeys/rootwork/practice/:slug` | `content-incourse.html` | CLOSE / video broken |
+| 5 | Studio index | `/studio/journeys` | `studio-journeys.html` | CLOSE |
+| 6 | Page builder | `/studio/journeys/new` + `/:id/page` | `builder-new.html` + `builder.html` | CLOSE (exceeds in places) |
+| 7 | Curriculum editor | `/studio/journeys/:id/curriculum` | `course-editor.html` | MOCK-ONLY |
+| 8 | Insights | `/studio/journeys/:id/insights` | `reporting.html` | MAJOR-GAP (metrics never render) |
+
+## New HIGH-severity defects (not previously tracked)
+
+1. **Insights metrics broken** — `getJourneyInsights` returns `{"error":{"message":"Course not
+   found"},"status":500}` as a **500-in-a-200** for a valid published journey. Likely cause: the
+   insights remote passes the **landing-page id** where `getInsights` expects the **course id**
+   (`courses.subjectId`). Fix: `apps/web/src/lib/remote/journey-insights.remote.ts` (+ service
+   lookup). → bead **Codex-xo3bl** (insights).
+2. **Insights silent failure** — on that rejection the panel shows 7 perpetual "Loading metric"
+   skeletons; no error/empty state, no console error. Violates the platform's no-silent-failure
+   rule. Fix: rejection handling in `insights/+page.svelte` / `JourneyInsightsPanel`. → same bead **Codex-xo3bl**.
+3. **In-course video broken (dev)** — HLS `master.m3u8` served from `localhost:8787` (access
+   worker) is not in the CSP `media-src` allowlist (`localhost:4100`, `*.nip.io:4100`, r2,
+   revelations.studio) → "Playback error." Affects all dev HLS. Fix: add the access-worker origin
+   to `media-src`, or serve dev HLS from an allowlisted origin. → bead **Codex-8tku7** (CSP media-src).
+
+## MED / by-design / config
+
+- **Sell (MED):** renders 6/11 prototype sections (ache, turn/pillars, how-it-feels, guide/bio,
+  FAQ hidden/unpopulated — all block types exist in the builder). Confirm intended per-journey config.
+- **Sell (MED):** intro-video + reel render as empty gray boxes (no poster imagery).
+- **Sell (LOW-MED):** intro-film aria-label "Play the 1800-second intro film" contradicts the
+  "Ninety seconds…" heading — a duration data/label bug. → quick-fix bead **Codex-3tmt1**.
+- **Checkout (HIGH, by-design):** payment stubbed ("connected with the monetization release");
+  no tiered "Choose your way in" offers, no order summary. Tracked with WP-6 monetization.
+- **Dashboard (LOW):** in-page tabs replaced by org sidebar; "Continue" doesn't name the lesson.
+- **In-course (LOW):** shipped uses auto-complete; prototype's explicit "✓ Mark complete" +
+  course-completion state not surfaced.
+- **Studio index (MED):** filter tabs are status (All/Draft/Published/Archived) vs prototype's
+  type (All/Journeys/Pages/Drafts). Card shows "6 enrolled" where prototype shows revenue "· 30d"
+  → addressed by **Codex-9p47t** (revenue batch read).
+- **Builder (MED):** `/new` offers 2/4 types (Course, Landing page; no Retreat/Bundle — future
+  page types per D1). Edit lacks Pricing + SEO panels + "Ready to publish?" checklist. Preview
+  toggle *exceeds* prototype (Tablet/Fluid, Light/Dark, side-by-side, full-screen).
+- **Curriculum (HIGH):** disconnected mock (hardcoded `stages` at `curriculum/+page.svelte:48`,
+  mock Save, server load fetches nothing) → full-stack WP **Codex-03cwh** (planned).
+- **Insights (MED, by-design):** prototype "journey funnel" omitted; Traffic provenance shown as
+  "not captured yet" (documented, not a defect).
+
+## Disposition
+- Revenue badge gap → **Codex-9p47t** (building this session).
+- Curriculum mock → **Codex-03cwh** (planned; `curriculum-editor-wp.md`).
+- New defects → beads filed (see below). Sell-config + builder-type + checkout items are
+  design/monetization decisions for the user, not silent fixes.

--- a/docs/design/course-journeys/curriculum-editor-wp.md
+++ b/docs/design/course-journeys/curriculum-editor-wp.md
@@ -1,0 +1,147 @@
+# Curriculum Editor — Full-Stack WP Plan
+
+**Bead:** `Codex-03cwh` (child of `Codex-a1tz6` P2 conformance) · **Status:** planned, build deferred
+**Decision (2026-07-24):** scope + plan only this session; do NOT build (pending PR stack + 1–2 WP/session norm).
+**Authoritative target:** `docs/design/course-journeys/prototype/course-editor.html` + SPEC §5 + the live schema.
+
+---
+
+## 1. Why this is a real WP (not "swap the seed")
+
+The shipped editor `apps/web/src/routes/_org/[slug]/studio/journeys/[id]/curriculum/+page.svelte`
+is an **aggressive-mode mock**: local `$state` seed of stages/practices + a `setTimeout`
+`handleSave`. Its own header comment names the seam:
+
+> INTEGRATION SEAM: WP-1 backs stages/practices and WP-5 BE adds a `getCourseCurriculum`
+> query + stage/practice CRUD commands — swap the seed + `handleSave` for those.
+
+But the mock also **models the domain wrong**, so wiring alone is insufficient:
+
+| | Shipped mock | Schema + prototype (correct) |
+|---|---|---|
+| Practice identity | Free-text `{ id, title, contentType }` authored inline | A **JOIN to an existing `content` row** (`stage_practices.contentId` FK) |
+| How you add one | Type a title, pick a type | **Content picker** — "Choose from your library or upload new" |
+| Layout | Single-pane list | **Two-pane**: curriculum tree (left) + **inspector** (right) |
+
+`course-editor.html` is explicit (lines ~285–287):
+`media-slot … "linked content · tap to choose" … <button>Choose…</button>` and the callout
+*"A practice points at one piece of content (video, audio or written). Pick from your
+library or upload new — the same item can appear in more than one journey."*
+
+So a faithful editor needs new backend **and** a rebuilt front end.
+
+---
+
+## 2. What already exists (verified from source)
+
+**Schema — `packages/database/src/schema/journeys.ts`** (landed by WP-1, `Codex-2pryk.2.2`):
+
+- `course_stages` — `id`, `courseId` (FK → `courses`, cascade), `name`, `gloss` (nullable),
+  `sortOrder` (the gate order), `createdAt/updatedAt/deletedAt` (**soft delete**).
+  Unique index `uq_course_stages_course_sort` on `(courseId, sortOrder)` **among non-deleted**.
+- `stage_practices` — **join**: PK `(stageId, contentId)`, `sortOrder` (default 0).
+  `stageId` FK → `course_stages` (cascade), `contentId` FK → `content` (cascade).
+  **Hard-delete** of the association is intentional (join row, mirrors `content_categories`).
+
+**Read (private) — `CourseJourneyService.loadStages(courseId)`** (`course-journey-service.ts:1439`):
+loads the ordered non-deleted stages, each with its practices, already used by the
+builder/dashboard/public reads. Reusable as the base for the editor read.
+
+**MISSING (grep-confirmed — zero hits):** any `createStage / updateStage / reorderStage /
+softDeleteStage / addPractice / removePractice / reorderPractices / getCourseCurriculum(ForEditor)`
+method, any curriculum validation schema, any content-api curriculum write route.
+
+**Space guard (HARDENING §5):** `content.orgId === course.orgId` is enforced **in the service
+layer** via a `spaceWhere` predicate (mirrors `categories-service`). There is **no**
+`syncContentCategories`-style helper — write each association explicitly.
+
+---
+
+## 3. Backend plan (`@codex/access` · `CourseJourneyService` or a new `CourseCurriculumService`)
+
+> Placement: the curriculum is `CourseJourneyService`'s domain (it owns `loadStages`). Adding
+> the CRUD there keeps the read/write together. If the file grows unwieldy, extract a
+> `CourseCurriculumService` sharing the same db. Register in `service-registry.ts` either way.
+
+### 3.1 Admin/editor read
+`getCourseCurriculumForEditor(organizationId, courseId): Promise<EditorCurriculum>`
+- Cross-org guard first: resolve `courses` scoped to `(id=courseId, organizationId, deletedAt IS NULL)`
+  → `NotFoundError` on miss (same guard shape as `CourseInsightsService.getInsights`).
+- Return non-deleted stages by `sortOrder`, each with its practices by `sortOrder`, **plus the
+  content-picker metadata the inspector needs** (content `title`, `type`, `thumbnailUrl`,
+  publish status) — a superset of the public `JourneyPracticeView` (which omits draft/media).
+- New shared type `EditorStageView`/`EditorPracticeView` in `@codex/shared-types` (additive,
+  structurally mirrored in `apps/web/src/lib/page-builder`, per the WP-0 freeze rule).
+
+### 3.2 Write commands (all org+course scoped, space-guarded, transactional)
+- `createStage(orgId, courseId, { name, gloss })` → append at `max(sortOrder)+1`.
+- `renameStage(orgId, stageId, { name, gloss })`.
+- `reorderStages(orgId, courseId, orderedStageIds[])` → rewrite `sortOrder` in one tx.
+  **Unique-index hazard:** `(courseId, sortOrder)` is unique among non-deleted, so a naive
+  per-row update collides mid-swap. Write all rows to a temporary offset (e.g. `+1000`) then
+  to final values within the same tx, or order the updates to avoid transient collisions.
+- `softDeleteStage(orgId, stageId)` → set `deletedAt`; its `stage_practices` rows are the join
+  (leave or cascade — deleting the stage row later cascades; soft-delete keeps them, so filter
+  by non-deleted stage on read).
+- `addPractice(orgId, stageId, contentId)` → **space guard** (`content.orgId === course.orgId`
+  via the stage's course), append at `max(sortOrder)+1`; PK collision = already attached (idempotent or 409).
+- `removePractice(orgId, stageId, contentId)` → hard-delete the join row.
+- `reorderPractices(orgId, stageId, orderedContentIds[])` → rewrite `sortOrder` in one tx
+  (no unique index on practice sortOrder, so simpler than stages).
+
+### 3.3 Validation (`@codex/validation/src/schemas/journeys.ts`)
+One schema per command (uuid ids, `name` length ≤ 255 mirroring the column, `gloss` optional).
+Mirror `journeyInsightsQuerySchema`'s org-resolver note: `organizationId` is for the resolver
+only; the route re-derives `ctx.organizationId`.
+
+### 3.4 content-api routes (`workers/content-api/src/routes/journeys.ts`, studio section)
+`requireOrgManagement: true`, forward `ctx.organizationId` (NEVER the client value),
+`rateLimit: 'api'`. Suggested paths under the existing studio group:
+- `GET  /studio/journeys/:id/curriculum` → editor read
+- `POST /studio/journeys/:id/curriculum/stages` (create) · `PATCH .../stages/:stageId` (rename)
+- `POST .../stages/reorder` · `DELETE .../stages/:stageId`
+- `POST .../stages/:stageId/practices` (add) · `DELETE .../stages/:stageId/practices/:contentId`
+- `POST .../stages/:stageId/practices/reorder`
+Resolve the course from the page id (`:id` = landing page → `subjectId`), org-scoped.
+
+### 3.5 Content picker source
+The inspector's "Choose…" needs the org's content list (video/audio/written). Confirm the
+existing content-list read (likely `ContentService.list*` / a content-api public/studio list)
+and reuse it — do **not** build a new content list. Flag as a build-time dependency to verify.
+
+---
+
+## 4. Front-end plan (`apps/web`)
+
+- **API client** (`src/lib/server/api.ts`): add `access.getCourseCurriculum` + one method per command.
+- **Remotes** (`src/lib/remote/journeys.remote.ts`): `getCourseCurriculum` query + command per
+  write, all via the `resolveStudioOrg()` host-derived pattern (least-privilege; worker is the
+  auth authority).
+- **Component**: rebuild `curriculum/+page.svelte` to the prototype's **two-pane** shape —
+  left: draggable stage/practice tree (reuse the existing reorder affordances + design tokens
+  already in the file); right: **inspector** that, for a selected practice, shows the linked
+  content (`media-slot`) + a "Choose…" **content-library picker** (Melt dialog/combobox), and
+  for a selected stage, name + gloss. Replace the free-text practice title/type with the picker.
+  Drop the mock seed + `handleSave`; drive off the query + commands with optimistic updates.
+- Keep the existing admin/owner server gate (`+page.server.ts`) — it's already correct.
+
+---
+
+## 5. Tests (live-Postgres, unique-id-scoped, NO `cleanupDatabase`)
+
+Mirror `packages/access/src/services/__tests__/course-round-d.integration.test.ts` /
+`course-studio-management.integration.test.ts`:
+- read returns ordered stages+practices with content metadata; excludes soft-deleted stages.
+- each command: happy path + org isolation (foreign course/stage/content → 404/blocked).
+- `reorderStages` does not violate the `(courseId, sortOrder)` unique index (the offset dance).
+- `addPractice` space guard: content from another org is rejected.
+- FE: extend `apps/web/src/lib/server/journeys/__tests__/round-d-seam.test.ts` for the remotes.
+
+---
+
+## 6. Suggested split (likely > 1 session)
+
+- **WP-A (BE):** schema is done → service read + all commands + validation + routes + tests.
+- **WP-B (FE):** two-pane rebuild + content picker + remotes, on top of WP-A.
+This lets the BE land and be verified before the larger FE rebuild, matching the epic's
+BE→FE worktree split.

--- a/packages/access/src/services/__tests__/course-journey-revenue.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-journey-revenue.integration.test.ts
@@ -1,0 +1,330 @@
+/**
+ * CourseInsightsService.getOrgJourneyRevenue integration tests (Codex-9p47t).
+ *
+ * The studio-index revenue badge reads an AUTHORITATIVE batch figure that
+ * `listJourneysForOrg` deliberately omits (revenueCents null, to avoid a per-row
+ * money join drifting from the per-journey Insights read). This suite proves the
+ * batch read against LIVE Postgres:
+ *   - gross = completed one-off purchases + SUM over course-subscription payout
+ *     split rows (same definition as `aggregateFinancials` → no drift);
+ *   - the 30d window excludes older revenue;
+ *   - the result is keyed by LANDING-PAGE id (what the index row carries);
+ *   - journeys with no revenue are OMITTED (the badge hides falsy values);
+ *   - cross-org isolation — a foreign org's revenue is never summed or exposed;
+ *   - non-course landing pages are ignored.
+ *
+ * Every isolation assertion seeds a real foreign/zero row and asserts its
+ * ABSENCE, so the test fails if scoping regresses. Data is scoped to freshly
+ * created, unique orgs per run, so a shared branch needs no inter-test cleanup.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  courseSubscriptionPlans,
+  courseSubscriptions,
+  courses,
+  landingPages,
+  organizations,
+  payouts,
+  purchases,
+} from '@codex/database/schema';
+import {
+  createUniqueSlug,
+  type Database,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from '@codex/test-utils';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { CourseInsightsService } from '../course-insights-service';
+
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number): Date => new Date(Date.now() - n * DAY);
+
+async function createCourse(
+  db: Database,
+  orgId: string,
+  creatorId: string
+): Promise<string> {
+  const [row] = await db
+    .insert(courses)
+    .values({
+      organizationId: orgId,
+      creatorId,
+      slug: createUniqueSlug('course'),
+      title: 'Test Course',
+      status: 'published',
+      priceCents: 5000,
+    })
+    .returning({ id: courses.id });
+  if (!row) throw new Error('failed to create course');
+  return row.id;
+}
+
+/** A course-type journey page pointing at `courseId` (subjectType 'course'). */
+async function createCourseLandingPage(
+  db: Database,
+  orgId: string,
+  creatorId: string,
+  courseId: string,
+  overrides: {
+    pageType?: string;
+    subjectType?: string | null;
+    subjectId?: string | null;
+    deletedAt?: Date | null;
+  } = {}
+): Promise<string> {
+  const [row] = await db
+    .insert(landingPages)
+    .values({
+      organizationId: orgId,
+      creatorId,
+      pageType: overrides.pageType ?? 'course',
+      slug: createUniqueSlug('page'),
+      title: 'Test Journey',
+      status: 'published',
+      subjectType:
+        overrides.subjectType === undefined ? 'course' : overrides.subjectType,
+      subjectId:
+        overrides.subjectId === undefined ? courseId : overrides.subjectId,
+      deletedAt: overrides.deletedAt ?? null,
+    })
+    .returning({ id: landingPages.id });
+  if (!row) throw new Error('failed to create landing page');
+  return row.id;
+}
+
+/** A completed one-off COURSE purchase (`purchases.courseId`); gross == amount. */
+async function insertCoursePurchase(
+  db: Database,
+  opts: {
+    customerId: string;
+    courseId: string;
+    amountPaidCents: number;
+    createdAt: Date;
+    status?: string;
+  }
+): Promise<void> {
+  await db.insert(purchases).values({
+    customerId: opts.customerId,
+    courseId: opts.courseId,
+    amountPaidCents: opts.amountPaidCents,
+    currency: 'gbp',
+    // check_revenue_split_equals_total: gross = platform + org + creator.
+    platformFeeCents: 0,
+    organizationFeeCents: 0,
+    creatorPayoutCents: opts.amountPaidCents,
+    stripePaymentIntentId: `pi_${randomUUID()}`,
+    status: opts.status ?? 'completed',
+    purchasedAt: opts.createdAt,
+    createdAt: opts.createdAt,
+  });
+}
+
+async function createCourseSubscription(
+  db: Database,
+  opts: { courseId: string; userId: string; createdAt: Date }
+): Promise<string> {
+  const [plan] = await db
+    .insert(courseSubscriptionPlans)
+    .values({ courseId: opts.courseId, priceMonthly: 500, priceAnnual: 5000 })
+    .returning({ id: courseSubscriptionPlans.id });
+  if (!plan) throw new Error('failed to create plan');
+  const [sub] = await db
+    .insert(courseSubscriptions)
+    .values({
+      userId: opts.userId,
+      courseId: opts.courseId,
+      planId: plan.id,
+      stripeSubscriptionId: `sub_${randomUUID()}`,
+      stripeCustomerId: `cus_${randomUUID()}`,
+      status: 'active',
+      billingInterval: 'month',
+      currentPeriodStart: opts.createdAt,
+      currentPeriodEnd: new Date(opts.createdAt.getTime() + 30 * DAY),
+      createdAt: opts.createdAt,
+    })
+    .returning({ id: courseSubscriptions.id });
+  if (!sub) throw new Error('failed to create subscription');
+  return sub.id;
+}
+
+/**
+ * One payout split row (paid) tied to a course subscription. `userId` is
+ * required by `check_payouts_user_required` for every type except
+ * `platform_fee` (the platform isn't a user).
+ */
+async function insertSubscriptionPayout(
+  db: Database,
+  opts: {
+    courseSubscriptionId: string;
+    amountCents: number;
+    payoutType: 'platform_fee' | 'organization_fee' | 'creator_payout';
+    userId?: string | null;
+    createdAt: Date;
+  }
+): Promise<void> {
+  await db.insert(payouts).values({
+    courseSubscriptionId: opts.courseSubscriptionId,
+    userId: opts.userId ?? null,
+    amountCents: opts.amountCents,
+    currency: 'gbp',
+    payoutType: opts.payoutType,
+    status: 'paid',
+    sourceType: 'subscription',
+    stripeChargeId: `ch_${randomUUID()}`,
+    resolvedAt: opts.createdAt,
+    createdAt: opts.createdAt,
+  });
+}
+
+describe('CourseInsightsService.getOrgJourneyRevenue (Codex-9p47t)', () => {
+  let db: Database;
+  let creatorId: string;
+  let buyer: string;
+  let subscriber: string;
+  let orgAId: string;
+  let orgBId: string;
+
+  // Org A journeys.
+  let lpWithRevenue: string; // course A1 — £50 purchase + £20 sub payouts
+  let lpNoRevenue: string; // course A2 — nothing
+  let lpNonCourse: string; // a plain landing page (no course subject)
+  // Org B journey (foreign).
+  let lpForeign: string; // course B — £100 purchase
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    [creatorId, buyer, subscriber] = await seedTestUsers(db, 3);
+
+    const [orgA] = await db
+      .insert(organizations)
+      .values({ name: 'Rev Org A', slug: createUniqueSlug('rev-org-a') })
+      .returning({ id: organizations.id });
+    const [orgB] = await db
+      .insert(organizations)
+      .values({ name: 'Rev Org B', slug: createUniqueSlug('rev-org-b') })
+      .returning({ id: organizations.id });
+    if (!orgA || !orgB) throw new Error('failed to create orgs');
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    // ── Org A / course A1 — £50 one-off + £20 subscription (two split rows),
+    //    all within 30d, PLUS a £99 purchase 40 days ago that must be excluded.
+    const courseA1 = await createCourse(db, orgAId, creatorId);
+    lpWithRevenue = await createCourseLandingPage(
+      db,
+      orgAId,
+      creatorId,
+      courseA1
+    );
+    await insertCoursePurchase(db, {
+      customerId: buyer,
+      courseId: courseA1,
+      amountPaidCents: 5000,
+      createdAt: daysAgo(3),
+    });
+    await insertCoursePurchase(db, {
+      customerId: buyer,
+      courseId: courseA1,
+      amountPaidCents: 9900,
+      createdAt: daysAgo(40), // outside the 30d window → excluded
+    });
+    const subA1 = await createCourseSubscription(db, {
+      courseId: courseA1,
+      userId: subscriber,
+      createdAt: daysAgo(3),
+    });
+    // Split rows sum to the £20 gross charge (proves SUM-over-splits).
+    await insertSubscriptionPayout(db, {
+      courseSubscriptionId: subA1,
+      amountCents: 500,
+      payoutType: 'platform_fee',
+      createdAt: daysAgo(3),
+    });
+    await insertSubscriptionPayout(db, {
+      courseSubscriptionId: subA1,
+      amountCents: 1500,
+      payoutType: 'creator_payout',
+      userId: creatorId, // non-platform_fee rows require a user
+      createdAt: daysAgo(3),
+    });
+
+    // ── Org A / course A2 — no revenue at all.
+    const courseA2 = await createCourse(db, orgAId, creatorId);
+    lpNoRevenue = await createCourseLandingPage(
+      db,
+      orgAId,
+      creatorId,
+      courseA2
+    );
+
+    // ── Org A / a non-course landing page (must be ignored).
+    lpNonCourse = await createCourseLandingPage(
+      db,
+      orgAId,
+      creatorId,
+      courseA2,
+      {
+        pageType: 'landing',
+        subjectType: null,
+        subjectId: null,
+      }
+    );
+
+    // ── Org B / course B — £100 one-off (foreign org).
+    const courseB = await createCourse(db, orgBId, creatorId);
+    lpForeign = await createCourseLandingPage(db, orgBId, creatorId, courseB);
+    await insertCoursePurchase(db, {
+      customerId: buyer,
+      courseId: courseB,
+      amountPaidCents: 10000,
+      createdAt: daysAgo(3),
+    });
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  it('sums purchases + subscription payout splits within 30d, keyed by landing-page id', async () => {
+    const svc = new CourseInsightsService({ db, environment: 'test' });
+    const result = await svc.getOrgJourneyRevenue(orgAId);
+    // 5000 (purchase) + 500 + 1500 (payout splits) = 7000; the £99 40-days-ago
+    // purchase is outside the 30d window and must NOT be counted.
+    expect(result[lpWithRevenue]).toBe(7000);
+  });
+
+  it('omits journeys with no revenue (badge hides falsy values)', async () => {
+    const svc = new CourseInsightsService({ db, environment: 'test' });
+    const result = await svc.getOrgJourneyRevenue(orgAId);
+    expect(result[lpNoRevenue]).toBeUndefined();
+  });
+
+  it('ignores non-course landing pages', async () => {
+    const svc = new CourseInsightsService({ db, environment: 'test' });
+    const result = await svc.getOrgJourneyRevenue(orgAId);
+    expect(result[lpNonCourse]).toBeUndefined();
+  });
+
+  it("never sums or exposes another org's revenue (cross-org isolation)", async () => {
+    const svc = new CourseInsightsService({ db, environment: 'test' });
+    const resultA = await svc.getOrgJourneyRevenue(orgAId);
+    // Org B's journey never appears in org A's map…
+    expect(resultA[lpForeign]).toBeUndefined();
+    // …and org A's total is exactly its own revenue (no foreign bleed).
+    expect(Object.values(resultA).reduce((a, b) => a + b, 0)).toBe(7000);
+
+    // Org B sees only its own £100.
+    const resultB = await svc.getOrgJourneyRevenue(orgBId);
+    expect(resultB[lpForeign]).toBe(10000);
+    expect(resultB[lpWithRevenue]).toBeUndefined();
+  });
+
+  it('respects the period window (7d excludes the 3-day-old-only totals correctly)', async () => {
+    const svc = new CourseInsightsService({ db, environment: 'test' });
+    // All org-A revenue is 3 days old, so a 7d window still includes it.
+    const sevenDay = await svc.getOrgJourneyRevenue(orgAId, '7d');
+    expect(sevenDay[lpWithRevenue]).toBe(7000);
+  });
+});

--- a/packages/access/src/services/course-insights-service.ts
+++ b/packages/access/src/services/course-insights-service.ts
@@ -45,6 +45,7 @@ import {
   courseEnrollments,
   courseSubscriptions,
   courses,
+  landingPages,
   payouts,
   purchases,
 } from '@codex/database/schema';
@@ -177,6 +178,115 @@ export class CourseInsightsService extends BaseService {
       };
     } catch (error) {
       this.handleError(error, 'getInsights');
+    }
+  }
+
+  /**
+   * BATCH course revenue for the studio index badge — gross revenue over
+   * `period` (default 30d) for every course-type journey the org owns, keyed by
+   * **landing-page id** (the id each index row already carries). This is the
+   * authoritative figure `listJourneysForOrg` deliberately returns as `null`
+   * (see its docstring): the per-row money join lives HERE, computed with the
+   * SAME definition as {@link aggregateFinancials} (one-off course purchases +
+   * course-subscription payouts), so the badge can never drift from the
+   * per-journey Insights read. Org-scoped by construction — the course ids come
+   * only from the org's own non-deleted `landing_pages`, so no foreign revenue
+   * can be summed. Only pages with `> 0` revenue are returned (the badge hides
+   * falsy values, matching the prototype's `it.revenue ? … : ''`).
+   */
+  async getOrgJourneyRevenue(
+    organizationId: string,
+    period: InsightsPeriod = '30d'
+  ): Promise<Record<string, number>> {
+    try {
+      // Org's non-deleted course-type journeys → (landingPageId, courseId). The
+      // inner join to a non-deleted, same-org course is the cross-org guard.
+      const pages = await this.db
+        .select({ landingPageId: landingPages.id, courseId: courses.id })
+        .from(landingPages)
+        .innerJoin(
+          courses,
+          and(
+            eq(courses.id, landingPages.subjectId),
+            eq(courses.organizationId, landingPages.organizationId),
+            isNull(courses.deletedAt)
+          )
+        )
+        .where(
+          and(
+            eq(landingPages.organizationId, organizationId),
+            eq(landingPages.subjectType, 'course'),
+            isNull(landingPages.deletedAt)
+          )
+        );
+
+      if (pages.length === 0) return {};
+
+      const courseIds = pages.map((p) => p.courseId);
+      const window = resolveInsightsWindow(period, new Date());
+
+      // Two GROUPED aggregates (no per-row N+1), each mirroring one arm of
+      // `aggregateFinancials`: completed one-off purchases + course-subscription
+      // payout ledger rows, summed within `[start, end)`, grouped by course.
+      const [purchaseRows, payoutRows] = await Promise.all([
+        this.db
+          .select({
+            courseId: purchases.courseId,
+            gross: sql<number>`coalesce(sum(${purchases.amountPaidCents}), 0)`,
+          })
+          .from(purchases)
+          .where(
+            and(
+              inArray(purchases.courseId, courseIds),
+              eq(purchases.status, PURCHASE_STATUS_COMPLETED),
+              gte(purchases.createdAt, window.start),
+              lt(purchases.createdAt, window.end)
+            )
+          )
+          .groupBy(purchases.courseId),
+        this.db
+          .select({
+            courseId: courseSubscriptions.courseId,
+            gross: sql<number>`coalesce(sum(${payouts.amountCents}), 0)`,
+          })
+          .from(payouts)
+          .innerJoin(
+            courseSubscriptions,
+            eq(payouts.courseSubscriptionId, courseSubscriptions.id)
+          )
+          .where(
+            and(
+              inArray(courseSubscriptions.courseId, courseIds),
+              inArray(payouts.status, [...PAYOUT_REVENUE_STATUSES]),
+              gte(payouts.createdAt, window.start),
+              lt(payouts.createdAt, window.end)
+            )
+          )
+          .groupBy(courseSubscriptions.courseId),
+      ]);
+
+      const byCourse = new Map<string, number>();
+      for (const r of purchaseRows) {
+        if (r.courseId) byCourse.set(r.courseId, Number(r.gross ?? 0));
+      }
+      for (const r of payoutRows) {
+        if (r.courseId) {
+          byCourse.set(
+            r.courseId,
+            (byCourse.get(r.courseId) ?? 0) + Number(r.gross ?? 0)
+          );
+        }
+      }
+
+      // Re-key by landing-page id; omit zero (the badge hides falsy values).
+      const out: Record<string, number> = {};
+      for (const p of pages) {
+        const cents = byCourse.get(p.courseId) ?? 0;
+        if (cents > 0) out[p.landingPageId] = cents;
+      }
+      return out;
+    } catch (error) {
+      this.handleError(error, 'getOrgJourneyRevenue');
     }
   }
 

--- a/packages/validation/src/schemas/journeys.ts
+++ b/packages/validation/src/schemas/journeys.ts
@@ -99,6 +99,23 @@ export const journeyInsightsQuerySchema = z.object({
 export type JourneyInsightsQuery = z.infer<typeof journeyInsightsQuerySchema>;
 
 /**
+ * Studio index BATCH-revenue query (Codex-9p47t) — `GET
+ * /api/journeys/insights/org-revenue`. Owner/admin only via
+ * `requireOrgManagement`. Returns authoritative gross revenue per journey keyed
+ * by landing-page id (the figure `listJourneysForOrg` omits to avoid drift).
+ * `organizationId` is consumed ONLY by the `procedure()` org resolver; the route
+ * re-derives the authoritative scope from `ctx.organizationId`. No `courseId` —
+ * this is org-wide. `period` defaults to 30 days (matching the badge label).
+ */
+export const orgJourneyRevenueQuerySchema = z.object({
+  organizationId: uuidSchema,
+  period: z.enum(['7d', '30d', '90d', 'all']).default('30d'),
+});
+export type OrgJourneyRevenueQuery = z.infer<
+  typeof orgJourneyRevenueQuerySchema
+>;
+
+/**
  * ── CREATOR / STUDIO management inputs (Codex-isr02 · page-builder write path) ──
  *
  * All creator routes are `requireOrgManagement`; `organizationId` is consumed

--- a/workers/content-api/src/routes/journey-insights.ts
+++ b/workers/content-api/src/routes/journey-insights.ts
@@ -1,6 +1,9 @@
 import type { JourneyInsightsData } from '@codex/access';
 import type { HonoEnv } from '@codex/shared-types';
-import { journeyInsightsQuerySchema } from '@codex/validation';
+import {
+  journeyInsightsQuerySchema,
+  orgJourneyRevenueQuerySchema,
+} from '@codex/validation';
 import { procedure } from '@codex/worker-utils';
 import { Hono } from 'hono';
 
@@ -48,6 +51,38 @@ app.get(
       return ctx.services.courseInsights.getInsights(
         ctx.organizationId,
         courseId,
+        period
+      );
+    },
+  })
+);
+
+/**
+ * GET /api/journeys/insights/org-revenue?organizationId=&period=
+ *
+ * BATCH authoritative gross revenue for every course-type journey the org owns,
+ * keyed by landing-page id — the studio index badge (Codex-9p47t). Same
+ * `requireOrgManagement` guard as the per-course insights read; the handler
+ * forwards `ctx.organizationId`, never the client value.
+ *
+ * @returns {Record<string, number>} landing-page id → gross revenue (GBP pence);
+ * pages with no revenue are omitted.
+ */
+app.get(
+  '/org-revenue',
+  procedure({
+    policy: {
+      auth: 'required',
+      requireOrgManagement: true,
+      rateLimit: 'api', // 100 req/min
+    },
+    input: {
+      query: orgJourneyRevenueQuerySchema,
+    },
+    handler: async (ctx): Promise<Record<string, number>> => {
+      const { period } = ctx.input.query;
+      return ctx.services.courseInsights.getOrgJourneyRevenue(
+        ctx.organizationId,
         period
       );
     },


### PR DESCRIPTION
## P2 reconciliation (Codex-a1tz6) — revenue build + audit/curriculum deliverables

**Stacked PR #5** — base `chore/journeys-portals-relabel` (#421). Merge AFTER #418→#419→#420→#421.

### 1. Per-journey revenue on the studio index (Codex-9p47t) — the code change
The studio index revenue badge slot was wired but **dead**: `listJourneysForOrg`
returns `revenueCents=null` *by design* (its docstring: avoid a per-row money join
drifting from the authoritative `CourseInsightsService` figure), so `{#if money(...)}`
was always false. Per the user's decision, revenue is surfaced via a **separate,
authoritative batch read** streamed into the index.

- `CourseInsightsService.getOrgJourneyRevenue(orgId, period='30d')` → `Record<landingPageId, cents>`.
  Two grouped aggregates — completed course purchases + course-subscription payout
  split rows — over `resolveInsightsWindow`, the **same definition as `aggregateFinancials`**
  (no drift). Org-scoped by construction (course ids come only from the org's own
  non-deleted `landing_pages`; inner-join to a same-org, non-deleted course is the guard).
- content-api `GET /api/journeys/insights/org-revenue` — `requireOrgManagement`,
  forwards `ctx.organizationId` (never the client value).
- `listJourneyRevenue` remote + api-client method; the index runs it as a **second
  streamed query** (`$derived`) and fills the `£X · 30d` badge keyed by landing-page id.
  `listJourneysForOrg` stays pure; the frozen `JourneyListItem` is untouched.
- `orgJourneyRevenueQuerySchema` validation.
- **Test:** live-Postgres integration — sum-over-splits, 30d window boundary, cross-org
  isolation (asserts *absence*), zero/non-course omission. Unique-id-scoped, no `cleanupDatabase`.

### Local gate (CI is down — gated locally)
- typecheck: `@codex/access`, `@codex/validation`, `content-api` ✅
- biome: all changed `.ts` ✅
- integration test: **5/5** against live Postgres ✅
- svelte-check: **86/86 baseline (0 net-new)**, changed files 0 errors + 0 warnings ✅

### Live verification (Playwright, Studio Alpha / Rootwork)
- Badge renders **`£128 · 30d`** = 9800 (purchases) + 3000 (subscription payouts)
  within 30d; the 44-day-old £49 correctly excluded — **matches a direct DB reproduction
  of the formula** (authoritative, no drift).
- **0 console errors**; **0 horizontal overflow @390px**; "Portals" label intact.

### 2. Docs — the other two P2 deliverables
- `conformance-audit-2026-07-24.md` — full 8-surface delta matrix vs the prototype.
  Surfaced two **new HIGH defects** (filed as beads, out of scope here): **Codex-xo3bl**
  (Insights returns "Course not found" as a 500-in-a-200 + infinite silent skeleton —
  likely landing-page-id vs course-id), **Codex-8tku7** (dev HLS blocked by CSP
  `media-src`), plus **Codex-3tmt1** (P3 intro-film aria duration).
- `curriculum-editor-wp.md` — implementation-ready plan for the deferred full-stack
  curriculum WP (**Codex-03cwh**): the editor is a mock, and a "practice" is a *join to
  an existing content row*, so it needs a content picker + two-pane rebuild + new BE
  CRUD/read — scoped, not built this session (user's decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
