### PR TITLE
feat(web): checkout fidelity pass vs prototype (Codex-2pryk.3.6)

### DIFF
--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/+page.server.ts
@@ -1,47 +1,88 @@
 /**
- * Journey checkout — offer/pay SHELL (Codex-2pryk.3.1 · WP-3).
+ * Journey checkout — offer/pay SHELL server load (Codex-2pryk.3.1 · WP-3;
+ * fidelity pass Codex-2pryk.3.6).
  *
- * The STRUCTURAL shell for the offer/pay step (HARDENING §E checkout row,
- * FRONTEND-MAP §1 checkout). It resolves the journey by slug through the SAME
- * `../journey-data` integration seam the sales page uses, so the sell page's
- * primary CTA (`buildJourneyUrl(..., { surface: 'checkout' })`) lands on a
- * coherent offer summary instead of a 404.
+ * The offer/pay step (HARDENING §E checkout row, FRONTEND-MAP §1 checkout). It
+ * resolves the journey by slug through the SAME `../journey-data` seam the sales
+ * page uses, then derives the presentational offer catalogue + order summary the
+ * page renders ("one course, three ways in", SPEC §7). The sell page's primary
+ * CTA (`buildJourneyUrl(..., { surface: 'checkout' })`) lands here.
  *
- * OUT OF WP-3 SCOPE (owned by WP-6 monetization): the real three-path offer
- * selection (SPEC §7 — tier / course-subscription / one-off), the Stripe
- * checkout form action (mirror `content/[contentSlug]` `handlePurchaseAction`),
- * and the `entitlements` write on webhook success. This shell renders the offer
- * + a placeholder pay affordance so the funnel is navigable end-to-end today.
+ * WHAT'S REAL vs. WHAT'S WP-6 (the settlement boundary):
+ *   - REAL, DB-backed: the course + its one-off price (`course.priceCents`), the
+ *     order-summary facts (practice/stage counts, content-type mix), the offer
+ *     teasers authored on the landing page's `invite` section, and the social
+ *     proof (`testimonials[0]`). All flow through the frozen `getCoursePage`.
+ *   - OUT OF SCOPE → WP-6 monetization: the LIVE three-path resolution (real
+ *     tier / `course_subscription_plans` prices), the Stripe checkout action,
+ *     and the `entitlements` write on webhook success. The recurring offer
+ *     prices shown here are page-builder teasers until then. See the offer model
+ *     for the provenance split (`./checkout-offer-model`).
  */
 import { error } from '@sveltejs/kit';
+import { asString } from '$lib/page-builder/render/coerce';
 import { CACHE_HEADERS } from '$lib/server/cache';
+import { resolveCanEnterCourse } from '$lib/server/journeys/round-d-seam';
 import { getCoursePage } from '../journey-data';
 import type { PageServerLoad } from './$types';
+import {
+  buildHeadNote,
+  deriveCheckoutOffers,
+  deriveCourseSummary,
+  resolvePreselectedOffer,
+} from './checkout-offer-model';
 
-export const load: PageServerLoad = async ({
-  params,
-  parent,
-  url,
-  setHeaders,
-}) => {
+export const load: PageServerLoad = async (event) => {
+  const { params, parent, url, setHeaders } = event;
+
   // Let the org layout (auth + branding + org resolution) settle first.
-  await parent();
+  const { user } = await parent();
 
   const coursePage = await getCoursePage({ slug: params.journeySlug });
   if (!coursePage) {
     throw error(404, 'This journey could not be found.');
   }
 
+  const { page, course, stages, testimonials } = coursePage;
+
+  // Presentational catalogue + order summary (pure, testable derivation).
+  const offers = deriveCheckoutOffers(page, course);
+  const summary = deriveCourseSummary(course, stages);
+
+  // Re-target the primary action when the viewer already has access: an
+  // enrolled member / owner has nothing to buy, so they're sent to the journey
+  // rather than shown a "buy again" CTA. Anonymous ⇒ definitionally not enrolled
+  // (skip the worker round-trip); `.catch()` degrades a resolver hiccup to the
+  // pre-purchase (join) view. The full purchase settlement is WP-6.
+  const enrolled = user
+    ? await resolveCanEnterCourse(event, user.id, course.id).catch(() => false)
+    : false;
+
   // Prices are server-authoritative and the pay step is per-user — a checkout
   // response must never sit in a shared cache (matches the content-detail
   // purchase precedent). PRIVATE. WP-6 owns the real, cache-free Stripe action.
   setHeaders(CACHE_HEADERS.PRIVATE);
 
+  const invite = page.sections.find(
+    (s) => s.type === 'invite' && s.enabled !== false
+  );
+
   return {
-    course: coursePage.course,
     orgSlug: params.slug,
-    // `?offer=` pre-selects one of the three access paths (HARDENING §E). The
-    // real path catalogue is WP-6; the shell just echoes the pre-selection.
-    preselectedOffer: url.searchParams.get('offer'),
+    course,
+    brandOverrides: page.brandOverrides,
+    offers,
+    summary,
+    headNote: buildHeadNote(offers),
+    // Risk-reversal fine print authored on the invite section (else undefined).
+    priceNote: invite ? asString(invite.props, 'priceNote') : undefined,
+    // Social proof — the first testimonial, or null (renders conditionally).
+    testimonial: testimonials[0] ?? null,
+    enrolled,
+    // `?offer=` pre-selects one of the paths (deep-link from the sell page).
+    preselectedOfferId: resolvePreselectedOffer(
+      offers,
+      url.searchParams.get('offer')
+    ),
   };
 };

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/+page.svelte
@@ -1,98 +1,334 @@
 <!--
-  @component JourneyCheckoutShell
+  @component JourneyCheckout
 
-  The offer/pay step (SPEC §7, FRONTEND-MAP §1 checkout). This is the WP-3
-  STRUCTURAL shell: it renders the resolved course as an offer summary and a
-  placeholder "continue to payment" affordance so the sell → pay funnel is
-  navigable today. The real three-path offer selection and the Stripe form
-  action land in WP-6 (monetization) — flagged inline.
+  The offer/pay step — "one course, three ways in" (SPEC §7, FRONTEND-MAP §1
+  checkout; prototype `docs/design/course-journeys/prototype/checkout.html`).
+
+  A PRESENTATIONAL order-summary + payment SHELL: the course, its order summary
+  and the offer catalogue are real DB-backed data (resolved in `+page.server.ts`
+  via the frozen `getCoursePage` seam); the offer selection is fully interactive
+  (radio-group → live fine print). The one thing this shell does NOT do is settle
+  a payment: the Stripe checkout action + the `entitlements` write on success are
+  owned by WP-6 monetization. Clicking "Continue" therefore surfaces the honest
+  connect-in-progress seam rather than faking a purchase confirmation.
+
+  IMMERSIVE PALETTE (D6 · the `.jp` pattern): this surface mirrors the sales
+  page's candlelit reading — the semantic `--color-*` tokens are re-pointed to
+  warm, low-chroma values DERIVED from the org's own `--color-brand-primary` via
+  OKLCH relative colour, so it reads warm/dark on ANY brand and re-themes with
+  the org brand + any per-page `brandOverrides`. Re-pointing `--color-heading`
+  here is also what tames org-brand.css's heading override (it reads the same
+  custom property). No hardcoded hex/px. Kept in sync with `JourneyRenderer`.
 -->
 <script lang="ts">
   import { page } from '$app/state';
   import { buildJourneyUrl } from '@codex/urls';
