### PR TITLE
feat(web): in-course practice player fidelity pass vs prototype (Codex-2pryk.3.7)

### DIFF
--- a/apps/web/src/lib/components/journeys/PracticePlaylist.svelte
+++ b/apps/web/src/lib/components/journeys/PracticePlaylist.svelte
@@ -1,9 +1,11 @@
 <!--
   @component PracticePlaylist
 
-  The in-course player's left rail: the whole course sequence grouped by stage,
-  the current practice highlighted, completion state per row, each linking to
-  its practice page. Presentational — completion set + current id are supplied.
+  The in-course player's left rail: the WHOLE journey map as a stage accordion
+  (SPEC §8.6). Each stage is a collapsible `<details>` group — the current
+  stage lands open, cleared stages collapse — so you can jump to any practice
+  without returning to the dashboard. Presentational: completion set + current
+  id are supplied by the page's live progress query.
 
   @prop {PlaylistEntry[]} playlist - Ordered course sequence from the load.
   @prop {ReadonlySet<string>} completedIds - Content ids with a completion row.
@@ -12,8 +14,8 @@
 -->
 <script lang="ts">
   import {
-    CheckCircleIcon,
-    CircleIcon,
+    CheckIcon,
+    ChevronRightIcon,
     FileTextIcon,
     MusicIcon,
     VideoIcon,
@@ -35,6 +37,8 @@
     stageName: string;
     entries: PlaylistEntry[];
   }
