### PR TITLE
feat(web): course dashboard fidelity pass vs prototype (Codex-2pryk.3.4)

### DIFF
--- a/apps/web/src/lib/components/journeys/CurriculumMap.svelte
+++ b/apps/web/src/lib/components/journeys/CurriculumMap.svelte
@@ -1,223 +1,379 @@
 <!--
   @component CurriculumMap
 
-  The journey dashboard's curriculum: ordered stages (gates), each with its
-  concurrent practice pool and a per-stage progress ring. Practices link into
-  the in-course player and show completion state (the `practice_completions`
-  row — source of truth). Presentational: completion + rollup are supplied.
+  "The whole arc" — the course curriculum as a stage accordion (SPEC §8.3,
+  prototype `course-dashboard.html` `.map`). One `<details>` per ordered stage:
+  the CURRENT stage (the one holding the resume target) is open; DONE stages
+  (every practice complete) and upcoming stages collapse. Each lesson row shows
+  its completion state (done ✓ / current ● / upcoming medium glyph) and links
+  into the in-course player.
 
-  @prop {JourneyStage[]} stages - Ordered curriculum from the server load.
-  @prop {ReadonlySet<string>} completedIds - Content ids with a completion row.
-  @prop {CourseRollup} rollup - Per-stage + overall counts (computed by caller).
-  @prop {string} courseSlug - For building /journeys/{slug}/practice/{slug} hrefs.
+  Presentational: completion + rollup + the resume pointer are supplied by the
+  dashboard root; colours read the re-pointed portal palette so the map stays
+  legible on the warm/dark surface.
 -->
 <script lang="ts">
   import {
-    CheckCircleIcon,
-    CircleIcon,
+    CheckIcon,
+    ChevronRightIcon,
     FileTextIcon,
     MusicIcon,
     VideoIcon,
   } from '$lib/components/ui/Icon';
   import type { CourseRollup } from '$lib/journeys/rollup';
+  import {
+    countWord,
+    practiceKindLabel,
+    practiceMinutes,
+    stageNumeral,
+  } from '$lib/journeys/practice-display';
   import type {
-    JourneyPractice,
     JourneyStage,
     PracticeContentType,
   } from '$lib/journeys/types';
-  import ProgressRing from './ProgressRing.svelte';
 
   interface Props {
     stages: JourneyStage[];
     completedIds: ReadonlySet<string>;
     rollup: CourseRollup;
     courseSlug: string;
+    /** Content id of the resume target — its row renders as "current" (●). */
+    currentContentId: string | null;
+    /** Stage that owns the resume target — auto-opened. */
+    currentStageId: string | null;
   }
 
-  const { stages, completedIds, rollup, courseSlug }: Props = $props();
+  const {
+    stages,
+    completedIds,
+    rollup,
+    courseSlug,
+    currentContentId,
+    currentStageId,
+  }: Props = $props();
 
   const orderedStages = $derived(
     [...stages].sort((a, b) => a.sortOrder - b.sortOrder)
   );
 
-  function iconFor(type: PracticeContentType) {
-    if (type === 'video') return VideoIcon;
-    if (type === 'audio') return MusicIcon;
-    return FileTextIcon;
-  }
-
-  function practiceHref(practice: JourneyPractice): string {
-    return `/journeys/${courseSlug}/practice/${practice.slug ?? practice.contentId}`;
-  }
-
   const EMPTY_COUNTS = { done: 0, total: 0, percent: 0 };
+
+  function iconFor(type: PracticeContentType) {
+    if (type === 'audio') return MusicIcon;
+    if (type === 'written') return FileTextIcon;
+    return VideoIcon;
+  }
+
+  function practiceHref(slug: string | null, contentId: string): string {
+    return `/journeys/${courseSlug}/practice/${slug ?? contentId}`;
+  }
 </script>
 