-  import { formatPrice } from '$lib/utils/format';
+  import { brandOverridesToStyleAttr } from '$lib/page-builder/render/brand-overrides';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
   const course = $derived(data.course);
-  const priceLabel = $derived(
-    course.priceCents !== null ? formatPrice(course.priceCents) : null
-  );
+  const offers = $derived(data.offers);
+  const summary = $derived(data.summary);
 
-  const backToSales = $derived(
+  // Per-page brand overrides re-derive the palette for this subtree so the
+  // checkout stays visually coherent with the sales page it continues.
+  const brandStyle = $derived(brandOverridesToStyleAttr(data.brandOverrides));
+
+  const salesUrl = $derived(
     buildJourneyUrl(
       page.url,
       { slug: course.slug, id: course.id },
       { surface: 'sales' }
     )
   );
+  const dashboardUrl = $derived(
+    buildJourneyUrl(
+      page.url,
+      { slug: course.slug, id: course.id },
+      { surface: 'dashboard' }
+    )
+  );
+
+  // The selected way in — deep-linkable via `?offer=`, then user-driven. `data`
+  // seeds the preselection; a user pick (`override`) then wins. Deriving rather
+  // than snapshotting `data` avoids capturing a stale server value and keeps the
+  // selection correct if the loader re-runs with a different `?offer=`.
+  let override = $state<string | null>(null);
+  const selectedId = $derived(override ?? data.preselectedOfferId);
+  const selectedOffer = $derived(
+    offers.find((offer) => offer.id === selectedId) ?? offers[0]
+  );
+
+  // Live fine print follows the chosen path's cadence (NN/g explicit terms).
+  const fineText = $derived.by(() => {
+    if (!selectedOffer) return '';
+    return selectedOffer.recurring
+      ? `Billed ${selectedOffer.priceLabel} ${selectedOffer.cadenceLabel}. Cancel anytime from your account.`
+      : `One payment. ${course.title} stays in your library for good.`;
+  });
+
+  // The pay CTA is wired only up to the WP-6 seam: clicking it reveals the
+  // honest connect-in-progress note (no fake settlement). An already-enrolled
+  // viewer skips it entirely — they're linked straight to the journey.
+  let initiated = $state(false);
 </script>
 
 <svelte:head>
-  <title>Join {course.title}</title>
+  <title>Choose your way into {course.title}</title>
   <!-- A per-user pay step is never a search target. -->
   <meta name="robots" content="noindex" />
 </svelte:head>
 
-<section class="checkout">
-  <div class="checkout__inner">
-    <a class="checkout__back" href={backToSales}>← Back to {course.title}</a>
+{#snippet spark()}
+  <svg
+    class="mark"
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      d="M8 1l1.6 4.4L14 7l-4.4 1.6L8 13l-1.6-4.4L2 7l4.4-1.6L8 1z"
+      fill="currentColor"
+    />
+  </svg>
+{/snippet}
 
-    <header class="checkout__head">
+<section
+  class="checkout"
+  data-org-brand={brandStyle ? '' : undefined}
+  style={brandStyle}
+>
+  <div class="checkout__atmos" aria-hidden="true"></div>
+
+  <div class="checkout__inner">
+    <a class="checkout__back" href={salesUrl}>← Back to {course.title}</a>
+
+    <header class="co-head">
       {#if course.kicker}
-        <p class="checkout__kicker">{course.kicker}</p>
+        <p class="co-head__kicker">{course.kicker}</p>
       {/if}
-      <h1 class="checkout__title">Join {course.title}</h1>
-      {#if course.lede}
-        <p class="checkout__lede">{course.lede}</p>
+      <h1 class="co-head__title">Choose your way in</h1>
+      {#if data.headNote}
+        <p class="co-head__note">{data.headNote}</p>
       {/if}
     </header>
 
-    <div class="checkout__offer">
-      <div class="checkout__offer-body">
-        <p class="checkout__offer-name">Own {course.title}</p>
-        <p class="checkout__offer-meta">
-          {course.stageCount} stages · {course.practiceCount} practices
-        </p>
+    <div class="co-grid">
+      <!-- LEFT: what you're getting -->
+      <aside class="summary">
+        <div class="summary__cover">
+          <span class="summary__cover-kicker">{summary.kicker}</span>
+          <h2 class="summary__cover-title">{summary.title}</h2>
+        </div>
+        <div class="summary__body">
+          <ul class="summary__list">
+            {#each summary.bullets as bullet (bullet)}
+              <li class="summary__item">
+                <span class="summary__mark">{@render spark()}</span>
+                <span>{bullet}</span>
+              </li>
+            {/each}
+          </ul>
+          <p class="summary__taste">
+            Meet the practice before you decide.
+            <a href={salesUrl}>Watch the intro →</a>
+          </p>
+        </div>
+      </aside>
+
+      <!-- RIGHT: the ways in -->
+      <div class="ways">
+        {#if offers.length > 0}
+          <div
+            class="offers"
+            role="radiogroup"
+            aria-label="Choose how to join {course.title}"
+          >
+            {#each offers as offer (offer.id)}
+              <label class="offer" class:offer--selected={selectedId === offer.id}>
+                <input
+                  class="offer__input"
+                  type="radio"
+                  name="offer"
+                  value={offer.id}
+                  checked={selectedId === offer.id}
+                  onchange={() => (override = offer.id)}
+                />
+                {#if offer.best}
+                  <span class="offer__best">Best value</span>
+                {/if}
+                <span class="offer__radio" aria-hidden="true"></span>
+                <div class="offer__body">
+                  <h3 class="offer__name">{offer.name}</h3>
+                  {#if offer.who}
+                    <p class="offer__who">{offer.who}</p>
+                  {/if}
+                  {#if offer.blurb}
+                    <p class="offer__blurb">{offer.blurb}</p>
+                  {/if}
+                  {#if offer.bullets.length > 0}
+                    <ul class="offer__bullets">
+                      {#each offer.bullets as item (item)}
+                        <li>{item}</li>
+                      {/each}
+                    </ul>
+                  {/if}
+                </div>
+                <div class="offer__price">
+                  <span class="offer__price-amount">{offer.priceLabel}</span>
+                  <span class="offer__price-cadence">{offer.cadenceLabel}</span>
+                </div>
+              </label>
+            {/each}
+          </div>
+
+          <div class="co-actions">
+            {#if data.enrolled}
+              <a class="co-cta" href={dashboardUrl}>
+                Enter the journey <span aria-hidden="true">→</span>
+              </a>
+              <span class="co-actions__fine">
+                You already have access to {course.title}.
+              </span>
+            {:else}
+              <button
+                type="button"
+                class="co-cta"
+                onclick={() => (initiated = true)}
+              >
+                Continue <span aria-hidden="true">→</span>
+              </button>
+              <span class="co-actions__fine">{fineText}</span>
+            {/if}
+          </div>
+
+          {#if initiated && !data.enrolled}
+            <p class="co-seam" role="status">
+              Secure checkout is being connected. Your choice — <b
+                >{selectedOffer?.name}</b
+              >
+              ({selectedOffer?.priceLabel}) — is ready; payment goes live with the
+              monetization release.
+            </p>
+          {/if}
+
+          {#if data.priceNote}
+            <p class="co-note">{data.priceNote}</p>
+          {/if}
+
+          <div class="co-trust">
+            <span class="co-trust__item">
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M8 1a3 3 0 0 0-3 3v2H4.5A1.5 1.5 0 0 0 3 7.5v6A1.5 1.5 0 0 0 4.5 15h7a1.5 1.5 0 0 0 1.5-1.5v-6A1.5 1.5 0 0 0 11.5 6H11V4a3 3 0 0 0-3-3zm0 1.4A1.6 1.6 0 0 1 9.6 4v2H6.4V4A1.6 1.6 0 0 1 8 2.4z"
+                  fill="currentColor"
+                />
+              </svg>
+              Secure checkout
+            </span>
+            <span class="co-trust__sep" aria-hidden="true">·</span>
+            <span class="co-trust__item">No hidden fees — VAT included</span>
+            <span class="co-trust__sep" aria-hidden="true">·</span>
+            <span class="co-trust__item">Cancel anytime, from your account</span>
+          </div>
+        {:else}
+          <p class="co-note">
+            {course.title} isn't open for enrolment just now.
+            <a href={salesUrl}>Back to the journey →</a>
+          </p>
+        {/if}
+
+        {#if data.testimonial}
+          <figure class="co-proof">
+            <blockquote class="co-proof__quote">
+              “{data.testimonial.quote}”
+            </blockquote>
+            <figcaption class="co-proof__by">
+              — {data.testimonial.authorName}{#if data.testimonial.authorContext}, {data
+                  .testimonial.authorContext}{/if}
+            </figcaption>
+          </figure>
+        {/if}
       </div>
-      {#if priceLabel}
-        <p class="checkout__price">{priceLabel}</p>
-      {/if}
     </div>
-
-    {#if data.preselectedOffer}
-      <p class="checkout__preselect">
-        Pre-selected offer: <b>{data.preselectedOffer}</b>
-      </p>
-    {/if}
-
-    <!--
-      WP-6 seam: the real three-path selection (tier / course-subscription /
-      one-off) + the Stripe checkout form action replace this placeholder. Kept
-      a plain, disabled affordance so the shell never implies a working pay flow.
-    -->
-    <button type="button" class="checkout__pay" disabled>
-      Continue to payment
-    </button>
-    <p class="checkout__note">
-      Secure checkout is being connected. Payment goes live with the
-      monetization release.
-    </p>
   </div>
 </section>
 
 <style>
+  /* ── Candlelit palette (mirrors JourneyRenderer `.journey-page`) ─────────── */
   .checkout {
-    padding-block: var(--space-16);
+    position: relative;
+    isolation: isolate;
+
+    /* Surfaces — deep, warm, ascending in lightness. */
+    --color-background: oklch(from var(--color-brand-primary) 0.16 calc(c * 0.5) h);
+    --color-surface: oklch(from var(--color-brand-primary) 0.21 calc(c * 0.45) h);
+    --color-surface-secondary: oklch(
+      from var(--color-brand-primary) 0.25 calc(c * 0.42) h
+    );
+    --color-surface-tertiary: oklch(
+      from var(--color-brand-primary) 0.29 calc(c * 0.4) h
+    );
+
+    /* Text — warm bone → dim, high contrast on the deep surfaces. */
+    --color-heading: oklch(from var(--color-brand-primary) 0.96 calc(c * 0.12) h);
+    --color-text: oklch(from var(--color-brand-primary) 0.9 calc(c * 0.08) h);
+    --color-text-secondary: oklch(
+      from var(--color-brand-primary) 0.76 calc(c * 0.07) h
+    );
+    --color-text-tertiary: oklch(
+      from var(--color-brand-primary) 0.62 calc(c * 0.07) h
+    );
+
+    /* Hairlines — faint warm embers. */
+    --color-border-subtle: oklch(
+      from var(--color-brand-primary) 0.3 calc(c * 0.3) h
+    );
+    --color-border: oklch(from var(--color-brand-primary) 0.36 calc(c * 0.32) h);
+    --color-border-strong: oklch(
+      from var(--color-brand-primary) 0.44 calc(c * 0.34) h
+    );
+    --color-border-hover: oklch(
+      from var(--color-brand-primary) 0.54 calc(c * 0.36) h
+    );
+
+    min-height: 100%;
+    padding-block: var(--space-16) var(--space-24);
     padding-inline: var(--space-5);
+    background: var(--color-background);
+    color: var(--color-text);
+    overflow: clip;
+  }
+
+  /* A single warm ember bloom near the top, fading into the deep body. */
+  .checkout__atmos {
+    position: absolute;
+    z-index: -1;
+    inset: 0 0 auto 0;
+    height: min(70svh, 44rem);
+    pointer-events: none;
+    background: radial-gradient(
+      60% 50% at 50% 0%,
+      color-mix(in oklab, var(--color-brand-primary) 20%, transparent),
+      transparent 70%
+    );
   }
 
   .checkout__inner {
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
-    max-width: 40rem;
+    max-width: 68rem;
     margin-inline: auto;
   }
 
@@ -101,6 +337,7 @@
     font-size: var(--text-sm);
     color: var(--color-text-secondary);
     text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-default);
   }
 
   .checkout__back:hover {
@@ -108,102 +345,449 @@
     text-decoration: underline;
   }
 
-  .checkout__head {
+  /* ── Head ────────────────────────────────────────────────────────────────── */
+  .co-head {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: var(--space-2);
+    text-align: center;
+    margin-block-end: var(--space-4);
   }
 
-  .checkout__kicker {
+  .co-head__kicker {
     margin: 0;
-    font-size: var(--text-sm);
+    font-size: var(--text-xs);
     font-weight: var(--font-semibold);
-    letter-spacing: 0.08em;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--color-text-secondary);
+    color: var(--color-brand-primary);
   }
 
-  .checkout__title {
+  .co-head__title {
     margin: 0;
     font-family: var(--font-heading);
-    font-size: var(--text-3xl);
+    font-weight: var(--font-normal);
+    font-size: var(--text-4xl);
     line-height: var(--leading-tight);
+    letter-spacing: -0.01em;
     color: var(--color-heading);
     text-wrap: balance;
   }
 
-  .checkout__lede {
+  .co-head__note {
     margin: 0;
     font-size: var(--text-base);
-    line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
   }
 
-  .checkout__offer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-4);
-    padding: var(--space-5);
-    border: var(--border-width) solid var(--color-border-strong);
-    border-radius: var(--radius-card);
-    background: var(--color-surface);
+  /* ── Grid ────────────────────────────────────────────────────────────────── */
+  .co-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-8);
+    align-items: start;
   }
 
-  .checkout__offer-body {
+  @media (--breakpoint-md) {
+    .co-grid {
+      grid-template-columns: 1fr 1.5fr;
+    }
+  }
+
+  /* ── Left: the summary ─────────────────────────────────────────────────────*/
+  .summary {
+    border-radius: var(--radius-card);
+    overflow: hidden;
+    border: var(--border-width) solid var(--color-border-subtle);
+    background: color-mix(in oklab, var(--color-surface) 70%, transparent);
+  }
+
+  @media (--breakpoint-md) {
+    .summary {
+      position: sticky;
+      top: var(--space-20);
+    }
+  }
+
+  .summary__cover {
+    display: grid;
+    align-content: end;
+    gap: var(--space-1);
+    min-height: 7rem;
+    padding: var(--space-4) var(--space-5);
+    background: radial-gradient(
+      120% 130% at 30% 0%,
+      color-mix(in oklab, var(--color-brand-primary) 48%, var(--color-surface)),
+      var(--color-background)
+    );
+  }
+
+  .summary__cover-kicker {
+    font-size: var(--text-xs);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: color-mix(in oklab, var(--color-heading) 80%, transparent);
+  }
+
+  .summary__cover-title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-2xl);
+    line-height: var(--leading-tight);
+    color: var(--color-heading);
+  }
+
+  .summary__body {
+    padding: var(--space-5);
+  }
+
+  .summary__list {
+    display: grid;
+    gap: var(--space-2-5);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .summary__item {
+    display: flex;
+    gap: var(--space-2-5);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-text-secondary);
+  }
+
+  .summary__mark {
+    flex-shrink: 0;
+    display: inline-flex;
+    color: var(--color-brand-primary);
+  }
+
+  .summary__taste {
+    margin: var(--space-4) 0 0;
+    padding-block-start: var(--space-4);
+    border-block-start: var(--border-width) solid var(--color-border-subtle);
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-text-tertiary);
+  }
+
+  .summary__taste a {
+    color: var(--color-brand-primary);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .summary__taste a:hover {
+    text-decoration: underline;
+  }
+
+  /* ── Right: the ways in ─────────────────────────────────────────────────────*/
+  .ways {
     display: flex;
     flex-direction: column;
-    gap: var(--space-1);
+    gap: var(--space-6);
   }
 
-  .checkout__offer-name {
+  .offers {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .offer {
+    position: relative;
+    display: grid;
+    grid-template-columns: var(--space-6) 1fr auto;
+    gap: var(--space-4);
+    align-items: start;
+    padding: var(--space-5) var(--space-5-5);
+    border-radius: var(--radius-card);
+    border: var(--border-width) solid var(--color-border-subtle);
+    background: color-mix(in oklab, var(--color-surface) 65%, transparent);
+    cursor: pointer;
+    transition:
+      border-color var(--duration-fast) var(--ease-default),
+      background-color var(--duration-fast) var(--ease-default),
+      transform var(--duration-fast) var(--ease-default);
+  }
+
+  .offer:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-border-hover);
+  }
+
+  .offer--selected {
+    border-color: var(--color-brand-primary);
+    background: color-mix(in oklab, var(--color-brand-primary) 10%, transparent);
+    box-shadow: inset 0 0 0 var(--border-width) var(--color-brand-primary);
+  }
+
+  /* The native radio drives selection + keyboard nav; it is visually replaced
+     by `.offer__radio`, but stays focusable — the ring lands on the card. */
+  .offer__input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .offer:has(.offer__input:focus-visible) {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--focus-offset);
+  }
+
+  .offer__radio {
+    inline-size: var(--space-5);
+    block-size: var(--space-5);
+    margin-block-start: var(--space-0-5);
+    border-radius: var(--radius-full);
+    border: var(--border-width-thick) solid var(--color-border-strong);
+    display: grid;
+    place-items: center;
+    transition: border-color var(--duration-fast) var(--ease-default);
+  }
+
+  .offer--selected .offer__radio {
+    border-color: var(--color-brand-primary);
+  }
+
+  .offer--selected .offer__radio::after {
+    content: '';
+    inline-size: var(--space-2-5);
+    block-size: var(--space-2-5);
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary);
+  }
+
+  .offer__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+  }
+
+  .offer__name {
     margin: 0;
-    font-weight: var(--font-semibold);
-    color: var(--color-text);
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-xl);
+    color: var(--color-heading);
   }
 
-  .checkout__offer-meta {
+  .offer__who {
+    margin: 0;
+    font-size: var(--text-xs);
+    letter-spacing: 0.04em;
+    color: var(--color-brand-primary);
+  }
+
+  .offer__blurb {
     margin: 0;
     font-size: var(--text-sm);
+    line-height: var(--leading-normal);
     color: var(--color-text-secondary);
   }
 
-  .checkout__price {
-    margin: 0;
+  .offer__bullets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1) var(--space-4);
+    margin: var(--space-1) 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .offer__bullets li {
+    display: flex;
+    gap: var(--space-1-5);
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
+  }
+
+  .offer__bullets li::before {
+    content: '·';
+    color: var(--color-brand-primary);
+  }
+
+  .offer__price {
+    text-align: end;
+    white-space: nowrap;
+  }
+
+  /* Narrow screens: drop the price onto its own row under the body (mirrors the
+     prototype's < ~780px reflow) so a long price never crushes the columns. */
+  @media (--below-md) {
+    .offer {
+      grid-template-columns: var(--space-5) 1fr;
+    }
+
+    .offer__price {
+      grid-column: 2;
+      text-align: start;
+    }
+  }
+
+  .offer__price-amount {
+    display: block;
     font-family: var(--font-heading);
     font-size: var(--text-2xl);
     color: var(--color-heading);
   }
 
-  .checkout__preselect {
-    margin: 0;
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
+  .offer__price-cadence {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
   }
 
-  .checkout__pay {
+  .offer__best {
+    position: absolute;
+    top: 0;
+    left: var(--space-5-5);
+    transform: translateY(-50%);
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-full);
+    font-size: var(--text-2xs, var(--text-xs));
+    font-weight: var(--font-bold);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-on-brand);
+    background: var(--color-brand-primary);
+  }
+
+  /* ── Actions ────────────────────────────────────────────────────────────── */
+  .co-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-5);
+    flex-wrap: wrap;
+  }
+
+  .co-cta {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: var(--space-3) var(--space-6);
+    gap: var(--space-2);
+    padding: var(--space-4) var(--space-8);
     border: var(--border-width) solid transparent;
     border-radius: var(--radius-button);
     font-family: var(--font-body);
     font-size: var(--text-base);
     font-weight: var(--font-semibold);
+    line-height: var(--leading-none);
+    text-decoration: none;
     color: var(--color-text-on-brand);
     background: var(--color-brand-primary);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-default),
+      transform var(--duration-fast) var(--ease-default);
   }
 
-  .checkout__pay:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
+  .co-cta:hover {
+    background: var(--color-brand-primary-hover);
   }
 
-  .checkout__note {
+  .co-cta:active {
+    transform: translateY(1px);
+  }
+
+  .co-cta:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-focus);
+    outline-offset: var(--focus-offset);
+  }
+
+  .co-actions__fine {
+    font-size: var(--text-sm);
+    color: var(--color-text-tertiary);
+    max-width: 34ch;
+  }
+
+  .co-seam {
+    margin: 0;
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-md);
+    border: var(--border-width) solid var(--color-border-subtle);
+    background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .co-seam b {
+    color: var(--color-text);
+    font-weight: var(--font-semibold);
+  }
+
+  .co-note {
     margin: 0;
     font-size: var(--text-sm);
     color: var(--color-text-tertiary);
-    text-align: center;
+  }
+
+  .co-note a {
+    color: var(--color-brand-primary);
+    text-decoration: none;
+  }
+
+  .co-note a:hover {
+    text-decoration: underline;
+  }
+
+  /* ── Trust cues ─────────────────────────────────────────────────────────── */
+  .co-trust {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
+  }
+
+  .co-trust__item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1-5);
+  }
+
+  .co-trust__sep {
+    opacity: 0.4;
+  }
+
+  /* ── Social proof ───────────────────────────────────────────────────────── */
+  .co-proof {
+    margin: 0;
+    padding: var(--space-4) var(--space-5);
+    border-radius: var(--radius-md);
+    border: var(--border-width) solid var(--color-border-subtle);
+    background: color-mix(in oklab, var(--color-surface) 55%, transparent);
+  }
+
+  .co-proof__quote {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
+  }
+
+  .co-proof__by {
+    margin-block-start: var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .checkout__back,
+    .offer,
+    .co-cta {
+      transition: none;
+    }
+
+    .offer:hover {
+      transform: none;
+    }
   }
 </style>

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/__tests__/checkout.test.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/__tests__/checkout.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Journey checkout — offer model + server-load contract (Codex-2pryk.3.6).
+ *
+ * Two suites, both Neon-free:
+ *   1. the PURE offer/summary derivation (`../checkout-offer-model`) — the
+ *      load-bearing logic that turns the frozen `getCoursePage` envelope into the
+ *      presentational catalogue. Locks the WP-6 provenance split: the one-off
+ *      price is ALWAYS server-authoritative (`course.priceCents`), recurring
+ *      prices are page-builder-authored teasers, and a course with no authored
+ *      offers still yields a single one-off path.
+ *   2. the server `load` shell — mocks the `../journey-data` seam (mirrors the
+ *      sell page test) to lock: 404 on a missing page, the PRIVATE (never
+ *      shared-cacheable) header, guest ⇒ not-enrolled without a worker hit, and
+ *      an enrolled resolver hiccup degrading to the pre-purchase view.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  JourneyCoursePage,
+  JourneyCourseView,
+  JourneyPageRecord,
+} from '$lib/page-builder';
+import { CACHE_HEADERS } from '$lib/server/cache';
+import {
+  buildHeadNote,
+  deriveCheckoutOffers,
+  deriveCourseSummary,
+  resolvePreselectedOffer,
+} from '../checkout-offer-model';
+
+const AUTHORED_OFFERS = [
+  {
+    id: 'membership',
+    name: 'Full membership',
+    priceLabel: '£12',
+    per: 'month',
+    best: true,
+    who: 'All-in on the whole path',
+    blurb: 'Every journey, every practice.',
+    bullets: ['All courses & journeys', 'Cancel anytime'],
+  },
+  {
+    id: 'course-sub',
+    name: 'Rootwork monthly',
+    priceLabel: '£6',
+    per: 'month',
+    who: 'Just here for Rootwork',
+    blurb: 'Just this course.',
+    bullets: ['Rootwork only', 'Cancel anytime'],
+  },
+  // No authored priceLabel → the one-off price is derived from course.priceCents.
+  {
+    id: 'one-off',
+    name: 'Own Rootwork',
+    per: 'once',
+    who: 'Prefer to own, not subscribe',
+    blurb: 'Buy it outright.',
+    bullets: ['Yours forever', 'No subscription'],
+  },
+];
+
+const COURSE: JourneyCourseView = {
+  id: '00000000-0000-4000-8000-0000000000c0',
+  slug: 'rootwork',
+  title: 'Rootwork',
+  kicker: 'A guided descent',
+  lede: null,
+  status: 'published',
+  priceCents: 4900,
+  stageCount: 2,
+  practiceCount: 5,
+};
+
+function pageWith(sections: JourneyPageRecord['sections']): JourneyPageRecord {
+  return {
+    id: '00000000-0000-4000-8000-0000000000a0',
+    organizationId: '00000000-0000-4000-8000-000000000001',
+    publishedAt: '2026-05-01T09:00:00.000Z',
+    pageType: 'course',
+    slug: 'rootwork',
+    title: 'Rootwork',
+    status: 'published',
+    subjectType: 'course',
+    subjectId: COURSE.id,
+    brandOverrides: null,
+    sections,
+  } as unknown as JourneyPageRecord;
+}
+
+const inviteWithOffers = pageWith([
+  {
+    id: 'sec-invite',
+    type: 'invite',
+    enabled: true,
+    props: { priceNote: 'VAT included', offers: AUTHORED_OFFERS },
+  },
+]);
+
+const STAGES = [
+  { practices: [{ contentType: 'video' }, { contentType: 'written' }] },
+  { practices: [{ contentType: 'video' }, { contentType: 'audio' }] },
+];
+
+describe('checkout-offer-model · deriveCheckoutOffers', () => {
+  it('reads the invite section offers, deriving the one-off price from course.priceCents', () => {
+    const offers = deriveCheckoutOffers(inviteWithOffers, COURSE);
+
+    expect(offers.map((o) => o.id)).toEqual([
+      'membership',
+      'course-sub',
+      'one-off',
+    ]);
+
+    const membership = offers[0];
+    expect(membership.priceLabel).toBe('£12'); // authored teaser (WP-6 replaces)
+    expect(membership.recurring).toBe(true);
+    expect(membership.cadenceLabel).toBe('per month');
+    expect(membership.best).toBe(true);
+    expect(membership.bullets).toContain('Cancel anytime');
+
+    const oneOff = offers[2];
+    expect(oneOff.priceLabel).toBe('£49'); // SERVER-authoritative, not authored
+    expect(oneOff.recurring).toBe(false);
+    expect(oneOff.cadenceLabel).toBe('one-off');
+  });
+
+  it('falls back to a single one-off offer (from course.priceCents) when none are authored', () => {
+    const offers = deriveCheckoutOffers(pageWith([]), COURSE);
+
+    expect(offers).toHaveLength(1);
+    expect(offers[0].id).toBe('one-off');
+    expect(offers[0].priceLabel).toBe('£49');
+    expect(offers[0].recurring).toBe(false);
+    expect(offers[0].best).toBe(true);
+  });
+
+  it('returns no offers when the course has no authored offers and no standalone price', () => {
+    const free = { ...COURSE, priceCents: null };
+    expect(deriveCheckoutOffers(pageWith([]), free)).toEqual([]);
+  });
+
+  it('drops a half-authored recurring offer that has no price to show', () => {
+    const page = pageWith([
+      {
+        id: 'sec-invite',
+        type: 'invite',
+        enabled: true,
+        props: { offers: [{ id: 'x', name: 'No price', per: 'month' }] },
+      },
+    ]);
+    // The bad recurring entry is dropped; the model degrades to the one-off.
+    const offers = deriveCheckoutOffers(page, COURSE);
+    expect(offers).toHaveLength(1);
+    expect(offers[0].id).toBe('one-off');
+  });
+});
+
+describe('checkout-offer-model · resolvePreselectedOffer', () => {
+  const offers = deriveCheckoutOffers(inviteWithOffers, COURSE);
+
+  it('honours ?offer= when it names a real path', () => {
+    expect(resolvePreselectedOffer(offers, 'course-sub')).toBe('course-sub');
+  });
+
+  it('falls back to the best path when the query names nothing real', () => {
+    expect(resolvePreselectedOffer(offers, 'bogus')).toBe('membership');
+    expect(resolvePreselectedOffer(offers, null)).toBe('membership');
+  });
+
+  it('is empty when there are no offers', () => {
+    expect(resolvePreselectedOffer([], 'membership')).toBe('');
+  });
+});
+
+describe('checkout-offer-model · deriveCourseSummary', () => {
+  it('builds DB-derived facts: counts, content mix, and an invitation', () => {
+    const summary = deriveCourseSummary(COURSE, STAGES);
+
+    expect(summary.kicker).toBe('A guided descent');
+    expect(summary.title).toBe('Rootwork');
+    expect(summary.bullets[0]).toBe('5 practices across 2 stages');
+    expect(summary.bullets.some((b) => b.includes('practice'))).toBe(true);
+    // First-seen order across stages: video → written → audio.
+    expect(summary.bullets).toContain('Video, written & audio practice');
+    expect(summary.bullets.at(-1)).toBe(
+      'Yours to return to, as often as you need'
+    );
+  });
+
+  it('uses a neutral kicker fallback and omits count/mix lines when absent', () => {
+    const bare = { ...COURSE, kicker: null, stageCount: 0, practiceCount: 0 };
+    const summary = deriveCourseSummary(bare, []);
+    expect(summary.kicker).toBe('The course');
+    expect(summary.bullets).toEqual([
+      'Yours to return to, as often as you need',
+    ]);
+  });
+});
+
+describe('checkout-offer-model · buildHeadNote', () => {
+  it('summarises the number of ways in when more than one', () => {
+    const offers = deriveCheckoutOffers(inviteWithOffers, COURSE);
+    expect(buildHeadNote(offers)).toBe('One course. Three ways in.');
+  });
+
+  it('is undefined for a single path', () => {
+    expect(
+      buildHeadNote(deriveCheckoutOffers(pageWith([]), COURSE))
+    ).toBeUndefined();
+  });
+});
+
+// ── server load shell ────────────────────────────────────────────────────────
+
+const MOCK_COURSE_PAGE = {
+  page: inviteWithOffers,
+  course: COURSE,
+  stages: STAGES,
+  testimonials: [
+    {
+      id: 't1',
+      quote: 'It met my body where it was.',
+      authorName: 'A member',
+      authorContext: 'six months in',
+      sortOrder: 0,
+    },
+  ],
+} as unknown as JourneyCoursePage;
+
+const { getCoursePageMock, resolveCanEnterCourseMock } = vi.hoisted(() => ({
+  getCoursePageMock: vi.fn(),
+  resolveCanEnterCourseMock: vi.fn(),
+}));
+
+vi.mock('../../journey-data', () => ({
+  getCoursePage: getCoursePageMock,
+}));
+
+vi.mock('$lib/server/journeys/round-d-seam', () => ({
+  resolveCanEnterCourse: resolveCanEnterCourseMock,
+}));
+
+type LoadInput = Parameters<typeof import('../+page.server').load>[0];
+type LoadData = Extract<
+  Awaited<ReturnType<typeof import('../+page.server').load>>,
+  object
+>;
+
+function makeEvent(
+  journeySlug: string,
+  {
+    user = null,
+    offer = null,
+  }: { user?: { id: string } | null; offer?: string | null } = {}
+) {
+  const setHeaders = vi.fn();
+  const url = new URL(
+    `http://acme.lvh.me:3000/journeys/${journeySlug}/checkout`
+  );
+  if (offer) url.searchParams.set('offer', offer);
+  const event = {
+    params: { slug: 'acme', journeySlug },
+    parent: async () => ({ user }),
+    setHeaders,
+    url,
+  } as unknown as LoadInput;
+  return { event, setHeaders };
+}
+
+describe('journey checkout +page.server load', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCoursePageMock.mockResolvedValue(MOCK_COURSE_PAGE);
+    resolveCanEnterCourseMock.mockResolvedValue(false);
+  });
+
+  it('derives offers + summary + testimonial and resolves ?offer= for a guest', async () => {
+    const { load } = await import('../+page.server');
+    const { event } = makeEvent('rootwork', { offer: 'course-sub' });
+
+    const data = (await load(event)) as LoadData;
+
+    expect(getCoursePageMock).toHaveBeenCalledWith({ slug: 'rootwork' });
+    expect(data.orgSlug).toBe('acme');
+    expect(data.offers.map((o) => o.id)).toEqual([
+      'membership',
+      'course-sub',
+      'one-off',
+    ]);
+    expect(data.summary.bullets[0]).toBe('5 practices across 2 stages');
+    expect(data.headNote).toBe('One course. Three ways in.');
+    expect(data.priceNote).toBe('VAT included');
+    expect(data.testimonial?.authorName).toBe('A member');
+    expect(data.preselectedOfferId).toBe('course-sub');
+    // Guest ⇒ definitionally not enrolled; no worker round-trip.
+    expect(data.enrolled).toBe(false);
+    expect(resolveCanEnterCourseMock).not.toHaveBeenCalled();
+  });
+
+  it('locks the PRIVATE (never shared-cacheable) header', async () => {
+    const { load } = await import('../+page.server');
+    const { event, setHeaders } = makeEvent('rootwork');
+
+    await load(event);
+
+    expect(setHeaders).toHaveBeenCalledTimes(1);
+    expect(setHeaders).toHaveBeenCalledWith(CACHE_HEADERS.PRIVATE);
+    const [[headers]] = setHeaders.mock.calls;
+    expect(headers['Cache-Control']).toBe('private, no-cache');
+    expect(headers['Cache-Control']).not.toMatch(/public|s-maxage/);
+  });
+
+  it('throws 404 when no published page matches the slug', async () => {
+    getCoursePageMock.mockResolvedValueOnce(null);
+    const { load } = await import('../+page.server');
+    const { event } = makeEvent('does-not-exist');
+
+    await expect(load(event)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('re-targets an enrolled viewer (resolver consulted) via the enrolled flag', async () => {
+    resolveCanEnterCourseMock.mockResolvedValueOnce(true);
+    const { load } = await import('../+page.server');
+    const { event } = makeEvent('rootwork', { user: { id: 'u1' } });
+
+    const data = (await load(event)) as LoadData;
+
+    expect(resolveCanEnterCourseMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'u1',
+      COURSE.id
+    );
+    expect(data.enrolled).toBe(true);
+  });
+
+  it('degrades to the pre-purchase view when the enrolment resolver throws', async () => {
+    resolveCanEnterCourseMock.mockRejectedValueOnce(new Error('seam down'));
+    const { load } = await import('../+page.server');
+    const { event } = makeEvent('rootwork', { user: { id: 'u1' } });
+
+    const data = (await load(event)) as LoadData;
+
+    expect(data.enrolled).toBe(false);
+  });
+});

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/checkout-offer-model.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/checkout-offer-model.ts
@@ -1,0 +1,243 @@
+/**
+ * Journey checkout — pure offer + summary derivation (Codex-2pryk.3.6).
+ *
+ * The checkout is the offer/pay SHELL (SPEC §7 "one course, three ways in").
+ * This module turns the awaited {@link JourneyCoursePage} into the presentational
+ * offer catalogue + order summary the page renders — no Svelte, no DOM, no
+ * server-only imports, so it is unit-testable in isolation (Neon-free).
+ *
+ * DATA PROVENANCE (the WP-6 boundary — read carefully):
+ *   - The ONE-OFF price is SERVER-AUTHORITATIVE: it is always re-derived from
+ *     the frozen `course.priceCents`, never trusted from authored copy.
+ *   - The recurring paths (membership / course-subscription) are PAGE-BUILDER
+ *     AUTHORED teasers read out of the landing page's `invite` section
+ *     (`props.offers`, the SAME {@link InviteOffer}-shaped bag the sell page
+ *     reads). Their prices are presentational until WP-6 monetization resolves
+ *     them against real tiers / `course_subscription_plans` + Stripe. When the
+ *     builder teases no offers, the checkout degrades to the single one-off
+ *     offer built from `course.priceCents`.
+ *
+ * `PageSection.props` is org-authored jsonb — NEVER trusted structurally; every
+ * field is pulled through the `render/coerce` guards so a malformed entry
+ * degrades to a fallback instead of throwing during SSR.
+ */
+import type {
+  JourneyCourseView,
+  JourneyPageRecord,
+  PageSection,
+} from '$lib/page-builder';
+import {
+  asObjectArray,
+  fieldBool,
+  fieldString,
+} from '$lib/page-builder/render/coerce';
+import { formatPrice, formatPriceCompact } from '$lib/utils/format';
+
+/** One selectable way into the course, shown as a radio-card on the checkout. */
+export interface CheckoutOffer {
+  id: string;
+  name: string;
+  /** Formatted headline price (e.g. `£49`, `£12`). GBP. */
+  priceLabel: string;
+  /** Machine-readable cadence — drives the "per X" label + the fine print. */
+  recurring: boolean;
+  /** Human cadence label (`one-off`, `per month`, …). */
+  cadenceLabel: string;
+  /** Scope × commitment micro-label (NN/g "explicit differences"). */
+  who?: string;
+  blurb?: string;
+  bullets: string[];
+  /** The recommended path — badged + pre-selected when the URL names nothing. */
+  best: boolean;
+}
+
+/** The left-hand "what you're getting" summary card. */
+export interface CheckoutSummary {
+  /** Cover kicker — the course's own kicker, else a neutral fallback. */
+  kicker: string;
+  title: string;
+  /** Factual, DB-derived "what's inside" lines. */
+  bullets: string[];
+}
+
+/** Minimal shape the derivation reads off a stage (public sales projection). */
+interface StageLike {
+  practices: { contentType: string }[];
+}
+
+/** Whole-pound prices render clean (`£49`); pence render in full (`£49.50`). */
+function formatCleanPrice(cents: number): string {
+  return cents % 100 === 0 ? formatPriceCompact(cents) : formatPrice(cents);
+}
+
+/** Field-level string-array reader (coerce has only prop-level `asStringArray`). */
+function fieldStringArray(
+  record: Record<string, unknown>,
+  key: string
+): string[] {
+  const value = record[key];
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/** The first enabled `invite` section, or undefined. */
+function findInviteSection(sections: PageSection[]): PageSection | undefined {
+  return sections.find((s) => s.type === 'invite' && s.enabled !== false);
+}
+
+/**
+ * Map one authored offer entry → a {@link CheckoutOffer}. Requires an `id` +
+ * `name`, and a resolvable price: an authored `priceLabel`, or the real
+ * `course.priceCents` for a non-recurring (one-off) path. Returns null (dropped)
+ * when neither is present, so a half-authored entry never shows a blank price.
+ */
+function mapOffer(
+  entry: Record<string, unknown>,
+  course: JourneyCourseView
+): CheckoutOffer | null {
+  const id = fieldString(entry, 'id');
+  const name = fieldString(entry, 'name');
+  if (!id || !name) return null;
+
+  const per = fieldString(entry, 'per');
+  const recurring = per !== undefined && per !== 'once';
+  const cadenceLabel = recurring ? `per ${per}` : 'one-off';
+
+  const authoredPrice = fieldString(entry, 'priceLabel');
+  const priceLabel =
+    authoredPrice ??
+    (!recurring && course.priceCents !== null
+      ? formatCleanPrice(course.priceCents)
+      : undefined);
+  if (!priceLabel) return null;
+
+  return {
+    id,
+    name,
+    priceLabel,
+    recurring,
+    cadenceLabel,
+    who: fieldString(entry, 'who'),
+    blurb: fieldString(entry, 'blurb'),
+    bullets: fieldStringArray(entry, 'bullets'),
+    best: fieldBool(entry, 'best'),
+  };
+}
+
+/**
+ * The selectable offers. Reads the `invite` section's authored `offers` bag;
+ * when none is teased, degrades to a single one-off offer built from the
+ * server-authoritative `course.priceCents`. Empty only when the course is not
+ * sold standalone AND no offers are authored.
+ */
+export function deriveCheckoutOffers(
+  page: JourneyPageRecord,
+  course: JourneyCourseView
+): CheckoutOffer[] {
+  const invite = findInviteSection(page.sections);
+  const authored = invite
+    ? asObjectArray<CheckoutOffer>(invite.props, 'offers', (entry) =>
+        mapOffer(entry, course)
+      )
+    : undefined;
+  if (authored && authored.length > 0) return authored;
+
+  if (course.priceCents !== null) {
+    return [
+      {
+        id: 'one-off',
+        name: `Own ${course.title}`,
+        priceLabel: formatCleanPrice(course.priceCents),
+        recurring: false,
+        cadenceLabel: 'one-off',
+        who: 'Prefer to own, not subscribe',
+        blurb: `Buy ${course.title} outright. Yours to return to, for good.`,
+        bullets: ['Yours forever', 'No subscription', 'Lifetime access'],
+        best: true,
+      },
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * Which offer starts selected. Honours `?offer=<id>` when it names a real path
+ * (deep-links from the sell page's teased paths), else the `best` path, else the
+ * first. Returns '' only when there are no offers.
+ */
+export function resolvePreselectedOffer(
+  offers: CheckoutOffer[],
+  wanted: string | null
+): string {
+  if (offers.length === 0) return '';
+  if (wanted && offers.some((o) => o.id === wanted)) return wanted;
+  return (offers.find((o) => o.best) ?? offers[0]).id;
+}
+
+/** Title-case a content-type token for the "what's inside" mix line. */
+function contentTypeLabel(type: string): string {
+  if (type === 'written') return 'written';
+  return type; // 'video' | 'audio' — already lower, joined into a sentence
+}
+
+/** "Video, audio & written practice" from the real practice content types. */
+function formatContentMix(stages: StageLike[]): string | undefined {
+  const seen: string[] = [];
+  for (const stage of stages) {
+    for (const practice of stage.practices) {
+      const label = contentTypeLabel(practice.contentType);
+      if (label && !seen.includes(label)) seen.push(label);
+    }
+  }
+  if (seen.length === 0) return undefined;
+  const capped = seen[0].charAt(0).toUpperCase() + seen[0].slice(1);
+  const rest = seen.slice(1);
+  const tail =
+    rest.length === 0
+      ? ''
+      : rest.length === 1
+        ? ` & ${rest[0]}`
+        : `, ${rest.slice(0, -1).join(', ')} & ${rest[rest.length - 1]}`;
+  return `${capped}${tail} practice`;
+}
+
+/**
+ * The left-hand order summary. Every factual line is DB-derived — the practice/
+ * stage counts and the content-type mix come straight off the awaited course +
+ * stages, so the card can never claim more than the course actually holds.
+ */
+export function deriveCourseSummary(
+  course: JourneyCourseView,
+  stages: StageLike[]
+): CheckoutSummary {
+  const bullets: string[] = [];
+
+  if (course.practiceCount > 0 && course.stageCount > 0) {
+    const practices = `${course.practiceCount} ${course.practiceCount === 1 ? 'practice' : 'practices'}`;
+    const stagesLabel = `${course.stageCount} ${course.stageCount === 1 ? 'stage' : 'stages'}`;
+    bullets.push(`${practices} across ${stagesLabel}`);
+  }
+
+  const mix = formatContentMix(stages);
+  if (mix) bullets.push(mix);
+
+  bullets.push('Yours to return to, as often as you need');
+
+  return {
+    kicker: course.kicker ?? 'The course',
+    title: course.title,
+    bullets,
+  };
+}
+
+/** Head sub-line — "One course. N ways in." when more than one path is offered. */
+export function buildHeadNote(offers: CheckoutOffer[]): string | undefined {
+  if (offers.length < 2) return undefined;
+  const words = ['zero', 'one', 'two', 'three', 'four', 'five', 'six'];
+  const n = words[offers.length] ?? String(offers.length);
+  return `One course. ${n.charAt(0).toUpperCase() + n.slice(1)} ways in.`;
+}


### PR DESCRIPTION
## What

Fidelity pass on the journey **checkout** — the offer/pay step ("one course, three ways in", SPEC §7) — to match the prototype `docs/design/course-journeys/prototype/checkout.html`. The route existed as a minimal one-price shell; this rebuilds it as the full prototype layout on real Codex tokens + the org brand.

**Route:** `apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/checkout/`

### Sections (all present, matching the prototype)
- **Head** — ember kicker (`course.kicker`), "Choose your way in", "One course. N ways in." note.
- **Order summary** (left, sticky on desktop) — cover (kicker + course title) + DB-derived "what's inside" bullets (practice/stage counts, real content-type mix e.g. "Video, written & audio practice") + a "watch the intro" taste line back to the sales page.
- **Offer chooser** (right) — a keyboard-navigable radio-group of offer cards: "best value" badge, `who` scope×commitment micro-label, blurb, bullets, price + cadence. Selecting a path flips the fine print live.
- **Actions** — primary CTA + live fine print; **trust row** (secure checkout · VAT included · cancel anytime); **social proof** (first testimonial).

### Data provenance (the important part)
- **Real, DB-backed** via the frozen `getCoursePage` seam: the course, its **one-off price** (`course.priceCents` → £49, server-authoritative), the summary facts, the offer teasers (authored on the landing page's `invite` section — the same `InviteOffer` bag the sell page reads), and the testimonial.
- A pure, unit-tested module (`checkout-offer-model.ts`) does the derivation, keeping logic out of the loader/template. The one-off price is always re-derived from `course.priceCents`; recurring prices are the authored teasers. With no authored offers it degrades to a single one-off path.

### Palette
Immersive candlelit surface **self-derived from the org's `--color-brand-primary` via OKLCH** (mirrors `JourneyRenderer`'s `.journey-page` re-pointing), so it re-themes on any org brand + per-page `brandOverrides`. Re-points `--color-heading` to tame org-brand.css's heading override. No hardcoded px/hex. On studio-alpha this renders deep crimson (its real brand hue), not the prototype's amber stand-in — correct, brand-adaptive behaviour.

## Deferred to WP-6 (monetization) — documented, not faked
- The **live three-path resolution** (real tier / `course_subscription_plans` prices + Stripe price IDs). Recurring offer prices here are page-builder teasers.
- The **Stripe checkout action** + the `entitlements` write on webhook success. The "Continue" CTA is wired only up to the seam: clicking it surfaces an honest "payment is being connected — goes live with the monetization release" note rather than a fake "You're in" confirmation. The prototype's post-purchase confirmation screen is that WP-6 settlement (the app already has a `/checkout/success` route).

## Verification (local, in-browser via Playwright)
- Dev stack: web + auth + organization-api + identity-api + content-api (checkout loader needs no ecom worker).
- **Guest / pre-purchase** (`studio-alpha.lvh.me:3000/journeys/rootwork/checkout`, logged out): head, sticky summary, three offer cards (£12 & £6 /month, **£49 one-off from the real price**), "Continue →" + fine print, trust row, testimonial — screenshot-diffed against the prototype.
- **Interactions asserted** (`browser_evaluate`): selecting the one-off path flips the fine print to one-off wording + fills its radio; clicking Continue reveals the WP-6 seam note; the mobile reflow drops the price onto its own row under the body.
- **Enrolled** (creator@test.com, owner + enrolled): CTA re-targets to "Enter the journey →" (dashboard) with "you already have access" — real `resolveCanEnterCourse`.
- **Mobile** (390px): single column, summary un-stuck, offer price reflow — verified by geometry + screenshot.
- **Console:** the only errors are environmental (dev-cdn images on :4100 and the org layout's ecom subscription refresh — neither worker was in this stack); the checkout page itself emits none.

## Gates
- `pnpm --filter web check` (svelte-check): **0 errors in changed files** (overall 86/43 is the pre-existing baseline, unchanged).
- Biome: clean on all changed files.
- Vitest: `checkout/__tests__/checkout.test.ts` — **16/16 pass** (model provenance split + load shell: 404, PRIVATE header, guest-not-enrolled, enrolled re-target, resolver degrade).

## Local fixture reproduction (NOT committed — local dev only)
The `rootwork` course + sections exist from surfaces 1 & 2. To author the three offer paths on the `invite` section (idempotent; the one-off carries no price so the loader derives £49):
```
node /Users/brucemckay/.claude/jobs/da29a162/tmp/seed-journey-fixture.mjs   # course + stages + practices (surface 1)
node /Users/brucemckay/.claude/jobs/da29a162/tmp/seed-sell-sections.mjs      # landing sections + testimonials (surface 2)
node /Users/brucemckay/.claude/jobs/da29a162/tmp/seed-checkout-offers.mjs     # authors invite.props.offers (this surface)
```
Without the offers fixture the page still works — it degrades to the single one-off offer built from `course.priceCents`.

## Remaining gaps / deviations
- The summary's "taste" line links to the sales page's intro rather than asserting a specific free practice, because the public `getCoursePage` read doesn't expose a per-practice `is_free` flag — kept honest rather than fabricating the claim.
- Palette is crimson on studio-alpha (its brand), not the prototype's amber — intentional brand adaptation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