+
+  const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x'];
 
   // Group the flattened playlist by stage, preserving order.
   const groups = $derived.by(() => {
@@ -60,42 +64,73 @@
     return FileTextIcon;
   }
 
+  function typeLabel(type: PracticeContentType): string {
+    if (type === 'video') return 'Video';
+    if (type === 'audio') return 'Audio';
+    return 'Reflection';
+  }
+
   function entryHref(entry: PlaylistEntry): string {
     return `/journeys/${courseSlug}/practice/${entry.slug ?? entry.contentId}`;
   }
 </script>
 
 <nav class="playlist" aria-label="Course practices">
-  {#each groups as group (group.stageId)}
-    <div class="playlist__group">
-      <h2 class="playlist__stage">{group.stageName}</h2>
+  {#each groups as group, index (group.stageId)}
+    {@const doneCount = group.entries.filter((e) => completedIds.has(e.contentId)).length}
+    {@const total = group.entries.length}
+    {@const allDone = doneCount === total}
+    {@const isCurrent = group.entries.some((e) => e.contentId === currentContentId)}
+    <details
+      class="playlist__stage"
+      class:playlist__stage--current={isCurrent}
+      class:playlist__stage--done={allDone && !isCurrent}
+      open={isCurrent}
+    >
+      <summary class="playlist__head">
+        <span class="playlist__rn" aria-hidden="true">{ROMAN[index] ?? index + 1}</span>
+        <span class="playlist__name">{group.stageName}</span>
+        <span class="playlist__count" aria-label="{doneCount} of {total} complete">
+          {doneCount}/{total}
+        </span>
+        <ChevronRightIcon size={16} class="playlist__chev" aria-hidden="true" />
+      </summary>
+
       <ul class="playlist__items">
         {#each group.entries as entry (entry.contentId)}
           {@const done = completedIds.has(entry.contentId)}
           {@const current = entry.contentId === currentContentId}
+          {@const state = done ? 'done' : current ? 'cur' : 'up'}
           {@const Icon = iconFor(entry.contentType)}
           <li>
             <a
-              class="item"
-              class:item--current={current}
-              class:item--done={done}
+              class="playlist__row"
+              class:playlist__row--done={done}
+              class:playlist__row--current={current}
               href={entryHref(entry)}
               aria-current={current ? 'page' : undefined}
             >
-              <span class="item__status" aria-hidden="true">
+              <span class="playlist__lic playlist__lic--{state}" aria-hidden="true">
                 {#if done}
-                  <CheckCircleIcon />
+                  <CheckIcon size={11} />
+                {:else if current}
+                  <span class="playlist__dot"></span>
                 {:else}
-                  <CircleIcon />
+                  <Icon size={11} />
                 {/if}
               </span>
-              <span class="item__type" aria-hidden="true"><Icon /></span>
-              <span class="item__title">{entry.title}</span>
+              <span class="playlist__col">
+                <span class="playlist__title">{entry.title}</span>
+                <span class="playlist__meta">{typeLabel(entry.contentType)}</span>
+              </span>
+              <span class="playlist__go" aria-hidden="true">
+                {current ? 'Here' : 'Open →'}
+              </span>
             </a>
           </li>
         {/each}
       </ul>
-    </div>
+    </details>
   {/each}
 </nav>
 
@@ -103,72 +138,211 @@
   .playlist {
     display: flex;
     flex-direction: column;
-    gap: var(--space-6);
-  }
-
-  .playlist__stage {
-    margin: 0 0 var(--space-2);
-    padding: 0 var(--space-3);
-    font-size: var(--text-xs);
-    text-transform: var(--text-transform-label);
-    letter-spacing: 0.06em;
-    color: var(--color-text-muted);
-  }
-
-  .playlist__items {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
     gap: var(--space-1);
   }
 
-  .item {
+  /* ── stage accordion ── */
+  .playlist__stage {
+    border: var(--border-width) var(--border-style) transparent;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+
+  .playlist__stage[open] {
+    background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+    border-color: var(--color-border-subtle);
+  }
+
+  .playlist__stage--current {
+    border-color: color-mix(in oklab, var(--color-brand-primary) 30%, transparent);
+  }
+
+  .playlist__head {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--radius-md);
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: background-color var(--duration-fast) ease;
+    padding: var(--space-2) var(--space-2);
+    cursor: pointer;
+    list-style: none;
+    border-radius: var(--radius-lg);
   }
 
-  .item:hover {
-    background: var(--color-surface-secondary);
+  .playlist__head::-webkit-details-marker {
+    display: none;
   }
 
-  .item:focus-visible {
+  .playlist__head:hover {
+    background: color-mix(in oklab, var(--color-text) 5%, transparent);
+  }
+
+  .playlist__head:focus-visible {
     outline: none;
     box-shadow: var(--shadow-focus-ring);
   }
 
-  .item--current {
-    background: var(--color-surface-secondary);
-    color: var(--color-heading);
-    font-weight: var(--font-medium);
+  .playlist__rn {
+    flex: none;
+    display: grid;
+    place-items: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    border-radius: var(--radius-full);
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-text) 20%, transparent);
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
   }
 
-  .item__status {
-    display: inline-flex;
-    color: var(--color-text-muted);
+  .playlist__stage--current .playlist__rn {
+    border-color: var(--color-brand-primary);
+    color: var(--color-brand-primary);
+    box-shadow: 0 0 var(--space-2) 0
+      color-mix(in oklab, var(--color-brand-primary) 32%, transparent);
   }
 
-  .item--done .item__status {
-    color: var(--color-success);
+  .playlist__stage--done .playlist__rn {
+    border-color: transparent;
+    background: color-mix(in oklab, var(--color-brand-primary) 20%, transparent);
+    color: var(--color-brand-primary);
   }
 
-  .item__type {
-    display: inline-flex;
-    color: var(--color-text-muted);
-  }
-
-  .item__title {
+  .playlist__name {
     flex: 1;
+    min-width: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-base);
+    line-height: var(--leading-tight);
+    color: var(--color-heading);
+  }
+
+  .playlist__count {
+    flex: none;
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  :global(.playlist__chev) {
+    flex: none;
+    color: var(--color-text-tertiary);
+    transition: transform var(--duration-fast) var(--ease-out);
+  }
+
+  .playlist__stage[open] :global(.playlist__chev) {
+    transform: rotate(90deg);
+  }
+
+  /* ── lesson rows ── */
+  .playlist__items {
+    list-style: none;
+    margin: 0;
+    padding: 0 var(--space-1) var(--space-2);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+  }
+
+  .playlist__row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    transition: background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .playlist__row:hover {
+    background: color-mix(in oklab, var(--color-text) 6%, transparent);
+  }
+
+  .playlist__row--current {
+    background: color-mix(in oklab, var(--color-brand-primary) 13%, transparent);
+  }
+
+  .playlist__row:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+  }
+
+  .playlist__lic {
+    flex: none;
+    display: grid;
+    place-items: center;
+    width: var(--space-5);
+    height: var(--space-5);
+    border-radius: var(--radius-full);
+    border: var(--border-width-thick) var(--border-style)
+      color-mix(in oklab, var(--color-text) 26%, transparent);
+    color: var(--color-text-tertiary);
+  }
+
+  .playlist__lic--done {
+    border-color: var(--color-brand-primary);
+    background: var(--color-brand-primary);
+    color: var(--color-text-on-brand);
+  }
+
+  .playlist__lic--cur {
+    border-color: var(--color-brand-primary);
+    color: var(--color-brand-primary);
+    box-shadow: 0 0 var(--space-2) 0
+      color-mix(in oklab, var(--color-brand-primary) 40%, transparent);
+  }
+
+  .playlist__dot {
+    width: var(--space-2);
+    height: var(--space-2);
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary);
+  }
+
+  .playlist__col {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .playlist__title {
+    font-family: var(--font-heading);
     font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    color: var(--color-heading);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .playlist__row--done .playlist__title {
+    color: var(--color-text-secondary);
+  }
+
+  .playlist__meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
+    margin-top: var(--space-0-5);
+  }
+
+  .playlist__go {
+    flex: none;
+    font-size: var(--text-xs);
+    color: var(--color-brand-primary);
+    opacity: 0;
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+
+  .playlist__row--current .playlist__go,
+  .playlist__row:hover .playlist__go {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.playlist__chev),
+    .playlist__go {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/components/journeys/PracticeWorkingPane.svelte
+++ b/apps/web/src/lib/components/journeys/PracticeWorkingPane.svelte
@@ -1,19 +1,27 @@
 <!--
   @component PracticeWorkingPane
 
-  The in-course player's working pane: the practice itself + its completion
-  affordance + prev/next nav. Completion follows the D-E boundary (SPEC §14.3):
+  The in-course player's working column (SPEC §8.6): lesson chrome (breadcrumb,
+  journey badge, title, type line), the practice itself, the stage "why", the
+  single completion + Next affordance, the peak-end completion card on the last
+  practice, and the prev / back-to-overview footer.
 
+  Completion follows the D-E boundary (SPEC §14.3):
     - video / audio → completion AUTO-writes on genuine 100% finish. No button;
-      a caption states "completes when you finish". Genuine finish is detected
-      from the SINGLE progress store: the player's tracker saves position on the
-      native `ended` event, so `playbackPercent` reaches 100 only on a true
-      finish (the 95% "watched" flag never reaches 100). Idempotent.
+      a status states "completes when you finish". Genuine finish is read from
+      the SINGLE progress store — the player saves position on the native
+      `ended` event, so `playbackPercent` reaches 100 only on a true finish
+      (the 95% "watched" flag never does). Idempotent.
     - written → an EXPLICIT "Mark complete" button (no playback signal).
 
-  Playback (no unmuted hover-autoplay — the players are click-initiated).
+  Players are click-initiated (no unmuted hover-autoplay). Written bodies render
+  server-sanitised `bodyHtml` via `{@html}` (mirrors the standalone content page).
 
   @prop {JourneyPractice} practice - The open practice.
+  @prop {string} courseTitle - Course title (breadcrumb + footer + overview link).
+  @prop {string} stageName - The practice's stage name (breadcrumb + "why").
+  @prop {string | null} stageGloss - The stage's reflective line, if any.
+  @prop {string} dashboardHref - Root-relative course dashboard link.
   @prop {string | null} streamingUrl - Signed HLS URL (media); null → degraded.
   @prop {string | null} waveformUrl - Signed waveform URL (audio).
   @prop {string | null} bodyHtml - Rendered body (written); server-sanitised.
@@ -21,17 +29,30 @@
   @prop {boolean} isComplete - Reactive completion (parent live query).
   @prop {number} playbackPercent - Reactive watch % (parent live query).
   @prop {string | null} prevHref - Previous practice, or null at the start.
+  @prop {string | null} prevTitle - Previous practice title (footer label).
   @prop {string | null} nextHref - Next practice, or null at the end.
+  @prop {string} nextLabel - Next affordance label (gate-crossing aware).
 -->
 <script lang="ts">
   import AudioPlayer from '$lib/components/AudioPlayer/AudioPlayer.svelte';
-  import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from '$lib/components/ui/Icon';
+  import {
+    ArrowLeftIcon,
+    ArrowRightIcon,
+    CheckIcon,
+    ClockIcon,
+    CompassIcon,
+    LibraryIcon,
+  } from '$lib/components/ui/Icon';
   import VideoPlayer from '$lib/components/VideoPlayer/VideoPlayer.svelte';
   import { markPracticeComplete } from '$lib/collections';
   import type { JourneyPractice } from '$lib/journeys/types';
 
   interface Props {
     practice: JourneyPractice;
+    courseTitle: string;
+    stageName: string;
+    stageGloss: string | null;
+    dashboardHref: string;
     streamingUrl: string | null;
     waveformUrl: string | null;
     bodyHtml: string | null;
@@ -39,11 +60,17 @@
     isComplete: boolean;
     playbackPercent: number;
     prevHref: string | null;
+    prevTitle: string | null;
     nextHref: string | null;
+    nextLabel: string;
   }
 
   const {
     practice,
+    courseTitle,
+    stageName,
+    stageGloss,
+    dashboardHref,
     streamingUrl,
     waveformUrl,
     bodyHtml,
@@ -51,12 +78,32 @@
     isComplete,
     playbackPercent,
     prevHref,
+    prevTitle,
     nextHref,
+    nextLabel,
   }: Props = $props();
 
   const isMedia = $derived(
     practice.contentType === 'video' || practice.contentType === 'audio'
   );
+  const isLast = $derived(nextHref === null);
+
+  const typeLabel = $derived(
+    practice.contentType === 'video'
+      ? 'Video'
+      : practice.contentType === 'audio'
+        ? 'Audio'
+        : 'Reflection'
+  );
+  const minutes = $derived(
+    practice.durationSeconds
+      ? Math.max(1, Math.round(practice.durationSeconds / 60))
+      : null
+  );
+  const typeLine = $derived(
+    minutes ? `${typeLabel} · ${minutes} min` : typeLabel
+  );
+  const verb = $derived(practice.contentType === 'audio' ? 'listen' : 'watch');
 
   // D-E auto-write: media completes on genuine 100% finish (not the 95% watch
   // flag). `markPracticeComplete` is idempotent so re-fires are safe.
@@ -73,17 +120,24 @@
 </script>
 
 <article class="pane">
-  <header class="pane__header">
-    <h1 class="pane__title">{practice.title}</h1>
-    {#if isComplete}
-      <span class="pane__badge" aria-label="Completed">
-        <CheckIcon /> Completed
-      </span>
-    {/if}
-  </header>
+  <nav class="pane__crumb" aria-label="Breadcrumb">
+    <a class="pane__crumb-link" href={dashboardHref}>{courseTitle}</a>
+    <span class="pane__crumb-sep" aria-hidden="true">›</span>
+    <span class="pane__crumb-stage">{stageName}</span>
+    <span class="pane__crumb-sep" aria-hidden="true">›</span>
+    <span class="pane__crumb-here" aria-current="page">{practice.title}</span>
+  </nav>
 
-  <div class="pane__stage">
-    {#if isMedia}
+  <span class="pane__badge">
+    <span class="pane__badge-glyph" aria-hidden="true">◈</span>
+    part of your journey
+  </span>
+
+  <h1 class="pane__title">{practice.title}</h1>
+  <p class="pane__type">{typeLine}</p>
+
+  {#if isMedia}
+    <div class="pane__media">
       {#if streamingUrl}
         {#if practice.contentType === 'video'}
           <VideoPlayer
@@ -102,56 +156,93 @@
           />
         {/if}
       {:else}
-        <!-- Round-D signs the R2 stream URL; until then, a degraded state. -->
+        <!-- canView withheld the signed stream — degraded, still in-course. -->
         <div class="pane__placeholder">
-          <p>This {practice.contentType} streams once the access plumbing lands.</p>
+          <p>This {practice.contentType} isn't available to stream right now.</p>
         </div>
       {/if}
-    {:else if bodyHtml}
+    </div>
+  {/if}
+
+  {#if stageGloss}
+    <p class="pane__why">{stageGloss}</p>
+  {/if}
+
+  {#if !isMedia}
+    {#if bodyHtml}
       <!-- Server-rendered, sanitised body (mirrors the standalone content page). -->
       <div class="pane__body">
         {@html bodyHtml}
       </div>
     {:else}
-      <div class="pane__placeholder">
-        <p>This practice has no content yet.</p>
+      <div class="pane__placeholder pane__placeholder--body">
+        <p>This reflection has no written guidance yet.</p>
       </div>
+    {/if}
+  {/if}
+
+  <div class="pane__actions">
+    {#if isMedia}
+      <span class="pane__auto" class:pane__auto--done={isComplete}>
+        {#if isComplete}
+          <CheckIcon size={16} class="pane__auto-glyph" />
+          Completed · your place is saved
+        {:else}
+          <ClockIcon size={16} class="pane__auto-glyph" />
+          Saves as you {verb} · completes when you finish
+        {/if}
+      </span>
+    {:else if isComplete}
+      <span class="pane__done-pill">
+        <CheckIcon size={16} /> Completed
+      </span>
+    {:else}
+      <button type="button" class="pane__mark" onclick={handleMarkComplete}>
+        <CheckIcon size={16} /> Mark complete
+      </button>
+    {/if}
+
+    {#if !isLast && nextHref}
+      <a class="pane__next" href={nextHref}>
+        {nextLabel}
+        <ArrowRightIcon size={18} class="pane__next-arrow" />
+      </a>
     {/if}
   </div>
 
-  <footer class="pane__footer">
-    <div class="pane__completion">
-      {#if isMedia}
-        {#if isComplete}
-          <span class="pane__complete-note">
-            <CheckIcon /> Completed on finish
-          </span>
-        {:else}
-          <span class="pane__auto-note">Completes when you finish</span>
-        {/if}
-      {:else if isComplete}
-        <span class="pane__complete-note">
-          <CheckIcon /> Marked complete
-        </span>
-      {:else}
-        <button type="button" class="pane__mark" onclick={handleMarkComplete}>
-          <CheckIcon /> Mark complete
-        </button>
-      {/if}
-    </div>
+  {#if isLast}
+    <!-- Peak-end: the journey closes on the last practice (SPEC §14.5). -->
+    <section class="pane__complete">
+      <span class="pane__seal" aria-hidden="true"><CheckIcon size={24} /></span>
+      <h2 class="pane__complete-title">You've walked the whole of {courseTitle}.</h2>
+      <p class="pane__complete-body">
+        The ground is in you now. Return to any practice whenever you need it —
+        or let the next journey find you.
+      </p>
+      <div class="pane__complete-row">
+        <a class="pane__next" href="/explore">
+          <CompassIcon size={18} /> Find your next journey
+        </a>
+        <a class="pane__ghost" href="/library">
+          <LibraryIcon size={18} /> Back to your library
+        </a>
+      </div>
+    </section>
+  {/if}
 
-    <nav class="pane__nav" aria-label="Practice navigation">
-      {#if prevHref}
-        <a class="pane__nav-link" href={prevHref}>
-          <ArrowLeftIcon /> Previous
-        </a>
-      {/if}
-      {#if nextHref}
-        <a class="pane__nav-link pane__nav-link--next" href={nextHref}>
-          Next <ArrowRightIcon />
-        </a>
-      {/if}
-    </nav>
+  <footer class="pane__foot">
+    {#if prevHref}
+      <a class="pane__foot-link" href={prevHref}>
+        <span class="pane__foot-label"><ArrowLeftIcon size={14} /> Previous</span>
+        <span class="pane__foot-title">{prevTitle}</span>
+      </a>
+    {:else}
+      <span></span>
+    {/if}
+    <a class="pane__foot-link pane__foot-link--map" href={dashboardHref}>
+      <span class="pane__foot-label">Back to</span>
+      <span class="pane__foot-title">{courseTitle} overview</span>
+    </a>
   </footer>
 </article>
 
@@ -159,41 +250,84 @@
   .pane {
     display: flex;
     flex-direction: column;
-    gap: var(--space-5);
+    align-items: flex-start;
+    max-width: 48rem;
+    margin-inline: auto;
+    padding: var(--space-8) var(--space-6) var(--space-16);
     min-width: 0;
   }
 
-  .pane__header {
+  /* ── breadcrumb ── */
+  .pane__crumb {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--space-3);
+    gap: var(--space-2);
     flex-wrap: wrap;
+    font-size: var(--text-sm);
+    color: var(--color-text-tertiary);
   }
 
-  .pane__title {
-    margin: 0;
-    font-family: var(--font-heading);
-    font-size: var(--text-2xl);
-    color: var(--color-heading);
+  .pane__crumb-link {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
   }
 
+  .pane__crumb-link:hover {
+    color: var(--color-brand-primary);
+  }
+
+  .pane__crumb-sep {
+    opacity: 0.5;
+  }
+
+  .pane__crumb-here {
+    color: var(--color-brand-primary);
+  }
+
+  /* ── journey badge ── */
   .pane__badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--space-1);
+    gap: var(--space-2);
+    margin-top: var(--space-4);
     padding: var(--space-1) var(--space-3);
     border-radius: var(--radius-full);
-    background: var(--color-success-100);
-    color: var(--color-success-700);
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-brand-primary) 30%, transparent);
+    background: color-mix(in oklab, var(--color-brand-primary) 12%, transparent);
+    color: var(--color-brand-primary);
     font-size: var(--text-xs);
     font-weight: var(--font-medium);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
   }
 
-  .pane__stage {
+  .pane__title {
+    margin: var(--space-3) 0 var(--space-1);
+    font-family: var(--font-heading);
+    font-size: var(--text-4xl);
+    font-weight: var(--font-normal);
+    line-height: var(--leading-tight);
+    color: var(--color-heading);
+    text-wrap: balance;
+  }
+
+  .pane__type {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-tertiary);
+  }
+
+  /* ── media / body ── */
+  .pane__media {
+    width: 100%;
+    margin-top: var(--space-6);
     border-radius: var(--radius-card);
     overflow: hidden;
-    min-width: 0;
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-brand-primary) 18%, transparent);
+    background: var(--color-surface-secondary);
   }
 
   .pane__placeholder {
@@ -202,90 +336,268 @@
     aspect-ratio: 16 / 9;
     padding: var(--space-8);
     text-align: center;
-    background: var(--color-surface-secondary);
-    color: var(--color-text-muted);
+    color: var(--color-text-tertiary);
+  }
+
+  .pane__placeholder--body {
+    aspect-ratio: auto;
+    width: 100%;
+    margin-top: var(--space-6);
     border-radius: var(--radius-card);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+  }
+
+  .pane__placeholder p {
+    margin: 0;
+    font-size: var(--text-sm);
+  }
+
+  .pane__why {
+    width: 100%;
+    margin: var(--space-6) 0 0;
+    padding-left: var(--space-4);
+    border-left: var(--border-width-thick) var(--border-style)
+      color-mix(in oklab, var(--color-brand-primary) 40%, transparent);
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-size: var(--text-lg);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
   }
 
   .pane__body {
-    padding: var(--space-2) 0;
-    color: var(--color-text);
-    font-size: var(--text-base);
+    width: 100%;
+    margin-top: var(--space-6);
+    font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
-  }
-
-  .pane__footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-4);
-    flex-wrap: wrap;
-    padding-top: var(--space-4);
-    border-top: var(--border-width) var(--border-style) var(--color-border-subtle);
-  }
-
-  .pane__auto-note,
-  .pane__complete-note {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    font-size: var(--text-sm);
-    color: var(--color-text-muted);
-  }
-
-  .pane__complete-note {
-    color: var(--color-success);
-  }
-
-  .pane__mark {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-2) var(--space-4);
-    border: var(--border-width) var(--border-style) var(--color-primary-600);
-    border-radius: var(--radius-button);
-    background: var(--color-primary-600);
-    color: var(--color-text-on-brand);
-    font-size: var(--text-sm);
-    font-weight: var(--font-medium);
-    cursor: pointer;
-    transition: background-color var(--duration-fast) ease;
-  }
-
-  .pane__mark:hover {
-    background: var(--color-primary-700);
-  }
-
-  .pane__mark:focus-visible {
-    outline: none;
-    box-shadow: var(--shadow-focus-ring);
-  }
-
-  .pane__nav {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-
-  .pane__nav-link {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--radius-button);
     color: var(--color-text-secondary);
-    text-decoration: none;
-    font-size: var(--text-sm);
-    transition: background-color var(--duration-fast) ease;
   }
 
-  .pane__nav-link:hover {
-    background: var(--color-surface-secondary);
+  .pane__body :global(p) {
+    margin: 0 0 var(--space-4);
+  }
+
+  .pane__body :global(h2),
+  .pane__body :global(h3) {
+    margin: var(--space-6) 0 var(--space-2);
+    font-family: var(--font-heading);
     color: var(--color-heading);
   }
 
-  .pane__nav-link:focus-visible {
+  /* ── actions: the single completion + Next ── */
+  .pane__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-top: var(--space-8);
+  }
+
+  .pane__mark,
+  .pane__next,
+  .pane__ghost,
+  .pane__done-pill,
+  .pane__auto {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-5);
+    border-radius: var(--radius-full);
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    text-decoration: none;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out),
+      transform var(--duration-fast) var(--ease-out);
+  }
+
+  .pane__mark {
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-text) 28%, transparent);
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .pane__mark:hover {
+    border-color: var(--color-brand-primary);
+  }
+
+  .pane__mark:focus-visible,
+  .pane__next:focus-visible,
+  .pane__ghost:focus-visible {
     outline: none;
     box-shadow: var(--shadow-focus-ring);
+  }
+
+  .pane__done-pill {
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-brand-primary) 40%, transparent);
+    background: color-mix(in oklab, var(--color-brand-primary) 16%, transparent);
+    color: var(--color-brand-primary);
+  }
+
+  .pane__next {
+    background: var(--color-brand-primary);
+    color: var(--color-text-on-brand);
+    border: var(--border-width) var(--border-style) transparent;
+  }
+
+  .pane__next:hover {
+    transform: translateY(-1px);
+  }
+
+  :global(.pane__next-arrow) {
+    transition: transform var(--duration-fast) var(--ease-out);
+  }
+
+  .pane__next:hover :global(.pane__next-arrow) {
+    transform: translateX(3px);
+  }
+
+  .pane__ghost {
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-text) 28%, transparent);
+    color: var(--color-text);
+  }
+
+  .pane__ghost:hover {
+    border-color: var(--color-brand-primary);
+  }
+
+  .pane__auto {
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    color: var(--color-text-tertiary);
+    font-weight: var(--font-medium);
+  }
+
+  .pane__auto--done {
+    border-color: color-mix(in oklab, var(--color-brand-primary) 40%, transparent);
+    color: var(--color-text-secondary);
+  }
+
+  :global(.pane__auto-glyph) {
+    color: var(--color-brand-primary);
+  }
+
+  /* ── peak-end completion card ── */
+  .pane__complete {
+    width: 100%;
+    margin-top: var(--space-10);
+    padding: var(--space-10) var(--space-6);
+    text-align: center;
+    border-radius: var(--radius-card);
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-brand-primary) 28%, transparent);
+    background: radial-gradient(
+      120% 130% at 50% 0%,
+      color-mix(in oklab, var(--color-brand-primary) 13%, transparent),
+      transparent
+    );
+  }
+
+  .pane__seal {
+    display: grid;
+    place-items: center;
+    width: var(--space-16);
+    height: var(--space-16);
+    margin: 0 auto var(--space-4);
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary);
+    color: var(--color-text-on-brand);
+  }
+
+  .pane__complete-title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-3xl);
+    line-height: var(--leading-tight);
+    color: var(--color-heading);
+    text-wrap: balance;
+  }
+
+  .pane__complete-body {
+    max-width: 42ch;
+    margin: var(--space-3) auto var(--space-6);
+    color: var(--color-text-secondary);
+    line-height: var(--leading-relaxed);
+  }
+
+  .pane__complete-row {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  /* ── footer: prev + back to overview (no second Next) ── */
+  .pane__foot {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+    margin-top: var(--space-10);
+    padding-top: var(--space-5);
+    border-top: var(--border-width) var(--border-style) var(--color-border-subtle);
+  }
+
+  .pane__foot-link {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    max-width: 48%;
+    text-decoration: none;
+    color: var(--color-text-secondary);
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .pane__foot-link:hover {
+    color: var(--color-brand-primary);
+  }
+
+  .pane__foot-link:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+    border-radius: var(--radius-sm);
+  }
+
+  .pane__foot-link--map {
+    text-align: right;
+    align-items: flex-end;
+  }
+
+  .pane__foot-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-xs);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-text-tertiary);
+  }
+
+  .pane__foot-title {
+    font-size: var(--text-sm);
+  }
+
+  @media (max-width: 40rem) {
+    .pane {
+      padding: var(--space-6) var(--space-4) var(--space-12);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pane__mark,
+    .pane__next,
+    .pane__ghost,
+    :global(.pane__next-arrow) {
+      transition: none;
+    }
+
+    .pane__next:hover {
+      transform: none;
+    }
   }
 </style>

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.server.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.server.ts
@@ -10,13 +10,18 @@
  * still gets the chrome; the stream URL is withheld.
  *
  * ─── ROUND-D SEAM ───────────────────────────────────────────────────────────
- * The resolver + practice fetch are mocked in
- * `$lib/server/journeys/round-d-seam.ts`; Round-D swaps them for real
- * `@codex/access` calls (incl. R2-signed stream URLs). This file is unchanged.
+ * The resolver + practice fetch go through `$lib/server/journeys/round-d-seam.ts`,
+ * which calls the real `@codex/access` routes (incl. R2-signed stream URLs).
+ *
+ * Alongside the practice we fetch the course dashboard (same enrollment-gated
+ * rollup the dashboard page reads) ONLY to surface the current stage's reflective
+ * `gloss` in the working pane. It runs in parallel and `.catch()`es to null, so a
+ * failure degrades the "why" line — it never weakens a gate or rejects the load.
  */
 import { error, redirect } from '@sveltejs/kit';
 import { evaluateCourseGate } from '$lib/journeys/gate';
 import {
+  fetchCourseDashboard,
   fetchInCoursePractice,
   resolveCanEnterCourse,
   resolveCanView,
@@ -61,12 +66,16 @@ export const load: PageServerLoad = async (event) => {
     );
   }
 
-  const practice = await fetchInCoursePractice(
-    event,
-    user!.id,
-    course!.id,
-    params.contentSlug
-  );
+  // Past the gate, both are present — the outcome is derived from their
+  // existence. Narrow here so the rest of the load needs no non-null assertion.
+  if (!user || !course) error(404, 'Course not found');
+
+  // Practice payload (gated) + the enrollment rollup (for the stage gloss) in
+  // parallel; the dashboard degrades to null without affecting the practice gate.
+  const [practice, dashboard] = await Promise.all([
+    fetchInCoursePractice(event, user.id, course.id, params.contentSlug),
+    fetchCourseDashboard(event, user.id, course.id).catch(() => null),
+  ]);
   if (!practice) error(404, 'Practice not found');
 
   // `canView` gates the media stream. Written practices are gated by course
@@ -74,12 +83,18 @@ export const load: PageServerLoad = async (event) => {
   const streamViewable =
     practice.practice.contentType === 'written'
       ? true
-      : await resolveCanView(event, user!.id, practice.practice.contentId);
+      : await resolveCanView(event, user.id, practice.practice.contentId);
+
+  // The current stage's reflective line (SPEC §5 `gloss`), if the rollup carries
+  // it — surfaced as the working pane's "why". Absent → the line just doesn't render.
+  const stageGloss =
+    dashboard?.stages.find((s) => s.id === practice.stage.id)?.gloss ?? null;
 
   return {
     practice: {
       ...practice,
       streamingUrl: streamViewable ? practice.streamingUrl : null,
     },
+    stageGloss,
   };
 };

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
@@ -1,14 +1,20 @@
 <!--
   @component InCoursePracticePage
 
-  The in-course player (SPEC §8.3 / §8.6): playlist rail + working pane. The
-  SAME content item renders differently INSIDE a course (stage context, next/
-  prev, progress, completion) than standalone — route context selects this UI.
-  Client-rendered (ssr=false); the server gate enforced canEnterCourse + canView.
+  The in-course player (SPEC §8.3 / §8.6): the WHOLE journey map as a sticky
+  rail + the working pane. The SAME content item renders differently INSIDE a
+  course (stage context, next/prev, progress, completion, peak-end close) than
+  standalone — route context selects this UI. Client-rendered (ssr=false); the
+  server gate enforced canEnterCourse + canView.
+
+  The page owns the candlelit dark palette: it re-points the semantic `--color-*`
+  tokens on `.practice` via OKLCH relative-colour from `--color-brand-primary`,
+  so every child (players, playlist, breadcrumb) inherits it and the org-brand
+  heading selector follows automatically. Accents stay on `--color-brand-primary`.
 
   Completion + playback read the SINGLE progress store (F19): the working pane
   auto-marks media on genuine 100% finish and writes explicit completions for
-  written practices; both update the playlist + dashboard reactively.
+  written practices; both update the playlist rail + dashboard reactively.
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
@@ -26,6 +32,7 @@
 
   const practiceData = $derived(data.practice);
   const current = $derived(practiceData.practice);
+  const courseTitle = $derived(practiceData.course.title);
   const courseSlug = $derived(
     practiceData.course.slug ?? practiceData.course.id
   );
@@ -63,102 +70,292 @@
   const playbackPercent = $derived(currentRow?.percentComplete ?? 0);
 
   // Prev/next within the flattened course sequence.
+  const playlist = $derived(practiceData.playlist);
   const currentIndex = $derived(
-    practiceData.playlist.findIndex((e) => e.contentId === current.contentId)
+    playlist.findIndex((e) => e.contentId === current.contentId)
   );
   function hrefFor(index: number): string | null {
-    const entry = practiceData.playlist[index];
+    const entry = playlist[index];
     if (!entry) return null;
     return `/journeys/${courseSlug}/practice/${entry.slug ?? entry.contentId}`;
   }
+  const prevEntry = $derived(playlist[currentIndex - 1] ?? null);
+  const nextEntry = $derived(playlist[currentIndex + 1] ?? null);
+  const currentEntry = $derived(playlist[currentIndex] ?? null);
   const prevHref = $derived(hrefFor(currentIndex - 1));
   const nextHref = $derived(hrefFor(currentIndex + 1));
+
+  // Gate-crossing cue: framing Next as opening the next stage (goal-gradient).
+  const nextLabel = $derived(
+    nextEntry && currentEntry && nextEntry.stageId !== currentEntry.stageId
+      ? `Open ${nextEntry.stageName}`
+      : 'Next practice'
+  );
+
+  // Rail progress rollup — completions across the whole course sequence.
+  const doneCount = $derived(
+    playlist.filter((e) => completedIds.has(e.contentId)).length
+  );
+  const total = $derived(playlist.length);
+  const pct = $derived(total ? Math.round((doneCount / total) * 100) : 0);
+
+  // Stage sequence (from the flattened playlist) → the gate note's next stage.
+  const stageOrder = $derived.by(() => {
+    const seen = new Set<string>();
+    const out: { id: string; name: string }[] = [];
+    for (const entry of playlist) {
+      if (!seen.has(entry.stageId)) {
+        seen.add(entry.stageId);
+        out.push({ id: entry.stageId, name: entry.stageName });
+      }
+    }
+    return out;
+  });
+  const currentStageName = $derived(practiceData.stage.name);
+  const nextStageName = $derived.by(() => {
+    const idx = stageOrder.findIndex((s) => s.id === practiceData.stage.id);
+    return idx >= 0 ? (stageOrder[idx + 1]?.name ?? null) : null;
+  });
 </script>
 
 <svelte:head>
-  <title>{current.title} · {practiceData.course.title}</title>
+  <title>{current.title} · {courseTitle}</title>
 </svelte:head>
 
-<div class="player">
-  <aside class="player__rail">
-    <a class="player__back" href={dashboardHref}>
-      <ArrowLeftIcon />
-      {practiceData.course.title}
-    </a>
-    <PracticePlaylist
-      playlist={practiceData.playlist}
-      {completedIds}
-      currentContentId={current.contentId}
-      {courseSlug}
-    />
-  </aside>
+<div class="practice">
+  <div class="practice__grid">
+    <aside class="practice__rail">
+      <a class="practice__back" href={dashboardHref}>
+        <ArrowLeftIcon size={16} />
+        {courseTitle} overview
+      </a>
 
-  <main class="player__main">
-    <PracticeWorkingPane
-      practice={current}
-      streamingUrl={practiceData.streamingUrl}
-      waveformUrl={practiceData.waveformUrl}
-      bodyHtml={practiceData.bodyHtml}
-      initialProgressSeconds={practiceData.initialProgressSeconds}
-      {isComplete}
-      {playbackPercent}
-      {prevHref}
-      {nextHref}
-    />
-  </main>
+      <div class="practice__prog">
+        <div class="practice__prog-top">
+          <span class="practice__prog-title">{courseTitle}</span>
+          <span class="practice__prog-pct">{doneCount}/{total} · {pct}%</span>
+        </div>
+        <div
+          class="practice__prog-bar"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="Course progress"
+        >
+          <i style:width="{pct}%"></i>
+        </div>
+      </div>
+
+      <p class="practice__rail-label">The whole journey</p>
+
+      <PracticePlaylist
+        {playlist}
+        {completedIds}
+        currentContentId={current.contentId}
+        {courseSlug}
+      />
+
+      <p class="practice__gate">
+        {#if nextStageName}
+          <b>Move at your own pace.</b> The whole path stays open — {nextStageName}
+          is here whenever {currentStageName} feels settled.
+        {:else}
+          <b>The last stage.</b> Move through {currentStageName} as slowly as you
+          need. There is no finish line but your own.
+        {/if}
+      </p>
+    </aside>
+
+    <main class="practice__main">
+      <PracticeWorkingPane
+        practice={current}
+        {courseTitle}
+        stageName={currentStageName}
+        stageGloss={data.stageGloss}
+        {dashboardHref}
+        streamingUrl={practiceData.streamingUrl}
+        waveformUrl={practiceData.waveformUrl}
+        bodyHtml={practiceData.bodyHtml}
+        initialProgressSeconds={practiceData.initialProgressSeconds}
+        {isComplete}
+        {playbackPercent}
+        {prevHref}
+        prevTitle={prevEntry?.title ?? null}
+        {nextHref}
+        {nextLabel}
+      />
+    </main>
+  </div>
 </div>
 
 <style>
-  .player {
-    display: grid;
-    grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
-    gap: var(--space-8);
-    max-width: 72rem;
-    margin: 0 auto;
-    padding: var(--space-6) var(--space-4);
-    align-items: start;
+  /* Candlelit dark palette — re-point the semantic tokens from the org brand
+     via OKLCH relative colour. Every descendant reads `--color-*`, so the whole
+     player (players, playlist, breadcrumb) inherits it; the org-brand heading
+     selector reads the same re-pointed `--color-heading` and follows. Accents
+     stay on `--color-brand-primary` (the org's real hue → the "ember"). */
+  .practice {
+    position: relative;
+    isolation: isolate;
+    min-height: 100dvh;
+    --color-background: oklch(from var(--color-brand-primary) 0.16 calc(c * 0.5) h);
+    --color-surface: oklch(from var(--color-brand-primary) 0.21 calc(c * 0.45) h);
+    --color-surface-secondary: oklch(from var(--color-brand-primary) 0.25 calc(c * 0.42) h);
+    --color-surface-tertiary: oklch(from var(--color-brand-primary) 0.29 calc(c * 0.4) h);
+    --color-heading: oklch(from var(--color-brand-primary) 0.96 calc(c * 0.12) h);
+    --color-text: oklch(from var(--color-brand-primary) 0.9 calc(c * 0.08) h);
+    --color-text-secondary: oklch(from var(--color-brand-primary) 0.76 calc(c * 0.07) h);
+    --color-text-tertiary: oklch(from var(--color-brand-primary) 0.62 calc(c * 0.07) h);
+    --color-text-muted: oklch(from var(--color-brand-primary) 0.62 calc(c * 0.07) h);
+    --color-border-subtle: oklch(from var(--color-brand-primary) 0.3 calc(c * 0.3) h);
+    --color-border: oklch(from var(--color-brand-primary) 0.36 calc(c * 0.32) h);
+    --color-border-strong: oklch(from var(--color-brand-primary) 0.44 calc(c * 0.34) h);
+    --color-border-hover: oklch(from var(--color-brand-primary) 0.54 calc(c * 0.36) h);
+    background: var(--color-background);
+    color: var(--color-text);
   }
 
-  .player__rail {
+  .practice__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 20rem) minmax(0, 1fr);
+    grid-template-areas: 'rail main';
+    align-items: start;
+    min-height: 100dvh;
+  }
+
+  .practice__rail {
+    grid-area: rail;
     position: sticky;
-    top: var(--space-6);
+    top: 0;
+    align-self: start;
+    max-height: 100dvh;
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
-    gap: var(--space-4);
-    min-width: 0;
+    gap: var(--space-3);
+    padding: var(--space-6) var(--space-4);
+    border-right: var(--border-width) var(--border-style) var(--color-border-subtle);
+    background: color-mix(in oklab, var(--color-surface) 55%, transparent);
   }
 
-  .player__back {
+  .practice__back {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
     font-size: var(--text-sm);
-    color: var(--color-text-secondary);
+    color: var(--color-text-tertiary);
     text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
   }
 
-  .player__back:hover {
-    color: var(--color-heading);
+  .practice__back:hover {
+    color: var(--color-brand-primary);
   }
 
-  .player__back:focus-visible {
+  .practice__back:focus-visible {
     outline: none;
     box-shadow: var(--shadow-focus-ring);
     border-radius: var(--radius-sm);
   }
 
-  .player__main {
+  /* ── rail progress ── */
+  .practice__prog {
+    margin-top: var(--space-3);
+  }
+
+  .practice__prog-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+    margin-bottom: var(--space-2);
+  }
+
+  .practice__prog-title {
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    color: var(--color-heading);
     min-width: 0;
   }
 
-  /* Rail drops above the working pane on narrow viewports. */
-  @media (max-width: 48rem) {
-    .player {
+  .practice__prog-pct {
+    flex: none;
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .practice__prog-bar {
+    height: var(--space-1-5);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    background: color-mix(in oklab, var(--color-text) 12%, transparent);
+  }
+
+  .practice__prog-bar > i {
+    display: block;
+    height: 100%;
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary);
+    transition: width var(--duration-normal) var(--ease-out);
+  }
+
+  .practice__rail-label {
+    margin: var(--space-2) 0 var(--space-1);
+    font-size: var(--text-xs);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--color-text-tertiary);
+  }
+
+  /* ── gate note ── */
+  .practice__gate {
+    margin-top: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-lg);
+    border: var(--border-width) var(--border-style)
+      color-mix(in oklab, var(--color-brand-primary) 22%, transparent);
+    background: color-mix(in oklab, var(--color-brand-primary) 6%, transparent);
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
+  }
+
+  .practice__gate b {
+    color: var(--color-brand-primary);
+    font-weight: var(--font-semibold);
+  }
+
+  .practice__main {
+    grid-area: main;
+    min-width: 0;
+  }
+
+  /* Rail drops below the working pane on narrow viewports (player first). */
+  @media (max-width: 54rem) {
+    .practice__grid {
       grid-template-columns: minmax(0, 1fr);
+      grid-template-areas: 'main' 'rail';
     }
 
-    .player__rail {
+    .practice__rail {
       position: static;
+      max-height: none;
+      overflow: visible;
+      border-right: none;
+      border-top: var(--border-width) var(--border-style) var(--color-border-subtle);
+    }
+
+    .practice__back {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .practice__prog-bar > i,
+    .practice__back {
+      transition: none;
     }
   }
 </style>

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
@@ -7,10 +7,10 @@
   standalone — route context selects this UI. Client-rendered (ssr=false); the
   server gate enforced canEnterCourse + canView.
 
-  The page owns the candlelit dark palette: it re-points the semantic `--color-*`
-  tokens on `.practice` via OKLCH relative-colour from `--color-brand-primary`,
-  so every child (players, playlist, breadcrumb) inherits it and the org-brand
-  heading selector follows automatically. Accents stay on `--color-brand-primary`.
+  The page INHERITS the design-system semantic theme (like the library / explore
+  / standalone-viewer surfaces) — no forced palette. Surfaces, text, and borders
+  come from the theme tokens; accents use the real `--color-brand-primary` (the
+  org brand); the video/audio player keeps its own dark `--color-player-*` chrome.
 
   Completion + playback read the SINGLE progress store (F19): the working pane
   auto-marks media on genuine 100% finish and writes explicit completions for
@@ -190,30 +190,11 @@
 </div>
 
 <style>
-  /* Candlelit dark palette — re-point the semantic tokens from the org brand
-     via OKLCH relative colour. Every descendant reads `--color-*`, so the whole
-     player (players, playlist, breadcrumb) inherits it; the org-brand heading
-     selector reads the same re-pointed `--color-heading` and follows. Accents
-     stay on `--color-brand-primary` (the org's real hue → the "ember"). */
+  /* Inherit the design-system semantic theme — no forced palette. The wrapper is
+     layout-only; surfaces / text / borders resolve from the theme tokens, accents
+     from the real `--color-brand-primary`, and the players keep `--color-player-*`. */
   .practice {
-    position: relative;
-    isolation: isolate;
     min-height: 100dvh;
-    --color-background: oklch(from var(--color-brand-primary) 0.16 calc(c * 0.5) h);
-    --color-surface: oklch(from var(--color-brand-primary) 0.21 calc(c * 0.45) h);
-    --color-surface-secondary: oklch(from var(--color-brand-primary) 0.25 calc(c * 0.42) h);
-    --color-surface-tertiary: oklch(from var(--color-brand-primary) 0.29 calc(c * 0.4) h);
-    --color-heading: oklch(from var(--color-brand-primary) 0.96 calc(c * 0.12) h);
-    --color-text: oklch(from var(--color-brand-primary) 0.9 calc(c * 0.08) h);
-    --color-text-secondary: oklch(from var(--color-brand-primary) 0.76 calc(c * 0.07) h);
-    --color-text-tertiary: oklch(from var(--color-brand-primary) 0.62 calc(c * 0.07) h);
-    --color-text-muted: oklch(from var(--color-brand-primary) 0.62 calc(c * 0.07) h);
-    --color-border-subtle: oklch(from var(--color-brand-primary) 0.3 calc(c * 0.3) h);
-    --color-border: oklch(from var(--color-brand-primary) 0.36 calc(c * 0.32) h);
-    --color-border-strong: oklch(from var(--color-brand-primary) 0.44 calc(c * 0.34) h);
-    --color-border-hover: oklch(from var(--color-brand-primary) 0.54 calc(c * 0.36) h);
-    background: var(--color-background);
-    color: var(--color-text);
   }
 
   .practice__grid {


### PR DESCRIPTION
## What

Rebuild-to-fidelity of the **in-course practice player** (surface 1 of the course-journeys fidelity pass) against `docs/design/course-journeys/prototype/content-incourse.html`, on real Codex tokens. Per the user's decision, the page **inherits the design-system semantic theme uniformly** with the library / explore / standalone-viewer surfaces — no forced palette. The server gate/security is unchanged.

Route: `apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/`

## Changes

**`+page.server.ts`** — fetch the course dashboard rollup **in parallel** with the (already-gated) practice payload and derive the current stage's reflective `gloss` for the working pane's "why" line. The dashboard call `.catch()`es to null so a failure degrades that one line, never the load or a gate. `canEnterCourse` / `canView` / the course-scoped practice-slug IDOR guard / the withheld-stream-URL behaviour are all untouched; `user`/`course` narrowed past the gate (no non-null assertions).

**`+page.svelte`** — the page **inherits the design-system theme** (transparent page background, real theme surface/text/border tokens, accents from the org's real `--color-brand-primary`); the `.practice` wrapper is layout-only. Full-bleed rail/main grid — rail left on desktop, **below** the working pane on mobile (player first). Rail owns: back link, progress rollup (done/total · %) + bar, "the whole journey" label, the playlist, and the gate note (next-stage-aware, last-stage variant).

> Note: an earlier revision forced a candlelit dark palette by re-pointing `--color-*` from `--color-brand-primary` via OKLCH. That override has been **removed** so all four journey surfaces inherit the theme consistently; the org-wide light/dark consistency is a separate task the user is filing.

**`PracticePlaylist.svelte`** — the whole journey map as a stage `<details>` accordion: roman-numeral stage badges, done/total counts, current stage auto-open, per-row done / current ("Here") / upcoming states with type icons.

**`PracticeWorkingPane.svelte`** — the full working column: breadcrumb, journey badge, serif title, type line, framed player (`VideoPlayer`/`AudioPlayer` reused — dark `--color-player-*` chrome untouched) or `{@html}` written body (server-sanitised in the seam), stage "why" quote, the **single** completion affordance (explicit "Mark complete" for written; auto-status for media) + a gate-aware **Next**, the peak-end completion card on the last practice, and a prev / back-to-overview footer. `markPracticeComplete` + the D-E 100%-finish media auto-write are preserved.

## Verification (Playwright MCP, studio-alpha / Rootwork fixture, desktop 1440 + mobile 390)

- **video** (`rootwork-welcome`), **written** (`rootwork-intention`, `rootwork-closing`), **audio** (`rootwork-breath-drum`) all render faithfully and **inherit the light theme**: `.practice` computed background is `rgba(0,0,0,0)` (transparent), and accents resolve to the org's real brand — `--color-brand-primary` = `#ea580c` (warm rust/orange, the "Of Blood and Bones"/Revelations brand), **not crimson**. Written body renders via `{@html}`; gate-crossing Next label ("Open The Practice") and the last-stage gate-note variant fire correctly; the peak-end completion card renders on the last practice.
- **Player chrome**: the video player box stays dark (its own `--color-player-*`); the audio player's *error-state* placeholder renders on the light theme surface (that's the AudioPlayer component's own placeholder, unaffected by this change).
- **Mark-complete**: the completion from the prior verified run **persisted to Neon** and re-hydrates correctly — after clearing localStorage and reloading, the store re-populates to 4/5 and the closing practice shows "Completed" (rail "The Practice" 2/3, progress **4/5 · 80%**), rendering reactively under the inherited theme. The mark-complete wiring (`markPracticeComplete` + the 100%-finish `$effect`) is byte-identical to the earlier end-to-end-proven run (this revision's diff is CSS/comment-only), where a click wrote a `source:'manual'` row and the dashboard read "4 of 5 · 80%".
- **390px**: zero horizontal overflow on the video and completion-card pages (`scrollWidth === clientWidth`, 0 offending elements); player-first stacking with the rail below.
- **Console**: only pre-existing env infra errors (dev-cdn `:4100` branding/avatar images, ecom-api subscription refresh — workers outside this surface's filter set). My components add zero console errors.
- **svelte-autofixer** on the touched `.svelte`: only the accepted `Set`-in-`$derived.by` note (recreated, never mutated; prop typed `ReadonlySet`).

## Gates

- `pnpm --filter web check` → **86 errors / 43 warnings** (the untouched dev baseline); **zero** referencing any changed file.
- `pnpm exec biome check` → clean (`.svelte` handled by svelte-check).
- `pnpm --filter web exec vitest run` on `journeys/gate.test.ts`, `collections/progress.test.ts`, `journeys/[journeySlug]/__tests__/page.server.test.ts` → **35/35 pass**.

## Honest notes

- The org brand for studio-alpha resolves to warm rust/orange (`--color-brand-primary` = `#ea580c`), **not** the green `#4ADE80` mentioned in the change request — the accents you'll see are that warm brand, not crimson and not green. Flagging in case the org's brand value is unexpected.
- Local video/audio show the player's "Playback error": the signed HLS host (`localhost:8787`) isn't in the dev CSP `media-src` allowlist and there's no transcoded media locally. Player chrome is correct; environment limit only.
- Playlist rows show the type label without minutes (`PlaylistEntry` carries no `durationSeconds`); the working-pane type line does show "· N min" from `JourneyPractice.durationSeconds`.

## Fixture repro

Org `studio-alpha`, course `rootwork` (2 stages, 5 practices, creator enrolled). Server-persisted completions currently at 4/5 (welcome/intention/grounding/closing) from the mark-complete verification. If rows are missing, recreate idempotently from the row-shapes in `packages/access/src/services/__tests__/course-round-d.integration.test.ts` against docker PG `neon-postgres-1` (db `main`, `postgres`/`postgres`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)