-<div class="curriculum">
-  {#each orderedStages as stage, stageIndex (stage.id)}
-    {@const counts = rollup.byStage.get(stage.id) ?? EMPTY_COUNTS}
-    {@const orderedPractices = [...stage.practices].sort(
-      (a, b) => a.sortOrder - b.sortOrder
-    )}
-    <section class="stage">
-      <header class="stage__header">
-        <div class="stage__heading">
-          <span class="stage__index">Stage {stageIndex + 1}</span>
-          <h2 class="stage__name">{stage.name}</h2>
-          {#if stage.gloss}
-            <p class="stage__gloss">{stage.gloss}</p>
-          {/if}
-        </div>
-        <div class="stage__progress">
-          <ProgressRing
-            percent={counts.percent}
-            size="var(--space-14)"
-            ariaLabel="{stage.name}: {counts.done} of {counts.total} practices complete"
-          />
-          <span class="stage__count">{counts.done}/{counts.total}</span>
-        </div>
-      </header>
+<section class="map">
+  <p class="map__kicker">
+    The whole arc — {countWord(orderedStages.length)}
+    {orderedStages.length === 1 ? 'stage' : 'stages'}
+  </p>
 
-      <ul class="practices">
-        {#each orderedPractices as practice (practice.contentId)}
-          {@const done = completedIds.has(practice.contentId)}
-          {@const Icon = iconFor(practice.contentType)}
-          <li class="practice" class:practice--done={done}>
-            <a class="practice__link" href={practiceHref(practice)}>
-              <span class="practice__status" aria-hidden="true">
+  <div class="map__stages">
+    {#each orderedStages as stage, stageIndex (stage.id)}
+      {@const counts = rollup.byStage.get(stage.id) ?? EMPTY_COUNTS}
+      {@const allDone = counts.total > 0 && counts.done === counts.total}
+      {@const isCurrent = stage.id === currentStageId}
+      {@const orderedPractices = [...stage.practices].sort(
+        (a, b) => a.sortOrder - b.sortOrder
+      )}
+      <details
+        class="stage"
+        class:stage--current={isCurrent}
+        class:stage--done={!isCurrent && allDone}
+        open={isCurrent}
+      >
+        <summary class="stage__head">
+          <span class="stage__numeral">{stageNumeral(stageIndex)}</span>
+          <span class="stage__labels">
+            <span class="stage__name">{stage.name}</span>
+            {#if stage.gloss}
+              <span class="stage__gloss">{stage.gloss}</span>
+            {/if}
+          </span>
+          <span class="stage__count">{counts.done}/{counts.total}</span>
+          <span class="stage__chevron"><ChevronRightIcon size={18} /></span>
+        </summary>
+
+        <div class="stage__lessons">
+          {#each orderedPractices as practice (practice.contentId)}
+            {@const done = completedIds.has(practice.contentId)}
+            {@const isCur = practice.contentId === currentContentId}
+            {@const minutes = practiceMinutes(practice.durationSeconds)}
+            {@const TypeIcon = iconFor(practice.contentType)}
+            <a
+              class="lrow"
+              class:lrow--done={done}
+              class:lrow--current={isCur}
+              href={practiceHref(practice.slug, practice.contentId)}
+            >
+              <span
+                class="lrow__icon"
+                class:lrow__icon--done={done}
+                class:lrow__icon--current={isCur}
+                aria-hidden="true"
+              >
                 {#if done}
-                  <CheckCircleIcon />
+                  <CheckIcon size={13} />
+                {:else if isCur}
+                  <span class="lrow__dot"></span>
                 {:else}
-                  <CircleIcon />
+                  <TypeIcon size={13} />
                 {/if}
               </span>
-              <span class="practice__type" aria-hidden="true"><Icon /></span>
-              <span class="practice__title">{practice.title}</span>
-              <span class="practice__meta">
-                {#if done}Complete{:else}{practice.contentType}{/if}
+              <span class="lrow__labels">
+                <span class="lrow__title">{practice.title}</span>
+                <span class="lrow__meta">
+                  {practiceKindLabel(practice.contentType)}{minutes
+                    ? ` · ${minutes} min`
+                    : ''}
+                </span>
               </span>
+              <span class="lrow__go">{isCur ? 'Resume →' : 'Open →'}</span>
             </a>
-          </li>
-        {/each}
-      </ul>
-    </section>
-  {/each}
-</div>
+          {/each}
+        </div>
+      </details>
+    {/each}
+  </div>
+</section>
 
 <style>
-  .curriculum {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-8);
-  }
-
-  .stage__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--space-4);
-    padding-bottom: var(--space-3);
-    margin-bottom: var(--space-4);
-    border-bottom: var(--border-width) var(--border-style) var(--color-border-subtle);
-  }
-
-  .stage__index {
-    display: block;
+  .map__kicker {
+    margin: 0 0 var(--space-4);
     font-size: var(--text-xs);
-    text-transform: var(--text-transform-label);
-    letter-spacing: 0.06em;
-    color: var(--color-text-muted);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--portal-text-faint);
   }
 
-  .stage__name {
-    margin: var(--space-0-5) 0 0;
-    font-family: var(--font-heading);
-    font-size: var(--text-xl);
-    color: var(--color-heading);
-  }
-
-  .stage__gloss {
-    margin: var(--space-1) 0 0;
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-    max-width: 52ch;
-  }
-
-  .stage__progress {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-1);
-    flex-shrink: 0;
-  }
-
-  .stage__count {
-    font-size: var(--text-xs);
-    color: var(--color-text-muted);
-  }
-
-  .practices {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  .map__stages {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
 
-  .practice__link {
+  /* ── stage (accordion) ─────────────────────────────────────────────────── */
+  .stage {
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--portal-text) 10%, transparent);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: color-mix(in oklab, var(--portal-surface) 45%, transparent);
+  }
+
+  .stage[open] {
+    border-color: color-mix(in oklab, var(--portal-text) 16%, transparent);
+    background: color-mix(in oklab, var(--portal-surface-2) 55%, transparent);
+  }
+
+  .stage--current {
+    border-color: color-mix(in oklab, var(--portal-ember) 34%, transparent);
+  }
+
+  .stage__head {
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-    border-radius: var(--radius-card);
-    color: var(--color-text);
-    text-decoration: none;
-    transition:
-      background-color var(--duration-fast) ease,
-      transform var(--duration-fast) ease;
+    padding: var(--space-4) var(--space-4);
+    cursor: pointer;
+    list-style: none;
   }
 
-  .practice__link:hover {
-    background: var(--color-surface-secondary);
+  .stage__head::-webkit-details-marker {
+    display: none;
   }
 
-  .practice__link:focus-visible {
+  .stage__head:focus-visible {
     outline: none;
     box-shadow: var(--shadow-focus-ring);
   }
 
-  .practice__status {
-    display: inline-flex;
-    color: var(--color-text-muted);
+  .stage__numeral {
+    flex: none;
+    width: var(--space-8);
+    height: var(--space-8);
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-size: var(--text-sm);
+    color: var(--portal-text-dim);
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--portal-text) 18%, transparent);
   }
 
-  .practice--done .practice__status {
-    color: var(--color-success);
+  .stage--done .stage__numeral {
+    background: color-mix(in oklab, var(--portal-ember) 20%, transparent);
+    border-color: transparent;
+    color: var(--portal-ember);
   }
 
-  .practice__type {
-    display: inline-flex;
-    color: var(--color-text-muted);
+  .stage--current .stage__numeral {
+    border-color: var(--portal-ember);
+    color: var(--portal-ember);
+    box-shadow: 0 0 var(--space-3) calc(var(--border-width) * 1)
+      color-mix(in oklab, var(--portal-ember) 35%, transparent);
   }
 
-  .practice__title {
+  .stage__labels {
+    min-width: 0;
     flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stage__name {
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    line-height: var(--leading-snug);
+    color: var(--portal-text);
+  }
+
+  .stage__gloss {
+    margin-top: var(--space-0-5);
+    font-size: var(--text-sm);
+    color: var(--portal-text-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .stage__count {
+    flex: none;
+    font-size: var(--text-sm);
+    color: var(--portal-text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stage__chevron {
+    flex: none;
+    display: inline-flex;
+    color: var(--portal-text-faint);
+    transition: transform var(--duration-normal) var(--ease-out);
+  }
+
+  .stage[open] .stage__chevron {
+    transform: rotate(90deg);
+  }
+
+  /* ── lesson rows ───────────────────────────────────────────────────────── */
+  .stage__lessons {
+    padding: 0 var(--space-2) var(--space-2);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .lrow {
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-2-5) var(--space-2-5);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    transition: background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .lrow:hover {
+    background: color-mix(in oklab, var(--portal-text) 6%, transparent);
+  }
+
+  .lrow--current {
+    background: color-mix(in oklab, var(--portal-ember) 12%, transparent);
+  }
+
+  .lrow:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .lrow__icon {
+    flex: none;
+    width: var(--space-6);
+    height: var(--space-6);
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    color: var(--portal-text-faint);
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--portal-text) 26%, transparent);
+  }
+
+  .lrow__icon--done {
+    background: var(--portal-ember);
+    border-color: var(--portal-ember);
+    color: var(--portal-ember-ink);
+  }
+
+  .lrow__icon--current {
+    border-color: var(--portal-ember);
+    color: var(--portal-ember);
+    box-shadow: 0 0 var(--space-2-5) calc(var(--border-width) * 1)
+      color-mix(in oklab, var(--portal-ember) 40%, transparent);
+  }
+
+  .lrow__dot {
+    width: var(--space-2);
+    height: var(--space-2);
+    border-radius: var(--radius-full);
+    background: var(--portal-ember);
+  }
+
+  .lrow__labels {
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .lrow__title {
+    font-family: var(--font-heading);
     font-size: var(--text-base);
-    color: var(--color-heading);
+    line-height: var(--leading-snug);
+    color: var(--portal-text);
   }
 
-  .practice--done .practice__title {
-    color: var(--color-text-secondary);
+  .lrow--done .lrow__title {
+    color: var(--portal-text-dim);
   }
 
-  .practice__meta {
+  .lrow__meta {
+    margin-top: var(--space-0-5);
     font-size: var(--text-xs);
-    text-transform: var(--text-transform-meta);
-    color: var(--color-text-muted);
+    color: var(--portal-text-faint);
   }
 
-  .practice--done .practice__meta {
-    color: var(--color-success);
+  .lrow__go {
+    flex: none;
+    font-size: var(--text-sm);
+    color: var(--portal-ember);
+    opacity: 0;
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+
+  .lrow:hover .lrow__go,
+  .lrow--current .lrow__go {
+    opacity: 1;
+  }
+
+  @media (--below-sm) {
+    .stage__gloss {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stage__chevron,
+    .lrow,
+    .lrow__go {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/components/journeys/JourneyContinueCard.svelte
+++ b/apps/web/src/lib/components/journeys/JourneyContinueCard.svelte
@@ -1,0 +1,243 @@
+<!--
+  @component JourneyContinueCard
+
+  The single "threshold" back into the course (SPEC §8.3 continue-where-left-off,
+  prototype `course-dashboard.html` `.cont`). One tap to resume: a media plate
+  (play/read glyph + overall %) beside the state-aware framing (Begin / Resume /
+  Revisit) and the practice's stage + medium + duration.
+
+  Presentational — the parent resolves WHICH practice to resume to and the
+  journey state; this component only renders the threshold. Colours read the
+  portal palette re-pointed by the dashboard root, so it stays legible and
+  brand-reactive on the warm/dark surface.
+-->
+<script lang="ts">
+  import { ArrowRightIcon, EditIcon, PlayIcon } from '$lib/components/ui/Icon';
+  import {
+    practiceKindLabel,
+    practiceMinutes,
+    stageNumeral,
+  } from '$lib/journeys/practice-display';
+  import type { PracticeContentType } from '$lib/journeys/types';
+
+  interface Props {
+    href: string;
+    title: string;
+    contentType: PracticeContentType;
+    stageName: string;
+    /** Zero-based stage position, for the roman numeral in the meta row. */
+    stageIndex: number;
+    durationSeconds: number | null;
+    /** Overall course completion 0–100 (the plate badge). */
+    percent: number;
+    /** Journey state → framing + CTA verb. */
+    state: 'begin' | 'resume' | 'revisit';
+  }
+
+  const {
+    href,
+    title,
+    contentType,
+    stageName,
+    stageIndex,
+    durationSeconds,
+    percent,
+    state,
+  }: Props = $props();
+
+  const minutes = $derived(practiceMinutes(durationSeconds));
+  const isWritten = $derived(contentType === 'written');
+
+  const eyebrow = $derived(
+    state === 'begin'
+      ? 'Begin your journey'
+      : state === 'revisit'
+        ? "You've walked this whole journey"
+        : 'Continue where you left off'
+  );
+  const cta = $derived(
+    state === 'begin' ? 'Begin' : state === 'revisit' ? 'Revisit' : 'Resume'
+  );
+
+  const meta = $derived(
+    [
+      `Stage ${stageNumeral(stageIndex)}`,
+      stageName,
+      practiceKindLabel(contentType),
+      minutes ? `${minutes} min` : null,
+    ]
+      .filter(Boolean)
+      .join(' · ')
+  );
+</script>
+
+<a class="cont" {href}>
+  <div class="cont__media" aria-hidden="true">
+    <span class="cont__play">
+      {#if isWritten}
+        <EditIcon size={22} />
+      {:else}
+        <PlayIcon size={22} fill="currentColor" />
+      {/if}
+    </span>
+    <span class="cont__pct">{percent}%</span>
+  </div>
+
+  <div class="cont__body">
+    <p class="cont__eyebrow">{eyebrow}</p>
+    <h2 class="cont__title">{title}</h2>
+    <p class="cont__meta">{meta}</p>
+    <span class="cont__cta">
+      {cta}
+      <span class="cont__arrow"><ArrowRightIcon size={16} /></span>
+    </span>
+  </div>
+</a>
+
+<style>
+  .cont {
+    display: flex;
+    gap: var(--space-5);
+    align-items: stretch;
+    padding: var(--space-4);
+    border-radius: var(--radius-xl, var(--radius-lg));
+    text-decoration: none;
+    background: color-mix(in oklab, var(--portal-ember) 9%, var(--portal-surface));
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--portal-ember) 30%, transparent);
+    box-shadow: 0 var(--space-5) var(--space-16) calc(-1 * var(--space-8))
+      color-mix(in oklab, var(--portal-ember) 55%, var(--portal-bg-deep));
+    transition:
+      transform var(--duration-normal) var(--ease-out),
+      border-color var(--duration-normal) var(--ease-out);
+  }
+
+  .cont:hover {
+    transform: translateY(calc(-1 * var(--space-0-5)));
+    border-color: color-mix(in oklab, var(--portal-ember) 55%, transparent);
+  }
+
+  .cont:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .cont__media {
+    flex: none;
+    width: clamp(7.5rem, 30vw, 12.5rem);
+    border-radius: var(--radius-lg);
+    position: relative;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    background: radial-gradient(
+      130% 120% at 50% 0%,
+      color-mix(in oklab, var(--portal-ember-soft) 45%, var(--portal-surface-2)),
+      var(--portal-bg-deep)
+    );
+  }
+
+  .cont__play {
+    width: var(--space-12);
+    height: var(--space-12);
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    color: var(--portal-ember-ink);
+    background: color-mix(in oklab, var(--portal-ember) 92%, var(--portal-text));
+    box-shadow: 0 var(--space-2) var(--space-6) calc(-1 * var(--space-1))
+      color-mix(in oklab, var(--portal-ember) 70%, var(--portal-bg-deep));
+  }
+
+  .cont__pct {
+    position: absolute;
+    bottom: var(--space-2);
+    left: var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--portal-text-dim);
+    background: color-mix(in oklab, var(--portal-bg-deep) 70%, transparent);
+    padding: var(--space-0-5) var(--space-2);
+    border-radius: var(--radius-full);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cont__body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: var(--space-2) var(--space-2) var(--space-2) 0;
+    min-width: 0;
+  }
+
+  .cont__eyebrow {
+    margin: 0;
+    font-size: var(--text-xs);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--portal-ember);
+  }
+
+  .cont__title {
+    margin: var(--space-1) 0;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-2xl);
+    line-height: var(--leading-tight);
+    color: var(--portal-text);
+  }
+
+  .cont__meta {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--portal-text-faint);
+  }
+
+  .cont__cta {
+    margin-top: var(--space-4);
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-5);
+    border-radius: var(--radius-full);
+    font-weight: var(--font-semibold);
+    font-size: var(--text-sm);
+    color: var(--portal-ember-ink);
+    background: linear-gradient(
+      180deg,
+      var(--portal-ember),
+      var(--portal-ember-soft)
+    );
+  }
+
+  .cont__arrow {
+    display: inline-flex;
+    transition: transform var(--duration-fast) var(--ease-out);
+  }
+
+  .cont:hover .cont__arrow {
+    transform: translateX(var(--space-1));
+  }
+
+  @media (--below-sm) {
+    .cont {
+      flex-direction: column;
+    }
+
+    .cont__media {
+      width: 100%;
+      aspect-ratio: 16 / 8;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cont,
+    .cont__arrow {
+      transition: none;
+    }
+
+    .cont:hover {
+      transform: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/journeys/practice-display.test.ts
+++ b/apps/web/src/lib/journeys/practice-display.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countWord,
+  practiceKindLabel,
+  practiceMinutes,
+  stageNumeral,
+} from './practice-display';
+
+describe('practiceKindLabel', () => {
+  it('maps each medium to its dashboard label', () => {
+    expect(practiceKindLabel('video')).toBe('Video');
+    expect(practiceKindLabel('audio')).toBe('Audio');
+    expect(practiceKindLabel('written')).toBe('Reflection');
+  });
+});
+
+describe('practiceMinutes', () => {
+  it('rounds seconds to whole minutes', () => {
+    expect(practiceMinutes(2400)).toBe(40);
+    expect(practiceMinutes(2700)).toBe(45);
+    expect(practiceMinutes(90)).toBe(2); // 1.5 → 2
+  });
+
+  it('floors to at least one minute for any positive duration', () => {
+    expect(practiceMinutes(20)).toBe(1);
+    expect(practiceMinutes(1)).toBe(1);
+  });
+
+  it('is null for unknown / non-positive durations (label omits the fragment)', () => {
+    expect(practiceMinutes(null)).toBeNull();
+    expect(practiceMinutes(0)).toBeNull();
+    expect(practiceMinutes(-30)).toBeNull();
+  });
+});
+
+describe('stageNumeral', () => {
+  it('renders lowercase roman numerals for in-range indices', () => {
+    expect(stageNumeral(0)).toBe('i');
+    expect(stageNumeral(1)).toBe('ii');
+    expect(stageNumeral(4)).toBe('v');
+  });
+
+  it('falls back to a 1-based digit beyond the table', () => {
+    expect(stageNumeral(12)).toBe('13');
+  });
+});
+
+describe('countWord', () => {
+  it('spells small counts and falls back to digits', () => {
+    expect(countWord(0)).toBe('zero');
+    expect(countWord(2)).toBe('two');
+    expect(countWord(5)).toBe('five');
+    expect(countWord(13)).toBe('13');
+  });
+});

--- a/apps/web/src/lib/journeys/practice-display.ts
+++ b/apps/web/src/lib/journeys/practice-display.ts
@@ -1,0 +1,72 @@
+/**
+ * Presentational helpers for journey practices (Codex-2pryk.3.4).
+ *
+ * Pure, framework-free projections of a practice's medium into the labels,
+ * durations and stage numerals the member dashboard renders — kept out of the
+ * components so they stay unit-testable and shared between the continue card and
+ * the curriculum map (which must agree on every label).
+ */
+import type { PracticeContentType } from './types';
+
+/** The human label for a practice's medium (dashboard meta rows). */
+export function practiceKindLabel(type: PracticeContentType): string {
+  switch (type) {
+    case 'audio':
+      return 'Audio';
+    case 'written':
+      return 'Reflection';
+    default:
+      return 'Video';
+  }
+}
+
+/**
+ * Whole-minute duration for a media practice, or `null` when unknown (written
+ * practices, or media whose media-item duration hasn't been resolved). Callers
+ * omit the "· N min" fragment when this is null.
+ */
+export function practiceMinutes(durationSeconds: number | null): number | null {
+  if (!durationSeconds || durationSeconds <= 0) return null;
+  return Math.max(1, Math.round(durationSeconds / 60));
+}
+
+const ROMAN = [
+  'i',
+  'ii',
+  'iii',
+  'iv',
+  'v',
+  'vi',
+  'vii',
+  'viii',
+  'ix',
+  'x',
+  'xi',
+  'xii',
+];
+
+/** Lowercase roman numeral for a zero-based stage index (falls back to 1-based digits). */
+export function stageNumeral(index: number): string {
+  return ROMAN[index] ?? String(index + 1);
+}
+
+/** English count word for small stage totals ("five stages"), else the digit. */
+const COUNT_WORDS = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+];
+
+export function countWord(n: number): string {
+  return COUNT_WORDS[n] ?? String(n);
+}

--- a/apps/web/src/lib/journeys/types.ts
+++ b/apps/web/src/lib/journeys/types.ts
@@ -29,6 +29,12 @@ export interface JourneyCourseSummary {
   slug: string | null;
   title: string;
   organizationSlug: string | null;
+  /**
+   * One-line course framing (the sell lede), surfaced on the member dashboard
+   * header. Optional/additive: summary builders that don't need it (e.g. the
+   * gate's by-slug resolver) may omit it.
+   */
+  lede?: string | null;
 }
 
 /**

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte
@@ -1,28 +1,35 @@
 <!--
   @component JourneyDashboardPage
 
-  The authed course dashboard (SPEC §8.3): enrollment + progress rollup, the
-  curriculum map with completion overlay, and continue-where-left-off. Client-
-  rendered (ssr=false); the server gate already enforced `canEnterCourse`.
+  The authed course dashboard (SPEC §8.3) — the member "journey portal": the
+  map + the single threshold back in. It does NOT play (the player is its own
+  surface); it shows the whole arc, how far you are, and ONE way to resume.
+  Client-rendered (ssr=false); the server gate already enforced `canEnterCourse`.
 
   Progress reads the SINGLE progress store (F19): the store hydrates from the
-  server's known completions, and completing a practice in the player updates
-  it reactively here (cross-tab + cross-device via `initProgressSync`).
+  server's known completions, and completing a practice in the player updates it
+  reactively here (cross-tab + cross-device via `initProgressSync`).
+
+  Surface (prototype `course-dashboard.html`): a warm/dark "descent" portal.
+  Its palette is SELF-DERIVED from the org brand via OKLCH on `.journey-portal`
+  (anchored on `--brand-color`), and the semantic heading/text tokens are
+  RE-POINTED there so the org-brand.css `[data-org-brand] :is(h1..h6)` backstop
+  resolves to the portal palette instead of the neutral org heading colour.
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
+  import CurriculumMap from '$lib/components/journeys/CurriculumMap.svelte';
+  import JourneyContinueCard from '$lib/components/journeys/JourneyContinueCard.svelte';
   import {
     loadCourseCompletionsFromServer,
     type PlaybackProgress,
     progressCollection,
     useLiveQuery,
   } from '$lib/collections';
-  import CurriculumMap from '$lib/components/journeys/CurriculumMap.svelte';
-  import ProgressRing from '$lib/components/journeys/ProgressRing.svelte';
-  import { ArrowRightIcon, PlayIcon } from '$lib/components/ui/Icon';
   import {
     computeCourseRollup,
     selectContinuePractice,
+    toPlaylist,
   } from '$lib/journeys/rollup';
 
   let { data } = $props();
@@ -67,131 +74,232 @@
   );
 
   const rollup = $derived(computeCourseRollup(dashboard.stages, completedIds));
+
+  // The resume target for the map's "current" highlight + auto-open. Null once
+  // the whole course is complete (nothing left to resume → no current row).
   const continueEntry = $derived(
     selectContinuePractice(dashboard.stages, completedIds, inProgressIds)
   );
 
-  const continueHref = $derived(
-    continueEntry
-      ? `/journeys/${courseSlug}/practice/${continueEntry.slug ?? continueEntry.contentId}`
-      : null
+  // Ordered stages once — the numeral in the continue meta + the map agree on it.
+  const orderedStages = $derived(
+    [...dashboard.stages].sort((a, b) => a.sortOrder - b.sortOrder)
   );
 
-  const isFresh = $derived(rollup.overall.done === 0);
+  // The continue CARD always offers a threshold: mid-journey it points at the
+  // resume target; once complete it points back to the very first practice
+  // ("Revisit"). Null only when the course has no practices at all.
+  const playlist = $derived(toPlaylist(dashboard.stages));
+  const resumeEntry = $derived(continueEntry ?? playlist[0] ?? null);
+
+  const resumeContext = $derived.by(() => {
+    if (!resumeEntry) return null;
+    const stageIndex = orderedStages.findIndex(
+      (s) => s.id === resumeEntry.stageId
+    );
+    const practice = orderedStages
+      .find((s) => s.id === resumeEntry.stageId)
+      ?.practices.find((p) => p.contentId === resumeEntry.contentId);
+    return {
+      href: `/journeys/${courseSlug}/practice/${resumeEntry.slug ?? resumeEntry.contentId}`,
+      title: resumeEntry.title,
+      contentType: practice?.contentType ?? resumeEntry.contentType,
+      durationSeconds: practice?.durationSeconds ?? null,
+      stageName: resumeEntry.stageName,
+      stageIndex: stageIndex < 0 ? 0 : stageIndex,
+    };
+  });
+
+  const resumeState = $derived(
+    rollup.isComplete
+      ? ('revisit' as const)
+      : rollup.overall.done === 0
+        ? ('begin' as const)
+        : ('resume' as const)
+  );
 </script>
 
 <svelte:head>
   <title>{dashboard.course.title} · Your journey</title>
 </svelte:head>
 
-<div class="dashboard">
-  <header class="dashboard__hero">
-    <div class="dashboard__intro">
-      <span class="dashboard__eyebrow">Your journey</span>
-      <h1 class="dashboard__title">{dashboard.course.title}</h1>
-      <p class="dashboard__status">
-        {#if rollup.isComplete}
-          You've completed every practice. Revisit anything, anytime.
-        {:else if isFresh}
-          Begin when you're ready — your first practice is one tap away.
-        {:else}
-          {rollup.overall.done} of {rollup.overall.total} practices complete.
-        {/if}
-      </p>
-
-      {#if continueHref}
-        <a class="dashboard__continue" href={continueHref}>
-          <PlayIcon />
-          {isFresh ? 'Begin the journey' : 'Continue where you left off'}
-          <ArrowRightIcon />
-        </a>
+<div class="journey-portal">
+  <div class="journey-portal__inner">
+    <header class="portal-head">
+      <p class="portal-head__eyebrow">Your journey</p>
+      <h1 class="portal-head__title">{dashboard.course.title}</h1>
+      {#if dashboard.course.lede}
+        <p class="portal-head__lede">{dashboard.course.lede}</p>
       {/if}
-    </div>
 
-    <div class="dashboard__ring" aria-hidden={rollup.overall.total === 0}>
-      <ProgressRing
+      <div class="portal-prog">
+        <div
+          class="portal-prog__bar"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={rollup.overall.percent}
+          aria-label="Overall course progress"
+        >
+          <i style="width: {rollup.overall.percent}%"></i>
+        </div>
+        {#if rollup.overall.total > 0}
+          <p class="portal-prog__label">
+            <strong>{rollup.overall.done} of {rollup.overall.total}</strong>
+            practices · {rollup.overall.percent}% through
+          </p>
+        {:else}
+          <p class="portal-prog__label">Your curriculum is being prepared.</p>
+        {/if}
+      </div>
+    </header>
+
+    {#if resumeContext}
+      <JourneyContinueCard
+        href={resumeContext.href}
+        title={resumeContext.title}
+        contentType={resumeContext.contentType}
+        stageName={resumeContext.stageName}
+        stageIndex={resumeContext.stageIndex}
+        durationSeconds={resumeContext.durationSeconds}
         percent={rollup.overall.percent}
-        size="var(--space-24)"
-        ariaLabel="Overall course progress: {rollup.overall.percent}%"
+        state={resumeState}
       />
-    </div>
-  </header>
+    {/if}
 
-  <CurriculumMap
-    stages={dashboard.stages}
-    {completedIds}
-    {rollup}
-    {courseSlug}
-  />
+    {#if orderedStages.length > 0}
+      <CurriculumMap
+        stages={dashboard.stages}
+        {completedIds}
+        {rollup}
+        {courseSlug}
+        currentContentId={continueEntry?.contentId ?? null}
+        currentStageId={continueEntry?.stageId ?? null}
+      />
+    {/if}
+  </div>
 </div>
 
 <style>
-  .dashboard {
+  .journey-portal {
+    /* ── Warm/dark "descent" portal, self-derived from the org brand ──────────
+       Anchor the whole palette on the brand primary hue, then FORCE lightness
+       for guaranteed contrast on any org colour (light-brand orgs still get a
+       focused dark space; the hue keeps it on-brand). Chroma is scaled down so
+       surfaces read as warm near-neutrals, not saturated blocks. */
+    --portal-anchor: var(--brand-color, var(--color-primary-600));
+
+    --portal-bg: oklch(from var(--portal-anchor) 0.15 calc(c * 0.3) h);
+    --portal-bg-deep: oklch(from var(--portal-anchor) 0.1 calc(c * 0.3) h);
+    --portal-surface: oklch(from var(--portal-anchor) 0.2 calc(c * 0.35) h);
+    --portal-surface-2: oklch(from var(--portal-anchor) 0.24 calc(c * 0.42) h);
+
+    --portal-text: oklch(from var(--portal-anchor) 0.94 calc(c * 0.08) h);
+    --portal-text-dim: oklch(from var(--portal-anchor) 0.82 calc(c * 0.07) h);
+    --portal-text-faint: oklch(from var(--portal-anchor) 0.64 calc(c * 0.07) h);
+
+    /* The glowing accent ("ember") + its dark ink for text on the accent. */
+    --portal-ember: oklch(from var(--portal-anchor) 0.72 calc(c * 0.9) h);
+    --portal-ember-soft: oklch(from var(--portal-anchor) 0.6 calc(c * 0.9) h);
+    --portal-ember-ink: oklch(from var(--portal-anchor) 0.18 calc(c * 0.5) h);
+
+    /* Re-point the semantic tokens so descendants — and the org-brand.css
+       `[data-org-brand] :is(h1..h6){color:var(--color-heading)}` backstop —
+       resolve to the portal palette instead of fighting its specificity. */
+    --color-heading: var(--portal-text);
+    --color-text: var(--portal-text-dim);
+    --color-text-secondary: var(--portal-text-dim);
+    --color-text-muted: var(--portal-text-faint);
+
+    min-height: 100dvh;
+    background: var(--portal-bg);
+    color: var(--portal-text-dim);
+    /* A whisper of warmth at the top edge — never load-bearing for contrast. */
+    background-image: radial-gradient(
+        120% 80% at 50% -10%,
+        color-mix(in oklab, var(--portal-ember) 12%, transparent),
+        transparent 55%
+      ),
+      radial-gradient(
+        90% 70% at 90% 108%,
+        color-mix(in oklab, var(--portal-ember-soft) 8%, transparent),
+        transparent 55%
+      );
+  }
+
+  .journey-portal__inner {
+    max-width: 48.75rem;
+    margin: 0 auto;
+    padding: clamp(var(--space-8), 5vw, var(--space-16))
+      clamp(var(--space-4), 4vw, var(--space-8)) var(--space-20);
     display: flex;
     flex-direction: column;
-    gap: var(--space-10);
-    max-width: 64rem;
-    margin: 0 auto;
-    padding: var(--space-8) var(--space-4);
+    gap: var(--space-8);
   }
 
-  .dashboard__hero {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-6);
-    flex-wrap: wrap;
-  }
-
-  .dashboard__intro {
-    min-width: 0;
-    flex: 1;
-  }
-
-  .dashboard__eyebrow {
+  /* ── header ─────────────────────────────────────────────────────────────── */
+  .portal-head__eyebrow {
+    margin: 0;
     font-size: var(--text-xs);
-    text-transform: var(--text-transform-label);
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--portal-ember);
   }
 
-  .dashboard__title {
-    margin: var(--space-1) 0 var(--space-2);
+  .portal-head__title {
+    margin: var(--space-2) 0 var(--space-3);
     font-family: var(--font-heading);
-    font-size: var(--text-3xl);
-    color: var(--color-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-4xl);
+    line-height: var(--leading-tight);
+    color: var(--portal-text);
   }
 
-  .dashboard__status {
-    margin: 0 0 var(--space-4);
-    font-size: var(--text-base);
-    color: var(--color-text-secondary);
+  .portal-head__lede {
+    margin: 0;
+    max-width: 52ch;
+    font-size: var(--text-lg);
+    line-height: var(--leading-relaxed);
+    color: var(--portal-text-dim);
   }
 
-  .dashboard__continue {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-3) var(--space-5);
-    border-radius: var(--radius-button);
-    background: var(--color-primary-600);
-    color: var(--color-text-on-brand);
-    font-size: var(--text-base);
+  .portal-prog {
+    margin-top: var(--space-6);
+  }
+
+  .portal-prog__bar {
+    height: var(--space-2);
+    border-radius: var(--radius-full);
+    background: color-mix(in oklab, var(--portal-text) 12%, transparent);
+    overflow: hidden;
+  }
+
+  .portal-prog__bar > i {
+    display: block;
+    height: 100%;
+    border-radius: var(--radius-full);
+    background: linear-gradient(
+      90deg,
+      var(--portal-ember-soft),
+      var(--portal-ember)
+    );
+    transition: width var(--duration-slow) var(--ease-out);
+  }
+
+  .portal-prog__label {
+    margin: var(--space-2) 0 0;
+    font-size: var(--text-sm);
+    color: var(--portal-text-faint);
+  }
+
+  .portal-prog__label strong {
+    color: var(--portal-text-dim);
     font-weight: var(--font-medium);
-    text-decoration: none;
-    transition: background-color var(--duration-fast) ease;
   }
 
-  .dashboard__continue:hover {
-    background: var(--color-primary-700);
-  }
-
-  .dashboard__continue:focus-visible {
-    outline: none;
-    box-shadow: var(--shadow-focus-ring);
-  }
-
-  .dashboard__ring {
-    flex-shrink: 0;
+  @media (prefers-reduced-motion: reduce) {
+    .portal-prog__bar > i {
+      transition: none;
+    }
   }
 </style>

--- a/packages/access/src/services/course-journey-service.ts
+++ b/packages/access/src/services/course-journey-service.ts
@@ -497,6 +497,7 @@ export class CourseJourneyService extends BaseService {
         id: courses.id,
         slug: courses.slug,
         title: courses.title,
+        lede: courses.lede,
         organizationSlug: organizations.slug,
       })
       .from(courses)
@@ -515,6 +516,7 @@ export class CourseJourneyService extends BaseService {
       id: row.id,
       slug: row.slug,
       title: row.title,
+      lede: row.lede ?? null,
       organizationSlug: row.organizationSlug ?? null,
     };
   }

--- a/packages/shared-types/src/journeys.ts
+++ b/packages/shared-types/src/journeys.ts
@@ -342,6 +342,12 @@ export interface JourneyCourseSummary {
   slug: string | null;
   title: string;
   organizationSlug: string | null;
+  /**
+   * One-line course framing (the sell lede), surfaced on the member dashboard
+   * header. Optional/additive: summary builders that don't need it (e.g. the
+   * gate's by-slug resolver) may omit it.
+   */
+  lede?: string | null;
 }
 
 /**


### PR DESCRIPTION
## What

Rebuilds the enrolled-member **course dashboard** (`/journeys/[journeySlug]/dashboard`) to match `docs/design/course-journeys/prototype/course-dashboard.html` pixel-for-pixel structurally, on **real Codex design tokens + the org brand** (the prototype's `fresh.css` / `--st-*` / ember-bone tokens were used for structure only, never copied).

The prior implementation used a progress ring + flat curriculum list. This pass turns it into the prototype's **journey portal**: a warm/dark "descent" surface with a header (eyebrow + title + lede + linear progress bar), a single **Continue "threshold" card**, and the curriculum as a **stage accordion**.

## Changes

**`feat(web)` — dashboard rebuild**
- **`+page.svelte`** — portal shell. The palette is **self-derived from the org brand via OKLCH** (anchored on `--brand-color`, lightness forced for guaranteed contrast on any org colour) and **re-points the semantic heading/text tokens on the page root**, so the `org-brand.css` `[data-org-brand] :is(h1..h6){color:var(--color-heading)}` backstop resolves to the portal palette instead of fighting its specificity (the documented gotcha). Data plumbing (rollup, completions store, continue selection) unchanged.
- **`JourneyContinueCard.svelte`** (new) — the single threshold back in: media plate (play/read glyph + overall %), state-aware framing (**Begin / Resume / Revisit**) and the resume practice's `Stage · medium · duration`. Always offers a threshold — falls back to the first practice for **Revisit** once the course is complete.
- **`CurriculumMap.svelte`** — rebuilt as the stage accordion: current stage open, done stages collapsed; per-lesson **done ✓ / current ● / upcoming-medium-glyph** states, roman numerals, per-stage gloss + `done/total` count.
- **`practice-display.ts`** (new, + unit tests) — pure label/minutes/roman-numeral helpers shared by the card and the map so their meta rows never drift.

**`feat(shared-types,access)` — additive contract (separate commit)**
- `JourneyCourseSummary` gains an optional `lede`; the course-journey service projects it in `loadCourseSummaryById`. Additive/optional — the by-slug gate resolver and the API-client shapes are unaffected. Lets the dashboard header render the course's one-line framing.

## Verification (in-browser, `studio-alpha.lvh.me:3000`, Chromium 1440×900 + 390×844)
- **DB-backed** data loads through the real round-D seam → content-api → `courses`/`course_stages`/`stage_practices`/`practice_completions` (no static mock). `lede` confirmed flowing end-to-end.
- Screenshot-diffed every section against the prototype: header, gradient progress bar (`3 of 5 practices · 60% through`), Continue card, stage accordion.
- Asserted interactions via `browser_evaluate`: current stage auto-opens + done stage collapses; **clicking a collapsed stage expands it** and reveals its lessons with correct practice hrefs; current lesson shows the ● dot + Resume.
- Verified all three states live: **Resume** (3/5), **Revisit** (5/5 → "You've walked this whole journey", CTA falls back to the first practice), and the begin/fresh derivation.
- **Mobile** (390px): Continue card stacks (media full-width 16:8), stage gloss hides — matches the prototype.
- Console clean of app errors (only environmental: dev-cdn `:4100` logo/avatar images and ecom-api subscription stream — services not in this surface's dev stack).

## Gates
- `pnpm --filter web check` — **0 errors/warnings in changed files** (path-grepped after ANSI-strip; the ~86 remaining are pre-existing in unrelated files).
- `pnpm exec biome check` — clean (also enforced by the pre-commit hook).
- `vitest` — journeys unit suites green (rollup, gate, round-d-seam, dashboard `+page.server`: 22 passed) + new `practice-display` tests (7 passed).

## Local fixture (NOT committed — dev reproduction only)
`pnpm db:seed` does not create a course. A rich published `rootwork` course already exists for `studio-alpha` from prior journeys work; the fixture script makes it **idempotently reproducible** and sets a demonstrative completion state (Orientation done → collapsed; The Practice in progress → open) so the dashboard exercises every visual state.
- Script: `/Users/brucemckay/.claude/jobs/da29a162/tmp/seed-journey-fixture.mjs`
- Run: `node /Users/brucemckay/.claude/jobs/da29a162/tmp/seed-journey-fixture.mjs`
- Creates/ensures: published course + 2 stages + 5 practices (video/written/audio) + enrollment + 3/5 completions + a published `landing_pages` row (so the sell/checkout surfaces can reuse it).
- Working URL: `http://studio-alpha.lvh.me:3000/journeys/rootwork/dashboard`

## Deviations
- The prototype's Fraunces serif + gold "ember" are its brand stand-ins; this renders on the org's own heading font and a brand-derived accent (rose for studio-alpha) — correct, brand-reactive behaviour.
- The prototype's `.switch` top nav is a stand-in for the real org navigation (already provided by the org layout); not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)