### PR TITLE
feat(web): journey sales-page fidelity restore (Codex-2pryk.3.x)

### DIFF
--- a/apps/web/src/lib/components/ui/IntroVideoModal/IntroVideoModal.svelte
+++ b/apps/web/src/lib/components/ui/IntroVideoModal/IntroVideoModal.svelte
@@ -167,6 +167,27 @@
     hlsInstance?.destroy();
     hlsInstance = null;
   });
+
+  /**
+   * Portal the modal root out of the section subtree.
+   *
+   * The sales-page section renderer wraps every section in `.jp-section`
+   * (`position: relative; isolation: isolate`) and the intro/reel stages add a
+   * second `isolation: isolate`. A `position: fixed` overlay mounted inside that
+   * subtree has its `z-index` ranked only WITHIN the section, so later sections
+   * paint their text OVER the fullscreen video. Re-parenting to `.org-layout`
+   * (NOT raw `<body>` — it carries the org-brand + `--color-player-*` cascade
+   * this modal styles against) lets the modal stack against the root instead.
+   */
+  function portal(node: HTMLElement) {
+    const target = document.querySelector('.org-layout') ?? document.body;
+    target.appendChild(node);
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
 </script>
 
 {#if open}
@@ -178,6 +199,7 @@
     aria-modal="true"
     aria-label={title || 'Intro video'}
     bind:this={dialogEl}
+    use:portal
     onclick={handleOverlayClick}
     onkeydown={handleKey}
   >

--- a/apps/web/src/lib/page-builder/render/FloatingCta.svelte
+++ b/apps/web/src/lib/page-builder/render/FloatingCta.svelte
@@ -1,0 +1,109 @@
+<!--
+  @component FloatingCta
+
+  Persistent bottom-centre conversion pill for the public journey sales page —
+  the real-token equivalent of the prototype's `.floatcta`. It is parked
+  off-screen and slides up once the reader passes the first viewport, giving an
+  always-available "begin" affordance that follows them down the long page.
+
+  PROGRESSIVE ENHANCEMENT. The markup renders on the server (so hydration
+  matches), starts hidden + `inert`, and the slide is a pure CSS transform gated
+  on `.is-shown`. Only a real, top-level visitor arms the scroll listener — the
+  studio builder renders this component inside a preview iframe, where it stays
+  parked off-screen and inert so it never covers the builder chrome or fights
+  its own scroll. Under reduced motion it snaps in without the slide.
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import CtaLink from './CtaLink.svelte';
+
+  interface Props {
+    /** Navigation target — checkout (pre-purchase) or dashboard (enrolled). */
+    href: string;
+    /** Short lead-in copy, e.g. the course title. */
+    label: string;
+    /** CTA button text. */
+    ctaText: string;
+  }
+
+  const { href, label, ctaText }: Props = $props();
+
+  let shown = $state(false);
+
+  onMount(() => {
+    // Real top-level visitors only. In the studio builder's preview iframe
+    // (`window.self !== window.top`) the pill stays parked + inert.
+    if (window.self !== window.top) return;
+
+    let ticking = false;
+    const update = () => {
+      ticking = false;
+      shown = window.scrollY > window.innerHeight * 0.5;
+    };
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(update);
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    update();
+    return () => window.removeEventListener('scroll', onScroll);
+  });
+</script>
+
+<div class="floatcta" class:is-shown={shown} inert={!shown}>
+  <span class="floatcta__copy">{label}</span>
+  <CtaLink {href} size="md">{ctaText}</CtaLink>
+</div>
+
+<style>
+  .floatcta {
+    position: fixed;
+    left: 50%;
+    bottom: var(--space-5);
+    z-index: var(--z-fixed);
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    max-width: calc(100vw - var(--space-8));
+    padding: var(--space-2) var(--space-2) var(--space-2) var(--space-5);
+    border: var(--border-width) var(--border-style) var(--color-border);
+    border-radius: var(--radius-full);
+    background: color-mix(in oklab, var(--color-surface) 88%, transparent);
+    backdrop-filter: blur(var(--blur-lg));
+    -webkit-backdrop-filter: blur(var(--blur-lg));
+    box-shadow: var(--shadow-xl);
+    /* Parked below the fold; slides up when `.is-shown`. */
+    transform: translate(-50%, 200%);
+    transition: transform var(--duration-slow) var(--ease-out);
+  }
+
+  .floatcta.is-shown {
+    transform: translate(-50%, 0);
+  }
+
+  .floatcta__copy {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media (--below-sm) {
+    .floatcta {
+      padding: var(--space-2);
+    }
+    .floatcta__copy {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .floatcta {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/page-builder/render/JourneyRenderer.svelte
+++ b/apps/web/src/lib/page-builder/render/JourneyRenderer.svelte
@@ -18,6 +18,7 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { buildJourneyUrl } from '@codex/urls';
+  import FloatingCta from './FloatingCta.svelte';
   import SectionRenderer from './SectionRenderer.svelte';
   import { brandOverridesToStyleAttr } from './brand-overrides';
   import type { JourneySalesContext, SellPreview } from './types';
@@ -71,6 +72,11 @@
 >
   <div class="journey-page__atmos" aria-hidden="true"></div>
   <SectionRenderer sections={coursePage.page.sections} {context} />
+  <FloatingCta
+    href={enrolled ? dashboardUrl : checkoutUrl}
+    label={coursePage.course.title}
+    ctaText={enrolled ? 'Continue →' : 'Begin →'}
+  />
 </div>
 
 <style>

--- a/apps/web/src/lib/page-builder/render/coerce.ts
+++ b/apps/web/src/lib/page-builder/render/coerce.ts
@@ -55,6 +55,80 @@ export function asObjectArray<T>(
   return out.length > 0 ? out : undefined;
 }
 
+/**
+ * BUILDER-SHAPE BRIDGE (Codex-2pryk.3.x · flat→array normalisation).
+ *
+ * The page builder + `section-catalog` `defaultProps` author sections as FLAT,
+ * numbered keys (`{kicker, heading, body}`, `{q1, a1, q2, a2, …}`), while the
+ * public sections below read the richer array shapes (`beats[]`, `items[]`,
+ * `testimonials[]`). Nothing ever reconciled the two contracts, so a creator
+ * could fill a section in the builder, publish, and watch it vanish from the
+ * public page (the array was never written → the section self-hid).
+ *
+ * These three readers close that gap at the READ boundary: the array shape still
+ * wins when present, and the flat keys are the fallback. No migration, no change
+ * to the sections' own prop contracts, and existing pages start rendering on the
+ * next load.
+ */
+
+/** First non-empty string among `keys`, in preference order. */
+export function asStringFrom(
+  props: SectionProps,
+  keys: readonly string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = asString(props, key);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Every non-empty string at `keys`, in order — used to synthesise a short list
+ * from discrete flat fields (e.g. ache `beats` ← `[heading, body]`). Undefined
+ * when none are present, so callers keep their `{#if list}` self-hide guard.
+ */
+export function asStringsFrom(
+  props: SectionProps,
+  keys: readonly string[]
+): string[] | undefined {
+  const out: string[] = [];
+  for (const key of keys) {
+    const value = asString(props, key);
+    if (value !== undefined) out.push(value);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Collect numbered sibling keys into an array of records — the builder's
+ * `q1/a1`, `q2/a2`… convention. `fields` maps a logical field name onto its key
+ * PREFIX (`{ question: 'q', answer: 'a' }` reads `q1`+`a1`, `q2`+`a2`, …).
+ * Iteration stops at `max`; each index is passed through `map`, and a null
+ * result drops that entry (so a half-filled pair is skipped, not rendered blank).
+ */
+export function asNumberedGroups<T>(
+  props: SectionProps,
+  fields: Readonly<Record<string, string>>,
+  map: (group: Record<string, string | undefined>, index: number) => T | null,
+  max = 12
+): T[] | undefined {
+  const out: T[] = [];
+  for (let i = 1; i <= max; i += 1) {
+    const group: Record<string, string | undefined> = {};
+    let present = false;
+    for (const [name, prefix] of Object.entries(fields)) {
+      const value = asString(props, `${prefix}${i}`);
+      group[name] = value;
+      if (value !== undefined) present = true;
+    }
+    if (!present) continue;
+    const mapped = map(group, i);
+    if (mapped !== null) out.push(mapped);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 /** A boolean prop with an explicit default (non-boolean values fall back). */
 export function asBool(
   props: SectionProps,

--- a/apps/web/src/lib/page-builder/render/reveal.ts
+++ b/apps/web/src/lib/page-builder/render/reveal.ts
@@ -1,0 +1,77 @@
+/**
+ * `reveal` — scroll-into-view enhancement action for journey sales sections.
+ *
+ * Mirrors the prototype's shared `fresh.js` reveal: the first time the node
+ * crosses the viewport threshold it gains the `is-in` class and is unobserved
+ * (one-shot). The paired CSS transitions `opacity`/`transform` from an armed
+ * hidden state to the resting state.
+ *
+ * PROGRESSIVE ENHANCEMENT (SSR-safe). The hidden state is applied by THIS action
+ * (`reveal--armed`), never in static CSS — so server-rendered HTML and no-JS /
+ * reduced-motion clients paint the fully-revealed content and never get stuck
+ * invisible. Motion is enhancement layered on top of a legible baseline, per the
+ * journeys design brief (SPEC §6: "CSS-first motion, always degradable").
+ *
+ * Usage:
+ *   <div use:reveal>…</div>              // default threshold/margin
+ *   <div use:reveal={{ once: false }}>…  // re-arm when scrolled back out
+ * Pair with `.reveal` + optional `.d1`…`.d5` stagger classes (see sell tokens).
+ */
+export interface RevealOptions {
+  /** Visibility ratio that triggers the reveal. Default 0.12 (matches prototype). */
+  threshold?: number;
+  /** Observer root margin. Default trims 8% off the bottom so it fires a touch early. */
+  rootMargin?: string;
+  /** Re-hide + replay when the node leaves and re-enters. Default true (one-shot). */
+  once?: boolean;
+}
+
+const ARMED = 'reveal--armed';
+const IN = 'is-in';
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export function reveal(node: HTMLElement, options: RevealOptions = {}) {
+  // No motion path: reduced-motion or environments without IntersectionObserver
+  // (incl. SSR) reveal immediately and stay put — the accessible baseline.
+  if (typeof IntersectionObserver === 'undefined' || prefersReducedMotion()) {
+    node.classList.add(IN);
+    return;
+  }
+
+  const once = options.once ?? true;
+
+  // Arm from JS so no-JS never hides content.
+  node.classList.add(ARMED);
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          node.classList.add(IN);
+          if (once) observer.unobserve(entry.target);
+        } else if (!once) {
+          node.classList.remove(IN);
+        }
+      }
+    },
+    {
+      threshold: options.threshold ?? 0.12,
+      rootMargin: options.rootMargin ?? '0px 0px -8% 0px',
+    }
+  );
+
+  observer.observe(node);
+
+  return {
+    destroy() {
+      observer.disconnect();
+    },
+  };
+}

--- a/apps/web/src/lib/page-builder/render/sections/AcheSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/AcheSection.svelte
@@ -19,7 +19,7 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { asString, asStringArray } from '../coerce';
+  import { asStringArray, asStringFrom, asStringsFrom } from '../coerce';
   import type { AcheSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -31,9 +31,14 @@
 
   const { config }: Props = $props();
 
+  // `beats[]` is the authored shape; the builder's flat `{kicker, heading, body}`
+  // is the fallback so a builder-filled ache still renders (see coerce.ts's
+  // BUILDER-SHAPE BRIDGE note). Absent both → `beats` stays undefined → self-hide.
   const p: AcheSectionProps = $derived({
-    eyebrow: asString(config, 'eyebrow'),
-    beats: asStringArray(config, 'beats'),
+    eyebrow: asStringFrom(config, ['eyebrow', 'kicker']),
+    beats:
+      asStringArray(config, 'beats') ??
+      asStringsFrom(config, ['heading', 'body']),
   });
 
   const beats = $derived(p.beats ?? []);

--- a/apps/web/src/lib/page-builder/render/sections/AcheSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/AcheSection.svelte
@@ -1,12 +1,24 @@
 <!--
   @component AcheSection
 
-  Names the held pain before hope is offered (SPEC §4.1 `ache`). A stacked
-  sequence of "beats" — short statements read one after another. Renders nothing
-  when no beats are configured (the section self-hides rather than showing an
-  empty shell). Text-only, no JS, legible under reduced motion.
+  Names the held pain before hope is offered (SPEC §4.1 `ache`). A sequence of
+  short "beats" read one after another.
+
+  TWO renderings, progressively enhanced:
+  • BASELINE (SSR, no-JS, reduced-motion): a clean, fully-legible stacked
+    sequence — every beat visible at once. This is what the server emits, so the
+    section is never blank and never depends on JS.
+  • ENHANCED (browser + motion OK): the prototype's cinematic pinned reveal — a
+    tall scroll `track` pins a 100vh `stage`; scrolling advances one beat at a
+    time (crossfade), a breathing aura warms the frame, a segmented rail tracks
+    progress, and a vignette focuses the centre.
+
+  Enhancement is gated on `mounted && !reduced` so the accessible baseline always
+  ships first; the scroll math lives in an `$effect` that re-wires if the
+  reduced-motion preference flips mid-session.
 -->
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { asString, asStringArray } from '../coerce';
   import type { AcheSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
@@ -23,19 +35,99 @@
     eyebrow: asString(config, 'eyebrow'),
     beats: asStringArray(config, 'beats'),
   });
+
+  const beats = $derived(p.beats ?? []);
+
+  let mounted = $state(false);
+  let reduced = $state(false);
+  let activeIndex = $state(0);
+  let trackEl = $state<HTMLElement | undefined>(undefined);
+
+  // The pinned reveal needs motion + at least two beats to sequence between.
+  const enhanced = $derived(mounted && !reduced && beats.length > 1);
+
+  onMount(() => {
+    mounted = true;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  // Scroll driver: map the track's progress through the viewport onto an active
+  // beat index. Re-runs (and tears down) whenever `enhanced` or the track flips.
+  $effect(() => {
+    if (!enhanced || !trackEl) return;
+    const track = trackEl;
+    const count = beats.length;
+    let ticking = false;
+
+    const update = () => {
+      ticking = false;
+      const total = track.offsetHeight - window.innerHeight;
+      if (total <= 0) {
+        activeIndex = 0;
+        return;
+      }
+      const scrolled = Math.min(
+        Math.max(-track.getBoundingClientRect().top, 0),
+        total
+      );
+      const idx = Math.floor((scrolled / total) * count);
+      activeIndex = Math.min(Math.max(idx, 0), count - 1);
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(update);
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    update();
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
+  });
 </script>
 
-{#if p.beats}
-  <div class="ache">
-    <div class="ache__glow" aria-hidden="true"></div>
-    <div class="ache__inner">
-      {#if p.eyebrow}
-        <p class="ache__eyebrow">{p.eyebrow}</p>
-      {/if}
-      <div class="ache__beats">
-        {#each p.beats as beat, i (i)}
-          <p class="ache__beat">{beat}</p>
-        {/each}
+{#if beats.length > 0}
+  <div
+    class="ache"
+    class:ache--enhanced={enhanced}
+    style="--beat-count: {beats.length}"
+  >
+    <div class="ache__track" bind:this={trackEl}>
+      <div class="ache__stage">
+        <div class="ache__aura" aria-hidden="true"></div>
+        <div class="ache__frame">
+          {#if p.eyebrow}
+            <p class="ache__chapter">{p.eyebrow}</p>
+          {/if}
+
+          <div class="ache__beats">
+            {#each beats as beat, i (i)}
+              <p class="ache__beat" class:is-active={enhanced && i === activeIndex}>
+                {beat}
+              </p>
+            {/each}
+          </div>
+
+          {#if enhanced}
+            <div class="ache__progress" aria-hidden="true">
+              {#each beats as _, i (i)}
+                <span class="ache__seg" class:is-on={i <= activeIndex}></span>
+              {/each}
+            </div>
+          {/if}
+        </div>
       </div>
     </div>
   </div>
@@ -45,47 +137,96 @@
   .ache {
     position: relative;
     isolation: isolate;
-    padding-block: var(--space-20);
-    padding-inline: var(--space-5);
-    overflow: hidden;
-    text-align: center;
   }
 
-  .ache__glow {
+  .ache__track {
+    position: relative;
+  }
+
+  .ache__stage {
+    position: relative;
+    display: grid;
+    place-items: center;
+    padding-block: var(--space-20);
+    padding-inline: var(--space-5);
+    overflow: clip;
+  }
+
+  /* Breathing warmth behind the words — fills the frame, never a void. */
+  .ache__aura {
     position: absolute;
-    z-index: -1;
+    z-index: 0;
     left: 50%;
     top: 50%;
+    translate: -50% -50%;
     width: min(78vw, 38.75rem);
     aspect-ratio: 1;
-    transform: translate(-50%, -50%);
     border-radius: var(--radius-full);
-    opacity: 0.4;
-    filter: blur(var(--blur-2xl));
     pointer-events: none;
+    opacity: 0.6;
+    filter: blur(var(--blur-2xl));
     background: radial-gradient(
       circle at 50% 50%,
-      color-mix(in oklab, var(--color-brand-accent) 24%, transparent),
-      transparent 66%
+      color-mix(in oklab, var(--color-brand-accent) 30%, transparent),
+      color-mix(in oklab, var(--color-brand-primary) 12%, transparent) 42%,
+      transparent 68%
     );
   }
 
-  .ache__inner {
+  /* Cinematic vignette darkening the edges to focus the centre. */
+  .ache__stage::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    background: radial-gradient(
+      125% 95% at 50% 50%,
+      transparent 52%,
+      color-mix(in oklab, var(--color-background) 55%, transparent) 100%
+    );
+  }
+
+  .ache__frame {
+    position: relative;
+    z-index: 2;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-8);
+    width: 100%;
     max-width: 48rem;
     margin-inline: auto;
+    text-align: center;
   }
 
-  .ache__eyebrow {
+  .ache__chapter {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
     margin: 0;
     font-size: var(--text-sm);
     font-weight: var(--font-semibold);
-    letter-spacing: 0.1em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-text-tertiary);
+  }
+
+  /* Ceremonial flanking hairlines. */
+  .ache__chapter::before,
+  .ache__chapter::after {
+    content: '';
+    width: clamp(1.5rem, 6vw, 3rem);
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in oklab, var(--color-brand-accent) 55%, transparent)
+    );
+  }
+
+  .ache__chapter::after {
+    transform: scaleX(-1);
   }
 
   .ache__beats {
@@ -103,5 +244,102 @@
     letter-spacing: -0.01em;
     color: var(--color-heading);
     text-wrap: balance;
+  }
+
+  .ache__progress {
+    display: none;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .ache__seg {
+    width: clamp(1.6rem, 5vw, 2.9rem);
+    height: 2px;
+    border-radius: var(--radius-full);
+    background: color-mix(in oklab, var(--color-text-tertiary) 55%, transparent);
+    transition:
+      background var(--duration-slow) var(--ease-out),
+      box-shadow var(--duration-slow) var(--ease-out);
+  }
+
+  .ache__seg.is-on {
+    background: var(--color-brand-accent);
+    box-shadow: 0 0 14px color-mix(in oklab, var(--color-brand-accent) 55%, transparent);
+  }
+
+  /* ── ENHANCED: pinned one-beat-at-a-time reveal ──
+     Only applied when JS has confirmed motion is welcome (`.ache--enhanced`);
+     the baseline above stays the SSR / no-JS / reduced-motion fallback. */
+  .ache--enhanced .ache__track {
+    /* Scroll length: one viewport of travel per beat, plus a lead viewport. */
+    height: calc((var(--beat-count) + 1) * 100vh);
+  }
+
+  .ache--enhanced .ache__stage {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    padding-block: 0;
+  }
+
+  .ache--enhanced .ache__aura {
+    animation: ache-breathe 8s ease-in-out infinite;
+  }
+
+  .ache--enhanced .ache__beats {
+    display: block;
+    position: relative;
+    align-self: stretch;
+    min-height: clamp(220px, 40vh, 360px);
+  }
+
+  .ache--enhanced .ache__beat {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    translate: -50% -50%;
+    width: 100%;
+    max-width: 32rem;
+    margin: 0;
+    opacity: 0;
+    /* Enter offset composes over the centring `translate`. */
+    transform: translateY(0.9rem) scale(0.99);
+    filter: blur(3px);
+    transition:
+      opacity 0.85s var(--ease-out),
+      transform 0.85s var(--ease-out),
+      filter 0.85s var(--ease-out);
+    pointer-events: none;
+  }
+
+  .ache--enhanced .ache__beat.is-active {
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+
+  .ache--enhanced .ache__progress {
+    display: flex;
+  }
+
+  @keyframes ache-breathe {
+    0%,
+    100% {
+      transform: scale(0.92);
+      opacity: 0.5;
+    }
+    50% {
+      transform: scale(1.05);
+      opacity: 0.78;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ache__aura {
+      animation: none;
+    }
+    .ache__seg {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/FaqSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/FaqSection.svelte
@@ -22,7 +22,12 @@
   self-hide-when-unconfigured guard.
 -->
 <script lang="ts">
-  import { asString, asObjectArray, fieldString } from '../coerce';
+  import {
+    asString,
+    asObjectArray,
+    asNumberedGroups,
+    fieldString,
+  } from '../coerce';
   import { reveal } from '../reveal';
   import type { FaqSectionProps, FaqEntry, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
@@ -38,12 +43,21 @@
   const p: FaqSectionProps = $derived({
     eyebrow: asString(config, 'eyebrow'),
     heading: asString(config, 'heading'),
-    items: asObjectArray<FaqEntry>(config, 'items', (entry) => {
-      const question = fieldString(entry, 'question');
-      const answer = fieldString(entry, 'answer');
-      if (!question || !answer) return null;
-      return { question, answer };
-    }),
+    // `items[]` is the authored shape; the builder writes numbered `q1/a1, q2/a2…`
+    // pairs, which are the fallback (see coerce.ts's BUILDER-SHAPE BRIDGE note).
+    items:
+      asObjectArray<FaqEntry>(config, 'items', (entry) => {
+        const question = fieldString(entry, 'question');
+        const answer = fieldString(entry, 'answer');
+        if (!question || !answer) return null;
+        return { question, answer };
+      }) ??
+      asNumberedGroups<FaqEntry>(
+        config,
+        { question: 'q', answer: 'a' },
+        ({ question, answer }) =>
+          question && answer ? { question, answer } : null
+      ),
   });
 
   const heading = $derived(p.heading ?? 'The honest answers.');

--- a/apps/web/src/lib/page-builder/render/sections/FaqSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/FaqSection.svelte
@@ -1,13 +1,29 @@
 <!--
   @component FaqSection
 
-  The honest answers (SPEC §4.1 `faq`) — an accessible accordion built on the
-  Melt-wrapped `ui/Accordion` (WAI-ARIA + keyboard for free). Self-hides when no
-  entries are configured.
+  The honest answers (SPEC §4.1 `faq`) — an objection-handling accordion.
+
+  TWO renderings, progressively enhanced:
+  • BASELINE (SSR, no-JS, reduced-motion): native <details>/<summary> — a
+    fully-legible, keyboard-operable accordion that toggles instantly with zero
+    JS. This is what the server emits, so the section is never blank and never
+    depends on JS for its core behaviour (WAI-ARIA + keyboard come for free).
+  • ENHANCED (browser + motion OK): the prototype's cinematic language — each
+    row fades/rises into view on scroll (`use:reveal`, staggered), the +/− glyph
+    morphs between states, the question text and glyph warm on hover/open, and
+    the answer panel animates its height smoothly (`use:smoothDetails`) instead
+    of snapping.
+
+  Motion is layered on top of the accessible baseline: the reveal action
+  self-arms from JS so no-JS never hides content, and `smoothDetails` bails to
+  the browser's instant native toggle under `prefers-reduced-motion`.
+
+  Prop contract is unchanged (eyebrow/heading/items) — same coercers, same
+  self-hide-when-unconfigured guard.
 -->
 <script lang="ts">
-  import * as Accordion from '$lib/components/ui/Accordion';
   import { asString, asObjectArray, fieldString } from '../coerce';
+  import { reveal } from '../reveal';
   import type { FaqSectionProps, FaqEntry, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -31,30 +47,106 @@
   });
 
   const heading = $derived(p.heading ?? 'The honest answers.');
+  const items = $derived(p.items ?? []);
+
+  // Stagger cap — mirrors the prototype's .faq-r1…r5 delay ladder.
+  const delayClass = (i: number): string => `d${Math.min(i + 1, 5)}`;
+
+  // ── ENHANCEMENT: smooth open/close height.
+  //    A client-only Svelte action (never runs during SSR). Keeps native
+  //    <details> as the source of truth; under reduced-motion it does nothing
+  //    and lets the browser toggle instantly — the accessible baseline. Read at
+  //    click time so a mid-session preference flip is always respected.
+  function smoothDetails(node: HTMLDetailsElement) {
+    const summary = node.querySelector<HTMLElement>('.faq__q');
+    const panel = node.querySelector<HTMLElement>('.faq__panel');
+    if (!summary || !panel) return;
+
+    let animating = false;
+
+    const prefersReduced = () =>
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const onClick = (event: MouseEvent) => {
+      // Reduced motion (or no measurable panel): let the browser toggle instantly.
+      if (prefersReduced()) return;
+      event.preventDefault();
+      if (animating) return;
+
+      if (node.open) {
+        // ── closing ──
+        animating = true;
+        panel.style.height = `${panel.scrollHeight}px`;
+        requestAnimationFrame(() => {
+          panel.style.height = '0px';
+        });
+        const onEnd = (ev: TransitionEvent) => {
+          if (ev.propertyName !== 'height') return;
+          panel.removeEventListener('transitionend', onEnd);
+          node.open = false;
+          panel.style.height = '';
+          animating = false;
+        };
+        panel.addEventListener('transitionend', onEnd);
+      } else {
+        // ── opening ──
+        animating = true;
+        node.open = true; // reveal content so it can be measured
+        const target = panel.scrollHeight;
+        panel.style.height = '0px';
+        requestAnimationFrame(() => {
+          panel.style.height = `${target}px`;
+        });
+        const onEnd = (ev: TransitionEvent) => {
+          if (ev.propertyName !== 'height') return;
+          panel.removeEventListener('transitionend', onEnd);
+          panel.style.height = ''; // let it flow at natural height
+          animating = false;
+        };
+        panel.addEventListener('transitionend', onEnd);
+      }
+    };
+
+    summary.addEventListener('click', onClick);
+    return {
+      destroy() {
+        summary.removeEventListener('click', onClick);
+      },
+    };
+  }
 </script>
 
-{#if p.items}
+{#if items.length > 0}
   <div class="faq">
     <div class="faq__inner">
-      <header class="faq__head">
+      <header class="faq__head faq-reveal" use:reveal>
         {#if p.eyebrow}
           <p class="faq__eyebrow">{p.eyebrow}</p>
         {/if}
         <h2 class="faq__heading">{heading}</h2>
+        <div class="faq__rule" aria-hidden="true"></div>
       </header>
 
-      <!-- Single-open: one answer at a time keeps the FAQ compact. (The
-           Melt-wrapped Accordion's Props narrows `multiple` to `false`, so
-           multi-open would need an unsafe cast — single-open is the clean,
-           type-honest default.) -->
-      <Accordion.Root>
-        {#each p.items as item, i (i)}
-          <Accordion.Item value={`faq-${i}`}>
-            <Accordion.Trigger>{item.question}</Accordion.Trigger>
-            <Accordion.Content>{item.answer}</Accordion.Content>
-          </Accordion.Item>
+      <div class="faq__list">
+        {#each items as item, i (i)}
+          <details
+            class="faq__item faq-reveal {delayClass(i)}"
+            use:reveal
+            use:smoothDetails
+          >
+            <summary class="faq__q">
+              <span class="faq__q-text">{item.question}</span>
+              <span class="faq__ic" aria-hidden="true"></span>
+            </summary>
+            <div class="faq__panel">
+              <div class="faq__panel-inner">
+                <p class="faq__a">{item.answer}</p>
+              </div>
+            </div>
+          </details>
         {/each}
-      </Accordion.Root>
+      </div>
     </div>
   </div>
 {/if}
@@ -70,18 +162,19 @@
     margin-inline: auto;
   }
 
+  /* ── header ── */
   .faq__head {
     text-align: center;
     margin-bottom: var(--space-10);
   }
 
   .faq__eyebrow {
-    margin: 0 0 var(--space-2);
+    margin: 0 0 var(--space-3);
     font-size: var(--text-sm);
     font-weight: var(--font-semibold);
-    letter-spacing: 0.08em;
+    letter-spacing: 0.32em;
     text-transform: uppercase;
-    color: var(--color-text-secondary);
+    color: var(--color-brand-accent);
   }
 
   .faq__heading {
@@ -93,5 +186,214 @@
     letter-spacing: -0.015em;
     color: var(--color-heading);
     text-wrap: balance;
+  }
+
+  /* ceremonial ember hairline under the heading */
+  .faq__rule {
+    width: 3rem;
+    height: 1px;
+    margin: var(--space-6) auto 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in oklab, var(--color-brand-accent) 60%, transparent),
+      transparent
+    );
+  }
+
+  /* ── list ── */
+  .faq__list {
+    border-top: var(--border-width) solid var(--color-border-subtle);
+  }
+
+  .faq__item {
+    border-bottom: var(--border-width) solid var(--color-border-subtle);
+  }
+
+  /* summary = the question row */
+  .faq__q {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-5);
+    padding-block: var(--space-5);
+    list-style: none;
+    cursor: pointer;
+    outline: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .faq__q::-webkit-details-marker {
+    display: none;
+  }
+
+  .faq__q::marker {
+    content: '';
+  }
+
+  .faq__q-text {
+    flex: 1;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-xl);
+    line-height: var(--leading-snug);
+    letter-spacing: -0.005em;
+    color: var(--color-text);
+    transition: color var(--duration-normal) var(--ease-out);
+  }
+
+  .faq__item:hover .faq__q-text,
+  .faq__item[open] .faq__q-text {
+    color: var(--color-heading);
+  }
+
+  /* keyboard focus ring lives on the text, not the whole row */
+  .faq__q:focus-visible .faq__q-text {
+    color: var(--color-heading);
+    text-decoration: underline;
+    text-decoration-color: color-mix(
+      in oklab,
+      var(--color-brand-accent) 70%,
+      transparent
+    );
+    text-underline-offset: var(--space-1);
+  }
+
+  /* ── the +/− indicator ── */
+  .faq__ic {
+    position: relative;
+    flex: none;
+    width: var(--space-9);
+    height: var(--space-9);
+    margin-top: 2px;
+    border-radius: var(--radius-full);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-primary) 26%, transparent);
+    transition:
+      border-color var(--duration-slow) var(--ease-out),
+      background var(--duration-slow) var(--ease-out);
+  }
+
+  .faq__item:hover .faq__ic,
+  .faq__item[open] .faq__ic {
+    border-color: color-mix(
+      in oklab,
+      var(--color-brand-primary) 62%,
+      transparent
+    );
+    background: color-mix(in oklab, var(--color-brand-primary) 8%, transparent);
+  }
+
+  .faq__ic::before,
+  .faq__ic::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0.75rem;
+    height: 1.5px;
+    border-radius: var(--radius-xs);
+    background: var(--color-brand-accent);
+    transform: translate(-50%, -50%);
+    transition:
+      transform var(--duration-slow) var(--ease-out),
+      opacity var(--duration-slow) var(--ease-out);
+  }
+
+  /* vertical bar of the plus — collapses to leave a minus on open */
+  .faq__ic::after {
+    transform: translate(-50%, -50%) rotate(90deg);
+  }
+
+  .faq__item[open] .faq__ic::after {
+    transform: translate(-50%, -50%) rotate(0deg);
+    opacity: 0;
+  }
+
+  /* ── answer panel ── */
+  .faq__panel {
+    overflow: hidden;
+    transition: height var(--duration-slow) var(--ease-out);
+  }
+
+  .faq__panel-inner {
+    padding-block: 0 var(--space-5);
+    padding-inline: 0 var(--space-12);
+  }
+
+  .faq__a {
+    margin: 0;
+    max-width: 60ch;
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
+    opacity: 0;
+    transform: translateY(var(--space-1));
+    transition:
+      opacity var(--duration-slower) var(--ease-out),
+      transform var(--duration-slower) var(--ease-out);
+  }
+
+  .faq__item[open] .faq__a {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* ── reveal-on-scroll: armed from JS (see reveal.ts) so SSR / no-JS / reduced
+       motion paint the fully-revealed baseline and never get stuck hidden. ── */
+  .faq-reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(var(--space-6));
+    transition:
+      opacity var(--duration-slower) var(--ease-out),
+      transform var(--duration-slower) var(--ease-out);
+  }
+
+  .faq-reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  .faq-reveal.d1 {
+    transition-delay: 50ms;
+  }
+  .faq-reveal.d2 {
+    transition-delay: 120ms;
+  }
+  .faq-reveal.d3 {
+    transition-delay: 190ms;
+  }
+  .faq-reveal.d4 {
+    transition-delay: 260ms;
+  }
+  .faq-reveal.d5 {
+    transition-delay: 330ms;
+  }
+
+  @media (width <= 35rem) {
+    .faq__panel-inner {
+      padding-inline: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .faq__q-text,
+    .faq__ic,
+    .faq__ic::before,
+    .faq__ic::after,
+    .faq__panel,
+    .faq__a {
+      transition: none !important;
+    }
+    .faq__a {
+      opacity: 1;
+      transform: none;
+    }
+    .faq-reveal.reveal--armed {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/FeelSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/FeelSection.svelte
@@ -1,12 +1,33 @@
 <!--
   @component FeelSection
 
-  What it feels like (left) + what's inside (right) — SPEC §4.1 `feel`. The
-  inclusions list is the concrete "what you get" companion to the emotional
-  left column. Renders nothing when neither column has content.
+  What a practice FEELS like (left) + what's inside (right) — SPEC §4.1 `feel`.
+  The emotional left column carries the copy and the "free-taste" preview player
+  (the prototype's visual centrepiece); the right column is the "what's inside"
+  timeline whose ember spine stitches the inclusions together.
+
+  TWO renderings, progressively enhanced:
+  • BASELINE (SSR, no-JS, reduced-motion): a fully-legible two-column layout —
+    all copy, the waveform drawn at rest, the inclusion timeline complete. This
+    is what the server emits, so the section is never blank and never JS-gated.
+  • ENHANCED (browser + motion OK): the prototype's cinematic language — blocks
+    fade/rise into view on scroll (`use:reveal`, staggered), the free-taste
+    player animates as a breathing equaliser with a live playhead + click-to-seek
+    and a pulsing play ring, and the timeline markers rotate + glow on hover.
+
+  Motion is layered on top of the accessible baseline and gated on
+  `mounted && !reduced`; the reveal action self-arms from JS so no-JS never hides
+  content, and the waveform bars are computed deterministically (pure, SSR-safe)
+  so they paint identically on the server and the client.
+
+  Prop contract is unchanged (eyebrow/heading/body/inclusions). The optional
+  free-taste player reads `previewTitle`/`previewSub`/`previewDuration` DEFENSIVELY
+  from the config bag (no shared-type change) and self-hides when unconfigured.
 -->
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { asString, asObjectArray, fieldString } from '../coerce';
+  import { reveal } from '../reveal';
   import type { FeelSectionProps, FeelInclusion, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -28,78 +49,262 @@
       return { label, detail: fieldString(entry, 'detail') };
     }),
   });
+
+  // ── Optional free-taste player, read defensively from the config bag.
+  //    Not in the frozen FeelSectionProps type (see desiredSharedChanges); read
+  //    straight off `config` with the existing coercers so an absent/malformed
+  //    field self-hides the player rather than throwing during SSR.
+  const previewTitle = $derived(asString(config, 'previewTitle'));
+  const previewSub = $derived(asString(config, 'previewSub'));
+  const previewDuration = $derived.by(() => {
+    const raw = config['previewDuration'];
+    return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : 480;
+  });
+  const hasPlayer = $derived(!!previewTitle);
+
+  const inclusions = $derived(p.inclusions ?? []);
+  const hasContent = $derived(
+    !!(p.eyebrow || p.heading || p.body || inclusions.length > 0 || hasPlayer)
+  );
+
+  // ── Deterministic waveform — pure, so SSR and the client paint the same bars.
+  //    Quiet at the ends, full through the middle, textured per-bar (matches the
+  //    prototype's organic arch). Rendered at rest in the baseline; the equaliser
+  //    animation + playhead are layered only once motion is confirmed welcome.
+  const BAR_COUNT = 56;
+  interface Bar {
+    h: number;
+    dur: number;
+    delay: number;
+  }
+  const bars: Bar[] = (() => {
+    const out: Bar[] = [];
+    for (let i = 0; i < BAR_COUNT; i++) {
+      const x = i / (BAR_COUNT - 1);
+      const env = 0.3 + 0.7 * Math.sin(Math.PI * x);
+      const tex = 0.5 + 0.5 * Math.sin(i * 0.9) * Math.cos(i * 0.37);
+      const h = Math.max(0.14, Math.min(1, env * (0.42 + 0.58 * Math.abs(tex))));
+      out.push({
+        h: Number((h * 100).toFixed(1)),
+        dur: Number((0.85 + (i % 7) * 0.11).toFixed(2)),
+        delay: Number(((i % 11) * 0.05).toFixed(2)),
+      });
+    }
+    return out;
+  })();
+
+  let mounted = $state(false);
+  let reduced = $state(false);
+
+  // ── Mock free-taste transport (a visual "taste", no real audio — mirrors the
+  //    prototype). `elapsed` advances via rAF only when motion is welcome.
+  let playing = $state(false);
+  let elapsed = $state(0);
+
+  const enhanced = $derived(mounted && !reduced);
+  const progress = $derived(previewDuration > 0 ? elapsed / previewDuration : 0);
+  const playedBars = $derived(Math.round(progress * BAR_COUNT));
+  const headPct = $derived(Math.min(Math.max(progress * 100, 0), 100));
+
+  const fmt = (secs: number): string => {
+    const s = Math.max(0, Math.min(previewDuration, Math.round(secs)));
+    const m = Math.floor(s / 60);
+    return `${m}:${String(s % 60).padStart(2, '0')}`;
+  };
+  const curLabel = $derived(fmt(elapsed));
+  const totLabel = $derived(fmt(previewDuration));
+
+  onMount(() => {
+    mounted = true;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  // Advance the playhead while playing (motion path only). Tears down on pause /
+  // reduced-motion / unmount so no rAF leaks across the section's lifetime.
+  $effect(() => {
+    if (!playing || !enhanced) return;
+    let raf = 0;
+    let last = performance.now();
+    const tick = (now: number) => {
+      elapsed += (now - last) / 1000;
+      last = now;
+      if (elapsed >= previewDuration) {
+        elapsed = 0;
+        playing = false;
+        return;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  });
+
+  function togglePlay() {
+    playing = !playing;
+  }
+
+  function seek(event: MouseEvent) {
+    const el = event.currentTarget as HTMLElement;
+    const rect = el.getBoundingClientRect();
+    const frac = Math.min(Math.max((event.clientX - rect.left) / rect.width, 0), 1);
+    elapsed = frac * previewDuration;
+  }
 </script>
 
-{#if p.heading || p.body || p.inclusions}
+{#if hasContent}
   <div class="feel">
     <div class="feel__inner">
-      <div class="feel__left">
-        {#if p.eyebrow}
-          <p class="feel__eyebrow">{p.eyebrow}</p>
-        {/if}
-        {#if p.heading}
-          <h2 class="feel__heading">{p.heading}</h2>
-        {/if}
-        {#if p.body}
-          <p class="feel__body">{p.body}</p>
+      <div class="feel__grid">
+        <!-- LEFT · what it feels like -->
+        <div class="feel__col">
+          {#if p.eyebrow || p.heading || p.body}
+            <div class="feel-reveal" use:reveal>
+              {#if p.eyebrow}
+                <p class="feel__eyebrow">{p.eyebrow}</p>
+              {/if}
+              {#if p.heading}
+                <h2 class="feel__heading">{p.heading}</h2>
+              {/if}
+              {#if p.body}
+                <p class="feel__body">{p.body}</p>
+              {/if}
+            </div>
+          {/if}
+
+          {#if hasPlayer}
+            <div class="feel__player feel-reveal d1" use:reveal>
+              <div
+                class="feel-taste"
+                role="group"
+                aria-label="Free taste — {previewTitle} preview"
+              >
+                <div class="feel-taste__aura" aria-hidden="true"></div>
+                <div class="feel-taste__head">
+                  <button
+                    class="feel-play"
+                    class:is-playing={playing}
+                    type="button"
+                    aria-pressed={playing}
+                    aria-label={playing ? 'Pause preview' : 'Play preview'}
+                    onclick={togglePlay}
+                  >
+                    {#if playing}
+                      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <rect x="6" y="5" width="4" height="14" rx="1.2" />
+                        <rect x="14" y="5" width="4" height="14" rx="1.2" />
+                      </svg>
+                    {:else}
+                      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path
+                          d="M8 5.5v13a1 1 0 0 0 1.54.84l10-6.5a1 1 0 0 0 0-1.68l-10-6.5A1 1 0 0 0 8 5.5Z"
+                        />
+                      </svg>
+                    {/if}
+                  </button>
+                  <div class="feel-taste__meta">
+                    <div class="feel-taste__title">{previewTitle}</div>
+                    {#if previewSub}
+                      <div class="feel-taste__sub">{previewSub}</div>
+                    {/if}
+                  </div>
+                  <div class="feel-taste__time" aria-hidden="true">
+                    <span class="feel-cur">{curLabel}</span>
+                    <span class="feel-sep">/</span>
+                    <span>{totLabel}</span>
+                  </div>
+                </div>
+
+                <div
+                  class="feel-wave"
+                  class:is-playing={playing && enhanced}
+                  role="presentation"
+                  aria-hidden="true"
+                  onclick={seek}
+                >
+                  {#each bars as bar, i (i)}
+                    <i
+                      class:is-on={i < playedBars}
+                      style="--h: {bar.h}%; --d: {bar.dur}s; --delay: {bar.delay}s"
+                    ></i>
+                  {/each}
+                  <span class="feel-wave__head" style="left: {headPct}%"></span>
+                </div>
+              </div>
+            </div>
+          {/if}
+        </div>
+
+        <!-- RIGHT · what's inside -->
+        {#if inclusions.length > 0}
+          <div class="feel__col">
+            <div class="feel__inside feel-reveal d2" use:reveal>
+              <ul class="feel-list">
+                {#each inclusions as inclusion, i (i)}
+                  <li>
+                    <span class="feel-list__m" aria-hidden="true">&#10022;</span>
+                    <span class="feel-list__lead">{inclusion.label}</span>
+                    {#if inclusion.detail}
+                      <span class="feel-list__sub">{inclusion.detail}</span>
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          </div>
         {/if}
       </div>
-
-      {#if p.inclusions}
-        <ul class="feel__inclusions">
-          {#each p.inclusions as inclusion, i (i)}
-            <li class="feel__inclusion">
-              <span class="feel__inclusion-label">{inclusion.label}</span>
-              {#if inclusion.detail}
-                <span class="feel__inclusion-detail">{inclusion.detail}</span>
-              {/if}
-            </li>
-          {/each}
-        </ul>
-      {/if}
     </div>
   </div>
 {/if}
 
 <style>
   .feel {
+    position: relative;
     padding-block: var(--space-20);
     padding-inline: var(--space-5);
   }
 
   .feel__inner {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-10);
     max-width: 68rem;
     margin-inline: auto;
   }
 
-  @media (--breakpoint-md) {
-    .feel__inner {
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  .feel__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-12);
+    align-items: stretch;
+  }
+
+  @media (width >= 54rem) {
+    .feel__grid {
+      grid-template-columns: minmax(0, 1.04fr) minmax(0, 0.96fr);
       gap: var(--space-16);
-      align-items: start;
     }
   }
 
-  .feel__left {
+  .feel__col {
     display: flex;
     flex-direction: column;
-    gap: var(--space-4);
   }
 
   .feel__eyebrow {
     margin: 0;
     font-size: var(--text-sm);
     font-weight: var(--font-semibold);
-    letter-spacing: 0.08em;
+    letter-spacing: 0.28em;
     text-transform: uppercase;
-    color: var(--color-text-secondary);
+    color: var(--color-brand-accent);
   }
 
   .feel__heading {
-    margin: 0;
+    margin: var(--space-3) 0 0;
     font-family: var(--font-heading);
     font-weight: var(--font-normal);
     font-size: var(--text-3xl);
@@ -110,42 +315,389 @@
   }
 
   .feel__body {
-    margin: 0;
+    margin: var(--space-4) 0 0;
+    max-width: 46ch;
     font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
   }
 
-  .feel__inclusions {
+  /* ═══ LEFT · the free-taste player ═══ */
+  .feel__player {
+    /* Pin to the base of the column so the tall left column fills, no void. */
+    margin-top: auto;
+    padding-top: var(--space-8);
+  }
+
+  .feel-taste {
+    position: relative;
+    border-radius: var(--radius-xl);
+    padding: var(--space-6);
+    background: linear-gradient(
+      180deg,
+      var(--color-surface-elevated),
+      var(--color-surface-secondary)
+    );
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-primary) 24%, var(--color-border-subtle));
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+  }
+
+  /* Warm hearth glow inside the card — the breathing aura signature. */
+  .feel-taste__aura {
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      120% 90% at 12% 0%,
+      color-mix(in oklab, var(--color-brand-primary) 16%, transparent),
+      transparent 58%
+    );
+  }
+
+  .feel-taste__head,
+  .feel-wave {
+    position: relative;
+    z-index: 1;
+  }
+
+  .feel-taste__head {
     display: flex;
-    flex-direction: column;
-    gap: 0;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  /* play / pause button */
+  .feel-play {
+    flex: none;
+    position: relative;
+    width: clamp(3.5rem, 8vw, 4.125rem);
+    height: clamp(3.5rem, 8vw, 4.125rem);
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    color: var(--color-text-on-brand);
+    background: linear-gradient(
+      180deg,
+      var(--color-brand-primary),
+      var(--color-brand-accent)
+    );
+    box-shadow: var(--shadow-md);
+    transition:
+      transform var(--duration-fast) var(--ease-out),
+      box-shadow var(--duration-normal) var(--ease-out);
+  }
+
+  .feel-play:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .feel-play:active {
+    transform: translateY(0);
+  }
+
+  .feel-play:focus-visible {
+    outline: var(--border-width-thick) solid var(--color-heading);
+    outline-offset: var(--space-1);
+  }
+
+  .feel-play svg {
+    width: 42%;
+    height: 42%;
+    display: block;
+  }
+
+  /* pulse ring while playing */
+  .feel-play::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-full);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .feel-play.is-playing::after {
+    animation: feel-pulse 2s var(--ease-out) infinite;
+  }
+
+  @keyframes feel-pulse {
+    0% {
+      opacity: 0.55;
+      transform: scale(1);
+    }
+    70%,
+    100% {
+      opacity: 0;
+      transform: scale(1.5);
+    }
+  }
+
+  .feel-taste__meta {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .feel-taste__title {
+    font-family: var(--font-heading);
+    color: var(--color-heading);
+    font-size: var(--text-lg);
+    line-height: var(--leading-snug);
+  }
+
+  .feel-taste__sub {
+    font-size: var(--text-sm);
+    color: var(--color-text-tertiary);
+    margin-top: var(--space-1);
+    letter-spacing: 0.01em;
+  }
+
+  .feel-taste__time {
+    flex: none;
+    align-self: flex-start;
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+
+  .feel-taste__time .feel-cur {
+    color: var(--color-brand-accent);
+  }
+
+  .feel-taste__time .feel-sep {
+    color: var(--color-text-tertiary);
+    margin: 0 var(--space-1);
+  }
+
+  /* waveform = equaliser + scrubber in one */
+  .feel-wave {
+    margin-top: var(--space-6);
+    height: clamp(3.625rem, 9vw, 4.625rem);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    cursor: pointer;
+  }
+
+  .feel-wave i {
+    flex: 1 1 0;
+    min-width: 0;
+    height: var(--h, 40%);
+    border-radius: var(--radius-xs);
+    transform-origin: center;
+    background: color-mix(in oklab, var(--color-text) 22%, transparent);
+    transition: background var(--duration-slow) var(--ease-out);
+  }
+
+  .feel-wave i.is-on {
+    background: linear-gradient(
+      180deg,
+      var(--color-brand-primary),
+      var(--color-brand-accent)
+    );
+  }
+
+  /* Equaliser dance — enhancement only (class gated on motion in the markup). */
+  .feel-wave.is-playing i {
+    animation: feel-eq var(--d, 1.1s) var(--ease-out) infinite;
+    animation-delay: var(--delay, 0s);
+  }
+
+  @keyframes feel-eq {
+    0%,
+    100% {
+      transform: scaleY(0.56);
+    }
+    50% {
+      transform: scaleY(1);
+    }
+  }
+
+  /* playhead */
+  .feel-wave__head {
+    position: absolute;
+    top: 6%;
+    bottom: 6%;
+    width: 1.5px;
+    background: color-mix(in oklab, var(--color-brand-accent) 85%, var(--color-heading));
+    transform: translateX(-50%);
+    box-shadow: 0 0 10px color-mix(in oklab, var(--color-brand-accent) 70%, transparent);
+    transition: left var(--duration-fast) linear;
+    pointer-events: none;
+  }
+
+  .feel-wave__head::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 9px;
+    height: 9px;
+    border-radius: var(--radius-full);
+    transform: translate(-50%, -50%);
+    background: var(--color-brand-accent);
+    box-shadow:
+      0 0 0 3px color-mix(in oklab, var(--color-background) 70%, transparent),
+      0 0 12px color-mix(in oklab, var(--color-brand-accent) 80%, transparent);
+  }
+
+  /* ═══ RIGHT · what's inside ═══ */
+  .feel__inside {
+    margin-top: auto;
+  }
+
+  .feel-list {
+    list-style: none;
+    position: relative;
     margin: 0;
     padding: 0;
-    list-style: none;
-  }
-
-  .feel__inclusion {
     display: flex;
     flex-direction: column;
-    gap: var(--space-1);
+  }
+
+  /* the spine — a faint ember thread stitching the markers together */
+  .feel-list::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    left: calc(clamp(1.9rem, 3.5vw, 2.3rem) / 2);
+    top: var(--space-4);
+    bottom: var(--space-4);
+    width: 1px;
+    transform: translateX(-50%);
+    background: linear-gradient(
+      180deg,
+      transparent,
+      color-mix(in oklab, var(--color-brand-primary) 40%, transparent) 12%,
+      color-mix(in oklab, var(--color-brand-primary) 40%, transparent) 88%,
+      transparent
+    );
+  }
+
+  .feel-list li {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: clamp(1.9rem, 3.5vw, 2.3rem) 1fr;
+    gap: var(--space-4);
+    align-items: center;
     padding: var(--space-4) 0;
-    border-top: var(--border-width) solid var(--color-border-subtle);
   }
 
-  .feel__inclusion:last-child {
-    border-bottom: var(--border-width) solid var(--color-border-subtle);
-  }
-
-  .feel__inclusion-label {
-    font-weight: var(--font-semibold);
-    font-size: var(--text-base);
-    color: var(--color-text);
-  }
-
-  .feel__inclusion-detail {
+  .feel-list__m {
+    grid-row: span 2;
+    align-self: center;
+    width: clamp(1.9rem, 3.5vw, 2.3rem);
+    height: clamp(1.9rem, 3.5vw, 2.3rem);
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    background: var(--color-surface-secondary);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-primary) 34%, transparent);
+    color: var(--color-brand-accent);
     font-size: var(--text-sm);
-    line-height: var(--leading-normal);
-    color: var(--color-text-secondary);
+    line-height: var(--leading-none);
+    transition:
+      transform var(--duration-normal) var(--ease-out),
+      border-color var(--duration-normal) var(--ease-out),
+      box-shadow var(--duration-normal) var(--ease-out),
+      color var(--duration-normal) var(--ease-out);
+  }
+
+  .feel-list li:hover .feel-list__m {
+    transform: scale(1.12) rotate(90deg);
+    border-color: var(--color-brand-primary);
+    color: var(--color-heading);
+    box-shadow: 0 0 22px -4px color-mix(in oklab, var(--color-brand-primary) 55%, transparent);
+  }
+
+  .feel-list__lead,
+  .feel-list__sub {
+    grid-column: 2;
+  }
+
+  .feel-list__lead {
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    color: var(--color-text);
+    font-size: var(--text-lg);
+    line-height: var(--leading-snug);
+    transition: color var(--duration-slow) var(--ease-out);
+  }
+
+  .feel-list li:hover .feel-list__lead {
+    color: var(--color-heading);
+  }
+
+  .feel-list__sub {
+    color: var(--color-text-tertiary);
+    font-size: var(--text-sm);
+    margin-top: var(--space-1);
+  }
+
+  /* ── reveal-on-scroll: armed from JS (see reveal.ts) so SSR / no-JS / reduced
+       motion paint the fully-revealed baseline and never get stuck hidden. ── */
+  .feel-reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(var(--space-6));
+    transition:
+      opacity var(--duration-slower) var(--ease-out),
+      transform var(--duration-slower) var(--ease-out);
+  }
+
+  .feel-reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  .feel-reveal.d1 {
+    transition-delay: 80ms;
+  }
+
+  .feel-reveal.d2 {
+    transition-delay: 160ms;
+  }
+
+  @media (max-width: 54rem) {
+    .feel__player,
+    .feel__inside {
+      margin-top: var(--space-6);
+    }
+
+    .feel__body {
+      max-width: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .feel-reveal:global(.reveal--armed) {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+    .feel-wave.is-playing i {
+      animation: none;
+    }
+    .feel-play.is-playing::after {
+      animation: none;
+    }
+    .feel-wave__head {
+      transition: none;
+    }
+    .feel-list__m,
+    .feel-list__lead {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/GuideSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/GuideSection.svelte
@@ -2,11 +2,22 @@
   @component GuideSection
 
   The maker's bio (SPEC §4.1 `guide`) — "made by someone who had to find the
-  ground first". Optional portrait + name + multi-paragraph bio + credentials.
-  Renders nothing when neither a bio nor a name is configured.
+  ground first". Optional portrait + name + multi-paragraph bio + credentials,
+  with an optional pull-quote climax.
+
+  TWO renderings, progressively enhanced (mirrors the prototype `guide` fragment):
+  • BASELINE (SSR, no-JS, reduced-motion): the copy and a fully-composed candlelit
+    "meet your guide" poster paint immediately — every layer visible, nothing
+    hidden behind JS. Renders nothing when neither a bio nor a name/heading is set.
+  • ENHANCED (browser + motion OK): copy + poster rise into view on scroll
+    (staggered `use:reveal`), a soft ember aura breathes inside the poster, and the
+    frame warms on hover. All motion is CSS, gated by `prefers-reduced-motion` so
+    the reduced-motion path holds the composed baseline (the `reveal` action itself
+    skips arming under reduced motion / SSR, so content is never stuck hidden).
 -->
 <script lang="ts">
   import { asString, asStringArray } from '../coerce';
+  import { reveal } from '../reveal';
   import { safeHref } from '../safe-href';
   import type { GuideSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
@@ -28,6 +39,11 @@
     credentials: asStringArray(config, 'credentials'),
   });
 
+  // The prototype's emotional climax is a pull-quote. It is not yet part of the
+  // shared GuideSectionProps contract, so read it defensively from config and
+  // simply omit the quote when absent (see desiredSharedChanges for the lead).
+  const quote = $derived(asString(config, 'quote'));
+
   // A single-glyph mark for the decorative candlelit poster when no portrait is
   // configured — the guide's initial, evoking a portrait placeholder.
   const mark = $derived(
@@ -42,36 +58,80 @@
            when configured; otherwise a decorative brand-lit panel holds the
            column's visual weight (matching the prototype's play-frame) without
            implying playback we don't have. -->
-      <div class="guide__poster" class:guide__poster--photo={p.portraitUrl}>
+      <div
+        class="guide__poster reveal reveal--stage"
+        class:guide__poster--photo={p.portraitUrl}
+        style="--reveal-delay: var(--duration-slow)"
+        use:reveal
+      >
         {#if p.portraitUrl}
           <img
             src={safeHref(p.portraitUrl)}
             alt={p.name ? `Portrait of ${p.name}` : ''}
             loading="lazy"
           />
+          <!-- Seat the photo in the same candlelit frame: quiet edge fall-off. -->
+          <span class="guide__vignette" aria-hidden="true"></span>
+          <span class="guide__sheen" aria-hidden="true"></span>
         {:else}
+          <!-- Breathing ember rising from lower-centre — a lit presence, never a
+               void — plus a vignette, top sheen, and fine grain for depth. -->
+          <span class="guide__ember" aria-hidden="true"></span>
+          <span class="guide__grain" aria-hidden="true"></span>
+          <span class="guide__vignette" aria-hidden="true"></span>
+          <span class="guide__sheen" aria-hidden="true"></span>
           <span class="guide__mark" aria-hidden="true">{mark}</span>
         {/if}
       </div>
+
       <div class="guide__body">
         {#if p.eyebrow}
-          <p class="guide__eyebrow">{p.eyebrow}</p>
+          <p class="guide__eyebrow reveal" use:reveal>{p.eyebrow}</p>
         {/if}
         {#if p.heading}
-          <h2 class="guide__heading">{p.heading}</h2>
+          <h2
+            class="guide__heading reveal"
+            style="--reveal-delay: var(--duration-fast)"
+            use:reveal
+          >
+            {p.heading}
+          </h2>
         {/if}
         {#if p.name}
-          <p class="guide__name">{p.name}</p>
+          <p
+            class="guide__name reveal"
+            style="--reveal-delay: var(--duration-normal)"
+            use:reveal
+          >
+            {p.name}
+          </p>
         {/if}
         {#if p.bio}
-          <div class="guide__bio">
+          <div
+            class="guide__bio reveal"
+            style="--reveal-delay: var(--duration-normal)"
+            use:reveal
+          >
             {#each p.bio as paragraph, i (i)}
               <p>{paragraph}</p>
             {/each}
           </div>
         {/if}
+        {#if quote}
+          <blockquote
+            class="guide__quote reveal"
+            style="--reveal-delay: var(--duration-slow)"
+            use:reveal
+          >
+            <p>{quote}</p>
+          </blockquote>
+        {/if}
         {#if p.credentials}
-          <ul class="guide__credentials">
+          <ul
+            class="guide__credentials reveal"
+            style="--reveal-delay: var(--duration-slow)"
+            use:reveal
+          >
             {#each p.credentials as credential, i (i)}
               <li>{credential}</li>
             {/each}
@@ -84,6 +144,7 @@
 
 <style>
   .guide {
+    position: relative;
     padding-block: var(--space-20);
     padding-inline: var(--space-5);
   }
@@ -109,6 +170,7 @@
      video frames, so the guide reads as part of one candlelit world. */
   .guide__poster {
     position: relative;
+    isolation: isolate;
     aspect-ratio: 4 / 5;
     border-radius: var(--radius-card);
     overflow: hidden;
@@ -133,6 +195,20 @@
         color-mix(in oklab, var(--color-brand-primary) 55%, #000),
       inset 0 var(--border-width) 0
         color-mix(in oklab, var(--color-heading) 10%, transparent);
+    transition:
+      box-shadow var(--duration-slow) var(--ease-smooth),
+      transform var(--duration-slow) var(--ease-smooth);
+  }
+
+  /* Hover warmth — the frame lifts a touch and the glow deepens. Aesthetic only;
+     the poster is decorative, not an actionable control. */
+  .guide__poster:hover {
+    transform: translateY(-0.2rem);
+    box-shadow:
+      0 var(--space-10) var(--space-16) calc(-1 * var(--space-10))
+        color-mix(in oklab, var(--color-brand-primary) 65%, #000),
+      inset 0 var(--border-width) 0
+        color-mix(in oklab, var(--color-heading) 14%, transparent);
   }
 
   .guide__poster--photo {
@@ -140,13 +216,87 @@
   }
 
   .guide__poster img {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
     display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
 
+  /* Soft, tall ember glow that breathes like a lit form (prototype `guide__ember`). */
+  .guide__ember {
+    position: absolute;
+    z-index: 1;
+    left: 50%;
+    bottom: 14%;
+    width: 58%;
+    aspect-ratio: 3 / 4;
+    translate: -50% 0;
+    pointer-events: none;
+    filter: blur(var(--blur-xl));
+    background: radial-gradient(
+      50% 50% at 50% 55%,
+      color-mix(in oklab, var(--color-brand-primary) 72%, transparent),
+      color-mix(in oklab, var(--color-brand-accent, var(--color-brand-primary)) 30%, transparent) 55%,
+      transparent 72%
+    );
+    animation: guide-breathe 7.5s var(--ease-in-out) infinite;
+  }
+
+  @keyframes guide-breathe {
+    0%,
+    100% {
+      opacity: 0.55;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.9;
+      transform: translateY(-2%) scale(1.06);
+    }
+  }
+
+  /* Fine grain for texture. Inline SVG data URI is CSP-safe (no external asset). */
+  .guide__grain {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.14;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='gn'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23gn)'/%3E%3C/svg%3E");
+  }
+
+  /* Inner vignette — darkens the edges so the warm centre reads as depth. */
+  .guide__vignette {
+    position: absolute;
+    z-index: 3;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      78% 78% at 50% 52%,
+      transparent 42%,
+      color-mix(in oklab, var(--color-background) 62%, transparent) 100%
+    );
+  }
+
+  /* Top catch-light sheen. */
+  .guide__sheen {
+    position: absolute;
+    z-index: 4;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-heading) 10%, transparent),
+      transparent 22%
+    );
+  }
+
   .guide__mark {
+    position: relative;
+    z-index: 5;
     font-family: var(--font-heading);
     font-size: var(--text-6xl, var(--text-display));
     font-weight: var(--font-normal);
@@ -202,6 +352,39 @@
     color: var(--color-text);
   }
 
+  /* Pull quote — the emotional climax: large serif, brand-lit accent rule. */
+  .guide__quote {
+    position: relative;
+    margin: var(--space-4) 0 0;
+    padding-left: var(--space-5);
+    border-left: var(--border-width-thick) solid
+      color-mix(in oklab, var(--color-brand-accent, var(--color-brand-primary)) 55%, transparent);
+    max-width: 32ch;
+  }
+
+  .guide__quote::before {
+    content: '\201C';
+    position: absolute;
+    left: var(--space-3);
+    top: -0.35em;
+    font-family: var(--font-heading);
+    font-size: var(--text-5xl);
+    line-height: 1;
+    color: color-mix(in oklab, var(--color-brand-accent, var(--color-brand-primary)) 34%, transparent);
+    pointer-events: none;
+  }
+
+  .guide__quote p {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-weight: var(--font-normal);
+    font-size: var(--text-2xl);
+    line-height: var(--leading-snug);
+    letter-spacing: -0.01em;
+    color: color-mix(in oklab, var(--color-brand-accent, var(--color-brand-primary)) 40%, var(--color-heading));
+  }
+
   .guide__credentials {
     display: flex;
     flex-wrap: wrap;
@@ -217,5 +400,51 @@
     border: var(--border-width) solid var(--color-border-subtle);
     font-size: var(--text-xs);
     color: var(--color-text-secondary);
+  }
+
+  /* ── reveal-on-scroll ──
+     Base `.reveal` (no armed class) is the fully-visible SSR / no-JS baseline.
+     The `reveal` action adds `reveal--armed` (hidden) only once JS confirms
+     motion is welcome, then `is-in` when the node scrolls into view. */
+  .reveal {
+    transition:
+      opacity var(--duration-slowest) var(--ease-smooth),
+      transform var(--duration-slowest) var(--ease-smooth);
+    transition-delay: var(--reveal-delay, 0ms);
+  }
+
+  .reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(1.4rem);
+  }
+
+  .reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  .reveal--stage:global(.reveal--armed) {
+    transform: translateY(1.5rem) scale(0.985);
+  }
+
+  .reveal--stage:global(.reveal--armed.is-in) {
+    transform: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .guide__ember {
+      animation: none;
+    }
+    .guide__poster {
+      transition: none;
+    }
+    .guide__poster:hover {
+      transform: none;
+    }
+    /* Hold the composed state — the reveal action already skips arming under
+       reduced motion; this guards any residual transition. */
+    .reveal {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/HeroSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/HeroSection.svelte
@@ -3,11 +3,26 @@
 
   Opening headline, kicker and primary CTA (SPEC §4.1 `hero`). Falls back to the
   awaited course fields when a copy prop is absent, so an unconfigured hero still
-  renders a coherent first paint (SEO-critical). Atmosphere is purely decorative
-  and never load-bearing for legibility — the headline sits on `--color-heading`
-  over `--color-background`, which stays legible on any org brand (dark included).
+  renders a coherent first paint (SEO-critical).
+
+  TWO renderings, progressively enhanced (mirrors AcheSection):
+  • BASELINE (SSR, no-JS, reduced-motion): a clean, fully-legible centred column —
+    every word visible, glow static, motes/scroll-cue hidden. This is what the
+    server emits, so the section is never blank and never depends on JS. The
+    headline sits on `--color-heading` over `--color-background`, legible on any
+    org brand (dark included).
+  • ENHANCED (browser + motion OK): the prototype's cinematic opening — a breathing
+    warm core, slow rising motes, an edge vignette, a word-by-word kinetic headline,
+    staggered fade-up entrances, a heart-beating trust dot and a descending
+    scroll-cue spark.
+
+  Enhancement is gated on `mounted && !reduced` (the `.hero--enhanced` class) so
+  the accessible baseline always ships first; a `matchMedia` listener re-wires if
+  the reduced-motion preference flips mid-session. All atmosphere is decorative
+  and never load-bearing for legibility.
 -->
 <script lang="ts">
+  import { onMount } from 'svelte';
   import CtaLink from '../CtaLink.svelte';
   import { asString } from '../coerce';
   import type { HeroSectionProps, JourneySalesContext } from '../types';
@@ -34,6 +49,11 @@
   const headline = $derived(p.headline ?? context.course.title);
   const subheadline = $derived(p.subheadline ?? context.course.lede ?? undefined);
 
+  // Split the (dynamic) headline into words so each can animate in on a stagger —
+  // the prototype's kinetic signature. Pure + SSR-safe; baseline just renders the
+  // words inline with no motion.
+  const words = $derived(headline.split(/\s+/).filter((w) => w.length > 0));
+
   // CTA branches on the viewer's enrolment (the sales page is otherwise fully
   // public): an enrolled member goes to their dashboard; everyone else is sent
   // to the offer/checkout surface to join.
@@ -45,18 +65,56 @@
       ? 'Go to your dashboard'
       : (p.ctaLabel ?? 'Begin the journey')
   );
+
+  // Decorative motes — count only; per-mote geometry lives in CSS (nth-child).
+  const MOTE_COUNT = 12;
+  const motes = Array.from({ length: MOTE_COUNT });
+
+  let mounted = $state(false);
+  let reduced = $state(false);
+
+  // Motion is layered only once JS confirms it is welcome; otherwise the static
+  // composed baseline above is what the viewer keeps.
+  const enhanced = $derived(mounted && !reduced);
+
+  onMount(() => {
+    mounted = true;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
 </script>
 
-<div class="hero">
-  <div class="hero__glow" aria-hidden="true"></div>
+<header class="hero" class:hero--enhanced={enhanced}>
+  <div class="hero__atmos" aria-hidden="true">
+    <div class="hero__glow"></div>
+    <div class="hero__motes">
+      {#each motes as _, i (i)}
+        <span class="hero__mote"></span>
+      {/each}
+    </div>
+    <div class="hero__vignette"></div>
+  </div>
+
   <div class="hero__inner">
     {#if eyebrow}
       <p class="hero__eyebrow">{eyebrow}</p>
     {/if}
-    <h1 class="hero__headline">{headline}</h1>
+
+    <h1 class="hero__headline">
+      {#each words as word, i (i)}
+        <span class="hero__word" style="--word-i: {i}">{`${word} `}</span>
+      {/each}
+    </h1>
+
     {#if subheadline}
       <p class="hero__sub">{subheadline}</p>
     {/if}
+
     <div class="hero__actions">
       <CtaLink href={ctaHref} variant="primary" size="lg">
         {ctaLabel}
@@ -67,6 +125,7 @@
         </CtaLink>
       {/if}
     </div>
+
     {#if p.trust}
       <p class="hero__trust">
         <span class="hero__trust-dot" aria-hidden="true"></span>
@@ -74,49 +133,117 @@
       </p>
     {/if}
   </div>
-</div>
+
+  <!-- Scroll cue: a light descending a hairline. Enhancement-only + decorative. -->
+  <div class="hero__cue" aria-hidden="true">
+    <span class="hero__cue-line"><span class="hero__cue-spark"></span></span>
+    <svg
+      class="hero__cue-chevron"
+      width="16"
+      height="10"
+      viewBox="0 0 16 10"
+      fill="none"
+    >
+      <path
+        d="M1 1l7 7 7-7"
+        stroke="currentColor"
+        stroke-width="1.4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </div>
+</header>
 
 <style>
   .hero {
     position: relative;
     isolation: isolate;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-height: min(88svh, 45rem);
-    padding-block: var(--space-16);
+    min-height: 100vh;
+    min-height: 100svh;
+    padding-block: var(--space-24) var(--space-16);
+    padding-inline: var(--space-5);
     overflow: hidden;
     text-align: center;
   }
 
-  /* Decorative warm core — subtle, never relied on for contrast. */
+  /* ── atmosphere layers (all decorative, behind content) ── */
+  .hero__atmos {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  /* breathing warm core — the "living light" behind the headline */
   .hero__glow {
     position: absolute;
-    z-index: -1;
     left: 50%;
-    top: 42%;
-    width: min(90vw, 48.75rem);
+    top: 40%;
+    width: min(92vw, 48.75rem);
     aspect-ratio: 1;
     transform: translate(-50%, -50%);
     border-radius: var(--radius-full);
-    opacity: 0.5;
+    opacity: 0.55;
     filter: blur(var(--blur-2xl));
-    pointer-events: none;
     background: radial-gradient(
       circle at 50% 46%,
-      color-mix(in oklab, var(--color-brand-primary) 22%, transparent),
-      color-mix(in oklab, var(--color-brand-accent) 12%, transparent) 46%,
+      color-mix(in oklab, var(--color-brand-primary) 24%, transparent),
+      color-mix(in oklab, var(--color-brand-accent) 14%, transparent) 46%,
       transparent 70%
     );
   }
 
+  /* slow rising embers — hidden in the baseline (they only read while moving) */
+  .hero__motes {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    display: none;
+  }
+
+  .hero__mote {
+    position: absolute;
+    bottom: -0.75rem;
+    width: 0.1875rem;
+    height: 0.1875rem;
+    border-radius: var(--radius-full);
+    opacity: 0;
+    background: radial-gradient(
+      circle,
+      color-mix(in oklab, var(--color-brand-primary) 92%, white),
+      color-mix(in oklab, var(--color-brand-primary) 20%, transparent) 70%
+    );
+    box-shadow: 0 0 6px color-mix(in oklab, var(--color-brand-primary) 55%, transparent);
+  }
+
+  /* edge vignette to focus the centre and blend into the next section.
+     Theme-aware: darkens toward the page background (subtle on light themes). */
+  .hero__vignette {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      125% 95% at 50% 42%,
+      transparent 55%,
+      color-mix(in oklab, var(--color-background) 58%, transparent) 100%
+    );
+  }
+
+  /* ── content column ── */
   .hero__inner {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-5);
+    width: 100%;
     max-width: 56rem;
-    padding-inline: var(--space-5);
+    margin-inline: auto;
   }
 
   .hero__eyebrow {
@@ -130,7 +257,10 @@
 
   .hero__headline {
     margin: 0;
+    max-width: 16ch;
+    margin-inline: auto;
     font-family: var(--font-heading);
+    font-weight: var(--font-normal);
     font-size: var(--text-display);
     line-height: var(--leading-tight);
     letter-spacing: -0.02em;
@@ -138,9 +268,15 @@
     text-wrap: balance;
   }
 
+  /* Baseline: plain inline words. Enhancement upgrades to inline-block + stagger. */
+  .hero__word {
+    white-space: pre;
+  }
+
   .hero__sub {
     margin: 0;
     max-width: 42ch;
+    margin-inline: auto;
     font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
@@ -150,6 +286,7 @@
   .hero__actions {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     justify-content: center;
     gap: var(--space-3);
     margin-top: var(--space-2);
@@ -171,5 +308,246 @@
     background: var(--color-brand-primary);
     box-shadow: 0 0 0 var(--space-1)
       color-mix(in oklab, var(--color-brand-primary) 22%, transparent);
+  }
+
+  /* ── scroll cue: hidden in the baseline, revealed only when enhanced ── */
+  .hero__cue {
+    position: absolute;
+    bottom: clamp(var(--space-3), 3vh, var(--space-8));
+    left: 0;
+    right: 0;
+    z-index: 1;
+    margin-inline: auto;
+    width: max-content;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--color-text-tertiary);
+  }
+
+  .hero__cue-line {
+    position: relative;
+    width: 1px;
+    height: 2.875rem;
+    overflow: hidden;
+    background: linear-gradient(
+      to bottom,
+      transparent,
+      color-mix(in oklab, var(--color-heading) 22%, transparent) 45%,
+      transparent
+    );
+  }
+
+  .hero__cue-spark {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    width: 0.1875rem;
+    height: 0.6875rem;
+    margin-left: -0.09375rem;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(var(--color-brand-primary), transparent);
+    box-shadow: 0 0 9px color-mix(in oklab, var(--color-brand-primary) 80%, transparent);
+  }
+
+  .hero__cue-chevron {
+    color: var(--color-text-tertiary);
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════════
+     ENHANCED — layered on top of the legible baseline once JS confirms motion
+     is welcome (`.hero--enhanced`). Nothing here is required for legibility.
+     ═══════════════════════════════════════════════════════════════════════ */
+
+  .hero--enhanced .hero__glow {
+    animation: hero-breathe 11s ease-in-out infinite;
+  }
+
+  .hero--enhanced .hero__motes {
+    display: block;
+  }
+
+  .hero--enhanced .hero__mote {
+    animation: hero-rise linear infinite;
+  }
+
+  /* Per-mote geometry — left position, size, drift (--dx), peak opacity (--o),
+     duration + delay. Sizes/offsets in rem + viewport units (no hardcoded px). */
+  .hero--enhanced .hero__mote:nth-child(1)  { left: 7%;  width: 0.125rem;  height: 0.125rem;  --dx: 1.125rem;  --o: 0.40; animation-duration: 20s; animation-delay: 0s; }
+  .hero--enhanced .hero__mote:nth-child(2)  { left: 15%; width: 0.1875rem; height: 0.1875rem; --dx: -0.9375rem; --o: 0.34; animation-duration: 25s; animation-delay: 3s; }
+  .hero--enhanced .hero__mote:nth-child(3)  { left: 24%; width: 0.125rem;  height: 0.125rem;  --dx: 1.375rem;  --o: 0.48; animation-duration: 16s; animation-delay: 6s; }
+  .hero--enhanced .hero__mote:nth-child(4)  { left: 33%; width: 0.25rem;   height: 0.25rem;   --dx: -0.625rem; --o: 0.30; animation-duration: 28s; animation-delay: 1s; }
+  .hero--enhanced .hero__mote:nth-child(5)  { left: 42%; width: 0.125rem;  height: 0.125rem;  --dx: 0.8125rem; --o: 0.52; animation-duration: 21s; animation-delay: 9s; }
+  .hero--enhanced .hero__mote:nth-child(6)  { left: 50%; width: 0.1875rem; height: 0.1875rem; --dx: -1.3125rem; --o: 0.38; animation-duration: 26s; animation-delay: 4s; }
+  .hero--enhanced .hero__mote:nth-child(7)  { left: 59%; width: 0.125rem;  height: 0.125rem;  --dx: 1rem;      --o: 0.46; animation-duration: 18s; animation-delay: 11s; }
+  .hero--enhanced .hero__mote:nth-child(8)  { left: 67%; width: 0.1875rem; height: 0.1875rem; --dx: -0.75rem;  --o: 0.34; animation-duration: 23s; animation-delay: 2s; }
+  .hero--enhanced .hero__mote:nth-child(9)  { left: 76%; width: 0.125rem;  height: 0.125rem;  --dx: 1.25rem;   --o: 0.50; animation-duration: 17s; animation-delay: 7s; }
+  .hero--enhanced .hero__mote:nth-child(10) { left: 84%; width: 0.25rem;   height: 0.25rem;   --dx: -1rem;     --o: 0.28; animation-duration: 27s; animation-delay: 5s; }
+  .hero--enhanced .hero__mote:nth-child(11) { left: 91%; width: 0.125rem;  height: 0.125rem;  --dx: 0.6875rem; --o: 0.44; animation-duration: 20s; animation-delay: 10s; }
+  .hero--enhanced .hero__mote:nth-child(12) { left: 96%; width: 0.1875rem; height: 0.1875rem; --dx: -1.125rem; --o: 0.36; animation-duration: 22s; animation-delay: 13s; }
+
+  /* Kinetic headline — each word rises + de-blurs on its own beat. */
+  .hero--enhanced .hero__word {
+    display: inline-block;
+    animation: hero-word-in 0.9s var(--ease-out) both;
+    animation-delay: calc(var(--word-i, 0) * 0.08s + 0.2s);
+  }
+
+  /* Staggered fade-up entrances for the surrounding copy. */
+  .hero--enhanced .hero__eyebrow {
+    animation: hero-fade-up 0.8s var(--ease-out) 0.1s both;
+  }
+  .hero--enhanced .hero__sub {
+    animation: hero-fade-up 0.8s var(--ease-out) 1.05s both;
+  }
+  .hero--enhanced .hero__actions {
+    animation: hero-fade-up 0.8s var(--ease-out) 1.25s both;
+  }
+  .hero--enhanced .hero__trust {
+    animation: hero-fade-up 0.8s var(--ease-out) 1.42s both;
+  }
+  .hero--enhanced .hero__trust-dot {
+    animation: hero-heartbeat 4.5s ease-in-out infinite;
+  }
+
+  .hero--enhanced .hero__cue {
+    display: flex;
+    animation: hero-fade-up 0.9s var(--ease-out) 1.65s both;
+  }
+  .hero--enhanced .hero__cue-spark {
+    animation: hero-spark 2.8s var(--ease-out) infinite;
+  }
+  .hero--enhanced .hero__cue-chevron {
+    animation: hero-cue-bob 2.8s ease-in-out infinite;
+  }
+
+  @keyframes hero-word-in {
+    from {
+      opacity: 0;
+      transform: translateY(0.42em);
+      filter: blur(10px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+      filter: blur(0);
+    }
+  }
+
+  @keyframes hero-fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(1.125rem);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @keyframes hero-breathe {
+    0%,
+    100% {
+      transform: translate(-50%, -50%) scale(1);
+      opacity: 0.5;
+    }
+    50% {
+      transform: translate(-50%, -50%) scale(1.09);
+      opacity: 0.78;
+    }
+  }
+
+  @keyframes hero-rise {
+    0% {
+      transform: translate3d(0, 0, 0);
+      opacity: 0;
+    }
+    12% {
+      opacity: var(--o, 0.42);
+    }
+    50% {
+      transform: translate3d(calc(var(--dx, 0.75rem) * 0.5), -48vh, 0);
+    }
+    88% {
+      opacity: var(--o, 0.42);
+    }
+    100% {
+      transform: translate3d(var(--dx, 0.75rem), -94vh, 0);
+      opacity: 0;
+    }
+  }
+
+  @keyframes hero-heartbeat {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.9;
+    }
+    50% {
+      transform: scale(1.35);
+      opacity: 0.5;
+    }
+  }
+
+  @keyframes hero-spark {
+    0% {
+      transform: translateY(0);
+      opacity: 0;
+    }
+    22% {
+      opacity: 1;
+    }
+    78% {
+      opacity: 1;
+    }
+    100% {
+      transform: translateY(2.3125rem);
+      opacity: 0;
+    }
+  }
+
+  @keyframes hero-cue-bob {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(0.1875rem);
+    }
+  }
+
+  @media (max-width: 35rem) {
+    .hero__actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
+
+  /* Belt-and-braces: even if `.hero--enhanced` is applied, honour a reduced-motion
+     preference by holding the final composed state (the enhanced flag already
+     gates this, but this covers a mid-animation preference flip). */
+  @media (prefers-reduced-motion: reduce) {
+    .hero__glow,
+    .hero__mote,
+    .hero__word,
+    .hero__eyebrow,
+    .hero__sub,
+    .hero__actions,
+    .hero__trust,
+    .hero__trust-dot,
+    .hero__cue,
+    .hero__cue-spark,
+    .hero__cue-chevron {
+      animation: none !important;
+    }
+    .hero__word {
+      opacity: 1;
+      transform: none;
+      filter: none;
+    }
+    .hero__motes {
+      display: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/IntroVideoSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/IntroVideoSection.svelte
@@ -7,12 +7,21 @@
   public preview, no auth). While the preview promise is pending we show a
   poster skeleton; a resolution failure `.catch()`-es to null and the section
   degrades to just its copy. Playback reuses `ui/IntroVideoModal` (HLS.js).
+
+  TWO renderings, progressively enhanced (mirrors the prototype `intro` fragment):
+  • BASELINE (SSR, no-JS, reduced-motion): the copy and a fully-composed candlelit
+    play-frame paint immediately — every layer visible, nothing hidden behind JS.
+  • ENHANCED (browser + motion OK): copy + frame rise into view on scroll (staggered
+    `use:reveal`), a key-light aura breathes behind the ember play button, and two
+    pulse rings ripple outward. All motion is CSS, gated by `prefers-reduced-motion`
+    so the reduced-motion path holds the composed baseline.
 -->
 <script lang="ts">
   import { IntroVideoModal } from '$lib/components/ui/IntroVideoModal';
   import { PlayIcon } from '$lib/components/ui/Icon';
   import SectionSkeleton from '../SectionSkeleton.svelte';
   import { asString } from '../coerce';
+  import { reveal } from '../reveal';
   import type { IntroVideoSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -33,35 +42,85 @@
   const heading = $derived(p.heading ?? 'Ninety seconds inside the work.');
 
   let open = $state(false);
+
+  /** Advisory duration → a compact `M:SS` badge. Never fabricates a value. */
+  function formatDuration(seconds: number | null | undefined): string | null {
+    if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) {
+      return null;
+    }
+    const total = Math.round(seconds);
+    const mins = Math.floor(total / 60);
+    const secs = total % 60;
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  }
 </script>
 
 <div class="intro">
   <div class="intro__lead">
     {#if p.eyebrow}
-      <p class="intro__eyebrow">{p.eyebrow}</p>
+      <p class="intro__eyebrow reveal" use:reveal>{p.eyebrow}</p>
     {/if}
-    <h2 class="intro__heading">{heading}</h2>
+    <h2
+      class="intro__heading reveal"
+      style="--reveal-delay: var(--duration-fast)"
+      use:reveal
+    >
+      {heading}
+    </h2>
     {#if p.sub}
-      <p class="intro__sub">{p.sub}</p>
+      <p
+        class="intro__sub reveal"
+        style="--reveal-delay: var(--duration-normal)"
+        use:reveal
+      >
+        {p.sub}
+      </p>
     {/if}
   </div>
 
-  <div class="intro__stage" style={p.posterUrl ? `--poster: url(${JSON.stringify(p.posterUrl)})` : undefined}>
+  <div
+    class="intro__stage reveal reveal--stage"
+    style={p.posterUrl
+      ? `--reveal-delay: var(--duration-slow); --poster: url(${JSON.stringify(p.posterUrl)})`
+      : '--reveal-delay: var(--duration-slow)'}
+    use:reveal
+  >
+    <!-- Breathing key-light behind the words — warmth, never a void. -->
+    <div class="intro__aura" aria-hidden="true"></div>
+    <!-- Cinematic vignette + top catch-light sheen seat the frame. -->
+    <div class="intro__vignette" aria-hidden="true"></div>
+    <div class="intro__sheen" aria-hidden="true"></div>
+
     {#await context.sellPreview}
       <SectionSkeleton shape="media" label="Loading the intro film" />
     {:then preview}
       {#if preview?.intro}
         {@const intro = preview.intro}
-        <button
-          type="button"
-          class="intro__play"
-          onclick={() => (open = true)}
-          aria-label="Play the {Math.round(intro.durationSeconds ?? 90)}-second intro film"
-        >
-          <span class="intro__play-icon" aria-hidden="true">
-            <PlayIcon />
+        {@const durationLabel = formatDuration(intro.durationSeconds)}
+        <div class="intro__controls">
+          <span class="intro__pulse" aria-hidden="true"></span>
+          <span class="intro__pulse intro__pulse--2" aria-hidden="true"></span>
+          <button
+            type="button"
+            class="intro__play"
+            onclick={() => (open = true)}
+            aria-label="Play the {Math.round(
+              intro.durationSeconds ?? 90
+            )}-second intro film"
+          >
+            <span class="intro__play-icon" aria-hidden="true">
+              <PlayIcon />
+            </span>
+          </button>
+        </div>
+
+        {#if durationLabel}
+          <span class="intro__duration" aria-hidden="true">
+            <span class="intro__duration-dot"></span>
+            {durationLabel}
           </span>
-        </button>
+        {/if}
+
         <IntroVideoModal
           {open}
           src={intro.playlistUrl}
@@ -155,8 +214,80 @@
     place-items: center;
   }
 
+  /* Soft central key-light — the warmth falling on the seated figure. */
+  .intro__aura {
+    position: absolute;
+    z-index: 0;
+    left: 50%;
+    top: 46%;
+    translate: -50% -50%;
+    width: min(64%, 35rem);
+    aspect-ratio: 1;
+    border-radius: var(--radius-full);
+    pointer-events: none;
+    opacity: 0.82;
+    filter: blur(var(--blur-2xl));
+    background: radial-gradient(
+      circle at 50% 46%,
+      color-mix(in oklab, var(--color-brand-accent, var(--color-brand-primary)) 42%, transparent),
+      color-mix(in oklab, var(--color-brand-primary) 16%, transparent) 46%,
+      transparent 70%
+    );
+    animation: intro-breathe 9s var(--ease-in-out) infinite;
+  }
+
+  @keyframes intro-breathe {
+    0%,
+    100% {
+      opacity: 0.66;
+      scale: 1;
+    }
+    50% {
+      opacity: 0.9;
+      scale: 1.07;
+    }
+  }
+
+  /* Deep vignette — seats the warm centre in shadow, cinematic edge fall-off. */
+  .intro__vignette {
+    position: absolute;
+    z-index: 1;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      86% 82% at 50% 45%,
+      transparent 44%,
+      color-mix(in oklab, var(--color-background) 58%, transparent) 100%
+    );
+  }
+
+  /* Top catch-light sheen. */
+  .intro__sheen {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-heading) 9%, transparent),
+      transparent 22%
+    );
+  }
+
+  .intro__controls {
+    position: relative;
+    z-index: 3;
+    display: grid;
+    place-items: center;
+  }
+
+  .intro__controls > * {
+    grid-area: 1 / 1;
+  }
+
   .intro__play {
     position: relative;
+    z-index: 1;
     display: inline-grid;
     place-items: center;
     width: var(--space-16);
@@ -169,19 +300,25 @@
     box-shadow: 0 0 var(--space-8)
       color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
     transition:
-      transform var(--duration-fast) var(--ease-default),
-      background-color var(--duration-fast) var(--ease-default);
+      transform var(--duration-slow) var(--ease-smooth),
+      background-color var(--duration-fast) var(--ease-default),
+      box-shadow var(--duration-slow) var(--ease-smooth);
   }
 
-  /* a slow breathing pulse ring — the ember, waiting to be watched */
-  .intro__play::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
+  /* Two breathing pulse rings — the ember, waiting to be watched. */
+  .intro__pulse {
+    z-index: 0;
+    width: var(--space-16);
+    height: var(--space-16);
+    border-radius: var(--radius-full);
     border: var(--border-width) solid
-      color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
-    animation: intro-pulse 3.2s var(--ease-default) infinite;
+      color-mix(in oklab, var(--color-brand-primary) 55%, transparent);
+    pointer-events: none;
+    animation: intro-pulse 3.2s var(--ease-out) infinite;
+  }
+
+  .intro__pulse--2 {
+    animation-delay: 1.6s;
   }
 
   @keyframes intro-pulse {
@@ -197,7 +334,9 @@
 
   .intro__play:hover {
     background: var(--color-brand-primary-hover);
-    transform: scale(1.06);
+    transform: translateY(-0.15rem) scale(1.05);
+    box-shadow: 0 var(--space-4) var(--space-10) calc(-1 * var(--space-4))
+      color-mix(in oklab, var(--color-brand-primary) 70%, #000);
   }
 
   .intro__play:focus-visible {
@@ -212,21 +351,91 @@
     margin-left: 3px; /* optical centring of the play triangle */
   }
 
+  /* Corner chrome — a quiet duration badge, only when advisory data resolves. */
+  .intro__duration {
+    position: absolute;
+    z-index: 4;
+    right: var(--space-4);
+    bottom: var(--space-4);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding-block: var(--space-1);
+    padding-inline: var(--space-3);
+    border-radius: var(--radius-full);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-heading) 16%, transparent);
+    background: color-mix(in oklab, var(--color-background) 55%, transparent);
+    -webkit-backdrop-filter: blur(var(--blur-sm));
+    backdrop-filter: blur(var(--blur-sm));
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    letter-spacing: 0.06em;
+    color: color-mix(in oklab, var(--color-heading) 82%, transparent);
+    pointer-events: none;
+  }
+
+  .intro__duration-dot {
+    width: var(--space-1-5, 0.375rem);
+    height: var(--space-1-5, 0.375rem);
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary);
+    box-shadow: 0 0 8px
+      color-mix(in oklab, var(--color-brand-primary) 70%, transparent);
+  }
+
   .intro__empty {
     width: 100%;
     height: 100%;
   }
 
+  /* ── reveal-on-scroll ──
+     Base `.reveal` (no armed class) is the fully-visible SSR / no-JS baseline.
+     The `reveal` action adds `reveal--armed` (hidden) only once JS confirms
+     motion is welcome, then `is-in` when the node scrolls into view. */
+  .reveal {
+    transition:
+      opacity var(--duration-slowest) var(--ease-smooth),
+      transform var(--duration-slowest) var(--ease-smooth);
+    transition-delay: var(--reveal-delay, 0ms);
+  }
+
+  .reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(1.5rem);
+  }
+
+  .reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  .reveal--stage:global(.reveal--armed) {
+    transform: translateY(1.6rem) scale(0.986);
+  }
+
+  .reveal--stage:global(.reveal--armed.is-in) {
+    transform: none;
+  }
+
   @media (prefers-reduced-motion: reduce) {
-    .intro__play {
-      transition: none;
+    .intro__aura {
+      animation: none;
     }
-    .intro__play::after {
+    .intro__pulse {
       animation: none;
       opacity: 0;
     }
+    .intro__play {
+      transition: none;
+    }
     .intro__play:hover {
       transform: none;
+    }
+    /* Hold the composed state — the reveal action already skips arming under
+       reduced motion, this guards any residual transition. */
+    .reveal {
+      transition: none;
     }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/InviteSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/InviteSection.svelte
@@ -7,11 +7,29 @@
   lives on the checkout route (WP-6). When the builder teases offer paths via the
   `offers` prop they render as cards; otherwise the invite shows the one-off
   price. Every path funnels to `context.checkoutUrl`. Currency is GBP.
+
+  TWO renderings, progressively enhanced (SPEC §6: CSS-first motion, always
+  degradable):
+  • BASELINE (SSR, no-JS, reduced-motion): a clean, fully-legible centred close —
+    eyebrow, heading, sub, and the offer(s), all visible immediately. This is what
+    the server emits, so the section is never blank and never depends on JS.
+  • ENHANCED (browser + motion OK): the prototype's cinematic close — a breathing
+    "warm ground" rises from below, a descent hairline drops a travelling spark
+    that arrives at a glowing seed, a centred vignette focuses the frame, and each
+    block fades/rises into view on scroll (staggered) via the shared `reveal`
+    action.
+
+  Ambient loops (breathe / descent spark / seed pulse) are gated on
+  `mounted && !reduced` so the accessible baseline always ships first; the
+  reduced-motion preference is re-read live so a mid-session flip settles the
+  frame. The reveal action is self-gating (SSR-safe, reduced-motion aware).
 -->
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { formatPrice } from '$lib/utils/format';
   import CtaLink from '../CtaLink.svelte';
   import { asString, asObjectArray, fieldString, fieldBool } from '../coerce';
+  import { reveal } from '../reveal';
   import type { InviteSectionProps, InviteOffer, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -57,22 +75,48 @@
   const oneOffPrice = $derived(
     context.course.priceCents !== null ? formatPrice(context.course.priceCents) : null
   );
+
+  let mounted = $state(false);
+  let reduced = $state(false);
+
+  // Ambient loops (breathe / descent / pulse) only after JS confirms motion is
+  // welcome; the static baseline stays the SSR / no-JS / reduced-motion render.
+  const enhanced = $derived(mounted && !reduced);
+
+  onMount(() => {
+    mounted = true;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
 </script>
 
-<div class="invite">
+<div class="invite" class:invite--enhanced={enhanced}>
+  <!-- The descent: a hairline from above dropping a travelling spark that
+       arrives at a glowing seed — "you have come all the way down". -->
+  <div class="invite__descent" aria-hidden="true">
+    <span class="invite__seed"></span>
+  </div>
+
   <div class="invite__inner">
     <header class="invite__head">
       {#if p.eyebrow}
-        <p class="invite__eyebrow">{p.eyebrow}</p>
+        <p class="invite__eyebrow invite__reveal" use:reveal>{p.eyebrow}</p>
       {/if}
-      <h2 class="invite__heading">{heading}</h2>
+      <h2 class="invite__heading invite__reveal invite__reveal--d1" use:reveal>
+        {heading}
+      </h2>
       {#if p.sub}
-        <p class="invite__sub">{p.sub}</p>
+        <p class="invite__sub invite__reveal invite__reveal--d2" use:reveal>{p.sub}</p>
       {/if}
     </header>
 
     {#if p.offers}
-      <ul class="invite__offers">
+      <ul class="invite__offers invite__reveal invite__reveal--d3" use:reveal>
         {#each p.offers as offer (offer.id)}
           <li class="invite__offer" data-best={offer.best ? 'true' : undefined}>
             {#if offer.best}
@@ -99,7 +143,10 @@
         {/each}
       </ul>
     {:else}
-      <div class="invite__single">
+      <div class="invite__single invite__reveal invite__reveal--d3" use:reveal>
+        <!-- The threshold: a warm doorway seated on its own ember pool so
+             beginning feels contained, safe, inevitable. -->
+        <div class="invite__pool" aria-hidden="true"></div>
         {#if oneOffPrice}
           <p class="invite__price">
             <span class="invite__price-amount">{oneOffPrice}</span>
@@ -117,12 +164,108 @@
 </div>
 
 <style>
+  /* THE INVITATION — the emotional close. You have descended; here is the
+     ground, warm and waiting. Brand light rises from below, a descent-spark
+     arrives, the offer is a warm threshold to step through. */
   .invite {
-    padding-block: var(--space-24);
+    position: relative;
+    min-height: 100svh;
+    display: grid;
+    place-items: center;
+    padding-block: var(--space-24) var(--space-20);
     padding-inline: var(--space-5);
+    overflow: clip;
+    isolation: isolate;
+  }
+
+  /* Warm ground: brand light rising from the floor + a settling dark base.
+     This is the deep you arrive at — it fills the lower space, never a void. */
+  .invite::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -2;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        115% 62% at 50% 122%,
+        color-mix(in oklab, var(--color-brand-accent) 26%, transparent),
+        transparent 62%
+      ),
+      radial-gradient(
+        85% 50% at 50% 112%,
+        color-mix(in oklab, var(--color-brand-primary) 24%, transparent),
+        transparent 58%
+      ),
+      linear-gradient(
+        180deg,
+        transparent 40%,
+        color-mix(in oklab, var(--color-background) 62%, transparent)
+      );
+  }
+
+  /* Centred vignette focuses the eye and deepens the cinematic close. */
+  .invite::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background: radial-gradient(
+      120% 90% at 50% 46%,
+      transparent 52%,
+      color-mix(in oklab, var(--color-background) 72%, transparent)
+    );
+  }
+
+  /* ── the descent hairline + arriving spark + glowing seed ── */
+  .invite__descent {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 1px;
+    height: clamp(4rem, 13vh, 9.375rem);
+    z-index: 0;
+    pointer-events: none;
+    background: linear-gradient(
+      180deg,
+      transparent,
+      color-mix(in oklab, var(--color-brand-accent) 52%, transparent)
+    );
+  }
+
+  .invite__descent::before {
+    /* the arriving spark — hidden until the ambient loop animates it */
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: -0.25rem;
+    transform: translateX(-50%);
+    width: 0.25rem;
+    height: 0.25rem;
+    border-radius: var(--radius-full);
+    opacity: 0;
+    background: var(--color-brand-accent);
+    box-shadow: 0 0 12px 3px color-mix(in oklab, var(--color-brand-accent) 70%, transparent);
+  }
+
+  .invite__seed {
+    /* the point of arrival — the ground */
+    position: absolute;
+    bottom: -0.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0.4375rem;
+    height: 0.4375rem;
+    border-radius: var(--radius-full);
+    background: var(--color-brand-accent);
+    box-shadow: 0 0 18px 5px color-mix(in oklab, var(--color-brand-accent) 55%, transparent);
   }
 
   .invite__inner {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -220,12 +363,35 @@
     color: var(--color-text);
   }
 
+  /* the threshold — a warm doorway to step through, seated on its own ember
+     pool so beginning feels contained, safe, inevitable. */
   .invite__single {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-4);
+    padding: var(--space-8) var(--space-10);
+    border-radius: var(--radius-card);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-accent) 22%, transparent);
+    background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+    -webkit-backdrop-filter: blur(var(--blur-sm));
+    backdrop-filter: blur(var(--blur-sm));
     text-align: center;
+  }
+
+  /* the warm pool it rests in */
+  .invite__pool {
+    position: absolute;
+    inset: -14% -8% -34%;
+    z-index: -1;
+    pointer-events: none;
+    background: radial-gradient(
+      60% 65% at 50% 70%,
+      color-mix(in oklab, var(--color-brand-accent) 20%, transparent),
+      transparent 72%
+    );
   }
 
   .invite__price {
@@ -254,5 +420,110 @@
     line-height: var(--leading-normal);
     color: var(--color-text-secondary);
     flex-grow: 1;
+  }
+
+  /* ── reveal-on-scroll (shared `reveal` action) ──
+     The hidden state is armed by JS (`reveal--armed`), never in static CSS, so
+     SSR / no-JS / reduced-motion paint the fully-revealed content. `is-in` is
+     added when the block crosses the viewport; stagger classes offset siblings. */
+  .invite__reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(1.5rem);
+    transition:
+      opacity 0.9s var(--ease-out),
+      transform 0.9s var(--ease-out);
+  }
+
+  .invite__reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  .invite__reveal--d1:global(.reveal--armed) {
+    transition-delay: 0.1s;
+  }
+
+  .invite__reveal--d2:global(.reveal--armed) {
+    transition-delay: 0.22s;
+  }
+
+  .invite__reveal--d3:global(.reveal--armed) {
+    transition-delay: 0.34s;
+  }
+
+  /* ── ENHANCED: ambient loops, only once JS confirms motion is welcome ── */
+  .invite--enhanced::before {
+    animation: invite-breathe 8s ease-in-out infinite;
+  }
+
+  .invite--enhanced .invite__descent::before {
+    animation: invite-descend 5s var(--ease-out) infinite;
+  }
+
+  .invite--enhanced .invite__seed {
+    animation: invite-pulse 5s ease-in-out infinite;
+  }
+
+  @keyframes invite-breathe {
+    0%,
+    100% {
+      opacity: 0.84;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes invite-descend {
+    0% {
+      top: -0.25rem;
+      opacity: 0;
+    }
+    18% {
+      opacity: 1;
+    }
+    72% {
+      opacity: 1;
+    }
+    100% {
+      top: 100%;
+      opacity: 0;
+    }
+  }
+
+  @keyframes invite-pulse {
+    0%,
+    60%,
+    100% {
+      transform: translateX(-50%) scale(1);
+      box-shadow: 0 0 18px 5px color-mix(in oklab, var(--color-brand-accent) 55%, transparent);
+    }
+    78% {
+      transform: translateX(-50%) scale(1.5);
+      box-shadow: 0 0 26px 8px color-mix(in oklab, var(--color-brand-accent) 72%, transparent);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .invite__single {
+      width: 100%;
+      padding-inline: var(--space-6);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .invite::before {
+      animation: none;
+      opacity: 1;
+    }
+    .invite__descent::before {
+      display: none;
+    }
+    .invite__seed {
+      animation: none;
+    }
+    .invite__reveal:global(.reveal--armed) {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/MapSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/MapSection.svelte
@@ -7,16 +7,33 @@
   and NO completion state (those belong to the member dashboard, WP-4). The
   practice's `completed` field is omitted server-side on the public page.
 
+  TWO renderings, progressively enhanced (mirrors AcheSection):
+  • BASELINE (SSR, no-JS, reduced-motion): every gate and practice card is fully
+    lit and legible at once, the spine is drawn to full height. This is what the
+    server emits, so the section is never blank and never depends on JS.
+  • ENHANCED (browser + motion OK): the prototype's cinematic descent — a single
+    monotonic scroll value grows the ember spine downward, and as the drawn edge
+    passes each gate node that gate ignites in turn (node warms, its meta rises,
+    its concurrent practice cards fade up with a stagger). The header + closing
+    note fade/rise in on scroll via the shared `reveal` action.
+
+  Enhancement is gated on `mounted && !reduced` (the `descent--enhanced` class),
+  so the accessible baseline always ships first; the scroll math lives in an
+  `$effect` that re-wires if the reduced-motion preference flips mid-session.
+
   CONTRACT GAP (flagged for the conductor): the prototype's free-taste door — a
   single "free" practice badge on the map — has no field on the frozen
   `JourneyPracticeView`. It is intentionally NOT rendered here to keep typecheck
   clean; when WP-6/WP-2 add a public `isFree`/`preview` flag to the practice
-  read-model, add the badge here (additive).
+  read-model, add the badge here (additive). Likewise per-practice minutes and a
+  total-minutes stat need new read-model fields before they can surface.
 -->
 <script lang="ts">
   import { asString } from '../coerce';
+  import { reveal } from '../reveal';
   import type { MapSectionProps, JourneySalesContext } from '../types';
   import type { JourneyContentType, SectionProps } from '$lib/page-builder';
+  import { onMount } from 'svelte';
 
   interface Props {
     config: SectionProps;
@@ -43,15 +60,115 @@
     written: 'Reflection',
   };
 
+  const CONTENT_TYPE_GLYPH: Record<JourneyContentType, string> = {
+    video: '▶',
+    audio: '♪',
+    written: '✎',
+  };
+
+  const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x'];
+
   function typeLabel(type: string): string {
     return CONTENT_TYPE_LABEL[type as JourneyContentType] ?? 'Practice';
   }
+
+  function typeGlyph(type: string): string {
+    return CONTENT_TYPE_GLYPH[type as JourneyContentType] ?? '•';
+  }
+
+  function roman(index: number): string {
+    return ROMAN[index] ?? String(index + 1);
+  }
+
+  // ── Progressive enhancement state ──
+  let mounted = $state(false);
+  let reduced = $state(false);
+  let bodyEl = $state<HTMLElement | undefined>(undefined);
+  let drawEl = $state<HTMLElement | undefined>(undefined);
+  // How many leading gates have been reached by the descending ember (monotonic).
+  let litCount = $state(0);
+
+  // The descent needs motion + at least one gate to ignite.
+  const enhanced = $derived(mounted && !reduced && stages.length > 0);
+
+  onMount(() => {
+    mounted = true;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  // Scroll driver: a single monotonic "reach" value grows the spine draw and,
+  // as its drawn edge passes each gate node's centre, lights that gate + pool.
+  // Re-runs (and tears down) whenever `enhanced` or the body element flips.
+  $effect(() => {
+    if (!enhanced || !bodyEl) return;
+    const body = bodyEl;
+    const draw = drawEl;
+    let maxDrawn = 0;
+    // Non-reactive high-water mark so we never read `litCount` inside the effect
+    // (a read+write of the same state would loop the effect).
+    let litLocal = 0;
+    let ticking = false;
+
+    const update = () => {
+      ticking = false;
+      const br = body.getBoundingClientRect();
+      const vh = window.innerHeight || document.documentElement.clientHeight;
+      const ref = vh * 0.62; // the descending "reach" line
+      const drawn = Math.max(0, Math.min(br.height, ref - br.top));
+      if (drawn > maxDrawn) maxDrawn = drawn; // monotonic — the path stays walked
+      if (draw) draw.style.height = `${maxDrawn}px`;
+
+      const nodes = body.querySelectorAll<HTMLElement>('.descent__node');
+      let lit = 0;
+      for (let i = 0; i < nodes.length; i++) {
+        const r = nodes[i].getBoundingClientRect();
+        const cy = r.top - br.top + r.height / 2; // node centre, relative to body top
+        if (maxDrawn >= cy - 6) lit = i + 1;
+      }
+      if (lit > litLocal) {
+        litLocal = lit;
+        litCount = lit;
+      }
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(update);
+      }
+    };
+    const onResize = () => {
+      maxDrawn = 0;
+      onScroll();
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onResize, { passive: true });
+    if (typeof document !== 'undefined' && document.fonts?.ready) {
+      document.fonts.ready.then(onScroll).catch(() => {});
+    }
+    const raf = requestAnimationFrame(update);
+    const settle = setTimeout(update, 400);
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onResize);
+      cancelAnimationFrame(raf);
+      clearTimeout(settle);
+    };
+  });
 </script>
 
 {#if stages.length > 0}
-  <div class="descent">
+  <div class="descent" class:descent--enhanced={enhanced}>
     <div class="descent__inner">
-      <header class="descent__head">
+      <header class="descent__head reveal" use:reveal>
         {#if p.eyebrow}
           <p class="descent__eyebrow">{p.eyebrow}</p>
         {/if}
@@ -69,32 +186,54 @@
         </p>
       </header>
 
-      <ol class="descent__stages">
-        {#each stages as stage, i (stage.id)}
-          <li class="descent__stage">
-            <div class="descent__node" aria-hidden="true">{i + 1}</div>
-            <div class="descent__stage-body">
-              <h3 class="descent__stage-name">{stage.name}</h3>
-              {#if stage.gloss}
-                <p class="descent__gloss">{stage.gloss}</p>
-              {/if}
+      <div class="descent__body" bind:this={bodyEl}>
+        <div class="descent__spine" aria-hidden="true">
+          <span class="descent__spine-track"></span>
+          <span class="descent__spine-draw" bind:this={drawEl}></span>
+        </div>
+
+        <ol class="descent__stages">
+          {#each stages as stage, i (stage.id)}
+            {@const lit = !enhanced || i < litCount}
+            <li class="descent__band" class:is-lit={lit}>
+              <div class="descent__gate">
+                <span class="descent__node" aria-hidden="true">
+                  <span class="descent__rn">{roman(i)}</span>
+                </span>
+                <div class="descent__gate-meta">
+                  <h3 class="descent__gate-name">{stage.name}</h3>
+                  {#if stage.gloss}
+                    <p class="descent__gloss">{stage.gloss}</p>
+                  {/if}
+                </div>
+              </div>
+
               {#if stage.practices.length > 0}
-                <ul class="descent__practices">
+                <div class="descent__practices">
                   {#each [...stage.practices].sort((a, b) => a.sortOrder - b.sortOrder) as practice (practice.contentId)}
-                    <li class="descent__practice">
-                      <span class="descent__practice-title">{practice.title}</span>
-                      <span class="descent__practice-type">{typeLabel(practice.contentType)}</span>
-                    </li>
+                    <article class="descent__card">
+                      <div class="descent__card-top">
+                        <span class="descent__card-type">
+                          <span class="descent__card-glyph" aria-hidden="true"
+                            >{typeGlyph(practice.contentType)}</span
+                          >
+                          {typeLabel(practice.contentType)}
+                        </span>
+                        <span class="descent__card-lock" aria-hidden="true">🔒</span>
+                      </div>
+                      <h4 class="descent__card-title">{practice.title}</h4>
+                      <span class="descent__sr">included with membership</span>
+                    </article>
                   {/each}
-                </ul>
+                </div>
               {/if}
-            </div>
-          </li>
-        {/each}
-      </ol>
+            </li>
+          {/each}
+        </ol>
+      </div>
 
       {#if p.foot}
-        <p class="descent__foot">{p.foot}</p>
+        <p class="descent__foot reveal" use:reveal>{p.foot}</p>
       {/if}
     </div>
   </div>
@@ -102,6 +241,9 @@
 
 <style>
   .descent {
+    --descent-node: clamp(2.75rem, 5vw, 3.75rem);
+    --descent-spine-x: calc(var(--descent-node) / 2);
+    position: relative;
     padding-block: var(--space-20);
     padding-inline: var(--space-5);
   }
@@ -111,6 +253,7 @@
     margin-inline: auto;
   }
 
+  /* ── header ── */
   .descent__head {
     display: flex;
     flex-direction: column;
@@ -143,6 +286,7 @@
 
   .descent__sub {
     margin: 0;
+    max-width: 44rem;
     font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
@@ -169,111 +313,373 @@
   }
 
   .descent__stat b {
+    font-family: var(--font-heading);
     font-weight: var(--font-semibold);
     color: var(--color-brand-primary);
   }
 
+  /* ── the spine + stack ── */
+  .descent__body {
+    position: relative;
+  }
+
+  .descent__spine {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--descent-spine-x);
+    width: var(--border-width-thick);
+    transform: translateX(-50%);
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  .descent__spine-track {
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-full);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-heading) 2%, transparent),
+      color-mix(in oklab, var(--color-border) 90%, transparent) 12%,
+      color-mix(in oklab, var(--color-border) 90%, transparent) 88%,
+      color-mix(in oklab, var(--color-heading) 2%, transparent)
+    );
+  }
+
+  /* Baseline: the spine reads as fully drawn (no JS to animate it). */
+  .descent__spine-draw {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: var(--radius-full);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-brand-accent) 45%, transparent),
+      var(--color-brand-accent)
+    );
+    box-shadow: 0 0 10px color-mix(in oklab, var(--color-brand-accent) 60%, transparent);
+  }
+
+  /* The glowing edge dot only rides the draw while it is animating. */
+  .descent__spine-draw::after {
+    content: '';
+    display: none;
+    position: absolute;
+    bottom: -3px;
+    left: 50%;
+    width: 9px;
+    height: 9px;
+    transform: translateX(-50%);
+    border-radius: var(--radius-full);
+    background: var(--color-brand-accent);
+    box-shadow: 0 0 12px 2px color-mix(in oklab, var(--color-brand-accent) 75%, transparent);
+  }
+
   .descent__stages {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-direction: column;
-    gap: var(--space-8);
+    gap: var(--space-12);
     margin: 0;
     padding: 0;
     list-style: none;
   }
 
-  .descent__stage {
+  /* ── a band: [gate] [concurrent practices] ── */
+  .descent__band {
     position: relative;
     display: grid;
-    grid-template-columns: auto 1fr;
-    gap: var(--space-5);
+    grid-template-columns: minmax(13rem, 16.5rem) minmax(0, 1fr);
+    column-gap: var(--space-8);
     align-items: start;
   }
 
-  /* The spine: a line descending from each node to the next. */
-  .descent__stage:not(:last-child) .descent__node::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    width: var(--border-width-thick);
-    height: calc(100% + var(--space-8));
-    transform: translateX(-50%);
-    background: var(--color-border-subtle);
+  /* gate = spine node + name/gloss */
+  .descent__gate {
+    display: grid;
+    grid-template-columns: var(--descent-node) minmax(0, 1fr);
+    column-gap: var(--space-4);
+    align-items: start;
   }
 
   .descent__node {
-    position: relative;
+    grid-row: 1 / span 2;
+    width: var(--descent-node);
+    height: var(--descent-node);
+    border-radius: var(--radius-full);
     display: grid;
     place-items: center;
-    width: var(--space-11);
-    height: var(--space-11);
-    border-radius: var(--radius-full);
-    border: var(--border-width-thick) solid var(--color-brand-primary);
-    background: var(--color-surface);
+    /* Baseline / lit look — the final warm state. */
+    background: radial-gradient(
+      circle at 50% 34%,
+      color-mix(in oklab, var(--color-brand-accent) 26%, var(--color-surface-secondary)),
+      var(--color-surface)
+    );
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-accent) 60%, transparent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--color-brand-accent) 22%, transparent),
+      0 10px 34px -14px color-mix(in oklab, var(--color-brand-accent) 80%, transparent),
+      inset 0 1px 0 color-mix(in oklab, var(--color-heading) 12%, transparent);
+  }
+
+  .descent__rn {
     font-family: var(--font-heading);
+    font-style: italic;
+    font-weight: var(--font-normal);
     font-size: var(--text-lg);
-    color: var(--color-brand-primary);
+    color: var(--color-brand-accent);
   }
 
-  .descent__stage-body {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
-    padding-top: var(--space-1);
+  .descent__gate-meta {
+    padding-top: var(--space-0-5);
   }
 
-  .descent__stage-name {
+  .descent__gate-name {
     margin: 0;
     font-family: var(--font-heading);
+    font-weight: var(--font-normal);
     font-size: var(--text-xl);
     line-height: var(--leading-snug);
+    letter-spacing: -0.01em;
     color: var(--color-heading);
   }
 
   .descent__gloss {
-    margin: 0;
+    margin: var(--space-2) 0 0;
     font-size: var(--text-base);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
   }
 
+  /* the concurrent pool — peers side by side, wrap as needed */
   .descent__practices {
     display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-    margin: var(--space-2) 0 0;
-    padding: 0;
-    list-style: none;
+    flex-wrap: wrap;
+    gap: var(--space-3);
   }
 
-  .descent__practice {
+  .descent__card {
+    position: relative;
+    flex: 1 1 11rem;
+    min-width: 0;
+    padding: var(--space-4);
+    border-radius: var(--radius-card);
+    background: var(--color-surface-secondary);
+    border: var(--border-width) solid var(--color-border-subtle);
+  }
+
+  .descent__card:hover {
+    border-color: color-mix(in oklab, var(--color-brand-accent) 45%, transparent);
+    background: var(--color-surface);
+    box-shadow: 0 12px 34px -20px color-mix(in oklab, var(--color-brand-accent) 60%, transparent);
+  }
+
+  .descent__card-top {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
-    gap: var(--space-4);
-    padding: var(--space-2) 0;
-    border-top: var(--border-width) solid var(--color-border-subtle);
-    font-size: var(--text-sm);
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
   }
 
-  .descent__practice-title {
-    color: var(--color-text);
-  }
-
-  .descent__practice-type {
-    flex-shrink: 0;
+  .descent__card-type {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1-5);
     font-size: var(--text-xs);
-    letter-spacing: 0.04em;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--color-text-tertiary);
   }
 
+  .descent__card-glyph {
+    color: var(--color-brand-accent);
+    font-size: var(--text-xs);
+  }
+
+  .descent__card-lock {
+    font-size: var(--text-sm);
+    color: var(--color-text-tertiary);
+    flex: none;
+  }
+
+  .descent__card-title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-base);
+    line-height: var(--leading-snug);
+    color: var(--color-heading);
+  }
+
+  /* closing note */
   .descent__foot {
     margin: var(--space-12) 0 0;
+    padding-top: var(--space-8);
+    border-top: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-accent) 14%, transparent);
     text-align: center;
     font-size: var(--text-base);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
+  }
+
+  .descent__sr {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ── shared reveal action (header + foot): armed only from JS, so SSR / no-JS
+     paints the revealed state. ── */
+  .reveal {
+    opacity: 1;
+  }
+  .reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(var(--space-4));
+    transition:
+      opacity 0.7s var(--ease-out),
+      transform 0.7s var(--ease-out);
+  }
+  .reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* ── ENHANCED: the ember descent ──
+     Only applied when JS has confirmed motion is welcome (`.descent--enhanced`);
+     the baseline above stays the SSR / no-JS / reduced-motion fallback. */
+
+  /* Start the draw empty; the scroll driver sets its height in px. */
+  .descent--enhanced .descent__spine-draw {
+    height: 0;
+    transition: height 0.22s var(--ease-out);
+  }
+  .descent--enhanced .descent__spine-draw::after {
+    display: block;
+  }
+
+  /* Transitions live on the always-matching enhanced selector so the un-lit →
+     lit change animates in both directions. */
+  .descent--enhanced .descent__node {
+    transition:
+      opacity 0.6s var(--ease-out),
+      transform 0.6s var(--ease-out),
+      border-color 0.6s var(--ease-out),
+      box-shadow 0.6s var(--ease-out),
+      background 0.6s var(--ease-out);
+  }
+  .descent--enhanced .descent__rn {
+    transition: color 0.6s var(--ease-out);
+  }
+  .descent--enhanced .descent__gate-meta {
+    transition:
+      opacity 0.7s var(--ease-out),
+      transform 0.7s var(--ease-out);
+  }
+  .descent--enhanced .descent__card {
+    transition:
+      opacity 0.7s var(--ease-out),
+      transform 0.7s var(--ease-out),
+      border-color 0.3s var(--ease-out),
+      background 0.3s var(--ease-out),
+      box-shadow 0.3s var(--ease-out);
+  }
+
+  /* Armed (pre-lit) hidden/dim state — enhanced only. */
+  .descent--enhanced .descent__band:not(.is-lit) .descent__node {
+    opacity: 0.48;
+    transform: scale(0.94);
+    border-color: var(--color-border-subtle);
+    background: var(--color-surface-secondary);
+    box-shadow: inset 0 1px 0 color-mix(in oklab, var(--color-heading) 8%, transparent);
+  }
+  .descent--enhanced .descent__band:not(.is-lit) .descent__rn {
+    color: var(--color-text-tertiary);
+  }
+  .descent--enhanced .descent__band:not(.is-lit) .descent__gate-meta {
+    opacity: 0;
+    transform: translateY(var(--space-4));
+  }
+  .descent--enhanced .descent__band:not(.is-lit) .descent__card {
+    opacity: 0;
+    transform: translateY(var(--space-5));
+  }
+
+  /* concurrent-pool stagger as a band ignites */
+  .descent--enhanced .descent__band.is-lit .descent__card:nth-child(2) {
+    transition-delay: 0.06s;
+  }
+  .descent--enhanced .descent__band.is-lit .descent__card:nth-child(3) {
+    transition-delay: 0.12s;
+  }
+  .descent--enhanced .descent__band.is-lit .descent__card:nth-child(4) {
+    transition-delay: 0.18s;
+  }
+
+  /* ── mobile: stack cleanly — gate (node + name + gloss), then its practices ── */
+  @media (max-width: 45rem) {
+    .descent__band {
+      display: block;
+      position: relative;
+      padding-left: calc(var(--descent-node) + var(--space-4));
+    }
+    .descent__gate {
+      display: block;
+    }
+    .descent__node {
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+    .descent__gate-meta {
+      padding-top: var(--space-1);
+    }
+    .descent__gloss {
+      max-width: 46ch;
+    }
+    .descent__practices {
+      margin-top: var(--space-4);
+    }
+    .descent__card {
+      flex: 1 1 8.25rem;
+    }
+  }
+
+  @media (max-width: 24rem) {
+    .descent__card {
+      flex-basis: 100%;
+    }
+  }
+
+  /* ── reduced motion: everything shown, nothing draws ── */
+  @media (prefers-reduced-motion: reduce) {
+    .descent__spine-draw {
+      transition: none;
+    }
+    .descent__spine-draw::after {
+      display: none;
+    }
+    .descent__node,
+    .descent__rn,
+    .descent__gate-meta,
+    .descent__card {
+      transition: none;
+    }
+    .reveal:global(.reveal--armed) {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/ProofSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/ProofSection.svelte
@@ -4,9 +4,25 @@
   Testimonials (SPEC §4.1 `proof`) — "what the ground gives back". Renders from
   the awaited `context.testimonials` (public, no auth). Self-hides when the
   course has no testimonials.
+
+  TWO renderings, progressively enhanced:
+  • BASELINE (SSR, no-JS, reduced-motion): a clean, fully-legible grid of quote
+    cards — every card visible at once. This is what the server emits, so the
+    section is never blank and never depends on JS.
+  • ENHANCED (browser + motion OK): the prototype's staggered reveal-on-scroll —
+    the header and each card fade + rise into place one after another as the
+    section enters the viewport (via the shared `reveal` action), a faint warmth
+    glows behind the header, cards carry an oversized decorative quotation mark
+    and a warm gradient avatar, and hovering a card lifts it while a candle-catch
+    hairline brightens along its top edge.
+
+  Motion is layered by the `reveal` action, which arms the hidden state from JS
+  only — so the accessible baseline always ships first and reduced-motion / no-JS
+  fall back to the composed static state.
 -->
 <script lang="ts">
   import { asString } from '../coerce';
+  import { reveal } from '../reveal';
   import type { ProofSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -22,16 +38,26 @@
     heading: asString(config, 'heading'),
   });
 
+  // Optional aggregate trust cue — read defensively from config so the shared
+  // ProofSectionProps type needn't change to render it, and absent → omitted.
+  const trustLabel = $derived(asString(config, 'trustLabel'));
+
   const testimonials = $derived(
     [...context.testimonials].sort((a, b) => a.sortOrder - b.sortOrder)
   );
   const heading = $derived(p.heading ?? 'What the ground gives back.');
+
+  /** First letter of a name for the gradient avatar (falls back to a bullet). */
+  function initial(name: string): string {
+    const match = name.trim().match(/\p{L}|\p{N}/u);
+    return match ? match[0].toUpperCase() : '•';
+  }
 </script>
 
 {#if testimonials.length > 0}
   <div class="proof">
     <div class="proof__inner">
-      <header class="proof__head">
+      <header class="proof__head reveal" use:reveal>
         {#if p.eyebrow}
           <p class="proof__eyebrow">{p.eyebrow}</p>
         {/if}
@@ -39,28 +65,55 @@
       </header>
 
       <ul class="proof__grid">
-        {#each testimonials as testimonial (testimonial.id)}
-          <li class="proof__item">
+        {#each testimonials as testimonial, i (testimonial.id)}
+          <li
+            class="proof__item reveal"
+            style="--reveal-delay: {i * 90}ms"
+            use:reveal
+          >
             <figure class="proof__figure">
               <blockquote class="proof__quote">{testimonial.quote}</blockquote>
               <figcaption class="proof__cite">
-                <span class="proof__author">{testimonial.authorName}</span>
-                {#if testimonial.authorContext}
-                  <span class="proof__context">{testimonial.authorContext}</span>
-                {/if}
+                <span class="proof__avatar" aria-hidden="true"
+                  >{initial(testimonial.authorName)}</span
+                >
+                <span class="proof__id">
+                  <span class="proof__author">{testimonial.authorName}</span>
+                  {#if testimonial.authorContext}
+                    <span class="proof__context">{testimonial.authorContext}</span>
+                  {/if}
+                </span>
               </figcaption>
             </figure>
           </li>
         {/each}
       </ul>
+
+      {#if trustLabel}
+        <p class="proof__trust reveal" style="--reveal-delay: {testimonials.length * 90}ms" use:reveal>
+          <span class="proof__stack" aria-hidden="true">
+            {#each testimonials.slice(0, 5) as testimonial (testimonial.id)}
+              <span class="proof__dot"></span>
+            {/each}
+          </span>
+          <span class="proof__count">{trustLabel}</span>
+        </p>
+      {/if}
     </div>
   </div>
 {/if}
 
 <style>
   .proof {
+    position: relative;
     padding-block: var(--space-20);
     padding-inline: var(--space-5);
+    /* Faint local warmth behind the header — never a void, tinted by the brand. */
+    background: radial-gradient(
+      78% 55% at 50% 0%,
+      color-mix(in oklab, var(--color-brand-primary) 9%, transparent),
+      transparent 62%
+    );
   }
 
   .proof__inner {
@@ -101,6 +154,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    align-items: stretch;
   }
 
   @media (--breakpoint-md) {
@@ -110,11 +164,18 @@
     }
   }
 
+  @media (--breakpoint-lg) {
+    .proof__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
   .proof__item {
     display: flex;
   }
 
   .proof__figure {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
@@ -122,23 +183,134 @@
     padding: var(--space-6);
     border-radius: var(--radius-card);
     border: var(--border-width) solid var(--color-border-subtle);
-    background: var(--color-surface-secondary);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-surface-secondary) 90%, transparent),
+      color-mix(in oklab, var(--color-surface) 70%, transparent)
+    );
+    box-shadow: 0 24px 55px -38px
+      color-mix(in oklab, var(--color-brand-primary) 40%, transparent);
+    overflow: hidden;
+    transition:
+      transform var(--duration-normal) var(--ease-out),
+      border-color var(--duration-normal) var(--ease-out),
+      box-shadow var(--duration-normal) var(--ease-out);
+  }
+
+  /* Candle-catch hairline along the top edge — brightens on hover. */
+  .proof__figure::after {
+    content: '';
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in oklab, var(--color-brand-accent) 55%, transparent) 22%,
+      color-mix(in oklab, var(--color-brand-accent) 55%, transparent) 78%,
+      transparent
+    );
+    opacity: 0.45;
+    transition: opacity var(--duration-normal) var(--ease-out);
+  }
+
+  @media (hover: hover) {
+    .proof__item:hover .proof__figure {
+      transform: translateY(-4px);
+      border-color: color-mix(
+        in oklab,
+        var(--color-brand-accent) 34%,
+        var(--color-border-subtle)
+      );
+      box-shadow: 0 30px 60px -34px
+        color-mix(in oklab, var(--color-brand-primary) 55%, transparent);
+    }
+    .proof__item:hover .proof__figure::after {
+      opacity: 1;
+    }
   }
 
   .proof__quote {
+    position: relative;
+    z-index: 1;
     margin: 0;
+    padding-top: var(--space-8);
     font-family: var(--font-heading);
     font-weight: var(--font-normal);
     font-size: var(--text-xl);
     line-height: var(--leading-snug);
+    letter-spacing: -0.005em;
     color: var(--color-heading);
     text-wrap: pretty;
   }
 
+  /* Oversized decorative quotation mark, low-opacity, behind the text. */
+  .proof__quote::before {
+    content: '\201C';
+    position: absolute;
+    top: -0.4rem;
+    left: -0.3rem;
+    z-index: -1;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-5xl);
+    line-height: 1;
+    color: color-mix(in oklab, var(--color-brand-accent) 24%, transparent);
+    pointer-events: none;
+  }
+
   .proof__cite {
+    margin-top: auto;
+    padding-top: var(--space-4);
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .proof__avatar {
+    flex: none;
+    display: grid;
+    place-items: center;
+    width: 2.875rem;
+    height: 2.875rem;
+    border-radius: var(--radius-full);
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-lg);
+    color: var(--color-text-inverse, var(--color-background));
+    box-shadow:
+      inset 0 0 0 1px color-mix(in oklab, var(--color-heading) 18%, transparent),
+      0 6px 16px -8px color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
+  }
+
+  /* Per-person warm hue — pure CSS gradient circles from brand tokens. */
+  .proof__item:nth-child(3n + 1) .proof__avatar {
+    background: radial-gradient(
+      circle at 34% 28%,
+      color-mix(in oklab, var(--color-brand-accent) 90%, white 4%),
+      var(--color-brand-primary) 88%
+    );
+  }
+  .proof__item:nth-child(3n + 2) .proof__avatar {
+    background: radial-gradient(
+      circle at 34% 28%,
+      color-mix(in oklab, var(--color-brand-primary) 85%, white 6%),
+      color-mix(in oklab, var(--color-brand-accent) 60%, var(--color-brand-primary))
+    );
+  }
+  .proof__item:nth-child(3n + 3) .proof__avatar {
+    background: radial-gradient(
+      circle at 34% 28%,
+      color-mix(in oklab, var(--color-brand-accent) 70%, var(--color-brand-primary)),
+      var(--color-brand-primary) 90%
+    );
+  }
+
+  .proof__id {
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
+    line-height: var(--leading-snug);
   }
 
   .proof__author {
@@ -150,5 +322,116 @@
   .proof__context {
     font-size: var(--text-sm);
     color: var(--color-text-secondary);
+    letter-spacing: 0.01em;
+  }
+
+  /* Aggregate trust cue — understated, closes the section. */
+  .proof__trust {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    margin: var(--space-10) 0 0;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+  }
+
+  .proof__stack {
+    display: inline-flex;
+  }
+
+  .proof__dot {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: var(--radius-full);
+    box-shadow:
+      inset 0 0 0 1px color-mix(in oklab, var(--color-heading) 18%, transparent),
+      0 0 0 2px var(--color-background);
+  }
+
+  .proof__dot + .proof__dot {
+    margin-left: -0.625rem;
+  }
+
+  .proof__stack .proof__dot:nth-child(3n + 1) {
+    background: radial-gradient(
+      circle at 34% 28%,
+      color-mix(in oklab, var(--color-brand-accent) 90%, white 4%),
+      var(--color-brand-primary) 88%
+    );
+  }
+  .proof__stack .proof__dot:nth-child(3n + 2) {
+    background: radial-gradient(
+      circle at 34% 28%,
+      color-mix(in oklab, var(--color-brand-primary) 85%, white 6%),
+      color-mix(in oklab, var(--color-brand-accent) 60%, var(--color-brand-primary))
+    );
+  }
+  .proof__stack .proof__dot:nth-child(3n + 3) {
+    background: radial-gradient(
+      circle at 34% 28%,
+      color-mix(in oklab, var(--color-brand-accent) 70%, var(--color-brand-primary)),
+      var(--color-brand-primary) 90%
+    );
+  }
+
+  /* ── reveal-on-scroll (armed by the `reveal` action from JS only) ──
+     No-JS / reduced-motion / SSR never see `.reveal--armed`, so the composed
+     static state is the accessible baseline. */
+  .reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(22px);
+    transition:
+      opacity 0.85s var(--ease-out),
+      transform 0.85s var(--ease-out);
+    transition-delay: var(--reveal-delay, 0ms);
+  }
+
+  .reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* ── mobile: swipeable snap-row that bleeds to the screen edges ── */
+  @media (--below-md) {
+    .proof__grid {
+      display: flex;
+      grid-template-columns: none;
+      gap: var(--space-4);
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      -webkit-overflow-scrolling: touch;
+      scroll-padding-inline: var(--space-5);
+      /* Bleed past the section inline padding for an edge-to-edge carousel. */
+      margin-inline: calc(-1 * var(--space-5));
+      padding-inline: var(--space-5);
+      padding-bottom: var(--space-2);
+      scrollbar-width: none;
+    }
+    .proof__grid::-webkit-scrollbar {
+      display: none;
+    }
+    .proof__item {
+      flex: 0 0 84%;
+      scroll-snap-align: center;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reveal:global(.reveal--armed) {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+    .proof__figure {
+      transition: none;
+    }
+    .proof__item:hover .proof__figure {
+      transform: none;
+    }
+    .proof__figure::after {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/ProofSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/ProofSection.svelte
@@ -21,7 +21,7 @@
   fall back to the composed static state.
 -->
 <script lang="ts">
-  import { asString } from '../coerce';
+  import { asNumberedGroups, asString, asStringFrom } from '../coerce';
   import { reveal } from '../reveal';
   import type { ProofSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
@@ -40,10 +40,39 @@
 
   // Optional aggregate trust cue — read defensively from config so the shared
   // ProofSectionProps type needn't change to render it, and absent → omitted.
-  const trustLabel = $derived(asString(config, 'trustLabel'));
+  // (`trust` is the builder's key for the same field.)
+  const trustLabel = $derived(asStringFrom(config, ['trustLabel', 'trust']));
+
+  type Testimonial = JourneySalesContext['testimonials'][number];
+
+  /**
+   * Testimonials are COURSE-owned data (`course_testimonials`), so the real rows
+   * always win. But the builder also exposes numbered `q1/n1/c1…` fields for this
+   * section, and nothing read them — a creator could type three testimonials,
+   * publish, and get an empty section because the course had no rows. Those
+   * authored fields are now the fallback (coerce.ts's BUILDER-SHAPE BRIDGE note).
+   */
+  const authored: Testimonial[] = $derived(
+    asNumberedGroups<Testimonial>(
+      config,
+      { quote: 'q', authorName: 'n', authorContext: 'c' },
+      ({ quote, authorName, authorContext }, index) =>
+        quote
+          ? {
+              id: `authored-${index}`,
+              sortOrder: index,
+              quote,
+              authorName: authorName ?? '',
+              authorContext,
+            }
+          : null
+    ) ?? []
+  );
 
   const testimonials = $derived(
-    [...context.testimonials].sort((a, b) => a.sortOrder - b.sortOrder)
+    context.testimonials.length > 0
+      ? [...context.testimonials].sort((a, b) => a.sortOrder - b.sortOrder)
+      : authored
   );
   const heading = $derived(p.heading ?? 'What the ground gives back.');
 

--- a/apps/web/src/lib/page-builder/render/sections/ReelSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/ReelSection.svelte
@@ -2,16 +2,34 @@
   @component ReelSection
 
   A cinematic practice-preview clip that sits just before the descent map (SPEC
-  §4.1 `reel`). Deliberately not the intro film: an ultrawide 2.4:1 frame with an
-  editorial split header. Like the intro, the header renders immediately and the
-  play affordance is STREAMED from the public preview (no auth). Reuses
-  `ui/IntroVideoModal` for HLS playback.
+  §4.1 `reel`). Deliberately NOT the intro film: an ultrawide 2.4:1 letterbox
+  with an editorial split header, a "framed footage" chrome (viewfinder corners,
+  a rec tag, a waveform scrubber), and a candlelit poster that breathes.
+
+  TWO renderings, progressively enhanced:
+  • BASELINE (SSR, no-JS, reduced-motion): the fully-composed cinematic still —
+    header, letterbox frame, layered atmosphere, corner marks, caption whisper
+    and a static player-chrome bar. Every word legible; nothing depends on JS.
+    The play affordance itself is STREAMED (public preview, no auth) via
+    `{#await}` with a skeleton, matching the shell+stream contract.
+  • ENHANCED (browser + motion OK): the prototype's signature motion layered on
+    top — header + stage fade/rise into view (IntersectionObserver via the shared
+    `reveal` action), the candlelight bloom breathes, the incense haze drifts, the
+    rec dot pulses, the play button carries an invitation ring, and (when the org
+    supplies more than one) the whispered caption cross-fades on a slow cycle.
+
+  Real playback stays in `ui/IntroVideoModal` (HLS) — the frame is the poster and
+  the click target; motion is gated on `mounted && !reduced` so the accessible
+  still always ships first. Tokens are the real Codex design system (the
+  prototype's ember/bone/ink palette were stand-ins); the frame stays theme-aware
+  rather than baking in a candlelit dark.
 -->
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { IntroVideoModal } from '$lib/components/ui/IntroVideoModal';
   import { PlayIcon } from '$lib/components/ui/Icon';
-  import SectionSkeleton from '../SectionSkeleton.svelte';
-  import { asString } from '../coerce';
+  import { reveal } from '../reveal';
+  import { asString, asStringArray } from '../coerce';
   import type { ReelSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -31,50 +49,232 @@
 
   const heading = $derived(p.heading ?? 'This is what a descent looks like.');
 
+  /**
+   * Whispered subtitle(s). Read defensively from config (not yet in the shared
+   * `ReelSectionProps` type — see desiredSharedChanges): `captions` (an array)
+   * takes precedence, else a single `caption`. Absent ⇒ no caption line renders.
+   */
+  const captions = $derived(
+    asStringArray(config, 'captions') ??
+      (asString(config, 'caption') ? [asString(config, 'caption') as string] : [])
+  );
+
+  /** Optional decorative rec-tag label (defensive read); defaults to "Preview". */
+  const tagLabel = $derived(asString(config, 'tag') ?? 'Preview');
+
+  // Unique-per-instance id so multiple reels on a page never share the waveform
+  // <symbol>. Increments in identical order on server + client ⇒ hydration-safe.
+  const waveId = `reel-wave-${nextWaveId()}`;
+
   let open = $state(false);
+  let mounted = $state(false);
+  let reduced = $state(false);
+  let captionIndex = $state(0);
+  let captionFading = $state(false);
+
+  const currentCaption = $derived(captions[captionIndex] ?? captions[0]);
+  const cycleCaptions = $derived(mounted && !reduced && captions.length > 1);
+
+  function formatDuration(seconds: number | null | undefined): string | undefined {
+    if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) {
+      return undefined;
+    }
+    const total = Math.round(seconds);
+    const mins = Math.floor(total / 60);
+    const secs = total % 60;
+    return `${mins}:${String(secs).padStart(2, '0')}`;
+  }
+
+  onMount(() => {
+    mounted = true;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  // Slow ambient cross-fade through the whispered captions — enhancement only.
+  $effect(() => {
+    if (!cycleCaptions) {
+      captionFading = false;
+      return;
+    }
+    const total = captions.length;
+    let swap: ReturnType<typeof setTimeout> | undefined;
+    const cycle = setInterval(() => {
+      captionFading = true;
+      swap = setTimeout(() => {
+        captionIndex = (captionIndex + 1) % total;
+        captionFading = false;
+      }, 420);
+    }, 5600);
+    return () => {
+      clearInterval(cycle);
+      if (swap) clearTimeout(swap);
+    };
+  });
 </script>
 
 <div class="reel">
   <div class="reel__inner">
-    <div class="reel__head">
-      <div class="reel__title-wrap">
+    <header class="reel__head">
+      <div class="reel__lead reveal" use:reveal>
         {#if p.eyebrow}
           <p class="reel__eyebrow">{p.eyebrow}</p>
         {/if}
-        <h2 class="reel__title">{heading}</h2>
+        <h2 class="reel__title" id={waveId + '-heading'}>{heading}</h2>
       </div>
       {#if p.sub}
-        <p class="reel__sub">{p.sub}</p>
+        <p class="reel__sub reveal reveal--d1" use:reveal>{p.sub}</p>
       {/if}
-    </div>
+    </header>
 
-    <div class="reel__stage" style={p.posterUrl ? `--poster: url(${JSON.stringify(p.posterUrl)})` : undefined}>
-      {#await context.sellPreview}
-        <SectionSkeleton shape="media" label="Loading the practice preview" />
-      {:then preview}
-        {#if preview?.reel}
-          {@const reel = preview.reel}
-          <button
-            type="button"
-            class="reel__play"
-            onclick={() => (open = true)}
-            aria-label="Play the practice preview"
-          >
-            <span class="reel__play-icon" aria-hidden="true">
-              <PlayIcon />
-            </span>
-          </button>
-          <IntroVideoModal
-            {open}
-            src={reel.playlistUrl}
-            title={heading}
-            onclose={() => (open = false)}
-          />
-        {:else}
-          <div class="reel__empty" aria-hidden="true"></div>
-        {/if}
-      {/await}
-    </div>
+    <figure
+      class="reel__stage reveal reveal--d2"
+      use:reveal
+      style={p.posterUrl
+        ? `--poster: url(${JSON.stringify(p.posterUrl)})`
+        : undefined}
+    >
+      <div class="reel__frame">
+        <!-- layered candlelit atmosphere (decorative) -->
+        <div class="reel__poster" aria-hidden="true">
+          <span class="reel__base"></span>
+          <span class="reel__body"></span>
+          <span class="reel__rim"></span>
+          <span class="reel__glow" class:is-live={mounted && !reduced}></span>
+          <span class="reel__haze" class:is-live={mounted && !reduced}></span>
+          {#if p.posterUrl}
+            <span class="reel__image"></span>
+          {/if}
+          <span class="reel__vignette"></span>
+          <span class="reel__grain"></span>
+        </div>
+
+        <!-- viewfinder corner marks — "this is framed footage" -->
+        <span class="reel__corner reel__corner--tl" aria-hidden="true"></span>
+        <span class="reel__corner reel__corner--tr" aria-hidden="true"></span>
+        <span class="reel__corner reel__corner--bl" aria-hidden="true"></span>
+        <span class="reel__corner reel__corner--br" aria-hidden="true"></span>
+
+        <!-- top meta: rec tag + total duration (duration streams with preview) -->
+        <div class="reel__topmeta" aria-hidden="true">
+          <span class="reel__tag">
+            <span class="reel__dot" class:is-live={mounted && !reduced}></span>
+            {tagLabel}
+          </span>
+          {#await context.sellPreview then preview}
+            {@const dur = formatDuration(preview?.reel?.durationSeconds)}
+            {#if dur}
+              <span class="reel__dur">{dur}</span>
+            {/if}
+          {/await}
+        </div>
+
+        <span class="reel__scrim" aria-hidden="true"></span>
+
+        <div class="reel__lower">
+          {#if currentCaption}
+            <p class="reel__caption" class:is-fading={captionFading}>
+              {currentCaption}
+            </p>
+          {/if}
+
+          <div class="reel__chrome">
+            {#await context.sellPreview}
+              <span class="reel__play reel__play--pending" aria-hidden="true">
+                <span class="reel__play-icon"><PlayIcon /></span>
+              </span>
+              <div class="reel__track reel__track--pending" aria-hidden="true">
+                <div class="reel__skeleton"></div>
+              </div>
+            {:then preview}
+              {#if preview?.reel}
+                {@const reel = preview.reel}
+                <button
+                  type="button"
+                  class="reel__play"
+                  class:is-armed={mounted && !reduced}
+                  onclick={() => (open = true)}
+                  aria-label="Play the practice preview"
+                >
+                  <span class="reel__play-icon" aria-hidden="true">
+                    <PlayIcon />
+                  </span>
+                </button>
+                <div class="reel__track" aria-hidden="true">
+                  <svg
+                    class="reel__wave reel__wave--base"
+                    viewBox="0 0 480 40"
+                    preserveAspectRatio="none"
+                  >
+                    <g id={waveId} fill="currentColor">
+                      <rect x="4" y="15" width="7" height="10" rx="3" />
+                      <rect x="19" y="13" width="7" height="14" rx="3" />
+                      <rect x="34" y="10" width="7" height="20" rx="3" />
+                      <rect x="49" y="7" width="7" height="26" rx="3" />
+                      <rect x="64" y="9" width="7" height="22" rx="3" />
+                      <rect x="79" y="12" width="7" height="16" rx="3" />
+                      <rect x="94" y="14" width="7" height="12" rx="3" />
+                      <rect x="109" y="11" width="7" height="18" rx="3" />
+                      <rect x="124" y="6" width="7" height="28" rx="3" />
+                      <rect x="139" y="3" width="7" height="34" rx="3" />
+                      <rect x="154" y="5" width="7" height="30" rx="3" />
+                      <rect x="169" y="9" width="7" height="22" rx="3" />
+                      <rect x="184" y="13" width="7" height="14" rx="3" />
+                      <rect x="199" y="15" width="7" height="10" rx="3" />
+                      <rect x="214" y="12" width="7" height="16" rx="3" />
+                      <rect x="229" y="8" width="7" height="24" rx="3" />
+                      <rect x="244" y="4" width="7" height="32" rx="3" />
+                      <rect x="259" y="6" width="7" height="28" rx="3" />
+                      <rect x="274" y="10" width="7" height="20" rx="3" />
+                      <rect x="289" y="14" width="7" height="12" rx="3" />
+                      <rect x="304" y="12" width="7" height="16" rx="3" />
+                      <rect x="319" y="9" width="7" height="22" rx="3" />
+                      <rect x="334" y="5" width="7" height="30" rx="3" />
+                      <rect x="349" y="7" width="7" height="26" rx="3" />
+                      <rect x="364" y="11" width="7" height="18" rx="3" />
+                      <rect x="379" y="14" width="7" height="12" rx="3" />
+                      <rect x="394" y="15" width="7" height="10" rx="3" />
+                      <rect x="409" y="12" width="7" height="16" rx="3" />
+                      <rect x="424" y="9" width="7" height="22" rx="3" />
+                      <rect x="439" y="11" width="7" height="18" rx="3" />
+                      <rect x="454" y="14" width="7" height="12" rx="3" />
+                      <rect x="469" y="16" width="7" height="8" rx="3" />
+                    </g>
+                  </svg>
+                  <svg
+                    class="reel__wave reel__wave--fill"
+                    viewBox="0 0 480 40"
+                    preserveAspectRatio="none"
+                  >
+                    <use href={'#' + waveId} />
+                  </svg>
+                  <span class="reel__playhead"></span>
+                </div>
+                <IntroVideoModal
+                  {open}
+                  src={reel.playlistUrl}
+                  title={heading}
+                  onclose={() => (open = false)}
+                />
+              {:else}
+                <!-- No preview configured: keep the still legible, no play. -->
+                <span class="reel__play reel__play--empty" aria-hidden="true">
+                  <span class="reel__play-icon"><PlayIcon /></span>
+                </span>
+                <div class="reel__track" aria-hidden="true">
+                  <div class="reel__rest-rail"></div>
+                </div>
+              {/if}
+            {/await}
+          </div>
+        </div>
+      </div>
+    </figure>
   </div>
 </div>
 
@@ -92,6 +292,7 @@
     margin-inline: auto;
   }
 
+  /* ── editorial split header: title left, whisper right ── */
   .reel__head {
     display: flex;
     flex-direction: column;
@@ -107,8 +308,12 @@
     }
   }
 
+  .reel__lead {
+    max-width: 30ch;
+  }
+
   .reel__eyebrow {
-    margin: 0 0 var(--space-2);
+    margin: 0 0 var(--space-3);
     font-size: var(--text-sm);
     font-weight: var(--font-semibold);
     letter-spacing: 0.08em;
@@ -121,7 +326,7 @@
     max-width: 24ch;
     font-family: var(--font-heading);
     font-weight: var(--font-normal);
-    font-size: var(--text-3xl);
+    font-size: clamp(var(--text-3xl), 5.4vw, var(--text-5xl));
     line-height: var(--leading-tight);
     letter-spacing: -0.015em;
     color: var(--color-heading);
@@ -139,13 +344,17 @@
   @media (--breakpoint-md) {
     .reel__sub {
       text-align: right;
+      padding-bottom: var(--space-1);
     }
   }
 
-  /* Ultrawide letterbox with a cinematic candlelit wash — a single warm bloom
-     low-centre over a deep body, derived from the org brand (never a flat box).
-     A real poster layers over the top when configured. */
+  /* ── the cinematic stage ── */
   .reel__stage {
+    margin: 0;
+    transform-origin: center bottom;
+  }
+
+  .reel__frame {
     position: relative;
     isolation: isolate;
     width: 100%;
@@ -154,69 +363,351 @@
     overflow: hidden;
     border: var(--border-width) solid
       color-mix(in oklab, var(--color-brand-primary) 22%, transparent);
-    background:
-      var(--poster, none) center / cover no-repeat,
-      radial-gradient(
-        50% 90% at 50% 78%,
-        color-mix(in oklab, var(--color-brand-primary) 34%, transparent),
-        transparent 70%
-      ),
-      linear-gradient(
-        178deg,
-        color-mix(in oklab, var(--color-brand-primary) 10%, var(--color-surface)),
-        var(--color-background)
-      );
+    background: var(--color-background);
     box-shadow:
       0 var(--space-8) var(--space-16) calc(-1 * var(--space-10))
-        color-mix(in oklab, var(--color-brand-primary) 50%, #000),
-      inset 0 var(--border-width) 0
-        color-mix(in oklab, var(--color-heading) 8%, transparent);
+        color-mix(in oklab, var(--color-brand-primary) 42%, #000),
+      0 var(--space-2) var(--space-8) calc(-1 * var(--space-5)) rgba(0, 0, 0, 0.4);
     display: grid;
     place-items: center;
   }
 
-  .reel__play {
-    position: relative;
-    display: inline-grid;
-    place-items: center;
-    width: var(--space-14);
-    height: var(--space-14);
-    border-radius: var(--radius-full);
-    border: none;
-    cursor: pointer;
-    color: var(--color-text-on-brand);
-    background: var(--color-brand-primary);
-    box-shadow: 0 0 var(--space-8)
-      color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
-    transition:
-      transform var(--duration-fast) var(--ease-default),
-      background-color var(--duration-fast) var(--ease-default);
-  }
-
-  .reel__play::after {
+  /* thin top sheen — reads like the surface of a screen */
+  .reel__frame::before {
     content: '';
     position: absolute;
     inset: 0;
+    z-index: 5;
+    pointer-events: none;
     border-radius: inherit;
-    border: var(--border-width) solid
-      color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
-    animation: reel-pulse 3.2s var(--ease-default) infinite;
+    box-shadow: inset 0 1px 0 color-mix(in oklab, var(--color-heading) 10%, transparent);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-heading) 5%, transparent),
+      transparent 12%
+    );
+  }
+
+  /* ── poster: layered warm atmosphere over a theme-aware base ── */
+  .reel__poster {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+
+  .reel__poster > * {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  /* warm base — a lift where the candle sits, resolved from the org brand */
+  .reel__base {
+    background: radial-gradient(
+      150% 130% at 26% 34%,
+      color-mix(in oklab, var(--color-surface) 88%, var(--color-brand-primary) 12%) 0%,
+      var(--color-surface) 42%,
+      var(--color-background) 72%
+    );
+  }
+
+  /* the reclining body — a low warm mass catching flame light */
+  .reel__body {
+    background: radial-gradient(
+      78% 130% at 58% 138%,
+      color-mix(in oklab, var(--color-brand-primary) 26%, transparent) 0%,
+      color-mix(in oklab, var(--color-brand-accent) 20%, transparent) 34%,
+      transparent 62%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.9;
+  }
+
+  /* rim light — a skin edge grazed by candlelight */
+  .reel__rim {
+    background: radial-gradient(
+      42% 60% at 38% 74%,
+      color-mix(in oklab, var(--color-brand-accent) 34%, transparent) 0%,
+      transparent 56%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.8;
+  }
+
+  /* candlelight — bloom + brighter core */
+  .reel__glow {
+    background: radial-gradient(
+      closest-side at 25% 40%,
+      color-mix(in oklab, var(--color-brand-primary) 92%, white 8%) 0%,
+      color-mix(in oklab, var(--color-brand-primary) 55%, transparent) 20%,
+      color-mix(in oklab, var(--color-brand-accent) 22%, transparent) 46%,
+      transparent 66%
+    );
+    mix-blend-mode: screen;
+    transform-origin: 25% 40%;
+    opacity: 0.9;
+  }
+
+  /* incense/haze drifting slowly across the frame */
+  .reel__haze {
+    background: radial-gradient(
+      60% 90% at 70% 20%,
+      color-mix(in oklab, var(--color-brand-accent) 12%, transparent),
+      transparent 60%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.6;
+  }
+
+  /* a real poster still layers over the atmosphere when configured */
+  .reel__image {
+    background: var(--poster, none) center / cover no-repeat;
+    opacity: 0.92;
+  }
+
+  .reel__vignette {
+    background: radial-gradient(
+      125% 120% at 50% 40%,
+      transparent 38%,
+      color-mix(in oklab, var(--color-background) 45%, transparent) 74%,
+      color-mix(in oklab, var(--color-background) 78%, #000) 100%
+    );
+  }
+
+  .reel__grain {
+    opacity: 0.07;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='rn'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23rn)'/%3E%3C/svg%3E");
+  }
+
+  /* motion is enhancement only — armed once JS confirms motion is welcome */
+  .reel__glow.is-live {
+    animation: reel-breath 8s var(--ease-in-out) infinite;
+  }
+
+  .reel__haze.is-live {
+    animation: reel-drift 22s var(--ease-in-out) infinite alternate;
+  }
+
+  @keyframes reel-breath {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.82;
+    }
+    50% {
+      transform: scale(1.07);
+      opacity: 1;
+    }
+  }
+
+  @keyframes reel-drift {
+    from {
+      transform: translate3d(-4%, 2%, 0);
+    }
+    to {
+      transform: translate3d(5%, -3%, 0);
+    }
+  }
+
+  /* ── viewfinder corner marks ── */
+  .reel__corner {
+    position: absolute;
+    z-index: 4;
+    width: clamp(1rem, 2.2vw, 1.6rem);
+    height: clamp(1rem, 2.2vw, 1.6rem);
+    border: 0 solid color-mix(in oklab, var(--color-brand-primary) 55%, transparent);
+    opacity: 0.55;
+    pointer-events: none;
+  }
+
+  .reel__corner--tl {
+    top: var(--space-5);
+    left: var(--space-5);
+    border-top-width: var(--border-width-thick);
+    border-left-width: var(--border-width-thick);
+  }
+
+  .reel__corner--tr {
+    top: var(--space-5);
+    right: var(--space-5);
+    border-top-width: var(--border-width-thick);
+    border-right-width: var(--border-width-thick);
+  }
+
+  .reel__corner--bl {
+    bottom: var(--space-5);
+    left: var(--space-5);
+    border-bottom-width: var(--border-width-thick);
+    border-left-width: var(--border-width-thick);
+  }
+
+  .reel__corner--br {
+    bottom: var(--space-5);
+    right: var(--space-5);
+    border-bottom-width: var(--border-width-thick);
+    border-right-width: var(--border-width-thick);
+  }
+
+  /* ── top meta: rec tag + duration ── */
+  .reel__topmeta {
+    position: absolute;
+    z-index: 4;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: clamp(1rem, 2.8vw, 1.75rem) clamp(1.2rem, 3vw, 2rem);
+    pointer-events: none;
+  }
+
+  .reel__tag {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.28em;
+    color: color-mix(in oklab, var(--color-heading) 74%, transparent);
+    text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  }
+
+  .reel__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: var(--radius-full);
+    background: var(--color-brand-primary);
+    box-shadow: 0 0 10px color-mix(in oklab, var(--color-brand-primary) 80%, transparent);
+  }
+
+  .reel__dot.is-live {
+    animation: reel-pulse 4s var(--ease-in-out) infinite;
   }
 
   @keyframes reel-pulse {
-    0% {
-      transform: scale(1);
-      opacity: 0.7;
-    }
+    0%,
     100% {
-      transform: scale(1.9);
-      opacity: 0;
+      opacity: 0.45;
+    }
+    50% {
+      opacity: 1;
     }
   }
 
+  .reel__dur {
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    letter-spacing: 0.06em;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-heading);
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-full);
+    background: color-mix(in oklab, var(--color-background) 55%, transparent);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-heading) 16%, transparent);
+    backdrop-filter: blur(var(--blur-sm));
+    text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  }
+
+  /* ── lower block: caption whisper + player chrome ── */
+  .reel__scrim {
+    position: absolute;
+    z-index: 2;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 62%;
+    pointer-events: none;
+    background: linear-gradient(
+      0deg,
+      color-mix(in oklab, var(--color-background) 90%, transparent) 0%,
+      color-mix(in oklab, var(--color-background) 55%, transparent) 42%,
+      transparent 100%
+    );
+  }
+
+  .reel__lower {
+    position: absolute;
+    z-index: 4;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.7rem, 2vw, 1.15rem);
+    padding: clamp(1rem, 3vw, 2rem);
+  }
+
+  .reel__caption {
+    align-self: center;
+    text-align: center;
+    margin: 0;
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-weight: var(--font-normal);
+    font-size: clamp(var(--text-base), 2.5vw, var(--text-2xl));
+    line-height: var(--leading-snug);
+    color: color-mix(in oklab, var(--color-heading) 90%, transparent);
+    text-shadow: 0 2px 14px rgba(0, 0, 0, 0.6);
+    max-width: 32ch;
+    transition: opacity var(--duration-slow) var(--ease-out);
+  }
+
+  .reel__caption::before {
+    content: '\201C';
+    opacity: 0.4;
+    margin-right: 0.06em;
+  }
+
+  .reel__caption::after {
+    content: '\201D';
+    opacity: 0.4;
+    margin-left: 0.06em;
+  }
+
+  .reel__caption.is-fading {
+    opacity: 0;
+  }
+
+  .reel__chrome {
+    display: flex;
+    align-items: center;
+    gap: clamp(0.7rem, 2vw, 1.15rem);
+  }
+
+  /* play button — glassy invitation, opens the real HLS modal */
+  .reel__play {
+    position: relative;
+    flex: none;
+    width: clamp(2.7rem, 4.4vw, 3.3rem);
+    height: clamp(2.7rem, 4.4vw, 3.3rem);
+    border-radius: var(--radius-full);
+    display: grid;
+    place-items: center;
+    color: var(--color-heading);
+    background: color-mix(in oklab, var(--color-brand-primary) 16%, transparent);
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-primary) 60%, transparent);
+    backdrop-filter: blur(var(--blur-md));
+    box-shadow: 0 var(--space-2) var(--space-8) calc(-1 * var(--space-3))
+      rgba(0, 0, 0, 0.6);
+    cursor: pointer;
+    transition:
+      transform var(--duration-fast) var(--ease-out),
+      background-color var(--duration-normal) var(--ease-out),
+      border-color var(--duration-normal) var(--ease-out);
+  }
+
   .reel__play:hover {
-    background: var(--color-brand-primary-hover);
-    transform: scale(1.06);
+    transform: translateY(-2px);
+    background: color-mix(in oklab, var(--color-brand-primary) 26%, transparent);
+  }
+
+  .reel__play:active {
+    transform: translateY(0) scale(0.96);
   }
 
   .reel__play:focus-visible {
@@ -224,28 +715,219 @@
     outline-offset: var(--focus-offset);
   }
 
+  .reel__play--pending,
+  .reel__play--empty {
+    cursor: default;
+    opacity: 0.65;
+  }
+
+  .reel__play--pending {
+    animation: reel-skeleton 1.4s var(--ease-in-out) infinite;
+  }
+
+  /* gentle invitation ring — enhancement only (armed by JS) */
+  .reel__play::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: var(--border-width) solid
+      color-mix(in oklab, var(--color-brand-primary) 55%, transparent);
+    opacity: 0;
+  }
+
+  .reel__play.is-armed::after {
+    animation: reel-ring 2.8s var(--ease-out) infinite;
+  }
+
+  @keyframes reel-ring {
+    0% {
+      transform: scale(1);
+      opacity: 0.7;
+    }
+    70% {
+      transform: scale(1.55);
+      opacity: 0;
+    }
+    100% {
+      transform: scale(1.55);
+      opacity: 0;
+    }
+  }
+
   .reel__play-icon {
     display: inline-flex;
-    width: var(--space-5);
-    height: var(--space-5);
+    width: 44%;
+    height: 44%;
     margin-left: 3px;
   }
 
-  .reel__empty {
-    width: 100%;
-    height: 100%;
+  /* waveform scrubber */
+  .reel__track {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: clamp(1.5rem, 3.4vw, 2.4rem);
   }
 
+  .reel__wave {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  .reel__wave--base {
+    color: color-mix(in oklab, var(--color-heading) 30%, transparent);
+  }
+
+  .reel__wave--fill {
+    color: var(--color-brand-primary);
+    clip-path: inset(0 100% 0 0);
+    filter: drop-shadow(
+      0 0 5px color-mix(in oklab, var(--color-brand-primary) 55%, transparent)
+    );
+  }
+
+  .reel__playhead {
+    position: absolute;
+    top: -12%;
+    bottom: -12%;
+    left: 0;
+    width: 2px;
+    background: var(--color-heading);
+    box-shadow: 0 0 10px color-mix(in oklab, var(--color-brand-primary) 90%, transparent);
+    opacity: 0;
+  }
+
+  .reel__rest-rail {
+    position: absolute;
+    inset: 45% 0 auto 0;
+    height: 2px;
+    border-radius: var(--radius-full);
+    background: color-mix(in oklab, var(--color-heading) 22%, transparent);
+  }
+
+  /* streamed-play skeleton */
+  .reel__track--pending {
+    display: flex;
+    align-items: center;
+  }
+
+  .reel__skeleton {
+    width: 100%;
+    height: 40%;
+    border-radius: var(--radius-full);
+    background: color-mix(in oklab, var(--color-heading) 18%, transparent);
+    animation: reel-skeleton 1.4s var(--ease-in-out) infinite;
+  }
+
+  @keyframes reel-skeleton {
+    0%,
+    100% {
+      opacity: 0.45;
+    }
+    50% {
+      opacity: 0.85;
+    }
+  }
+
+  /* ── reveal-on-scroll (armed by the shared `reveal` action) ──
+     Base `.reveal` (no armed class) is the fully-visible SSR / no-JS baseline.
+     The `reveal` action adds `reveal--armed` (hidden) only once JS confirms
+     motion is welcome, then `is-in` when the node scrolls in. The runtime
+     classes live in `:global()` so Svelte's scoper doesn't prune them. */
+  .reveal {
+    transition:
+      opacity var(--duration-slower) var(--ease-out),
+      transform var(--duration-slower) var(--ease-out);
+  }
+
+  .reveal:global(.reveal--armed) {
+    opacity: 0;
+    transform: translateY(26px);
+  }
+
+  .reveal--d1:global(.reveal--armed) {
+    transition-delay: 0.1s;
+  }
+
+  .reveal--d2:global(.reveal--armed) {
+    transition-delay: 0.2s;
+  }
+
+  .reel__stage:global(.reveal--armed) {
+    transform: translateY(34px) scale(0.985);
+  }
+
+  .reveal:global(.reveal--armed.is-in) {
+    opacity: 1;
+    transform: none;
+  }
+
+  .reel__stage:global(.reveal--armed.is-in) {
+    transform: none;
+  }
+
+  /* ── responsive: keep the letterbox graceful ── */
+  @media (max-width: 760px) {
+    .reel__head {
+      align-items: flex-start;
+    }
+    .reel__frame {
+      aspect-ratio: 4 / 3;
+      min-height: 280px;
+    }
+    .reel__caption::before,
+    .reel__caption::after {
+      content: none;
+    }
+  }
+
+  @media (max-width: 420px) {
+    .reel__frame {
+      aspect-ratio: 3 / 3.4;
+    }
+    .reel__tag {
+      letter-spacing: 0.2em;
+    }
+  }
+
+  /* ── reduced motion: the composed still, no movement ── */
   @media (prefers-reduced-motion: reduce) {
-    .reel__play {
-      transition: none;
+    .reel__glow,
+    .reel__haze,
+    .reel__dot,
+    .reel__play::after,
+    .reel__skeleton,
+    .reel__play--pending {
+      animation: none !important;
+    }
+    .reel__glow {
+      opacity: 1;
+      transform: scale(1.04);
     }
     .reel__play::after {
-      animation: none;
       opacity: 0;
     }
-    .reel__play:hover {
-      transform: none;
+    .reel__caption {
+      transition: none;
+    }
+    /* The reveal action already skips arming under reduced motion (it only adds
+       `is-in`); this guards any residual transition on the composed still. */
+    .reveal {
+      transition: none;
     }
   }
 </style>
+
+<script module lang="ts">
+  // Per-instance sequence for the waveform <symbol> id. Module-scoped so it
+  // increments in identical order during SSR and hydration (no id clashes,
+  // no hydration mismatch even with multiple reels on one page).
+  let waveSeq = 0;
+  function nextWaveId(): number {
+    return waveSeq++;
+  }
+</script>

--- a/apps/web/src/lib/page-builder/render/sections/TurnSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/TurnSection.svelte
@@ -1,12 +1,30 @@
 <!--
   @component TurnSection
 
-  The pivot from pain to promise (SPEC §4.1 `turn`). A two-column statement
-  (left) + lede and supporting points (right) on wide viewports; stacks on
+  The pivot from pain to promise, and the descent into the staged arc
+  (SPEC §4.1 `turn`). A two-column composition on wide viewports — the framing
+  statement + lede (left), and a numbered "descent arc" of supporting points
+  (right) threaded by a rail that draws downward into a warm root. Stacks on
   narrow. Renders nothing when neither a statement nor a lede is configured.
+
+  TWO renderings, progressively enhanced (mirrors AcheSection):
+  • BASELINE (SSR, no-JS, reduced-motion): the fully-composed, fully-legible
+    layout — statement, lede, thread, arc rail (drawn), root and every stage
+    visible at once. This is what the server emits, so the section is never
+    blank and never depends on JS.
+  • ENHANCED (browser + motion OK): the prototype's cinematic reveal-on-scroll —
+    headline/lede rise in, the thread stretches out, the arc rail draws down
+    into the root, and the stages stagger up as their roman numerals warm to
+    the brand accent.
+
+  Motion is layered via the shared `reveal` action on the root: it arms the
+  hidden state from JS (`reveal--armed`) and flips `is-in` when the section
+  scrolls into view — so the accessible baseline always ships first, and
+  reduced-motion / no-JS clients get the composed state with no armed hiding.
 -->
 <script lang="ts">
   import { asString, asStringArray } from '../coerce';
+  import { reveal } from '../reveal';
   import type { TurnSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
 
@@ -24,29 +42,85 @@
     lede: asString(config, 'lede'),
     points: asStringArray(config, 'points'),
   });
+
+  /** Lowercase roman numeral for a 1-based stage index (i, ii, iii, …). */
+  function toRoman(n: number): string {
+    const table: [number, string][] = [
+      [10, 'x'],
+      [9, 'ix'],
+      [5, 'v'],
+      [4, 'iv'],
+      [1, 'i'],
+    ];
+    let value = n;
+    let out = '';
+    for (const [amount, symbol] of table) {
+      while (value >= amount) {
+        out += symbol;
+        value -= amount;
+      }
+    }
+    return out || `${n}`;
+  }
+
+  /**
+   * A point may carry an optional gloss after a dash separator
+   * ("Regulation — finding the ground"). The bold name is everything before the
+   * first en/em dash; the gloss is the remainder. A plain point degrades to a
+   * name-only stage. Reads within the frozen `points: string[]` contract.
+   */
+  const stages = $derived(
+    (p.points ?? []).map((raw, i) => {
+      const match = raw.match(/\s+[—–]\s+/);
+      if (match && match.index !== undefined) {
+        return {
+          roman: toRoman(i + 1),
+          name: raw.slice(0, match.index).trim(),
+          gloss: raw.slice(match.index + match[0].length).trim() || undefined,
+        };
+      }
+      return { roman: toRoman(i + 1), name: raw, gloss: undefined };
+    })
+  );
 </script>
 
 {#if p.statement || p.lede}
-  <div class="turn">
+  <div class="turn" use:reveal>
+    <div class="turn__well" aria-hidden="true"></div>
     <div class="turn__inner">
-      <div class="turn__head">
-        {#if p.eyebrow}
-          <p class="turn__eyebrow">{p.eyebrow}</p>
-        {/if}
-        {#if p.statement}
-          <p class="turn__statement">{p.statement}</p>
-        {/if}
-      </div>
-      <div class="turn__body">
-        {#if p.lede}
-          <p class="turn__lede">{p.lede}</p>
-        {/if}
-        {#if p.points}
-          <ul class="turn__points">
-            {#each p.points as point, i (i)}
-              <li class="turn__point">{point}</li>
-            {/each}
-          </ul>
+      <div class="turn__grid">
+        <div class="turn__head">
+          {#if p.eyebrow}
+            <p class="turn__eyebrow">{p.eyebrow}</p>
+          {/if}
+          {#if p.statement}
+            <h2 class="turn__statement">{p.statement}</h2>
+          {/if}
+          {#if p.lede}
+            <p class="turn__lede">{p.lede}</p>
+          {/if}
+          <div class="turn__thread" aria-hidden="true"></div>
+        </div>
+
+        {#if stages.length > 0}
+          <div class="turn__arc">
+            <span class="turn__rail turn__rail--base" aria-hidden="true"></span>
+            <span class="turn__rail turn__rail--progress" aria-hidden="true"></span>
+            <span class="turn__root" aria-hidden="true"></span>
+            <ol class="turn__stages" aria-label="The stages of the descent">
+              {#each stages as stage, i (i)}
+                <li class="turn__stage" style="--d: {i}">
+                  <span class="turn__num" aria-hidden="true">{stage.roman}</span>
+                  <div class="turn__stage-body">
+                    <h3 class="turn__name">{stage.name}</h3>
+                    {#if stage.gloss}
+                      <p class="turn__gloss">{stage.gloss}</p>
+                    {/if}
+                  </div>
+                </li>
+              {/each}
+            </ol>
+          </div>
         {/if}
       </div>
     </div>
@@ -54,29 +128,68 @@
 {/if}
 
 <style>
+  /* ═══ THE TURN — the pivot, and the descent into the staged arc ═══ */
+
   .turn {
     position: relative;
     padding-block: var(--space-20);
     padding-inline: var(--space-5);
+    overflow: clip;
+    isolation: isolate;
+    text-align: left;
+  }
+
+  /* A warm well the eye descends toward — atmosphere behind the arc. */
+  .turn__well {
+    position: absolute;
+    z-index: -1;
+    left: 62%;
+    bottom: -16%;
+    width: min(115%, 60rem);
+    aspect-ratio: 1;
+    translate: -50% 0;
+    pointer-events: none;
+    filter: blur(var(--blur-xl));
+    background: radial-gradient(
+      circle at 50% 50%,
+      color-mix(in oklab, var(--color-brand-accent) 15%, transparent),
+      color-mix(in oklab, var(--color-brand-primary) 11%, transparent) 40%,
+      transparent 66%
+    );
   }
 
   .turn__inner {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-10);
     max-width: 68rem;
     margin-inline: auto;
   }
 
+  .turn__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-12);
+  }
+
   @media (--breakpoint-md) {
-    .turn__inner {
+    .turn__grid {
       grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
       gap: var(--space-16);
       align-items: center;
     }
+
+    .turn__well {
+      left: 50%;
+      bottom: 4%;
+      width: min(140%, 44rem);
+    }
+  }
+
+  /* ── left: the statement (pain → promise) ── */
+  .turn__head {
+    max-width: 34ch;
   }
 
   .turn__eyebrow {
+    display: block;
     margin: 0 0 var(--space-4);
     font-size: var(--text-sm);
     font-weight: var(--font-semibold);
@@ -97,44 +210,260 @@
     text-wrap: balance;
   }
 
-  .turn__body {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-6);
-  }
-
   .turn__lede {
-    margin: 0;
+    margin: var(--space-5) 0 0;
+    max-width: 40ch;
     font-size: var(--text-lg);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
   }
 
-  .turn__points {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
+  /* Decorative thread — the descent begins here. */
+  .turn__thread {
+    margin-top: var(--space-8);
+    width: clamp(3rem, 6vw, 5rem);
+    height: 2px;
+    border-radius: var(--radius-full);
+    transform-origin: left center;
+    opacity: 0.85;
+    background: linear-gradient(
+      90deg,
+      var(--color-brand-accent),
+      transparent
+    );
+  }
+
+  /* ── right: the descent arc ── */
+  .turn__arc {
+    position: relative;
+    padding-left: var(--space-2);
+  }
+
+  /* The rail: faint base + accent progress that draws downward. */
+  .turn__rail {
+    position: absolute;
+    left: var(--space-1);
+    top: var(--space-6);
+    bottom: var(--space-6);
+    width: 2px;
+    translate: -50% 0;
+    border-radius: var(--radius-full);
+  }
+
+  .turn__rail--base {
+    opacity: 0.32;
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-heading) 24%, transparent),
+      color-mix(in oklab, var(--color-brand-accent) 55%, transparent)
+    );
+  }
+
+  .turn__rail--progress {
+    transform-origin: top center;
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-brand-accent) 28%, transparent),
+      var(--color-brand-accent)
+    );
+    box-shadow: 0 0 12px color-mix(in oklab, var(--color-brand-accent) 45%, transparent);
+  }
+
+  /* The root — where the descent lands. */
+  .turn__root {
+    position: absolute;
+    left: var(--space-1);
+    bottom: var(--space-6);
+    width: var(--space-3);
+    height: var(--space-3);
+    border-radius: var(--radius-full);
+    translate: -50% 50%;
+    background: radial-gradient(
+      circle,
+      var(--color-brand-accent),
+      color-mix(in oklab, var(--color-brand-accent) 22%, transparent) 66%,
+      transparent
+    );
+    box-shadow: 0 0 18px 3px color-mix(in oklab, var(--color-brand-accent) 42%, transparent);
+  }
+
+  .turn__stages {
     margin: 0;
     padding: 0;
     list-style: none;
   }
 
-  .turn__point {
+  .turn__stage {
     position: relative;
-    padding-left: var(--space-6);
-    font-size: var(--text-base);
-    line-height: var(--leading-normal);
-    color: var(--color-text);
+    display: grid;
+    grid-template-columns: clamp(3rem, 6vw, 4.4rem) 1fr;
+    column-gap: clamp(0.7rem, 1.8vw, 1.3rem);
+    align-items: baseline;
+    padding-block: var(--space-5);
   }
 
-  .turn__point::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0.6em;
-    width: var(--space-2);
-    height: var(--space-2);
-    border-radius: var(--radius-full);
-    background: var(--color-brand-primary);
+  .turn__stage + .turn__stage {
+    border-top: 1px solid color-mix(in oklab, var(--color-heading) 8%, transparent);
+  }
+
+  .turn__num {
+    grid-column: 1;
+    justify-self: start;
+    padding-left: clamp(0.7rem, 1.6vw, 1.2rem);
+    font-family: var(--font-heading);
+    font-style: italic;
+    font-weight: var(--font-normal);
+    font-size: var(--text-3xl);
+    line-height: var(--leading-none);
+    letter-spacing: 0.02em;
+    color: color-mix(
+      in oklab,
+      var(--color-brand-accent) calc(58% + var(--d, 0) * 10%),
+      var(--color-text-secondary)
+    );
+    transition: color var(--duration-slowest) var(--ease-out);
+  }
+
+  .turn__stage-body {
+    grid-column: 2;
+    padding-left: calc(var(--d, 0) * clamp(0px, 1vw, 15px));
+  }
+
+  .turn__name {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-weight: var(--font-normal);
+    font-size: var(--text-xl);
+    line-height: var(--leading-snug);
+    letter-spacing: -0.005em;
+    color: var(--color-heading);
+  }
+
+  .turn__gloss {
+    margin: var(--space-2) 0 0;
+    max-width: 46ch;
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+    color: var(--color-text-secondary);
+  }
+
+  /* ── ENHANCED: reveal-on-scroll (armed from JS by `use:reveal`) ──
+     Hidden states apply ONLY while armed and not yet in-view. Reduced-motion /
+     no-JS clients get `is-in` without `reveal--armed`, so these never bite and
+     the composed baseline above renders as-is. */
+  .turn:global(.reveal--armed) .turn__eyebrow,
+  .turn:global(.reveal--armed) .turn__statement,
+  .turn:global(.reveal--armed) .turn__lede {
+    opacity: 0;
+    transform: translateY(1rem);
+    transition:
+      opacity var(--duration-slowest) var(--ease-out),
+      transform var(--duration-slowest) var(--ease-out);
+  }
+
+  .turn:global(.reveal--armed) .turn__statement {
+    transition-delay: 60ms;
+  }
+
+  .turn:global(.reveal--armed) .turn__lede {
+    transition-delay: 120ms;
+  }
+
+  .turn:global(.reveal--armed.is-in) .turn__eyebrow,
+  .turn:global(.reveal--armed.is-in) .turn__statement,
+  .turn:global(.reveal--armed.is-in) .turn__lede {
+    opacity: 1;
+    transform: none;
+  }
+
+  .turn:global(.reveal--armed) .turn__thread {
+    opacity: 0;
+    transform: scaleX(0);
+    transition:
+      transform var(--duration-slowest) var(--ease-out) 200ms,
+      opacity var(--duration-slower) var(--ease-out) 200ms;
+  }
+
+  .turn:global(.reveal--armed.is-in) .turn__thread {
+    opacity: 0.85;
+    transform: none;
+  }
+
+  .turn:global(.reveal--armed) .turn__stage {
+    opacity: 0;
+    transform: translateY(1.125rem);
+    transition:
+      opacity var(--duration-slowest) var(--ease-out),
+      transform var(--duration-slowest) var(--ease-out);
+    transition-delay: calc(var(--d) * 110ms);
+  }
+
+  .turn:global(.reveal--armed.is-in) .turn__stage {
+    opacity: 1;
+    transform: none;
+  }
+
+  .turn:global(.reveal--armed) .turn__num {
+    color: var(--color-text-tertiary);
+  }
+
+  .turn:global(.reveal--armed.is-in) .turn__num {
+    color: color-mix(
+      in oklab,
+      var(--color-brand-accent) calc(58% + var(--d, 0) * 10%),
+      var(--color-text-secondary)
+    );
+  }
+
+  .turn:global(.reveal--armed) .turn__rail--progress {
+    transform: scaleY(0);
+    transition: transform calc(var(--duration-slowest) * 2) var(--ease-smooth) 150ms;
+  }
+
+  .turn:global(.reveal--armed.is-in) .turn__rail--progress {
+    transform: scaleY(1);
+  }
+
+  .turn:global(.reveal--armed) .turn__root {
+    opacity: 0;
+    transform: scale(0.4);
+    transition:
+      opacity var(--duration-slowest) var(--ease-out) 1000ms,
+      transform var(--duration-slowest) var(--ease-out) 1000ms;
+  }
+
+  .turn:global(.reveal--armed.is-in) .turn__root {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* Belt-and-suspenders: if motion preference flips after arming, force the
+     composed state (the `reveal` action already withholds arming under
+     reduced-motion, but this guarantees no lingering hidden state). */
+  @media (prefers-reduced-motion: reduce) {
+    .turn:global(.reveal--armed) .turn__eyebrow,
+    .turn:global(.reveal--armed) .turn__statement,
+    .turn:global(.reveal--armed) .turn__lede,
+    .turn:global(.reveal--armed) .turn__thread,
+    .turn:global(.reveal--armed) .turn__stage,
+    .turn:global(.reveal--armed) .turn__root {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+    }
+
+    .turn:global(.reveal--armed) .turn__rail--progress {
+      transform: scaleY(1) !important;
+      transition: none !important;
+    }
+
+    .turn:global(.reveal--armed) .turn__num {
+      color: color-mix(
+        in oklab,
+        var(--color-brand-accent) calc(58% + var(--d, 0) * 10%),
+        var(--color-text-secondary)
+      ) !important;
+      transition: none !important;
+    }
   }
 </style>

--- a/apps/web/src/lib/page-builder/render/sections/TurnSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/TurnSection.svelte
@@ -23,7 +23,7 @@
   reduced-motion / no-JS clients get the composed state with no armed hiding.
 -->
 <script lang="ts">
-  import { asString, asStringArray } from '../coerce';
+  import { asStringArray, asStringFrom } from '../coerce';
   import { reveal } from '../reveal';
   import type { TurnSectionProps, JourneySalesContext } from '../types';
   import type { SectionProps } from '$lib/page-builder';
@@ -36,10 +36,13 @@
 
   const { config }: Props = $props();
 
+  // The builder authors this section as flat `{kicker, heading, body}`, which maps
+  // 1:1 onto eyebrow/statement/lede (see coerce.ts's BUILDER-SHAPE BRIDGE note).
+  // The section's own key names still win when present.
   const p: TurnSectionProps = $derived({
-    eyebrow: asString(config, 'eyebrow'),
-    statement: asString(config, 'statement'),
-    lede: asString(config, 'lede'),
+    eyebrow: asStringFrom(config, ['eyebrow', 'kicker']),
+    statement: asStringFrom(config, ['statement', 'heading']),
+    lede: asStringFrom(config, ['lede', 'body']),
     points: asStringArray(config, 'points'),
   });
 

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/practice/[contentSlug]/+page.svelte
@@ -210,6 +210,10 @@
     position: sticky;
     top: 0;
     align-self: start;
+    /* Pin to exactly viewport height so the border-right + surface fill the
+       whole column even when the journey map is shorter than the viewport
+       (otherwise the box is content-height and the rail stops mid-page). */
+    min-height: 100dvh;
     max-height: 100dvh;
     overflow-y: auto;
     display: flex;

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -19,7 +19,7 @@
 -->
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { beforeNavigate } from '$app/navigation';
+  import { beforeNavigate, invalidate } from '$app/navigation';
   import { page } from '$app/state';
   import type { PageStatus } from '@codex/shared-types';
   import {
@@ -31,6 +31,7 @@
     SectionList,
   } from '$lib/components/page-builder';
   import {
+    getCourseCurriculum,
     getJourneyForBuilder,
     saveJourneyPage,
   } from '$lib/remote/journeys.remote';
@@ -48,11 +49,30 @@
   // remote after WP-2 (identical `.current` access).
   const draftQuery = $derived(pageId ? getJourneyForBuilder({ id: pageId }) : null);
 
-  // Curriculum stages feed the map/descent section previews (course-owned). The
-  // real curriculum wiring (getCourseCurriculumForEditor → JourneyStagePreview)
-  // is a follow-up now that the real backend has landed; until then the builder
-  // renders an empty stage preview rather than the retired mock fixture.
-  const stages: JourneyStagePreview[] = [];
+  // Curriculum stages feed the map/descent section previews (course-owned). This
+  // was a hardcoded `[]` awaiting "real curriculum wiring", which meant the map
+  // showed ZERO stages in the builder while the public page rendered the real
+  // ones — the builder looked broken next to its own live page. Now reads the same
+  // admin curriculum the two-pane editor uses.
+  //
+  // `minutes` is 0 because `EditorPracticeView` carries no duration; the visible
+  // stats (practice counts, stage names/glosses, depth count) are all accurate,
+  // and the total-minutes cue reads 0 until durations reach this read model.
+  const curriculumQuery = $derived(
+    pageId ? getCourseCurriculum({ pageId }) : null
+  );
+
+  const stages: JourneyStagePreview[] = $derived(
+    (curriculumQuery?.current?.stages ?? []).map((stage) => ({
+      name: stage.name,
+      gloss: stage.gloss ?? '',
+      lessons: stage.practices.map((practice) => ({
+        title: practice.title,
+        type: practice.contentType,
+        minutes: 0,
+      })),
+    }))
+  );
 
   // ── Workspace view state ──────────────────────────────────────────────────
   type BuilderMode = 'design' | 'pricing' | 'brand' | 'seo';
@@ -151,12 +171,31 @@
         ...payload,
       });
       pageBuilder.markSaved();
+      // The PUBLIC sales load `depends('cache:versions')` precisely so a save can
+      // mark it stale; without this the client reuses its cached load data and the
+      // live page keeps showing pre-save content until a hard reload.
+      await invalidate('cache:versions');
       toast.success('Page saved');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to save page');
     } finally {
       saving = false;
     }
+  }
+
+  /**
+   * Open the REAL public sales page in a new tab — the only surface that renders
+   * the cinematic motion (the canvas mounts the static editable components; see
+   * the toolbar comment). Saves first when dirty so the live page matches what is
+   * on screen rather than silently showing the last-saved version.
+   */
+  async function handleViewLive(): Promise<void> {
+    if (pageBuilder.isDirty) await handleSave();
+    if (!slug) {
+      toast.error('Give the page a slug and save it before viewing live');
+      return;
+    }
+    window.open(`/journeys/${slug}`, '_blank', 'noopener');
   }
 
   async function handlePublish(): Promise<void> {
@@ -240,13 +279,30 @@
         >↷</button>
       </div>
 
+      <!--
+        "Full width" only hides the editor rails — the canvas still renders the
+        EDITABLE section components (`render-edit/`), which are deliberately static
+        so click-to-edit stays reliable. The cinematic motion (pinned ache, kinetic
+        hero, scroll reveals) lives in the PUBLIC renderer (`render/`), so seeing it
+        means opening the real page — hence the separate "View live" below.
+      -->
       <button
         type="button"
         class="jb__btn"
         class:jb__btn--on={previewMode}
+        title="Hide the editor rails (still the editable canvas, not the animated page)"
         onclick={() => (previewMode = !previewMode)}
       >
-        {previewMode ? 'Editing' : 'Preview'}
+        {previewMode ? 'Editing' : 'Full width'}
+      </button>
+      <button
+        type="button"
+        class="jb__btn"
+        title="Open the real sales page in a new tab — full animations, saves first"
+        disabled={saving}
+        onclick={handleViewLive}
+      >
+        View live ↗
       </button>
       <button type="button" class="jb__btn" disabled={!isDirty || saving} onclick={handleSave}>
         {saving ? 'Saving…' : 'Save'}

--- a/apps/web/src/tests/setup.ts
+++ b/apps/web/src/tests/setup.ts
@@ -48,6 +48,30 @@ if (typeof Element !== 'undefined') {
   });
 }
 
+// JSDOM shim: window.matchMedia is not implemented in jsdom. Components read
+// motion/theme preferences via `window.matchMedia('(prefers-reduced-motion: reduce)')`
+// inside onMount (e.g. the journey sales-page sections), which would throw when
+// those components are mounted in unit tests. Provide a minimal non-matching stub
+// (matches:false = the full-motion default). Real reduced-motion / responsive
+// behaviour is covered by E2E / in-browser verification.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string): MediaQueryList =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+  });
+}
+
 // Clean up DOM after each test (only if running in DOM environment)
 afterEach(() => {
   if (typeof document !== 'undefined' && document.body) {


### PR DESCRIPTION
## Why

The public journey **sales page** (rendered by `JourneyRenderer` → `SectionRenderer` → the section components) had shipped only the **static / reduced-motion fallback** of each section and dropped the prototype's signature motion + interaction. The result: sections read as flat and half-empty, the intro-video modal's overlaid text bled through later sections, and there was no persistent conversion CTA. **Scope note (corrected):** this PR changes the **public** journey renderer only (`page-builder/render/`). The studio builder canvas mounts a *separate* set of editable components (`page-builder/render-edit/sections/` — 8 components, where `ProseSection` backs ache/turn/feel and `VideoSection` backs introVideo/reel), which this PR does **not** touch. The `JourneyBuilderCanvas` doc comment claiming it uses "the SAME components the public page uses" is stale — it refers to sharing one renderer across several semantic *types* within `render-edit`, not sharing with `render/`. So the builder preview does **not** inherit these fixes.

Reference prototype: `docs/design/course-journeys/prototype/` (fragments + `sell.css` + `fresh.js`).

## What changed

Every fix maps a prototype signature onto **real Codex design tokens** (the prototype's `--ember`/`--bone`/`--st-*` are stand-ins) with a progressively-enhanced, SSR-safe, reduced-motion-gated baseline — the server/no-JS render is always the fully-legible static composition; motion layers on top only after JS confirms it's welcome.

**New shared primitives**
- `page-builder/render/reveal.ts` — a scroll-into-view Svelte action mirroring the prototype's `fresh.js` observer. Arms the hidden state *from JS* (so no-JS/SSR paint revealed), guards `IntersectionObserver` + `matchMedia` (reveals immediately when absent), one-shot by default.
- `page-builder/render/FloatingCta.svelte` — the persistent bottom-centre conversion pill (the prototype's `.floatcta`), parked off-screen and sliding in past the first viewport; inert + parked inside the builder preview iframe so it never covers builder chrome.

**Sections restored to fidelity** (each edits only its own file, prop contract unchanged, reads any new field defensively via the existing coercers and self-hides when absent):
- `AcheSection` — cinematic **pinned beat-reveal** (the exemplar): a tall scroll track pins a 100vh stage, scrolling crossfades one beat at a time, breathing aura + segmented progress rail + vignette. (Fixes the "overlaid / broken ache".)
- `HeroSection` — kinetic word-by-word headline, breathing warm core, rising embers, edge vignette, descending scroll cue (load-choreography, above the fold).
- `IntroVideoSection` — cinematic play-frame with breathing key-light aura, dual pulse rings on the ember play button, honest corner duration badge.
- `TurnSection` — the descent arc: numbered roman-numeral stages on a rail that draws down on reveal.
- `ReelSection`, `MapSection` (curriculum descent rail + per-stage practice cards + stat pills), `FeelSection`, `ProofSection` (testimonial grid → horizontal swipe carousel < md), `GuideSection`, `FaqSection`, `InviteSection` (offer cards: £12 recommended + £6 monthly).

**Stacking-context + layout fixes**
- `IntroVideoModal.svelte` — `use:portal` re-parents the fixed overlay to `.org-layout` (not raw `<body>` — preserves the org-brand + `--color-player-*` cascade), escaping the section renderer's `isolation: isolate` trap that ranked its `z-index` only within one section and let later sections paint over the video. (Fixes the overlaid-text modal.)
- `JourneyRenderer.svelte` — mounts `FloatingCta` after the sections.
- practice player `+page.svelte` — rail `min-height: 100dvh` so the sticky sidebar fills the column even when the journey map is shorter than the viewport. (Fixes the not-full-height sidebar.)

**Test infra**
- `src/tests/setup.ts` — jsdom `window.matchMedia` shim (alongside the existing `Element.animate` shim), required because the section `onMount` blocks now read the reduced-motion preference. Real motion behaviour is covered by in-browser verification.

## Verification

**Static gate (changed files):** `svelte-check` — 0 errors introduced (the one `IntroVideoModal:70` HLS error is pre-existing on `dev`, identical region, unrelated to the portal edit); `biome check` exit 0; `vitest` `page-builder/render` 29/29 pass.

**In-browser** (`studio-alpha.lvh.me:3000/journeys/rootwork`, creator@test.com):
- All **11 sections render in the correct order**; **0 document horizontal overflow** at 1440 and 390.
- Every reveal fires end-to-end on scroll (`is-in` count == reveal count for all sections) — no stuck-hidden content.
- Fidelity screenshots captured for introVideo, map, invite (+ ache/modal/FloatingCta verified earlier).
- Mobile (390): ProofSection is an intentional horizontal-swipe carousel (`overflow-x:auto` track) — content swipeable, document does not overflow.
- Only console error is a benign local dev-cdn 404 for the org logo webp (missing seed asset), unrelated.

## Second commit — four builder↔public seam bugs (reported from the live builder)

All four were pre-existing (`origin/dev` reproduces them); found while verifying the fidelity work and fixed here since they make the sell page look broken to a creator.

**1 · Builder-authored content in 4 sections was invisible when published.** The builder + `section-catalog.ts` `defaultProps` write **flat, numbered keys**; the public sections gate on **array shapes that are never written**:

| Section | Builder writes (verified in DB) | Public gate | Was | Now |
|---|---|---|---|---|
| `ache` | `{kicker, heading, body}` | `beats.length > 0` | 0px | **2700px** |
| `turn` | `{kicker, heading, body}` | `p.statement \|\| p.lede` | 0px | **443px** |
| `proof` | `{q1-3, n1-3, c1-3, eyebrow, heading, trust}` | `testimonials.length > 0` | 0px | **597px** |
| `faq` | `{q1-3, a1-3, heading}` | `items.length > 0` | 0px | **523px** |

Fixed at the READ boundary — `asStringFrom` / `asStringsFrom` / `asNumberedGroups` in `coerce.ts`, wired as **fallbacks** so the array shape still wins. No migration; existing pages render on next load. `ProofSection` additionally only read course-owned `context.testimonials` and ignored its own authored `q1/n1/c1` fields — those are now the fallback when the course has no rows.

**2 · Public page served pre-save content.** Proven *not* a server cache (a direct DB write appears in the server HTML instantly; header is `private, no-cache`; no duplicate slug rows). `handleSave()` simply never marked the public load stale, despite that load wiring `depends('cache:versions')` for exactly this purpose. Now `invalidate('cache:versions')` after a successful save.

**3 · "Preview" was misleading.** It only hid the editor rails — the canvas mounts the **static editable** components (`render-edit/`), never the animated public ones, so the cinematic motion could never appear there. Relabelled **"Full width"**, and added **"View live ↗"** which saves then opens the real sales page in a new tab.

**4 · Builder map showed 0 stages** while the public page rendered the real ones — `stages` was a hardcoded `[]` with a comment awaiting "real curriculum wiring". Now reads the same admin curriculum as the two-pane editor. (`minutes` stays 0 — `EditorPracticeView` carries no duration; counts and names are accurate.)

Verified on `of-blood-and-bones/journeys/poihg`: page height 4354 → 8616px, all 10 sections render, builder canvas reports the real "3 gated depths · 4 practices", and a builder edit → Save → public fetch served the new copy immediately (test data restored afterwards).

## Follow-ups (deferred — additive, not required to ship)

The frozen shared contract (`types.ts`) was intentionally **not** expanded; sections read new fields defensively and self-hide. Captured for a later pass:
- Authorable presentation fields: `GuideSectionProps.quote`, `ReelSectionProps.caption/captions/tag`, `ProofSectionProps.trustLabel`.
- Data-backed (need frozen read-model extension): per-practice `durationMinutes` + course `totalMinutes` for the map; `TurnSectionProps.stages[]`; wiring FeelSection's free-taste player to real `context.sellPreview.reel` HLS; a public free-preview flag on `JourneyPracticeView` for the map's "one door ajar" badge.
- Practice-rail full-height fix needs an enrolled user to view live.

Excluded from the commit: generated `apps/web/src/paraglide/messages/en.js` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
