### PR TITLE
feat(journeys): real pricing write path + close silent-swallow gaps

### DIFF
--- a/apps/web/src/lib/components/page-builder/JourneyBuilderCanvas.svelte
+++ b/apps/web/src/lib/components/page-builder/JourneyBuilderCanvas.svelte
@@ -3,8 +3,17 @@
 
   The INLINE WYSIWYG canvas for the journey sales-page builder
   (Codex-2pryk.3.3 · WP-5). Renders the store's enabled sections directly via the
-  shared {@link SectionRenderer} (the SAME components the public page uses), so
-  the canvas IS the page. Each block is:
+  EDITABLE {@link SectionRenderer} from `$lib/page-builder/render-edit`, so the
+  canvas IS the page — structurally, not pixel-for-pixel.
+
+  NOT the public components. `render-edit/` holds 8 static, contenteditable
+  sections; the public page renders 11 animated ones from `render/`. The canvas
+  therefore cannot show real motion, and a section with no `render-edit` twin does
+  not appear here at all. The route's "View live ↗" (which saves first) is the way
+  to see the true page. Unifying the two sets behind one `editable` flag is filed
+  as a follow-up.
+
+  Each block is:
     · selectable  — mousedown selects it (without stealing caret from text)
     · inline-editable — contenteditable copy writes straight to the store
     · block-toolbarred — move ↑/↓, duplicate, add-after, delete (on selection)

--- a/apps/web/src/lib/components/page-builder/PagePricingPanel.svelte
+++ b/apps/web/src/lib/components/page-builder/PagePricingPanel.svelte
@@ -4,24 +4,61 @@
   The "Access & pricing" page-mode panel (Codex-2pryk.3.3 · WP-5). Presents the
   journey's ways-in — membership tiers, a course subscription, a one-off purchase —
   as independent toggles + price fields, written to `PageBuilderState.offer` via
-  the store. Prices are GBP (£), stored in pence. NOTE: the AUTHORITATIVE access
-  rule lives on the course/content policy (SPEC §6.1); this panel is the sales
-  page's PRESENTATION of the offer.
+  the store. Prices are GBP (£), stored in pence.
+
+  The one-off price is not decoration: the route's Save persists this offer through
+  `updateJourneyOffer`, which writes the authoritative `courses.price_cents` in the
+  same transaction. A course with no price shows "isn't open for enrolment just
+  now" at checkout, so an ENABLED path with an empty price is flagged here (and
+  rejected by the service) rather than saved as an unsellable offer.
+
+  NOTE: the AUTHORITATIVE access RULE (who may enter) still lives on the
+  course/content policy (SPEC §6.1) — this panel owns what the journey COSTS.
 -->
 <script lang="ts">
   import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
 
   const offer = $derived(pageBuilder.pending?.offer ?? {});
+  const isCoursePage = $derived(pageBuilder.pending?.subjectType === 'course');
 
   const poundsOf = (cents: number | null | undefined): string =>
     cents == null ? '' : (cents / 100).toFixed(cents % 100 === 0 ? 0 : 2);
 
-  function setPounds(key: 'subscriptionPriceCents' | 'oneOffPriceCents', value: string): void {
+  // Price fields hold a LOCAL draft string while focused. Binding the input
+  // straight to `poundsOf(cents)` made decimals untypeable: "12." parses to 12 →
+  // 1200 pence → re-derives "12", so the DOM value snapped back and ate the ".".
+  // The draft is authoritative during editing; blur clears it so the field falls
+  // back to the canonical (normalised) pence value.
+  type PriceKey = 'subscriptionPriceCents' | 'oneOffPriceCents';
+  let drafts = $state<Partial<Record<PriceKey, string>>>({});
+
+  const shown = (key: PriceKey): string => drafts[key] ?? poundsOf(offer[key]);
+
+  function setPounds(key: PriceKey, value: string): void {
+    drafts[key] = value;
     const pounds = Number.parseFloat(value);
     pageBuilder.updateOffer({
+      // Round to whole pence — a price is an integer of the smallest unit, and
+      // fractional pence would fail the service's integer validation.
       [key]: Number.isFinite(pounds) ? Math.round(pounds * 100) : null,
     });
   }
+
+  function commitPounds(key: PriceKey): void {
+    delete drafts[key];
+  }
+
+  /** An enabled path with no price is unsellable — warn before the save 400s. */
+  const priceless = $derived.by<string[]>(() => {
+    const gaps: string[] = [];
+    if (offer.subscriptionEnabled && offer.subscriptionPriceCents == null) {
+      gaps.push('the course subscription');
+    }
+    if (offer.oneOffEnabled && offer.oneOffPriceCents == null) {
+      gaps.push('the one-off purchase');
+    }
+    return gaps;
+  });
 </script>
 
 <div class="panel">
@@ -62,8 +99,10 @@
       £<input
         class="way__input"
         inputmode="decimal"
-        value={poundsOf(offer.subscriptionPriceCents)}
+        aria-label="Monthly course subscription price in pounds"
+        value={shown('subscriptionPriceCents')}
         oninput={(e) => setPounds('subscriptionPriceCents', e.currentTarget.value)}
+        onblur={() => commitPounds('subscriptionPriceCents')}
       />/mo
     </span>
   </div>
@@ -81,14 +120,34 @@
       £<input
         class="way__input"
         inputmode="decimal"
-        value={poundsOf(offer.oneOffPriceCents)}
+        aria-label="One-off purchase price in pounds"
+        value={shown('oneOffPriceCents')}
         oninput={(e) => setPounds('oneOffPriceCents', e.currentTarget.value)}
+        onblur={() => commitPounds('oneOffPriceCents')}
       />
     </span>
   </div>
 
+  {#if priceless.length > 0}
+    <p class="panel__warn" role="status">
+      Set a price for {priceless.join(' and ')} — an enabled way in with no price can’t be
+      bought, so the checkout shows nothing.
+    </p>
+  {/if}
+
+  {#if offer.oneOffEnabled && !isCoursePage}
+    <p class="panel__warn" role="status">
+      Only a course journey can be sold as a one-off purchase.
+    </p>
+  {/if}
+
   <p class="panel__callout">
     <b>Membership</b> unlocks every journey — the buyer should feel it’s more than this one course.
+  </p>
+
+  <p class="panel__callout">
+    Pricing saves with the page’s <b>Save</b> — the one-off price becomes the course’s real
+    price, so the checkout can take it.
   </p>
 </div>
 
@@ -142,6 +201,17 @@
 
   .panel__callout b {
     color: var(--color-text-secondary);
+  }
+
+  .panel__warn {
+    margin: 0;
+    padding: var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-warning-200);
+    border-radius: var(--radius-md);
+    background-color: var(--color-warning-50);
+    font-size: var(--text-xs);
+    line-height: var(--leading-normal);
+    color: var(--color-warning-700);
   }
 
   .way {

--- a/apps/web/src/lib/components/page-builder/PageSeoPanel.svelte
+++ b/apps/web/src/lib/components/page-builder/PageSeoPanel.svelte
@@ -2,9 +2,16 @@
   @component PageSeoPanel
 
   The "SEO & web address" page-mode panel (Codex-2pryk.3.3 · WP-5). Edits the web
-  address (slug, real `PageBuilderState.slug`), meta title + description
-  (`PageBuilderState.seo`), and a share-image slot (stub). Writes through the
-  `pageBuilder` store so the address read-out + public head reflect immediately.
+  address (slug, real `PageBuilderState.slug`) — persisted by the page save and
+  live in the address read-out immediately.
+
+  META TITLE / DESCRIPTION ARE NOT YET PERSISTED. `landing_pages` has no `seo`
+  column (the `PageSeo` doc comment claiming "Backs landing_pages.seo jsonb" is
+  aspirational), and the save schema is `.strict()`, so `seo` has nowhere to go.
+  The fields are therefore DISABLED rather than accepting keystrokes the save
+  would discard while the toast said "Page saved" — the same silent swallow the
+  pricing panel had before `updateJourneyOffer` landed. Enabling them needs a
+  migration + save-schema + service field (bead filed).
 -->
 <script lang="ts">
   import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
@@ -45,14 +52,19 @@
       <span class="panel__hint">{orgDomain} / journeys / <b>{pending.slug || 'draft'}</b></span>
     </label>
 
+    <p class="panel__note">
+      Meta title, description and share image land with page metadata. Until then the
+      page’s own title is used, so nothing here is silently dropped.
+    </p>
+
     <label class="panel__field">
       <span class="panel__label">Meta title</span>
       <input
         type="text"
         class="panel__input"
+        disabled
         placeholder={pending.title}
         value={pending.seo?.title ?? ''}
-        oninput={(e) => pageBuilder.updateSeo({ title: e.currentTarget.value })}
       />
       <span class="panel__hint">Shown in search results &amp; the browser tab. Unset → the page title.</span>
     </label>
@@ -62,8 +74,8 @@
       <textarea
         class="panel__input panel__input--area"
         rows="3"
+        disabled
         value={pending.seo?.description ?? ''}
-        oninput={(e) => pageBuilder.updateSeo({ description: e.currentTarget.value })}
       ></textarea>
     </label>
 
@@ -133,6 +145,23 @@
   .panel__input--area {
     resize: vertical;
     line-height: var(--leading-normal);
+  }
+
+  .panel__input:disabled {
+    background-color: var(--color-surface-secondary);
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+  }
+
+  .panel__note {
+    margin: 0;
+    padding: var(--space-3);
+    border: var(--border-width) var(--border-style) var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface-secondary);
+    font-size: var(--text-xs);
+    line-height: var(--leading-normal);
+    color: var(--color-text-muted);
   }
 
   .panel__input:focus-visible {

--- a/apps/web/src/lib/page-builder/journey-queries.ts
+++ b/apps/web/src/lib/page-builder/journey-queries.ts
@@ -69,6 +69,11 @@ export interface EditorPracticeView {
   /** Publish status of the LINKED CONTENT (draft ⇒ not yet member-visible). */
   status: PageStatus;
   thumbnailUrl: string | null;
+  /**
+   * Runtime of the linked media; `null` for a written practice or unprobed media.
+   * Feeds the builder map's "≈ N min in all" cue.
+   */
+  durationSeconds: number | null;
   sortOrder: number;
 }
 

--- a/apps/web/src/lib/page-builder/page-builder-store.svelte.ts
+++ b/apps/web/src/lib/page-builder/page-builder-store.svelte.ts
@@ -385,7 +385,15 @@ function updateBrandOverrides(
   };
 }
 
-/** Merge a partial SEO patch into `pending.seo` (SEO builder mode). */
+/**
+ * Merge a partial SEO patch into `pending.seo` (SEO builder mode).
+ *
+ * CURRENTLY NO CONSUMER — `landing_pages` has no `seo` column and the `.strict()`
+ * save schema has no `seo` key, so `PageSeoPanel` disables those fields rather than
+ * accept keystrokes the save would discard. Kept as the seam persistence will wire
+ * back into (NOT dead code): re-enabling the panel needs a migration + save-schema
+ * field + service write, at which point this is the store-side write again.
+ */
 function updateSeo(patch: Partial<PageSeo>): void {
   if (!state.pending) return;
   state.pending.seo = { ...(state.pending.seo ?? {}), ...patch };

--- a/apps/web/src/lib/page-builder/render-edit/section-render.ts
+++ b/apps/web/src/lib/page-builder/render-edit/section-render.ts
@@ -11,8 +11,10 @@ import type { SectionProps } from '@codex/shared-types';
 
 /**
  * A curriculum stage as the map/descent section previews it. Sourced from the
- * course (not the page draft), so the builder supplies mock stages and the public
- * page supplies the real course outline.
+ * COURSE, not the page draft — so both surfaces supply real data: the builder maps
+ * the admin curriculum read (`getCourseCurriculum`), the public page the published
+ * course outline. `minutes` is 0 for a written practice or media with no probed
+ * duration.
  */
 export interface JourneyStagePreview {
   readonly name: string;
@@ -37,7 +39,7 @@ export interface SectionComponentProps {
   editable?: boolean;
   /** Write one `props` key (in-canvas inline edit → store). */
   onEdit?: (key: string, value: string) => void;
-  /** Curriculum stages for the map/descent section (builder supplies mocks). */
+  /** Curriculum stages for the map/descent section (course-sourced, never mocked). */
   stages?: readonly JourneyStagePreview[];
 }
 

--- a/apps/web/src/lib/page-builder/render-edit/sections/MapSection.svelte
+++ b/apps/web/src/lib/page-builder/render-edit/sections/MapSection.svelte
@@ -5,7 +5,8 @@
   rendered in its lit end-state (the scroll choreography can't run in an
   inner-scrolling canvas). Variants: descent (ember spine + gates, default) ·
   list (compact stage rows) · grid (stage cards). Stages come from the course
-  (via `stages`), not the page draft — the builder supplies mock stages. Copy
+  (via `stages`), not the page draft — the builder reads the real admin curriculum
+  (`getCourseCurriculum`), not a mock fixture. Copy
   (eyebrow/heading/sub/note) is page-editable. Styling in `../journey-sections.css`.
 -->
 <script lang="ts">

--- a/apps/web/src/lib/page-builder/render/sections/GuideSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/GuideSection.svelte
@@ -39,9 +39,11 @@
     credentials: asStringArray(config, 'credentials'),
   });
 
-  // The prototype's emotional climax is a pull-quote. It is not yet part of the
-  // shared GuideSectionProps contract, so read it defensively from config and
-  // simply omit the quote when absent (see desiredSharedChanges for the lead).
+  // The prototype's emotional climax is a pull-quote — now declared on
+  // `GuideSectionProps`. Still read through `asString` rather than `p.quote`
+  // because `props` is org-authored jsonb: the declared type describes intent, the
+  // coerce guard is what makes a malformed value degrade instead of throwing
+  // during SSR. Absent ⇒ the quote is omitted entirely.
   const quote = $derived(asString(config, 'quote'));
 
   // A single-glyph mark for the decorative candlelit poster when no portrait is

--- a/apps/web/src/lib/page-builder/render/sections/ProofSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/ProofSection.svelte
@@ -38,9 +38,10 @@
     heading: asString(config, 'heading'),
   });
 
-  // Optional aggregate trust cue — read defensively from config so the shared
-  // ProofSectionProps type needn't change to render it, and absent → omitted.
-  // (`trust` is the builder's key for the same field.)
+  // Optional aggregate trust cue — both keys are now declared on
+  // `ProofSectionProps`; absent → omitted. (`trust` is the legacy key for the same
+  // field, kept for pages authored before `trustLabel` settled.) Read through the
+  // coerce guard because `props` is org-authored jsonb.
   const trustLabel = $derived(asStringFrom(config, ['trustLabel', 'trust']));
 
   type Testimonial = JourneySalesContext['testimonials'][number];

--- a/apps/web/src/lib/page-builder/render/sections/ReelSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/ReelSection.svelte
@@ -50,9 +50,11 @@
   const heading = $derived(p.heading ?? 'This is what a descent looks like.');
 
   /**
-   * Whispered subtitle(s). Read defensively from config (not yet in the shared
-   * `ReelSectionProps` type — see desiredSharedChanges): `captions` (an array)
-   * takes precedence, else a single `caption`. Absent ⇒ no caption line renders.
+   * Whispered subtitle(s) — `caption` / `captions` / `tag` are now declared on
+   * `ReelSectionProps`. Still read through the coerce guards rather than `p.*`
+   * because `props` is org-authored jsonb (the type states intent; the guard is
+   * what survives a malformed value). `captions` (an array) takes precedence,
+   * else a single `caption`. Absent ⇒ no caption line renders.
    */
   const captions = $derived(
     asStringArray(config, 'captions') ??

--- a/apps/web/src/lib/page-builder/render/types.ts
+++ b/apps/web/src/lib/page-builder/render/types.ts
@@ -125,7 +125,15 @@ export interface AcheSectionProps {
   beats?: string[];
 }
 
-/** `turn` — the pivot from pain to promise. */
+/**
+ * `turn` — the pivot from pain to promise.
+ *
+ * NOTE: there is deliberately no `stages` field. `TurnSection` derives its roman
+ * -numeralled stage list FROM `points` by splitting each entry on an en/em dash
+ * ("Regulation — finding the ground"), so the authored shape stays one flat string
+ * array. A separate `stages` prop would be a second, divergent source for the same
+ * list.
+ */
 export interface TurnSectionProps {
   eyebrow?: string;
   statement?: string;
@@ -139,6 +147,15 @@ export interface ReelSectionProps {
   heading?: string;
   sub?: string;
   posterUrl?: string;
+  /**
+   * The whispered caption under the letterboxed frame. `captions` takes
+   * precedence and cross-fades on a slow cycle; `caption` is the single-line
+   * form. Absent ⇒ no caption line renders.
+   */
+  caption?: string;
+  captions?: string[];
+  /** Corner tag label above the frame. Defaults to `Preview` when absent. */
+  tag?: string;
 }
 
 /** `map` — the descent map (public, no progress); renders from context.stages. */
@@ -161,12 +178,30 @@ export interface FeelSectionProps {
   heading?: string;
   body?: string;
   inclusions?: FeelInclusion[];
+  /**
+   * The "free-taste" preview player. `previewTitle` is the switch — absent ⇒ the
+   * player self-hides. `previewDuration` is in seconds and drives the playhead.
+   *
+   * The transport is currently a VISUAL taste (an animated equaliser + playhead),
+   * not real playback: it is not yet wired to `context.sellPreview.reel`'s HLS
+   * manifest. These props describe the authored copy either way.
+   */
+  previewTitle?: string;
+  previewSub?: string;
+  previewDuration?: number;
 }
 
 /** `proof` — testimonials; renders from context.testimonials. */
 export interface ProofSectionProps {
   eyebrow?: string;
   heading?: string;
+  /**
+   * The quiet aggregate trust line beside the testimonials ("2,400+ practising").
+   * `ProofSection` also accepts the legacy key `trust` for pages authored before
+   * this name settled, so both are declared.
+   */
+  trustLabel?: string;
+  trust?: string;
 }
 
 /** `guide` — the maker's bio. */
@@ -177,6 +212,8 @@ export interface GuideSectionProps {
   bio?: string[];
   portraitUrl?: string;
   credentials?: string[];
+  /** The pull-quote climax under the bio. Omitted entirely when absent. */
+  quote?: string;
 }
 
 /** One FAQ entry. */

--- a/apps/web/src/lib/remote/journeys.remote.ts
+++ b/apps/web/src/lib/remote/journeys.remote.ts
@@ -18,6 +18,7 @@ import {
   createJourneyBodySchema,
   saveCurriculumBodySchema,
   saveJourneyPageBodySchema,
+  updateJourneyOfferBodySchema,
 } from '@codex/validation';
 import { error } from '@sveltejs/kit';
 import { z } from 'zod';
@@ -35,6 +36,7 @@ import type {
 } from '$lib/page-builder';
 import type { SellPreview } from '$lib/page-builder/render';
 import { createServerApi } from '$lib/server/api';
+import { ApiError } from '$lib/server/errors';
 import { persistPracticeCompletion } from '$lib/server/journeys/round-d-seam';
 import { getSubdomainContext } from '$lib/utils/subdomain';
 
@@ -287,6 +289,50 @@ export const saveJourneyPage = command(
       error(400, 'Journeys can only be saved within an organization');
     }
     await ctx.api.access.saveJourneyPage(ctx.orgId, record);
+  }
+);
+
+/**
+ * Set the journey's ways-in + prices (pence, GBP) — the pricing panel's write.
+ * Distinct from {@link saveJourneyPage}: the worker persists the offer AND the
+ * authoritative `courses.price_cents` in one transaction, so a price change makes
+ * the journey buyable without republishing the page body.
+ */
+export const updateJourneyOffer = command(
+  z.object({
+    pageId: z.string().uuid(),
+    offer: updateJourneyOfferBodySchema,
+  }),
+  async ({ pageId, offer }) => {
+    const ctx = await resolveStudioOrg();
+    if (!ctx) {
+      error(400, 'Journey pricing can only be set within an organization');
+    }
+    try {
+      // `command()` infers a `.nullable()` field as OPTIONAL (the same quirk the
+      // save schema's slug comment documents), so the parsed prices arrive as
+      // `number | undefined`. The worker's `priceCentsSchema` is nullable but NOT
+      // optional — an absent key 400s — so restore the explicit nulls here rather
+      // than let "no price" travel as a missing key.
+      return await ctx.api.access.updateJourneyOffer(ctx.orgId, pageId, {
+        tiersEnabled: offer.tiersEnabled,
+        subscriptionEnabled: offer.subscriptionEnabled,
+        subscriptionPriceCents: offer.subscriptionPriceCents ?? null,
+        oneOffEnabled: offer.oneOffEnabled,
+        oneOffPriceCents: offer.oneOffPriceCents ?? null,
+      });
+    } catch (err) {
+      // A 4xx here is the service's own pricing guidance ("Set a one-off price,
+      // or turn the one-off path off") — user-actionable, so forward it through
+      // `error()` where SvelteKit will deliver the text to the client toast. A
+      // bare throw would surface only a generic failure, which is how an
+      // unsellable offer could look like a mystery instead of a fixable mistake.
+      // 5xx is NOT forwarded: it may carry internals, so it propagates as-is.
+      if (ApiError.isApiError(err) && err.status >= 400 && err.status < 500) {
+        error(err.status, err.message);
+      }
+      throw err;
+    }
   }
 );
 

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -118,6 +118,7 @@ import type {
   JourneyCoursePage,
   JourneyListItem,
   JourneyPageRecord,
+  PageOffer,
 } from '$lib/page-builder';
 import type { SellPreview } from '$lib/page-builder/render';
 // Import local types that extend DB types with relations
@@ -1372,6 +1373,35 @@ export function createServerApi(
             record.id
           )}?organizationId=${encodeURIComponent(organizationId)}`,
           { method: 'PUT', body: JSON.stringify(record) }
+        ),
+
+      /**
+       * Set the journey's ways-in + prices (pence, GBP). The ONLY write path to a
+       * course's price — the worker persists the page's offer presentation and the
+       * authoritative `courses.price_cents` in one transaction, so the sales page
+       * and the checkout can never disagree about whether the journey is buyable.
+       * Separate from `saveJourneyPage` so a price change needs no republish.
+       */
+      updateJourneyOffer: (
+        organizationId: string,
+        pageId: string,
+        // The TOTAL offer bag (every path explicitly on/off). Declared inline
+        // rather than as `PageOffer` — whose fields are all optional for the
+        // render side — so a caller cannot omit a toggle and leave it ambiguous.
+        offer: {
+          tiersEnabled: boolean;
+          subscriptionEnabled: boolean;
+          subscriptionPriceCents: number | null;
+          oneOffEnabled: boolean;
+          oneOffPriceCents: number | null;
+        }
+      ) =>
+        request<PageOffer>(
+          'access',
+          `/api/journeys/studio/journeys/${encodeURIComponent(
+            pageId
+          )}/offer?organizationId=${encodeURIComponent(organizationId)}`,
+          { method: 'PATCH', body: JSON.stringify(offer) }
         ),
     },
 

--- a/apps/web/src/paraglide/messages/en.js
+++ b/apps/web/src/paraglide/messages/en.js
@@ -2367,6 +2367,54 @@ export const content_detail_more_from_creator = (params) => `More from ${params.
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
+export const content_detail_journey_part_of_kicker = () => `Part of a journey`
+
+
+/**
+ * @param {{ course: NonNullable<unknown> }} params
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const content_detail_journey_part_of_body = (params) => `This practice stands on its own — or arrives inside ${params.course}.`
+
+
+/**
+ * 
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const content_detail_journey_free_kicker = () => `If that lands`
+
+
+/**
+ * @param {{ course: NonNullable<unknown> }} params
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const content_detail_journey_free_title = (params) => `Keep going with ${params.course}`
+
+
+/**
+ * @param {{ course: NonNullable<unknown> }} params
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const content_detail_journey_free_body = (params) => `This practice is part of ${params.course}. Continue the whole path whenever you feel ready.`
+
+
+/**
+ * @param {{ course: NonNullable<unknown> }} params
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const content_detail_journey_see_journey = (params) => `See the ${params.course} journey`
+
+
+/**
+ * 
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
 export const studio_dashboard_title = () => `Dashboard`
 
 
@@ -9920,51 +9968,3 @@ export const email_payout_released_subject = () => `Your payout is on its way`
  */
 /* @__NO_SIDE_EFFECTS__ */
 export const email_payout_released_body = () => `Your pending earnings have been transferred to your Stripe account.`
-
-
-/**
- * 
- * @returns {string}
- */
-/* @__NO_SIDE_EFFECTS__ */
-export const content_detail_journey_part_of_kicker = () => `Part of a journey`
-
-
-/**
- * @param {{ course: NonNullable<unknown> }} params
- * @returns {string}
- */
-/* @__NO_SIDE_EFFECTS__ */
-export const content_detail_journey_part_of_body = (params) => `This practice stands on its own — or arrives inside ${params.course}.`
-
-
-/**
- * 
- * @returns {string}
- */
-/* @__NO_SIDE_EFFECTS__ */
-export const content_detail_journey_free_kicker = () => `If that lands`
-
-
-/**
- * @param {{ course: NonNullable<unknown> }} params
- * @returns {string}
- */
-/* @__NO_SIDE_EFFECTS__ */
-export const content_detail_journey_free_title = (params) => `Keep going with ${params.course}`
-
-
-/**
- * @param {{ course: NonNullable<unknown> }} params
- * @returns {string}
- */
-/* @__NO_SIDE_EFFECTS__ */
-export const content_detail_journey_free_body = (params) => `This practice is part of ${params.course}. Continue the whole path whenever you feel ready.`
-
-
-/**
- * @param {{ course: NonNullable<unknown> }} params
- * @returns {string}
- */
-/* @__NO_SIDE_EFFECTS__ */
-export const content_detail_journey_see_journey = (params) => `See the ${params.course} journey`

--- a/apps/web/src/routes/_org/[slug]/(space)/__tests__/page.server.test.ts
+++ b/apps/web/src/routes/_org/[slug]/(space)/__tests__/page.server.test.ts
@@ -21,6 +21,7 @@ const {
   getPublicCreatorsMock,
   getPublicStatsMock,
   listTiersMock,
+  listPublishedJourneysMock,
 } = vi.hoisted(() => ({
   getPublicContentMock: vi.fn(),
   getPublicCategoriesMock: vi.fn(),
@@ -28,6 +29,7 @@ const {
   getPublicCreatorsMock: vi.fn(),
   getPublicStatsMock: vi.fn(),
   listTiersMock: vi.fn(),
+  listPublishedJourneysMock: vi.fn(),
 }));
 
 vi.mock('$lib/remote/content.remote', () => ({
@@ -49,6 +51,15 @@ vi.mock('$lib/remote/org.remote', () => ({
 
 vi.mock('$lib/remote/subscription.remote', () => ({
   listTiers: listTiersMock,
+}));
+
+// The guided-journeys rail. This mock is not optional decoration: an UNMOCKED
+// remote `query()` resolves to SvelteKit's CLIENT implementation under vitest,
+// which dereferences `app.hooks.transport` — undefined outside a real client
+// runtime — so the load threw before returning and all six tests failed. Every
+// remote the load touches must be mocked here.
+vi.mock('$lib/remote/journeys.remote', () => ({
+  listPublishedJourneys: listPublishedJourneysMock,
 }));
 
 vi.mock('$lib/server/cache', () => ({
@@ -111,6 +122,7 @@ describe('org landing +page.server.ts — load shape', () => {
     });
     getPublicStatsMock.mockResolvedValue({ content: { total: 4 } });
     listTiersMock.mockResolvedValue([]);
+    listPublishedJourneysMock.mockResolvedValue([]);
   });
 
   it('awaits the catalogue fetch and returns it as allContent', async () => {

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -9,13 +9,15 @@
   outline+inspector for a single settings panel beside the canvas.
 
   It OWNS the `pageBuilder` store: open() on load → edit via rail/canvas → Save
-  (saveJourneyPageMock + markSaved) → close() on destroy. Every control mutates the
-  store; the canvas renders the store's pending draft directly, so edits are live.
+  (saveJourneyPage + updateJourneyOffer + markSaved) → close() on destroy. Every
+  control mutates the store; the canvas renders the store's pending draft directly,
+  so edits are live.
 
-  AGGRESSIVE-MODE MOCKS: `getJourneyForBuilderMock` / `saveJourneyPageMock` stand in
-  for the real remote fns; the conductor wires them after WP-2. Admin/owner gate
-  lives in +page.server.ts. Per-page brand overrides tint the canvas via the org
-  brand OKLCH layer (`data-org-brand` + brand vars on the canvas wrapper).
+  The remotes are REAL (`getJourneyForBuilder` / `saveJourneyPage` /
+  `updateJourneyOffer` — no mocks). Save drives two endpoints because pricing is a
+  separate resource from page copy; see `handleSave`. Admin/owner gate lives in
+  +page.server.ts. Per-page brand overrides tint the canvas via the org brand OKLCH
+  layer (`data-org-brand` + brand vars on the canvas wrapper).
 -->
 <script lang="ts">
   import { onDestroy } from 'svelte';
@@ -34,6 +36,7 @@
     getCourseCurriculum,
     getJourneyForBuilder,
     saveJourneyPage,
+    updateJourneyOffer,
   } from '$lib/remote/journeys.remote';
   import { pageBuilder } from '$lib/page-builder/page-builder-store.svelte';
   import type { JourneyStagePreview } from '$lib/page-builder/render-edit';
@@ -55,9 +58,10 @@
   // ones — the builder looked broken next to its own live page. Now reads the same
   // admin curriculum the two-pane editor uses.
   //
-  // `minutes` is 0 because `EditorPracticeView` carries no duration; the visible
-  // stats (practice counts, stage names/glosses, depth count) are all accurate,
-  // and the total-minutes cue reads 0 until durations reach this read model.
+  // `minutes` comes from the practice's linked media duration. It read a flat 0
+  // while `EditorPracticeView` carried no duration, so the map's "≈ N min in all"
+  // cue under-claimed every course; a written practice (or media with no probed
+  // duration) still contributes 0, which is the honest answer for it.
   const curriculumQuery = $derived(
     pageId ? getCourseCurriculum({ pageId }) : null
   );
@@ -69,7 +73,7 @@
       lessons: stage.practices.map((practice) => ({
         title: practice.title,
         type: practice.contentType,
-        minutes: 0,
+        minutes: Math.round((practice.durationSeconds ?? 0) / 60),
       })),
     }))
   );
@@ -160,6 +164,36 @@
     return parts.length ? parts.join(';') : undefined;
   });
 
+  /**
+   * Pull the human message out of a failed remote call. A `command()` that failed
+   * via SvelteKit's `error(status, message)` arrives as `{ body: { message } }`,
+   * NOT as `err.message` — reading only the latter is why a precise service
+   * message ("Set a one-off price…") shows up as a blank/generic failure.
+   */
+  function remoteErrorMessage(err: unknown): string | undefined {
+    if (err && typeof err === 'object' && 'body' in err) {
+      const body = (err as { body?: unknown }).body;
+      if (body && typeof body === 'object' && 'message' in body) {
+        const message = (body as { message?: unknown }).message;
+        if (typeof message === 'string' && message) return message;
+      }
+    }
+    return err instanceof Error && err.message ? err.message : undefined;
+  }
+
+  /**
+   * The page draft and the journey's OFFER are two resources with two endpoints —
+   * page copy via `saveJourneyPage`, pricing via `updateJourneyOffer` (which also
+   * writes the authoritative `courses.price_cents`). One Save button drives both so
+   * the creator has one mental model; `markSaved()` runs only once BOTH have
+   * landed, so a failed leg leaves the draft dirty and retryable.
+   *
+   * The page payload is built from NAMED fields rather than spread wholesale: the
+   * save schema is `.strict()`, so a stray key (`offer`, `organizationId`,
+   * `publishedAt`) must be a visible error here, not silently dropped server-side.
+   * That silent strip is exactly what made the pricing panel swallow input while
+   * reporting "Page saved".
+   */
   async function handleSave(): Promise<void> {
     const payload = pageBuilder.getSavePayload();
     const record = draftQuery?.current;
@@ -167,9 +201,47 @@
     saving = true;
     try {
       await saveJourneyPage({
-        ...record,
-        ...payload,
+        id: record.id,
+        pageType: payload.pageType,
+        slug: payload.slug,
+        title: payload.title,
+        status: payload.status,
+        subjectType: payload.subjectType,
+        subjectId: payload.subjectId,
+        brandOverrides: payload.brandOverrides,
+        sections: payload.sections,
       });
+
+      // Only when the offer actually changed — pricing is a commerce mutation
+      // under a `strict` rate limit, not something every copy edit should spend.
+      const offer = payload.offer;
+      if (offer && JSON.stringify(offer) !== JSON.stringify(pageBuilder.saved?.offer)) {
+        try {
+          await updateJourneyOffer({
+            pageId: record.id,
+            offer: {
+              tiersEnabled: offer.tiersEnabled ?? false,
+              subscriptionEnabled: offer.subscriptionEnabled ?? false,
+              subscriptionPriceCents: offer.subscriptionPriceCents ?? null,
+              oneOffEnabled: offer.oneOffEnabled ?? false,
+              oneOffPriceCents: offer.oneOffPriceCents ?? null,
+            },
+          });
+        } catch (err) {
+          // The page copy DID save; only pricing was refused (e.g. an enabled path
+          // with no price). Say exactly that — a bare "Failed to save page" would be
+          // false. `markSaved()` is skipped, so the draft stays dirty and a retry
+          // re-sends both legs.
+          const why = remoteErrorMessage(err);
+          toast.error(
+            why
+              ? `Page saved, but the pricing was not: ${why}`
+              : 'Page saved, but the pricing could not be saved.'
+          );
+          return;
+        }
+      }
+
       pageBuilder.markSaved();
       // The PUBLIC sales load `depends('cache:versions')` precisely so a save can
       // mark it stale; without this the client reuses its cached load data and the

--- a/packages/access/src/services/__tests__/course-curriculum-editor.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-curriculum-editor.integration.test.ts
@@ -27,6 +27,7 @@ import {
   courseStages,
   courses,
   landingPages,
+  mediaItems,
   organizations,
   stagePractices,
 } from '@codex/database/schema';
@@ -268,6 +269,72 @@ describe('CourseJourneyService curriculum editor (Codex-03cwh)', () => {
         contentType: 'written',
         status: 'draft',
         sortOrder: 1,
+      });
+    });
+
+    it('projects the linked media duration (and null for a practice with no media)', async () => {
+      // The builder map's "≈ N min in all" cue read a flat 0 while
+      // `EditorPracticeView` carried no duration, under-claiming every course.
+      const courseId = await createCourse(db, orgAId, creatorId);
+
+      // `status: 'ready'` is guarded by the `status_ready_requires_keys` CHECK, so
+      // the HLS master + thumbnail keys are supplied too — a real ready video.
+      const mediaKey = randomUUID();
+      const [media] = await db
+        .insert(mediaItems)
+        .values({
+          creatorId,
+          title: 'Womb Awakening Movement',
+          mediaType: 'video',
+          status: 'ready',
+          r2Key: `originals/${mediaKey}/video.mp4`,
+          hlsMasterPlaylistKey: `hls/${mediaKey}/master.m3u8`,
+          thumbnailKey: `thumbnails/${mediaKey}/thumb.jpg`,
+          durationSeconds: 420,
+        })
+        .returning({ id: mediaItems.id });
+      if (!media) throw new Error('failed to create media item');
+
+      const [withMedia] = await db
+        .insert(content)
+        .values(
+          createTestContentInput(creatorId, {
+            organizationId: orgAId,
+            status: 'published',
+            contentType: 'video',
+            mediaItemId: media.id,
+          })
+        )
+        .returning({ id: content.id });
+      if (!withMedia) throw new Error('failed to create content');
+
+      // A written practice links NO media — 0 minutes is the honest answer.
+      const writtenId = await createContent(db, {
+        creatorId,
+        orgId: orgAId,
+        contentType: 'written',
+      });
+
+      const stage = await seedStage(db, courseId, {
+        name: 'Arriving',
+        sortOrder: 0,
+      });
+      await seedPractice(db, stage, withMedia.id, 0);
+      await seedPractice(db, stage, writtenId, 1);
+
+      const result = await service.getCourseCurriculumForEditor(
+        orgAId,
+        courseId
+      );
+      const practices = result.stages[0]?.practices ?? [];
+
+      expect(practices[0]).toMatchObject({
+        contentId: withMedia.id,
+        durationSeconds: 420,
+      });
+      expect(practices[1]).toMatchObject({
+        contentId: writtenId,
+        durationSeconds: null,
       });
     });
 

--- a/packages/access/src/services/__tests__/course-journey-offer.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-journey-offer.integration.test.ts
@@ -1,0 +1,377 @@
+/**
+ * CourseJourneyService.updateJourneyOffer — the journey PRICING write path.
+ *
+ * Runs against live Postgres so the two-row transaction is exercised for real.
+ * This method is the ONLY write path to `courses.price_cents`, the column
+ * `deriveCheckoutOffers` reads; before it existed a creator could type a price in
+ * the builder, be told "Page saved", and still see "isn't open for enrolment just
+ * now" at checkout, because nothing ever wrote the column.
+ *
+ * The invariants under test:
+ *   1. A course page's offer AND its authoritative `courses.price_cents` move
+ *      together — the page can never advertise a price the checkout cannot read.
+ *   2. Disabling the one-off path nulls `price_cents` ("not sold standalone", §5).
+ *   3. An ENABLED path with no price is REFUSED, not persisted as unsellable.
+ *   4. A foreign / soft-deleted page is `NotFoundError` — never a cross-org write.
+ *   5. A soft-deleted subject course rolls the whole thing back, rather than
+ *      leaving an offer bag claiming a price no course row carries.
+ *
+ * Falsifiability: every assertion re-reads the persisted rows, so dropping any
+ * clause of the scope, the price mirror, or a guard fails the test.
+ */
+
+import { courses, landingPages, organizations } from '@codex/database/schema';
+import { NotFoundError, ValidationError } from '@codex/service-errors';
+import {
+  createUniqueSlug,
+  type Database,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from '@codex/test-utils';
+import { and, eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { CourseJourneyService } from '../course-journey-service';
+
+/** A TOTAL offer bag — every path explicitly on or off (the validated shape). */
+function offerBag(
+  overrides: Partial<{
+    tiersEnabled: boolean;
+    subscriptionEnabled: boolean;
+    subscriptionPriceCents: number | null;
+    oneOffEnabled: boolean;
+    oneOffPriceCents: number | null;
+  }> = {}
+) {
+  return {
+    tiersEnabled: false,
+    subscriptionEnabled: false,
+    subscriptionPriceCents: null,
+    oneOffEnabled: false,
+    oneOffPriceCents: null,
+    ...overrides,
+  };
+}
+
+describe('CourseJourneyService.updateJourneyOffer (journey pricing write path)', () => {
+  let db: Database;
+  let svc: CourseJourneyService;
+  let creatorId: string;
+  let orgAId: string;
+  let orgBId: string;
+
+  /** Course page in org A, with a live subject course. */
+  let pageId: string;
+  let courseId: string;
+  /** Plain (non-course) landing page in org A — no subject to price. */
+  let landingPageId: string;
+  /** Course page in org A whose subject course is SOFT-DELETED. */
+  let orphanPageId: string;
+  /** Course page in org B — org A must never be able to price it. */
+  let foreignPageId: string;
+  /** Soft-deleted course page in org A. */
+  let deletedPageId: string;
+
+  async function seedCoursePage(
+    orgId: string,
+    label: string,
+    opts: { courseDeleted?: boolean; pageDeleted?: boolean } = {}
+  ): Promise<{ pageId: string; courseId: string }> {
+    const [course] = await db
+      .insert(courses)
+      .values({
+        organizationId: orgId,
+        creatorId,
+        slug: createUniqueSlug(`${label}-course`),
+        title: `${label} course`,
+        status: 'draft',
+        priceCents: null,
+        ...(opts.courseDeleted ? { deletedAt: new Date() } : {}),
+      })
+      .returning({ id: courses.id });
+    if (!course) throw new Error(`failed to seed course for ${label}`);
+
+    const [page] = await db
+      .insert(landingPages)
+      .values({
+        organizationId: orgId,
+        creatorId,
+        pageType: 'course',
+        slug: createUniqueSlug(`${label}-page`),
+        title: `${label} page`,
+        status: 'draft',
+        subjectType: 'course',
+        subjectId: course.id,
+        sections: [],
+        ...(opts.pageDeleted ? { deletedAt: new Date() } : {}),
+      })
+      .returning({ id: landingPages.id });
+    if (!page) throw new Error(`failed to seed page for ${label}`);
+
+    return { pageId: page.id, courseId: course.id };
+  }
+
+  async function readPersisted(id: string) {
+    const [row] = await db
+      .select({ offer: landingPages.offer, subjectId: landingPages.subjectId })
+      .from(landingPages)
+      .where(eq(landingPages.id, id))
+      .limit(1);
+    return row;
+  }
+
+  async function readPrice(id: string): Promise<number | null | undefined> {
+    const [row] = await db
+      .select({ priceCents: courses.priceCents })
+      .from(courses)
+      .where(eq(courses.id, id))
+      .limit(1);
+    return row?.priceCents;
+  }
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    svc = new CourseJourneyService({ db, environment: 'test' });
+    [creatorId] = await seedTestUsers(db, 1);
+
+    const [orgA] = await db
+      .insert(organizations)
+      .values({ name: 'Offer Org A', slug: createUniqueSlug('offer-a') })
+      .returning({ id: organizations.id });
+    const [orgB] = await db
+      .insert(organizations)
+      .values({ name: 'Offer Org B', slug: createUniqueSlug('offer-b') })
+      .returning({ id: organizations.id });
+    if (!orgA || !orgB) throw new Error('failed to create orgs');
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    ({ pageId, courseId } = await seedCoursePage(orgAId, 'live'));
+    ({ pageId: orphanPageId } = await seedCoursePage(orgAId, 'orphan', {
+      courseDeleted: true,
+    }));
+    ({ pageId: foreignPageId } = await seedCoursePage(orgBId, 'foreign'));
+    ({ pageId: deletedPageId } = await seedCoursePage(orgAId, 'gone', {
+      pageDeleted: true,
+    }));
+
+    const [plain] = await db
+      .insert(landingPages)
+      .values({
+        organizationId: orgAId,
+        creatorId,
+        pageType: 'landing',
+        slug: createUniqueSlug('plain-page'),
+        title: 'Plain landing page',
+        status: 'draft',
+        subjectType: null,
+        subjectId: null,
+        sections: [],
+      })
+      .returning({ id: landingPages.id });
+    if (!plain) throw new Error('failed to seed plain landing page');
+    landingPageId = plain.id;
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  it('writes the offer bag AND mirrors the one-off price onto courses.price_cents', async () => {
+    const returned = await svc.updateJourneyOffer(
+      orgAId,
+      pageId,
+      offerBag({
+        oneOffEnabled: true,
+        oneOffPriceCents: 1850,
+        tiersEnabled: true,
+      })
+    );
+
+    expect(returned.oneOffPriceCents).toBe(1850);
+    expect(await readPrice(courseId)).toBe(1850);
+
+    const row = await readPersisted(pageId);
+    expect(row?.offer).toEqual(
+      offerBag({
+        oneOffEnabled: true,
+        oneOffPriceCents: 1850,
+        tiersEnabled: true,
+      })
+    );
+  });
+
+  it('persists a total bag — every path explicitly on or off, never absent', async () => {
+    await svc.updateJourneyOffer(
+      orgAId,
+      pageId,
+      offerBag({
+        subscriptionEnabled: true,
+        subscriptionPriceCents: 1200,
+        oneOffEnabled: true,
+        oneOffPriceCents: 4900,
+      })
+    );
+
+    const row = await readPersisted(pageId);
+    // Reading the KEYS (not just values) is the point: a partial bag would make
+    // "off" and "never set" indistinguishable on the next load.
+    expect(Object.keys(row?.offer ?? {}).sort()).toEqual([
+      'oneOffEnabled',
+      'oneOffPriceCents',
+      'subscriptionEnabled',
+      'subscriptionPriceCents',
+      'tiersEnabled',
+    ]);
+    expect(await readPrice(courseId)).toBe(4900);
+  });
+
+  it('disabling the one-off path nulls price_cents (not sold standalone)', async () => {
+    await svc.updateJourneyOffer(
+      orgAId,
+      pageId,
+      offerBag({ oneOffEnabled: true, oneOffPriceCents: 4900 })
+    );
+    expect(await readPrice(courseId)).toBe(4900);
+
+    await svc.updateJourneyOffer(
+      orgAId,
+      pageId,
+      offerBag({ tiersEnabled: true })
+    );
+    expect(await readPrice(courseId)).toBeNull();
+  });
+
+  it('REFUSES an enabled one-off with no price, and writes nothing', async () => {
+    await svc.updateJourneyOffer(
+      orgAId,
+      pageId,
+      offerBag({ oneOffEnabled: true, oneOffPriceCents: 2500 })
+    );
+
+    await expect(
+      svc.updateJourneyOffer(
+        orgAId,
+        pageId,
+        offerBag({ oneOffEnabled: true, oneOffPriceCents: null })
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+
+    // The prior good state must survive — a refusal is not a partial write.
+    expect(await readPrice(courseId)).toBe(2500);
+  });
+
+  it('REFUSES an enabled course subscription with no price', async () => {
+    await expect(
+      svc.updateJourneyOffer(
+        orgAId,
+        pageId,
+        offerBag({ subscriptionEnabled: true, subscriptionPriceCents: null })
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('REFUSES a one-off on a plain landing page — no course to sell', async () => {
+    await expect(
+      svc.updateJourneyOffer(
+        orgAId,
+        landingPageId,
+        offerBag({ oneOffEnabled: true, oneOffPriceCents: 1000 })
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+
+    expect((await readPersisted(landingPageId))?.offer).toBeNull();
+  });
+
+  it('allows a non-purchase offer on a plain landing page', async () => {
+    await svc.updateJourneyOffer(
+      orgAId,
+      landingPageId,
+      offerBag({ tiersEnabled: true })
+    );
+    expect((await readPersisted(landingPageId))?.offer).toEqual(
+      offerBag({ tiersEnabled: true })
+    );
+  });
+
+  it('rolls back when the subject course is soft-deleted — no orphan price claim', async () => {
+    await expect(
+      svc.updateJourneyOffer(
+        orgAId,
+        orphanPageId,
+        offerBag({ oneOffEnabled: true, oneOffPriceCents: 3000 })
+      )
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    // The offer bag must NOT have been left behind by the rolled-back transaction.
+    expect((await readPersisted(orphanPageId))?.offer).toBeNull();
+  });
+
+  it('IDOR: another org cannot price this org’s journey', async () => {
+    await expect(
+      svc.updateJourneyOffer(
+        orgAId,
+        foreignPageId,
+        offerBag({ oneOffEnabled: true, oneOffPriceCents: 100 })
+      )
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect((await readPersisted(foreignPageId))?.offer).toBeNull();
+  });
+
+  it('a soft-deleted page is NotFoundError', async () => {
+    await expect(
+      svc.updateJourneyOffer(
+        orgAId,
+        deletedPageId,
+        offerBag({ tiersEnabled: true })
+      )
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect((await readPersisted(deletedPageId))?.offer).toBeNull();
+  });
+
+  it('getJourneyForBuilder round-trips the persisted offer', async () => {
+    await svc.updateJourneyOffer(
+      orgAId,
+      pageId,
+      offerBag({ oneOffEnabled: true, oneOffPriceCents: 777 })
+    );
+
+    const draft = await svc.getJourneyForBuilder(orgAId, pageId);
+    expect(draft?.offer).toEqual(
+      offerBag({ oneOffEnabled: true, oneOffPriceCents: 777 })
+    );
+  });
+
+  it('a never-priced page loads with NO offer key, not a fabricated one', async () => {
+    const { pageId: freshPageId } = await seedCoursePage(orgAId, 'fresh');
+    const draft = await svc.getJourneyForBuilder(orgAId, freshPageId);
+    expect(draft).not.toBeNull();
+    expect('offer' in (draft ?? {})).toBe(false);
+  });
+
+  it('scopes the price write to the org — a same-id course in another org is untouched', async () => {
+    // Guards the `courses` UPDATE's org clause: without it, a page could drive a
+    // price onto a row that merely shares the subject id space.
+    const { pageId: bPageId, courseId: bCourseId } = await seedCoursePage(
+      orgBId,
+      'b-live'
+    );
+    await svc.updateJourneyOffer(
+      orgBId,
+      bPageId,
+      offerBag({ oneOffEnabled: true, oneOffPriceCents: 999 })
+    );
+
+    expect(await readPrice(bCourseId)).toBe(999);
+
+    // Org A's course keeps whatever the earlier cases left it at — never 999.
+    const [aCourse] = await db
+      .select({ priceCents: courses.priceCents })
+      .from(courses)
+      .where(and(eq(courses.id, courseId), eq(courses.organizationId, orgAId)))
+      .limit(1);
+    expect(aCourse?.priceCents).not.toBe(999);
+  });
+});

--- a/packages/access/src/services/course-journey-service.ts
+++ b/packages/access/src/services/course-journey-service.ts
@@ -71,6 +71,7 @@ import type {
   JourneyStage,
   JourneyStageView,
   JourneyTestimonialView,
+  PageOffer,
   PageSection,
   PageStatus,
   PlaylistEntry,
@@ -1175,6 +1176,7 @@ export class CourseJourneyService extends BaseService {
           subjectId: landingPages.subjectId,
           brandOverrides: landingPages.brandOverrides,
           sections: landingPages.sections,
+          offer: landingPages.offer,
         })
         .from(landingPages)
         .where(
@@ -1199,6 +1201,9 @@ export class CourseJourneyService extends BaseService {
         subjectId: row.subjectId,
         brandOverrides: (row.brandOverrides as BrandTokenOverrides) ?? null,
         sections: (row.sections as PageSection[]) ?? [],
+        // `offer` is optional on the draft; an unpriced page has no bag yet, so
+        // the pricing panel opens with every path off rather than a stale guess.
+        ...(row.offer ? { offer: row.offer as PageOffer } : {}),
       };
     } catch (error) {
       this.handleError(error, 'getJourneyForBuilder');
@@ -1433,6 +1438,131 @@ export class CourseJourneyService extends BaseService {
       });
     } catch (error) {
       this.handleError(error, 'saveJourneyPage');
+    }
+  }
+
+  /**
+   * Persist the journey's OFFER — which ways-in the sales page presents and what
+   * they cost (pence, GBP). This is the ONLY write path to a course's price.
+   *
+   * Two rows move together in ONE transaction, and that pairing is the point:
+   *   - `landing_pages.offer` — the page's PRESENTATION of the ways-in (which
+   *     toggles are on, the teaser prices the sell page shows).
+   *   - `courses.price_cents` — the AUTHORITATIVE one-off price. It is what
+   *     `deriveCheckoutOffers` reads, so a journey whose page says "£12 one-off"
+   *     while this column is NULL renders "not open for enrolment just now".
+   *     Writing them apart is what allowed that divergence, hence one transaction.
+   *
+   * Turning the one-off path OFF nulls `price_cents` — "not sold standalone" (§5),
+   * the same state a never-priced course is in.
+   *
+   * Scoped to `(pageId, organizationId, deletedAt IS NULL)` — a foreign or missing
+   * page throws `NotFoundError`, never a silent cross-org write (mirrors
+   * {@link saveJourneyPage}'s guard). The subject course is re-checked inside the
+   * transaction: a soft-deleted or foreign course would make the price update
+   * match zero rows, re-opening the very divergence this method closes, so it
+   * throws instead.
+   *
+   * @returns the persisted offer (the caller's saved baseline).
+   */
+  async updateJourneyOffer(
+    organizationId: string,
+    pageId: string,
+    // Declared inline (not `PageOffer`) because the persisted bag is TOTAL —
+    // every path explicitly on or off — while `PageOffer`'s fields are all
+    // optional for the render side. The validated body satisfies this.
+    offer: {
+      tiersEnabled: boolean;
+      subscriptionEnabled: boolean;
+      subscriptionPriceCents: number | null;
+      oneOffEnabled: boolean;
+      oneOffPriceCents: number | null;
+    }
+  ): Promise<PageOffer> {
+    try {
+      // An ENABLED path with no price is the silent-failure shape: the sales page
+      // advertises a way in that the checkout cannot price, so it shows nothing.
+      // Reject it at the boundary rather than persisting an unsellable offer.
+      if (offer.oneOffEnabled && offer.oneOffPriceCents === null) {
+        throw new ValidationError(
+          'Set a one-off price, or turn the one-off path off'
+        );
+      }
+      if (offer.subscriptionEnabled && offer.subscriptionPriceCents === null) {
+        throw new ValidationError(
+          'Set a monthly price, or turn the course subscription off'
+        );
+      }
+
+      return await this.txDb.transaction(async (tx) => {
+        const [existing] = await tx
+          .select({
+            id: landingPages.id,
+            subjectType: landingPages.subjectType,
+            subjectId: landingPages.subjectId,
+          })
+          .from(landingPages)
+          .where(
+            and(
+              eq(landingPages.id, pageId),
+              eq(landingPages.organizationId, organizationId),
+              isNull(landingPages.deletedAt)
+            )
+          )
+          .limit(1);
+
+        if (!existing) {
+          throw new NotFoundError('Journey page not found');
+        }
+
+        const isCoursePage =
+          existing.subjectType === 'course' && existing.subjectId !== null;
+
+        // A plain landing page has no course to sell, so a one-off purchase has
+        // nowhere authoritative to live. Fail loudly rather than persist a toggle
+        // no checkout can honour.
+        if (offer.oneOffEnabled && !isCoursePage) {
+          throw new ValidationError(
+            'Only a course journey can be sold as a one-off purchase'
+          );
+        }
+
+        await tx
+          .update(landingPages)
+          .set({ offer })
+          .where(
+            and(
+              eq(landingPages.id, pageId),
+              eq(landingPages.organizationId, organizationId)
+            )
+          );
+
+        if (isCoursePage && existing.subjectId) {
+          const updated = await tx
+            .update(courses)
+            .set({
+              priceCents: offer.oneOffEnabled ? offer.oneOffPriceCents : null,
+            })
+            .where(
+              and(
+                eq(courses.id, existing.subjectId),
+                eq(courses.organizationId, organizationId),
+                isNull(courses.deletedAt)
+              )
+            )
+            .returning({ id: courses.id });
+
+          // Zero rows ⇒ the subject course is gone or foreign. The offer bag
+          // would then claim a price the checkout can never read — roll back.
+          if (updated.length === 0) {
+            throw new NotFoundError('Journey course not found');
+          }
+        }
+
+        return offer;
+      });
+    } catch (error) {
+      this.handleError(error, 'updateJourneyOffer');
     }
   }
 
@@ -1731,6 +1861,7 @@ export class CourseJourneyService extends BaseService {
         status: content.status,
         thumbnailUrl: content.thumbnailUrl,
         mediaThumbnailKey: mediaItems.thumbnailKey,
+        mediaDurationSeconds: mediaItems.durationSeconds,
       })
       .from(stagePractices)
       .innerJoin(content, eq(content.id, stagePractices.contentId))
@@ -1753,6 +1884,9 @@ export class CourseJourneyService extends BaseService {
         contentType: toPracticeContentType(row.contentType),
         status: toPageStatus(row.status),
         thumbnailUrl: row.thumbnailUrl ?? row.mediaThumbnailKey ?? null,
+        // From the already-joined media item — null for a written practice, or
+        // media whose duration was never probed.
+        durationSeconds: row.mediaDurationSeconds ?? null,
         sortOrder: row.sortOrder,
       };
       const list = byStage.get(row.stageId);

--- a/packages/admin/src/services/analytics-service.ts
+++ b/packages/admin/src/services/analytics-service.ts
@@ -565,10 +565,17 @@ export class AdminAnalyticsService extends BaseService {
       const effectiveStart = options?.startDate ?? defaultStart;
       const effectiveEnd = options?.endDate ?? new Date();
 
+      // Correlates on `content.id`, NOT `purchases.contentId`. The two are equal
+      // through the inner join, but only `content.id` is in the GROUP BY — and a
+      // correlated subquery may reference only grouped columns, so the
+      // `purchases.contentId` form made Postgres reject the whole statement with
+      // "subquery uses ungrouped column". That regressed when WP-6 moved the
+      // SELECT/GROUP BY to `content.id` (purchases.contentId became nullable for
+      // course purchases) and left this correlation behind.
       const viewsInPeriod = sql<number>`(
         SELECT COUNT(DISTINCT ${schema.videoPlayback.userId})::int
         FROM ${schema.videoPlayback}
-        WHERE ${schema.videoPlayback.contentId} = ${schema.purchases.contentId}
+        WHERE ${schema.videoPlayback.contentId} = ${schema.content.id}
           AND ${schema.videoPlayback.updatedAt} >= ${effectiveStart}
           AND ${schema.videoPlayback.updatedAt} <= ${effectiveEnd}
       )::int`;

--- a/packages/database/src/migrations/0081_opposite_natasha_romanoff.sql
+++ b/packages/database/src/migrations/0081_opposite_natasha_romanoff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "landing_pages" ADD COLUMN "offer" jsonb;

--- a/packages/database/src/migrations/meta/0081_snapshot.json
+++ b/packages/database/src/migrations/meta/0081_snapshot.json
@@ -1,0 +1,9076 @@
+{
+  "id": "f1076954-1128-4844-8814-87f2edf906cb",
+  "prevId": "cbe75739-fd58-4097-9b15-eb6912b92f13",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_username": {
+          "name": "idx_unique_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_users_stripe_customer_id": {
+          "name": "idx_unique_users_stripe_customer_id",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"stripe_customer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_key": {
+          "name": "cover_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_categories_org_id": {
+          "name": "idx_categories_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_creator_id": {
+          "name": "idx_categories_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_category_slug_per_org": {
+          "name": "idx_unique_category_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"categories\".\"organization_id\" IS NOT NULL AND \"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_category_slug_personal": {
+          "name": "idx_unique_category_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"categories\".\"organization_id\" IS NULL AND \"categories\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_organization_id_organizations_id_fk": {
+          "name": "categories_organization_id_organizations_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "categories_creator_id_users_id_fk": {
+          "name": "categories_creator_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_categories": {
+      "name": "content_categories",
+      "schema": "",
+      "columns": {
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_content_categories_category_id": {
+          "name": "idx_content_categories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_categories_content_id": {
+          "name": "idx_content_categories_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_categories_content_id_content_id_fk": {
+          "name": "content_categories_content_id_content_id_fk",
+          "tableFrom": "content_categories",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_categories_category_id_categories_id_fk": {
+          "name": "content_categories_category_id_categories_id_fk",
+          "tableFrom": "content_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "content_categories_content_id_category_id_pk": {
+          "name": "content_categories_content_id_category_id_pk",
+          "columns": [
+            "content_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body": {
+          "name": "content_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_body_json": {
+          "name": "content_body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "shader_preset": {
+          "name": "shader_preset",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shader_config": {
+          "name": "shader_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_purchasable": {
+          "name": "is_purchasable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_in_tier_id": {
+          "name": "included_in_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_only": {
+          "name": "course_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_follower_gated": {
+          "name": "is_follower_gated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_team_only": {
+          "name": "is_team_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_creator_id": {
+          "name": "idx_content_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_organization_id": {
+          "name": "idx_content_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_media_item_id": {
+          "name": "idx_content_media_item_id",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_slug_org": {
+          "name": "idx_content_slug_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_status": {
+          "name": "idx_content_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_published_at": {
+          "name": "idx_content_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_category": {
+          "name": "idx_content_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_included_in_tier": {
+          "name": "idx_content_included_in_tier",
+          "columns": [
+            {
+              "expression": "included_in_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_published": {
+          "name": "idx_content_org_published",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_creator_org_published": {
+          "name": "idx_content_creator_org_published",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_org_featured": {
+          "name": "idx_content_org_featured",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"content\".\"featured\" = true AND \"content\".\"status\" = 'published' AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_per_org": {
+          "name": "idx_unique_content_slug_per_org",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NOT NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_content_slug_personal": {
+          "name": "idx_unique_content_slug_personal",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content\".\"organization_id\" IS NULL AND \"content\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_creator_id_users_id_fk": {
+          "name": "content_creator_id_users_id_fk",
+          "tableFrom": "content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "content_organization_id_organizations_id_fk": {
+          "name": "content_organization_id_organizations_id_fk",
+          "tableFrom": "content",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_media_item_id_media_items_id_fk": {
+          "name": "content_media_item_id_media_items_id_fk",
+          "tableFrom": "content",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_included_in_tier_id_subscription_tiers_id_fk": {
+          "name": "content_included_in_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "content",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "included_in_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_content_status": {
+          "name": "check_content_status",
+          "value": "\"content\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_content_type": {
+          "name": "check_content_type",
+          "value": "\"content\".\"content_type\" IN ('video', 'audio', 'written')"
+        },
+        "check_price_non_negative": {
+          "name": "check_price_non_negative",
+          "value": "\"content\".\"price_cents\" IS NULL OR \"content\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_master_playlist_key": {
+          "name": "hls_master_playlist_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hls_preview_key": {
+          "name": "hls_preview_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_key": {
+          "name": "waveform_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waveform_image_key": {
+          "name": "waveform_image_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runpod_job_id": {
+          "name": "runpod_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_error": {
+          "name": "transcoding_error",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_attempts": {
+          "name": "transcoding_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transcoding_priority": {
+          "name": "transcoding_priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "transcoding_progress": {
+          "name": "transcoding_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcoding_step": {
+          "name": "transcoding_step",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_key": {
+          "name": "mezzanine_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mezzanine_status": {
+          "name": "mezzanine_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_variants": {
+          "name": "ready_variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_integrated": {
+          "name": "loudness_integrated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_peak": {
+          "name": "loudness_peak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_range": {
+          "name": "loudness_range",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_creator_id": {
+          "name": "idx_media_items_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_status": {
+          "name": "idx_media_items_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_type": {
+          "name": "idx_media_items_type",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_runpod_job_id": {
+          "name": "idx_media_items_runpod_job_id",
+          "columns": [
+            {
+              "expression": "runpod_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_items_transcoding_status": {
+          "name": "idx_media_items_transcoding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcoding_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_items_creator_id_users_id_fk": {
+          "name": "media_items_creator_id_users_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_media_status": {
+          "name": "check_media_status",
+          "value": "\"media_items\".\"status\" IN ('uploading', 'uploaded', 'transcoding', 'ready', 'failed')"
+        },
+        "check_media_type": {
+          "name": "check_media_type",
+          "value": "\"media_items\".\"media_type\" IN ('video', 'audio')"
+        },
+        "check_mezzanine_status": {
+          "name": "check_mezzanine_status",
+          "value": "\"media_items\".\"mezzanine_status\" IS NULL OR \"media_items\".\"mezzanine_status\" IN ('pending', 'processing', 'ready', 'failed')"
+        },
+        "check_transcoding_priority": {
+          "name": "check_transcoding_priority",
+          "value": "\"media_items\".\"transcoding_priority\" >= 0 AND \"media_items\".\"transcoding_priority\" <= 4"
+        },
+        "check_max_transcoding_attempts": {
+          "name": "check_max_transcoding_attempts",
+          "value": "\"media_items\".\"transcoding_attempts\" >= 0 AND \"media_items\".\"transcoding_attempts\" <= 3"
+        },
+        "check_transcoding_progress_range": {
+          "name": "check_transcoding_progress_range",
+          "value": "\"media_items\".\"transcoding_progress\" IS NULL OR (\"media_items\".\"transcoding_progress\" >= 0 AND \"media_items\".\"transcoding_progress\" <= 100)"
+        },
+        "status_ready_requires_keys": {
+          "name": "status_ready_requires_keys",
+          "value": "\"media_items\".\"status\" != 'ready' OR (\n        \"media_items\".\"hls_master_playlist_key\" IS NOT NULL\n        AND \"media_items\".\"duration_seconds\" IS NOT NULL\n        AND (\n          (\"media_items\".\"media_type\" = 'video' AND \"media_items\".\"thumbnail_key\" IS NOT NULL)\n          OR (\"media_items\".\"media_type\" = 'audio' AND \"media_items\".\"waveform_key\" IS NOT NULL)\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_membership": {
+          "name": "idx_unique_org_membership",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_id": {
+          "name": "idx_org_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_user_id": {
+          "name": "idx_org_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_role": {
+          "name": "idx_org_memberships_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_status": {
+          "name": "idx_org_memberships_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_memberships_org_active_role": {
+          "name": "idx_org_memberships_org_active_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organization_memberships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_invited_by_users_id_fk": {
+          "name": "organization_memberships_invited_by_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_membership_role": {
+          "name": "check_membership_role",
+          "value": "\"organization_memberships\".\"role\" IN ('owner', 'admin', 'creator', 'subscriber', 'member')"
+        },
+        "check_membership_status": {
+          "name": "check_membership_status",
+          "value": "\"organization_memberships\".\"status\" IN ('active', 'inactive', 'invited')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.course_subscription_plans": {
+      "name": "course_subscription_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_sub_plans_course_id": {
+          "name": "idx_course_sub_plans_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_course_sub_plans_course": {
+          "name": "uq_course_sub_plans_course",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_subscription_plans\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_subscription_plans_course_id_courses_id_fk": {
+          "name": "course_subscription_plans_course_id_courses_id_fk",
+          "tableFrom": "course_subscription_plans",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_course_plan_price_monthly": {
+          "name": "check_course_plan_price_monthly",
+          "value": "\"course_subscription_plans\".\"price_monthly\" >= 0"
+        },
+        "check_course_plan_price_annual": {
+          "name": "check_course_plan_price_annual",
+          "value": "\"course_subscription_plans\".\"price_annual\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.course_subscriptions": {
+      "name": "course_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_course_subscriptions_user_id": {
+          "name": "idx_course_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_subscriptions_course_id": {
+          "name": "idx_course_subscriptions_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_subscriptions_plan_id": {
+          "name": "idx_course_subscriptions_plan_id",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_subscriptions_stripe_id": {
+          "name": "idx_course_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_course_subscription_per_user_course": {
+          "name": "uq_active_course_subscription_per_user_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_subscriptions_user_id_users_id_fk": {
+          "name": "course_subscriptions_user_id_users_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_subscriptions_course_id_courses_id_fk": {
+          "name": "course_subscriptions_course_id_courses_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_subscriptions_plan_id_course_subscription_plans_id_fk": {
+          "name": "course_subscriptions_plan_id_course_subscription_plans_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "course_subscription_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "course_subscriptions_organization_id_organizations_id_fk": {
+          "name": "course_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "course_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course_subscriptions_stripe_subscription_id_unique": {
+          "name": "course_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_course_subscription_status": {
+          "name": "check_course_subscription_status",
+          "value": "\"course_subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_course_subscription_billing_interval": {
+          "name": "check_course_subscription_billing_interval",
+          "value": "\"course_subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.course_tier_access": {
+      "name": "course_tier_access",
+      "schema": "",
+      "columns": {
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_course_tier_access_tier_id": {
+          "name": "idx_course_tier_access_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_tier_access_org_id": {
+          "name": "idx_course_tier_access_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_course_tier_access_course_org": {
+          "name": "fk_course_tier_access_course_org",
+          "tableFrom": "course_tier_access",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_course_tier_access_tier_org": {
+          "name": "fk_course_tier_access_tier_org",
+          "tableFrom": "course_tier_access",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_tier_access_course_id_tier_id_pk": {
+          "name": "course_tier_access_course_id_tier_id_pk",
+          "columns": [
+            "course_id",
+            "tier_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_enrollments": {
+      "name": "course_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_course_enrollments_user_id": {
+          "name": "idx_course_enrollments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_course_enrollments_course_id": {
+          "name": "idx_course_enrollments_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_course_enrollment_user_course": {
+          "name": "uq_course_enrollment_user_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_enrollments_user_id_users_id_fk": {
+          "name": "course_enrollments_user_id_users_id_fk",
+          "tableFrom": "course_enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_enrollments_course_id_courses_id_fk": {
+          "name": "course_enrollments_course_id_courses_id_fk",
+          "tableFrom": "course_enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_completions": {
+      "name": "practice_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_practice_completions_user_id": {
+          "name": "idx_practice_completions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_practice_completions_content_id": {
+          "name": "idx_practice_completions_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_practice_completion_user_content": {
+          "name": "uq_practice_completion_user_content",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_completions_user_id_users_id_fk": {
+          "name": "practice_completions_user_id_users_id_fk",
+          "tableFrom": "practice_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_completions_content_id_content_id_fk": {
+          "name": "practice_completions_content_id_content_id_fk",
+          "tableFrom": "practice_completions",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_practice_completion_source": {
+          "name": "check_practice_completion_source",
+          "value": "\"practice_completions\".\"source\" IN ('manual', 'auto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_onboarding": {
+      "name": "creator_onboarding",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'essentials'"
+        },
+        "welcome_seen_at": {
+          "name": "welcome_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creator_onboarding_user_id_users_id_fk": {
+          "name": "creator_onboarding_user_id_users_id_fk",
+          "tableFrom": "creator_onboarding",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agreement_proposals": {
+      "name": "agreement_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_proposal_id": {
+          "name": "parent_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by_role": {
+          "name": "proposed_by_role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_creator_share_percent": {
+          "name": "proposed_creator_share_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_term_months": {
+          "name": "proposed_term_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_effective_from": {
+          "name": "proposed_effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agreement_proposals_thread": {
+          "name": "idx_agreement_proposals_thread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_creator_status": {
+          "name": "idx_agreement_proposals_creator_status",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agreement_proposals_org_status": {
+          "name": "idx_agreement_proposals_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agreement_proposals_organization_id_organizations_id_fk": {
+          "name": "agreement_proposals_organization_id_organizations_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_creator_id_users_id_fk": {
+          "name": "agreement_proposals_creator_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk": {
+          "name": "agreement_proposals_parent_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "parent_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_proposed_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_proposed_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agreement_proposals_responded_by_user_id_users_id_fk": {
+          "name": "agreement_proposals_responded_by_user_id_users_id_fk",
+          "tableFrom": "agreement_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_agreement_proposals_revenue_type": {
+          "name": "check_agreement_proposals_revenue_type",
+          "value": "\"agreement_proposals\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_agreement_proposals_proposed_by_role": {
+          "name": "check_agreement_proposals_proposed_by_role",
+          "value": "\"agreement_proposals\".\"proposed_by_role\" IN ('owner', 'creator')"
+        },
+        "check_agreement_proposals_status": {
+          "name": "check_agreement_proposals_status",
+          "value": "\"agreement_proposals\".\"status\" IN ('open', 'accepted', 'declined', 'countered', 'withdrawn', 'superseded')"
+        },
+        "check_agreement_proposals_share_bps": {
+          "name": "check_agreement_proposals_share_bps",
+          "value": "\"agreement_proposals\".\"proposed_creator_share_percent\" >= 0 AND \"agreement_proposals\".\"proposed_creator_share_percent\" <= 10000"
+        },
+        "check_agreement_proposals_round_positive": {
+          "name": "check_agreement_proposals_round_positive",
+          "value": "\"agreement_proposals\".\"round_number\" >= 1"
+        },
+        "check_agreement_proposals_term_positive": {
+          "name": "check_agreement_proposals_term_positive",
+          "value": "\"agreement_proposals\".\"proposed_term_months\" IS NULL OR \"agreement_proposals\".\"proposed_term_months\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_access": {
+      "name": "content_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_content_access_user_id": {
+          "name": "idx_content_access_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_content_id": {
+          "name": "idx_content_access_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_access_organization_id": {
+          "name": "idx_content_access_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_access_user_id_users_id_fk": {
+          "name": "content_access_user_id_users_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_content_id_content_id_fk": {
+          "name": "content_access_content_id_content_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_access_organization_id_organizations_id_fk": {
+          "name": "content_access_organization_id_organizations_id_fk",
+          "tableFrom": "content_access",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_access_user_content_unique": {
+          "name": "content_access_user_content_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_access_type": {
+          "name": "check_access_type",
+          "value": "\"content_access\".\"access_type\" IN ('purchased', 'subscription', 'complimentary', 'preview')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.creator_organization_agreements": {
+      "name": "creator_organization_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_fee_percentage": {
+          "name": "organization_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenue_type": {
+          "name": "revenue_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_by_user_id": {
+          "name": "terminated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_proposal_id": {
+          "name": "current_proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiring_soon_email_sent_at": {
+          "name": "expiring_soon_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_creator_org_agreement_creator_id": {
+          "name": "idx_creator_org_agreement_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_org_id": {
+          "name": "idx_creator_org_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_effective": {
+          "name": "idx_creator_org_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_creator_org_agreement_active_lookup": {
+          "name": "idx_creator_org_agreement_active_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_creator_org_agreement_active_per_type": {
+          "name": "uq_creator_org_agreement_active_per_type",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revenue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"creator_organization_agreements\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "creator_organization_agreements_creator_id_users_id_fk": {
+          "name": "creator_organization_agreements_creator_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_organization_id_organizations_id_fk": {
+          "name": "creator_organization_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_terminated_by_user_id_users_id_fk": {
+          "name": "creator_organization_agreements_terminated_by_user_id_users_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "terminated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk": {
+          "name": "creator_organization_agreements_current_proposal_id_agreement_proposals_id_fk",
+          "tableFrom": "creator_organization_agreements",
+          "tableTo": "agreement_proposals",
+          "columnsFrom": [
+            "current_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "creator_org_agreement_unique": {
+          "name": "creator_org_agreement_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "organization_id",
+            "effective_from",
+            "revenue_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_org_fee_percentage": {
+          "name": "check_org_fee_percentage",
+          "value": "\"creator_organization_agreements\".\"organization_fee_percentage\" >= 0 AND \"creator_organization_agreements\".\"organization_fee_percentage\" <= 10000"
+        },
+        "check_creator_org_agreement_revenue_type": {
+          "name": "check_creator_org_agreement_revenue_type",
+          "value": "\"creator_organization_agreements\".\"revenue_type\" IN ('subscription', 'content_purchase')"
+        },
+        "check_creator_org_agreement_status": {
+          "name": "check_creator_org_agreement_status",
+          "value": "\"creator_organization_agreements\".\"status\" IN ('active', 'terminated', 'expired')"
+        },
+        "check_creator_org_agreement_terminated_shape": {
+          "name": "check_creator_org_agreement_terminated_shape",
+          "value": "(\"creator_organization_agreements\".\"status\" = 'terminated') = (\"creator_organization_agreements\".\"terminated_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_platform_agreements": {
+      "name": "organization_platform_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_platform_agreement_org_id": {
+          "name": "idx_org_platform_agreement_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_platform_agreement_effective": {
+          "name": "idx_org_platform_agreement_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_platform_agreements_organization_id_organizations_id_fk": {
+          "name": "organization_platform_agreements_organization_id_organizations_id_fk",
+          "tableFrom": "organization_platform_agreements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percentage": {
+          "name": "check_org_platform_fee_percentage",
+          "value": "\"organization_platform_agreements\".\"platform_fee_percentage\" >= 0 AND \"organization_platform_agreements\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_fee_config": {
+      "name": "platform_fee_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_fee_config_effective": {
+          "name": "idx_platform_fee_config_effective",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_platform_fee_percentage": {
+          "name": "check_platform_fee_percentage",
+          "value": "\"platform_fee_config\".\"platform_fee_percentage\" >= 0 AND \"platform_fee_config\".\"platform_fee_percentage\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platform_agreement_id": {
+          "name": "platform_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_org_agreement_id": {
+          "name": "creator_org_agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount_cents": {
+          "name": "refund_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispute_reason": {
+          "name": "dispute_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_dispute_id": {
+          "name": "stripe_dispute_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_purchases_customer_id": {
+          "name": "idx_purchases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_content_id": {
+          "name": "idx_purchases_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_course_id": {
+          "name": "idx_purchases_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_organization_id": {
+          "name": "idx_purchases_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_stripe_payment_intent": {
+          "name": "idx_purchases_stripe_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_created_at": {
+          "name": "idx_purchases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_purchased_at": {
+          "name": "idx_purchases_purchased_at",
+          "columns": [
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_platform_agreement": {
+          "name": "idx_purchases_platform_agreement",
+          "columns": [
+            {
+              "expression": "platform_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_creator_org_agreement": {
+          "name": "idx_purchases_creator_org_agreement",
+          "columns": [
+            {
+              "expression": "creator_org_agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_purchased": {
+          "name": "idx_purchases_customer_purchased",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_customer_status_content": {
+          "name": "idx_purchases_customer_status_content",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_created": {
+          "name": "idx_purchases_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_purchases_org_status_purchased": {
+          "name": "idx_purchases_org_status_purchased",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purchased_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "purchases_customer_id_users_id_fk": {
+          "name": "purchases_customer_id_users_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchases_content_id_content_id_fk": {
+          "name": "purchases_content_id_content_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_course_id_courses_id_fk": {
+          "name": "purchases_course_id_courses_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_organization_id_organizations_id_fk": {
+          "name": "purchases_organization_id_organizations_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchases_platform_agreement_id_organization_platform_agreements_id_fk": {
+          "name": "purchases_platform_agreement_id_organization_platform_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "organization_platform_agreements",
+          "columnsFrom": [
+            "platform_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk": {
+          "name": "purchases_creator_org_agreement_id_creator_organization_agreements_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "creator_organization_agreements",
+          "columnsFrom": [
+            "creator_org_agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchases_stripe_payment_intent_id_unique": {
+          "name": "purchases_stripe_payment_intent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_payment_intent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_purchase_target_one": {
+          "name": "check_purchase_target_one",
+          "value": "(CASE WHEN \"purchases\".\"content_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"purchases\".\"course_id\" IS NULL THEN 0 ELSE 1 END) = 1"
+        },
+        "check_purchase_status": {
+          "name": "check_purchase_status",
+          "value": "\"purchases\".\"status\" IN ('pending', 'completed', 'refunded', 'failed')"
+        },
+        "check_amount_positive": {
+          "name": "check_amount_positive",
+          "value": "\"purchases\".\"amount_paid_cents\" >= 0"
+        },
+        "check_platform_fee_positive": {
+          "name": "check_platform_fee_positive",
+          "value": "\"purchases\".\"platform_fee_cents\" >= 0"
+        },
+        "check_org_fee_positive": {
+          "name": "check_org_fee_positive",
+          "value": "\"purchases\".\"organization_fee_cents\" >= 0"
+        },
+        "check_creator_payout_positive": {
+          "name": "check_creator_payout_positive",
+          "value": "\"purchases\".\"creator_payout_cents\" >= 0"
+        },
+        "check_revenue_split_equals_total": {
+          "name": "check_revenue_split_equals_total",
+          "value": "\"purchases\".\"amount_paid_cents\" = \"purchases\".\"platform_fee_cents\" + \"purchases\".\"organization_fee_cents\" + \"purchases\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_user_id": {
+          "name": "idx_entitlements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_org_id": {
+          "name": "idx_entitlements_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_content_id": {
+          "name": "idx_entitlements_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_course_id": {
+          "name": "idx_entitlements_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_user_content": {
+          "name": "idx_entitlements_user_content",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_user_course": {
+          "name": "idx_entitlements_user_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_entitlement_live_content": {
+          "name": "uq_entitlement_live_content",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"entitlements\".\"revoked_at\" IS NULL AND \"entitlements\".\"content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_entitlement_live_course": {
+          "name": "uq_entitlement_live_course",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"entitlements\".\"revoked_at\" IS NULL AND \"entitlements\".\"course_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_user_id_users_id_fk": {
+          "name": "entitlements_user_id_users_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_organization_id_organizations_id_fk": {
+          "name": "entitlements_organization_id_organizations_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_content_id_content_id_fk": {
+          "name": "entitlements_content_id_content_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_course_id_courses_id_fk": {
+          "name": "entitlements_course_id_courses_id_fk",
+          "tableFrom": "entitlements",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_entitlement_resource_one": {
+          "name": "check_entitlement_resource_one",
+          "value": "(CASE WHEN \"entitlements\".\"content_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"entitlements\".\"course_id\" IS NULL THEN 0 ELSE 1 END) = 1"
+        },
+        "check_entitlement_source": {
+          "name": "check_entitlement_source",
+          "value": "\"entitlements\".\"source\" IN ('content_purchase', 'course_purchase', 'course_subscription', 'grant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_audit_log": {
+      "name": "fee_config_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_org_id": {
+          "name": "scope_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_creator_id": {
+          "name": "scope_creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_config_audit_scope": {
+          "name": "idx_fee_config_audit_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_org": {
+          "name": "idx_fee_config_audit_org",
+          "columns": [
+            {
+              "expression": "scope_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_creator": {
+          "name": "idx_fee_config_audit_creator",
+          "columns": [
+            {
+              "expression": "scope_creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_audit_changed_by": {
+          "name": "idx_fee_config_audit_changed_by",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_audit_log_scope_org_id_organizations_id_fk": {
+          "name": "fee_config_audit_log_scope_org_id_organizations_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "scope_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_scope_creator_id_users_id_fk": {
+          "name": "fee_config_audit_log_scope_creator_id_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scope_creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fee_config_audit_log_changed_by_users_id_fk": {
+          "name": "fee_config_audit_log_changed_by_users_id_fk",
+          "tableFrom": "fee_config_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_audit_scope": {
+          "name": "check_fee_config_audit_scope",
+          "value": "\"fee_config_audit_log\".\"scope\" IN ('platform', 'org', 'override')"
+        },
+        "check_fee_config_audit_scope_org_id": {
+          "name": "check_fee_config_audit_scope_org_id",
+          "value": "(\"fee_config_audit_log\".\"scope\" = 'platform' AND \"fee_config_audit_log\".\"scope_org_id\" IS NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'org' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NULL)\n        OR (\"fee_config_audit_log\".\"scope\" = 'override' AND \"fee_config_audit_log\".\"scope_org_id\" IS NOT NULL AND \"fee_config_audit_log\".\"scope_creator_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org": {
+      "name": "fee_config_org",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_org_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_updated_by_users_id_fk": {
+          "name": "fee_config_org_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_org_platform_fee_percent_bps": {
+          "name": "check_org_platform_fee_percent_bps",
+          "value": "\"fee_config_org\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org\".\"platform_fee_percent\" >= 0 AND \"fee_config_org\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_org_org_fee_percent_bps": {
+          "name": "check_org_org_fee_percent_bps",
+          "value": "\"fee_config_org\".\"org_fee_percent\" IS NULL OR (\"fee_config_org\".\"org_fee_percent\" >= 0 AND \"fee_config_org\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_org_min_platform_fee_non_negative": {
+          "name": "check_org_min_platform_fee_non_negative",
+          "value": "\"fee_config_org\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_org_min_transfer_non_negative": {
+          "name": "check_org_min_transfer_non_negative",
+          "value": "\"fee_config_org\".\"min_transfer_cents\" IS NULL OR \"fee_config_org\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_org_creator": {
+      "name": "fee_config_org_creator",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_fee_percent": {
+          "name": "org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fee_config_org_creator_org": {
+          "name": "idx_fee_config_org_creator_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_config_org_creator_creator": {
+          "name": "idx_fee_config_org_creator_creator",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_config_org_creator_organization_id_organizations_id_fk": {
+          "name": "fee_config_org_creator_organization_id_organizations_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_creator_id_users_id_fk": {
+          "name": "fee_config_org_creator_creator_id_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fee_config_org_creator_updated_by_users_id_fk": {
+          "name": "fee_config_org_creator_updated_by_users_id_fk",
+          "tableFrom": "fee_config_org_creator",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fee_config_org_creator_pkey": {
+          "name": "fee_config_org_creator_pkey",
+          "columns": [
+            "organization_id",
+            "creator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_override_platform_fee_percent_bps": {
+          "name": "check_override_platform_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"platform_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"platform_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"platform_fee_percent\" <= 10000)"
+        },
+        "check_override_org_fee_percent_bps": {
+          "name": "check_override_org_fee_percent_bps",
+          "value": "\"fee_config_org_creator\".\"org_fee_percent\" IS NULL OR (\"fee_config_org_creator\".\"org_fee_percent\" >= 0 AND \"fee_config_org_creator\".\"org_fee_percent\" <= 10000)"
+        },
+        "check_override_min_platform_fee_non_negative": {
+          "name": "check_override_min_platform_fee_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_platform_fee_cents\" IS NULL OR \"fee_config_org_creator\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_override_min_transfer_non_negative": {
+          "name": "check_override_min_transfer_non_negative",
+          "value": "\"fee_config_org_creator\".\"min_transfer_cents\" IS NULL OR \"fee_config_org_creator\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fee_config_platform": {
+      "name": "fee_config_platform",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "platform_fee_percent": {
+          "name": "platform_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_org_fee_percent": {
+          "name": "subscription_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "one_off_org_fee_percent": {
+          "name": "one_off_org_fee_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_platform_fee_cents": {
+          "name": "min_platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_transfer_cents": {
+          "name": "min_transfer_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fee_config_platform_updated_by_users_id_fk": {
+          "name": "fee_config_platform_updated_by_users_id_fk",
+          "tableFrom": "fee_config_platform",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_fee_config_platform_singleton": {
+          "name": "check_fee_config_platform_singleton",
+          "value": "\"fee_config_platform\".\"id\" = 'singleton'"
+        },
+        "check_platform_fee_percent_bps": {
+          "name": "check_platform_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"platform_fee_percent\" >= 0 AND \"fee_config_platform\".\"platform_fee_percent\" <= 10000"
+        },
+        "check_subscription_org_fee_percent_bps": {
+          "name": "check_subscription_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"subscription_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"subscription_org_fee_percent\" <= 10000"
+        },
+        "check_one_off_org_fee_percent_bps": {
+          "name": "check_one_off_org_fee_percent_bps",
+          "value": "\"fee_config_platform\".\"one_off_org_fee_percent\" >= 0 AND \"fee_config_platform\".\"one_off_org_fee_percent\" <= 10000"
+        },
+        "check_min_platform_fee_non_negative": {
+          "name": "check_min_platform_fee_non_negative",
+          "value": "\"fee_config_platform\".\"min_platform_fee_cents\" >= 0"
+        },
+        "check_min_transfer_non_negative": {
+          "name": "check_min_transfer_non_negative",
+          "value": "\"fee_config_platform\".\"min_transfer_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_followers": {
+      "name": "organization_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_unique_org_follower": {
+          "name": "idx_unique_org_follower",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_org": {
+          "name": "idx_org_followers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_followers_user": {
+          "name": "idx_org_followers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_followers_organization_id_organizations_id_fk": {
+          "name": "organization_followers_organization_id_organizations_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_followers_user_id_users_id_fk": {
+          "name": "organization_followers_user_id_users_id_fk",
+          "tableFrom": "organization_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_stages": {
+      "name": "course_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss": {
+          "name": "gloss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_stages_course_id": {
+          "name": "idx_course_stages_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_course_stages_course_sort": {
+          "name": "uq_course_stages_course_sort",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course_stages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_stages_course_id_courses_id_fk": {
+          "name": "course_stages_course_id_courses_id_fk",
+          "tableFrom": "course_stages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_testimonials": {
+      "name": "course_testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_context": {
+          "name": "author_context",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_media_id": {
+          "name": "avatar_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_course_testimonials_course_id": {
+          "name": "idx_course_testimonials_course_id",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_testimonials_course_id_courses_id_fk": {
+          "name": "course_testimonials_course_id_courses_id_fk",
+          "tableFrom": "course_testimonials",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_testimonials_avatar_media_id_media_items_id_fk": {
+          "name": "course_testimonials_avatar_media_id_media_items_id_fk",
+          "tableFrom": "course_testimonials",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "avatar_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kicker": {
+          "name": "kicker",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lede": {
+          "name": "lede",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guide": {
+          "name": "guide",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_media_id": {
+          "name": "intro_video_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_video_media_id": {
+          "name": "preview_video_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guide_video_media_id": {
+          "name": "guide_video_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_courses_org_id": {
+          "name": "idx_courses_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_courses_creator_id": {
+          "name": "idx_courses_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_courses_org_status": {
+          "name": "idx_courses_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"courses\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_courses_org_slug": {
+          "name": "uq_courses_org_slug",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"courses\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_courses_id_org": {
+          "name": "uq_courses_id_org",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_organization_id_organizations_id_fk": {
+          "name": "courses_organization_id_organizations_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "courses_creator_id_users_id_fk": {
+          "name": "courses_creator_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "courses_intro_video_media_id_media_items_id_fk": {
+          "name": "courses_intro_video_media_id_media_items_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "courses_preview_video_media_id_media_items_id_fk": {
+          "name": "courses_preview_video_media_id_media_items_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "preview_video_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "courses_guide_video_media_id_media_items_id_fk": {
+          "name": "courses_guide_video_media_id_media_items_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "guide_video_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_course_status": {
+          "name": "check_course_status",
+          "value": "\"courses\".\"status\" IN ('draft', 'published', 'archived')"
+        },
+        "check_course_price_non_negative": {
+          "name": "check_course_price_non_negative",
+          "value": "\"courses\".\"price_cents\" IS NULL OR \"courses\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.landing_pages": {
+      "name": "landing_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_overrides": {
+          "name": "brand_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "offer": {
+          "name": "offer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_landing_pages_org_id": {
+          "name": "idx_landing_pages_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_landing_pages_creator_id": {
+          "name": "idx_landing_pages_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_landing_pages_subject": {
+          "name": "idx_landing_pages_subject",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_landing_pages_org_status": {
+          "name": "idx_landing_pages_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"landing_pages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_landing_pages_org_slug": {
+          "name": "uq_landing_pages_org_slug",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"landing_pages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "landing_pages_organization_id_organizations_id_fk": {
+          "name": "landing_pages_organization_id_organizations_id_fk",
+          "tableFrom": "landing_pages",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "landing_pages_creator_id_users_id_fk": {
+          "name": "landing_pages_creator_id_users_id_fk",
+          "tableFrom": "landing_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_landing_page_status": {
+          "name": "check_landing_page_status",
+          "value": "\"landing_pages\".\"status\" IN ('draft', 'published', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stage_practices": {
+      "name": "stage_practices",
+      "schema": "",
+      "columns": {
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_stage_practices_content_id": {
+          "name": "idx_stage_practices_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stage_practices_stage_id_course_stages_id_fk": {
+          "name": "stage_practices_stage_id_course_stages_id_fk",
+          "tableFrom": "stage_practices",
+          "tableTo": "course_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stage_practices_content_id_content_id_fk": {
+          "name": "stage_practices_content_id_content_id_fk",
+          "tableFrom": "stage_practices",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stage_practices_stage_id_content_id_pk": {
+          "name": "stage_practices_stage_id_content_id_pk",
+          "columns": [
+            "stage_id",
+            "content_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_audit_logs": {
+      "name": "email_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "email_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_audit_logs_organization_id_organizations_id_fk": {
+          "name": "email_audit_logs_organization_id_organizations_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_audit_logs_creator_id_users_id_fk": {
+          "name": "email_audit_logs_creator_id_users_id_fk",
+          "tableFrom": "email_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "template_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "template_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_templates_org_id": {
+          "name": "idx_email_templates_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_creator_id": {
+          "name": "idx_email_templates_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_scope": {
+          "name": "idx_email_templates_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_templates_status": {
+          "name": "idx_email_templates_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_global": {
+          "name": "idx_unique_template_global",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'global' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_org": {
+          "name": "idx_unique_template_org",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'organization' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_template_creator": {
+          "name": "idx_unique_template_creator",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"scope\" = 'creator' AND \"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_org_scope": {
+          "name": "idx_templates_org_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_creator_scope": {
+          "name": "idx_templates_creator_scope",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_created_by_deleted_at": {
+          "name": "idx_templates_created_by_deleted_at",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope_deleted_at": {
+          "name": "idx_templates_status_scope_deleted_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_status_scope": {
+          "name": "idx_templates_status_scope",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_templates_active": {
+          "name": "idx_templates_active",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_template_lookup": {
+          "name": "idx_template_lookup",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_templates\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_organization_id_organizations_id_fk": {
+          "name": "email_templates_organization_id_organizations_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_creator_id_users_id_fk": {
+          "name": "email_templates_creator_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_templates_created_by_users_id_fk": {
+          "name": "email_templates_created_by_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "global_scope_no_owners": {
+          "name": "global_scope_no_owners",
+          "value": "\"email_templates\".\"scope\" != 'global' OR (\"email_templates\".\"organization_id\" IS NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "org_scope_requires_org": {
+          "name": "org_scope_requires_org",
+          "value": "\"email_templates\".\"scope\" != 'organization' OR (\"email_templates\".\"organization_id\" IS NOT NULL AND \"email_templates\".\"creator_id\" IS NULL)"
+        },
+        "creator_scope_requires_creator": {
+          "name": "creator_scope_requires_creator",
+          "value": "\"email_templates\".\"scope\" != 'creator' OR \"email_templates\".\"creator_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_marketing": {
+          "name": "email_marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_transactional": {
+          "name": "email_transactional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_digest": {
+          "name": "email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_connect_account_user_id": {
+          "name": "primary_connect_account_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_slug": {
+          "name": "idx_organizations_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_org_slug": {
+          "name": "idx_unique_org_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organizations_primary_connect_account_user_id_users_id_fk": {
+          "name": "organizations_primary_connect_account_user_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_connect_account_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payouts": {
+      "name": "payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_subscription_id": {
+          "name": "course_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_group": {
+          "name": "transfer_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "payout_type": {
+          "name": "payout_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscription'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payouts_stripe_transfer_id": {
+          "name": "uq_payouts_stripe_transfer_id",
+          "columns": [
+            {
+              "expression": "stripe_transfer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"stripe_transfer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_created": {
+          "name": "idx_payouts_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_status_created": {
+          "name": "idx_payouts_org_status_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_pending": {
+          "name": "idx_payouts_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payouts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_user_org_created": {
+          "name": "idx_payouts_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_subscription": {
+          "name": "idx_payouts_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_purchase": {
+          "name": "idx_payouts_purchase",
+          "columns": [
+            {
+              "expression": "purchase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_course_subscription": {
+          "name": "idx_payouts_course_subscription",
+          "columns": [
+            {
+              "expression": "course_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payouts_org_source_created": {
+          "name": "idx_payouts_org_source_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_payouts_platform_fee_per_charge": {
+          "name": "uq_payouts_platform_fee_per_charge",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payouts\".\"payout_type\" = 'platform_fee'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payouts_organization_id_organizations_id_fk": {
+          "name": "payouts_organization_id_organizations_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_user_id_users_id_fk": {
+          "name": "payouts_user_id_users_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payouts_subscription_id_subscriptions_id_fk": {
+          "name": "payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payouts_purchase_id_purchases_id_fk": {
+          "name": "payouts_purchase_id_purchases_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payouts_course_subscription_id_course_subscriptions_id_fk": {
+          "name": "payouts_course_subscription_id_course_subscriptions_id_fk",
+          "tableFrom": "payouts",
+          "tableTo": "course_subscriptions",
+          "columnsFrom": [
+            "course_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_payouts_amount_positive": {
+          "name": "check_payouts_amount_positive",
+          "value": "\"payouts\".\"amount_cents\" > 0"
+        },
+        "check_payouts_status": {
+          "name": "check_payouts_status",
+          "value": "\"payouts\".\"status\" IN ('paid', 'pending', 'failed', 'reversed', 'cancelled_by_refund')"
+        },
+        "check_payouts_reason": {
+          "name": "check_payouts_reason",
+          "value": "\"payouts\".\"reason\" IS NULL OR \"payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        },
+        "check_payouts_type": {
+          "name": "check_payouts_type",
+          "value": "\"payouts\".\"payout_type\" IN ('platform_fee', 'organization_fee', 'creator_payout', 'creator_payout_to_owner')"
+        },
+        "check_payouts_source": {
+          "name": "check_payouts_source",
+          "value": "\"payouts\".\"source_type\" IN ('purchase', 'subscription')"
+        },
+        "check_payouts_source_ref_one": {
+          "name": "check_payouts_source_ref_one",
+          "value": "(CASE WHEN \"payouts\".\"subscription_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"payouts\".\"purchase_id\" IS NULL THEN 0 ELSE 1 END) + (CASE WHEN \"payouts\".\"course_subscription_id\" IS NULL THEN 0 ELSE 1 END) <= 1"
+        },
+        "check_payouts_user_required": {
+          "name": "check_payouts_user_required",
+          "value": "(\"payouts\".\"payout_type\" = 'platform_fee') OR (\"payouts\".\"user_id\" IS NOT NULL)"
+        },
+        "check_payouts_paid_invariant": {
+          "name": "check_payouts_paid_invariant",
+          "value": "(\"payouts\".\"status\" NOT IN ('paid', 'reversed')) OR ((\"payouts\".\"stripe_transfer_id\" IS NOT NULL OR \"payouts\".\"stripe_charge_id\" IS NOT NULL) AND \"payouts\".\"resolved_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.video_playback": {
+      "name": "video_playback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_video_playback_user_id": {
+          "name": "idx_video_playback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_video_playback_content_id": {
+          "name": "idx_video_playback_content_id",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_playback_user_id_users_id_fk": {
+          "name": "video_playback_user_id_users_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_playback_content_id_content_id_fk": {
+          "name": "video_playback_content_id_content_id_fk",
+          "tableFrom": "video_playback",
+          "tableTo": "content",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_playback_user_id_content_id_unique": {
+          "name": "video_playback_user_id_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refund_reviews": {
+      "name": "refund_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_reversal_cents": {
+          "name": "attempted_reversal_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_refund_reviews_open_per_payout": {
+          "name": "uq_refund_reviews_open_per_payout",
+          "columns": [
+            {
+              "expression": "payout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"refund_reviews\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refund_reviews_purchase_id_purchases_id_fk": {
+          "name": "refund_reviews_purchase_id_purchases_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_payout_id_payouts_id_fk": {
+          "name": "refund_reviews_payout_id_payouts_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "payouts",
+          "columnsFrom": [
+            "payout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_creator_user_id_users_id_fk": {
+          "name": "refund_reviews_creator_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "refund_reviews_resolved_by_user_id_users_id_fk": {
+          "name": "refund_reviews_resolved_by_user_id_users_id_fk",
+          "tableFrom": "refund_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_refund_reviews_amount_positive": {
+          "name": "check_refund_reviews_amount_positive",
+          "value": "\"refund_reviews\".\"attempted_reversal_cents\" > 0"
+        },
+        "check_refund_reviews_resolution": {
+          "name": "check_refund_reviews_resolution",
+          "value": "\"refund_reviews\".\"resolution\" IS NULL OR \"refund_reviews\".\"resolution\" IN ('creator_absorbed', 'platform_absorbed', 'manually_reversed')"
+        },
+        "check_refund_reviews_resolved_pair": {
+          "name": "check_refund_reviews_resolved_pair",
+          "value": "(\"refund_reviews\".\"resolved_at\" IS NULL AND \"refund_reviews\".\"resolution\" IS NULL) OR (\"refund_reviews\".\"resolved_at\" IS NOT NULL AND \"refund_reviews\".\"resolution\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.branding_settings": {
+      "name": "branding_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_r2_path": {
+          "name": "logo_r2_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color_hex": {
+          "name": "primary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "secondary_color_hex": {
+          "name": "secondary_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color_hex": {
+          "name": "accent_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_color_hex": {
+          "name": "background_color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_body": {
+          "name": "font_body",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_heading": {
+          "name": "font_heading",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_value": {
+          "name": "radius_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "density_value": {
+          "name": "density_value",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "intro_video_media_item_id": {
+          "name": "intro_video_media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_video_url": {
+          "name": "intro_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_overrides": {
+          "name": "token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_mode_overrides": {
+          "name": "dark_mode_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dark_token_overrides": {
+          "name": "dark_token_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_layout": {
+          "name": "hero_layout",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "pricing_faq": {
+          "name": "pricing_faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "branding_settings_updated_at_idx": {
+          "name": "branding_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branding_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "branding_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branding_settings_intro_video_media_item_id_media_items_id_fk": {
+          "name": "branding_settings_intro_video_media_item_id_media_items_id_fk",
+          "tableFrom": "branding_settings",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "intro_video_media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_settings": {
+      "name": "contact_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Codex Platform'"
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'support@example.com'"
+        },
+        "contact_url": {
+          "name": "contact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "twitter_url": {
+          "name": "twitter_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok_url": {
+          "name": "tiktok_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_settings_updated_at_idx": {
+          "name": "contact_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "contact_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "contact_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_settings": {
+      "name": "feature_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enable_signups": {
+          "name": "enable_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_purchases": {
+          "name": "enable_purchases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_subscriptions": {
+          "name": "enable_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_settings_updated_at_idx": {
+          "name": "feature_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_settings_organization_id_platform_settings_organization_id_fk": {
+          "name": "feature_settings_organization_id_platform_settings_organization_id_fk",
+          "tableFrom": "feature_settings",
+          "tableTo": "platform_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_settings": {
+      "name": "platform_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_settings_updated_at_idx": {
+          "name": "platform_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_settings_organization_id_organizations_id_fk": {
+          "name": "platform_settings_organization_id_organizations_id_fk",
+          "tableFrom": "platform_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orphaned_image_files": {
+      "name": "orphaned_image_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_entity_id": {
+          "name": "original_entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_entity_type": {
+          "name": "original_entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cleanup_attempts": {
+          "name": "cleanup_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orphaned_files_status": {
+          "name": "idx_orphaned_files_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_orphaned_at": {
+          "name": "idx_orphaned_files_orphaned_at",
+          "columns": [
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_type_status": {
+          "name": "idx_orphaned_files_type_status",
+          "columns": [
+            {
+              "expression": "image_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orphaned_files_pending_cleanup": {
+          "name": "idx_orphaned_files_pending_cleanup",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "orphaned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_image_type": {
+          "name": "check_image_type",
+          "value": "\"orphaned_image_files\".\"image_type\" IN ('avatar', 'logo', 'content_thumbnail', 'transcoding_artifact')"
+        },
+        "check_entity_type": {
+          "name": "check_entity_type",
+          "value": "\"orphaned_image_files\".\"original_entity_type\" IS NULL OR \"orphaned_image_files\".\"original_entity_type\" IN ('user', 'organization', 'content', 'media_item')"
+        },
+        "check_orphan_status": {
+          "name": "check_orphan_status",
+          "value": "\"orphaned_image_files\".\"status\" IN ('pending', 'deleted', 'failed', 'retained')"
+        },
+        "check_cleanup_attempts": {
+          "name": "check_cleanup_attempts",
+          "value": "\"orphaned_image_files\".\"cleanup_attempts\" >= 0 AND \"orphaned_image_files\".\"cleanup_attempts\" <= 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_payouts": {
+      "name": "pending_payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gbp'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_payouts_user_id": {
+          "name": "idx_pending_payouts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_org_id": {
+          "name": "idx_pending_payouts_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_payouts_unresolved": {
+          "name": "idx_pending_payouts_unresolved",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_payouts_user_id_users_id_fk": {
+          "name": "pending_payouts_user_id_users_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_organization_id_organizations_id_fk": {
+          "name": "pending_payouts_organization_id_organizations_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_payouts_subscription_id_subscriptions_id_fk": {
+          "name": "pending_payouts_subscription_id_subscriptions_id_fk",
+          "tableFrom": "pending_payouts",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_pending_payout_positive": {
+          "name": "check_pending_payout_positive",
+          "value": "\"pending_payouts\".\"amount_cents\" > 0"
+        },
+        "check_pending_payout_reason": {
+          "name": "check_pending_payout_reason",
+          "value": "\"pending_payouts\".\"reason\" IN ('connect_not_ready', 'connect_restricted', 'transfer_failed', 'min_transfer_floor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stripe_connect_accounts": {
+      "name": "stripe_connect_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_connect_org_id": {
+          "name": "idx_stripe_connect_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_connect_stripe_id": {
+          "name": "idx_stripe_connect_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_connect_accounts_organization_id_organizations_id_fk": {
+          "name": "stripe_connect_accounts_organization_id_organizations_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_connect_accounts_user_id_users_id_fk": {
+          "name": "stripe_connect_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_connect_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_connect_accounts_stripe_account_id_unique": {
+          "name": "stripe_connect_accounts_stripe_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_account_id"
+          ]
+        },
+        "uq_stripe_connect_user": {
+          "name": "uq_stripe_connect_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_connect_status": {
+          "name": "check_connect_status",
+          "value": "\"stripe_connect_accounts\".\"status\" IN ('onboarding', 'active', 'restricted', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_annual": {
+          "name": "price_annual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_monthly_id": {
+          "name": "stripe_price_monthly_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_annual_id": {
+          "name": "stripe_price_annual_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_org_id": {
+          "name": "idx_subscription_tiers_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_tiers_org_active": {
+          "name": "idx_subscription_tiers_org_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_org_sort": {
+          "name": "uq_subscription_tiers_org_sort",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_tiers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_tiers_id_org": {
+          "name": "uq_subscription_tiers_id_org",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_tiers_organization_id_organizations_id_fk": {
+          "name": "subscription_tiers_organization_id_organizations_id_fk",
+          "tableFrom": "subscription_tiers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_tier_price_monthly_positive": {
+          "name": "check_tier_price_monthly_positive",
+          "value": "\"subscription_tiers\".\"price_monthly\" >= 0"
+        },
+        "check_tier_price_annual_positive": {
+          "name": "check_tier_price_annual_positive",
+          "value": "\"subscription_tiers\".\"price_annual\" >= 0"
+        },
+        "check_tier_sort_order_positive": {
+          "name": "check_tier_sort_order_positive",
+          "value": "\"subscription_tiers\".\"sort_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "churn_reason": {
+          "name": "churn_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_fee_cents": {
+          "name": "organization_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_payout_cents": {
+          "name": "creator_payout_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_user_id": {
+          "name": "idx_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_id": {
+          "name": "idx_subscriptions_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_tier_id": {
+          "name": "idx_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_stripe_id": {
+          "name": "idx_subscriptions_stripe_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_org_status": {
+          "name": "idx_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user_org": {
+          "name": "idx_subscriptions_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_active_subscription_per_user_org": {
+          "name": "uq_active_subscription_per_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_organization_id_organizations_id_fk": {
+          "name": "subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_subscription_status": {
+          "name": "check_subscription_status",
+          "value": "\"subscriptions\".\"status\" IN ('active', 'past_due', 'cancelling', 'cancelled', 'incomplete', 'paused')"
+        },
+        "check_billing_interval": {
+          "name": "check_billing_interval",
+          "value": "\"subscriptions\".\"billing_interval\" IN ('month', 'year')"
+        },
+        "check_churn_reason": {
+          "name": "check_churn_reason",
+          "value": "\"subscriptions\".\"churn_reason\" IS NULL OR \"subscriptions\".\"churn_reason\" IN ('too_expensive', 'not_enough_content', 'found_alternative', 'not_using_it', 'technical_issues', 'other')"
+        },
+        "check_sub_amount_positive": {
+          "name": "check_sub_amount_positive",
+          "value": "\"subscriptions\".\"amount_cents\" >= 0"
+        },
+        "check_sub_platform_fee_positive": {
+          "name": "check_sub_platform_fee_positive",
+          "value": "\"subscriptions\".\"platform_fee_cents\" >= 0"
+        },
+        "check_sub_org_fee_positive": {
+          "name": "check_sub_org_fee_positive",
+          "value": "\"subscriptions\".\"organization_fee_cents\" >= 0"
+        },
+        "check_sub_creator_payout_positive": {
+          "name": "check_sub_creator_payout_positive",
+          "value": "\"subscriptions\".\"creator_payout_cents\" >= 0"
+        },
+        "check_sub_revenue_split_equals_total": {
+          "name": "check_sub_revenue_split_equals_total",
+          "value": "\"subscriptions\".\"amount_cents\" = \"subscriptions\".\"platform_fee_cents\" + \"subscriptions\".\"organization_fee_cents\" + \"subscriptions\".\"creator_payout_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_table": {
+      "name": "test_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_table_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.email_send_status": {
+      "name": "email_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.template_scope": {
+      "name": "template_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "organization",
+        "creator"
+      ]
+    },
+    "public.template_status": {
+      "name": "template_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -568,6 +568,13 @@
       "when": 1784857425980,
       "tag": "0080_clumsy_forge",
       "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1785156849152,
+      "tag": "0081_opposite_natasha_romanoff",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/journeys.ts
+++ b/packages/database/src/schema/journeys.ts
@@ -1,4 +1,8 @@
-import type { BrandTokenOverrides, PageSection } from '@codex/shared-types';
+import type {
+  BrandTokenOverrides,
+  PageOffer,
+  PageSection,
+} from '@codex/shared-types';
 import { relations, sql } from 'drizzle-orm';
 import {
   boolean,
@@ -74,6 +78,14 @@ export const landingPages = pgTable(
     // inside the jsonb, NOT a CHECK enum (forward-compat — WP-0 interp C).
     brandOverrides: jsonb('brand_overrides').$type<BrandTokenOverrides>(),
     sections: jsonb('sections').$type<PageSection[]>().notNull().default([]),
+
+    // The page's PRESENTATION of the journey's ways-in (§7 "one course, three
+    // ways in") — which paths the sales page shows + their teaser prices in
+    // pence, GBP. NOT the source of truth for access or for what a buyer is
+    // charged: the authoritative one-off price is `courses.price_cents`, which
+    // `updateJourneyOffer` writes in the SAME transaction that writes this bag.
+    // Nullable — a page authored before pricing was set has no offer.
+    offer: jsonb('offer').$type<PageOffer>(),
 
     createdAt: timestamp('created_at', { withTimezone: true })
       .defaultNow()

--- a/packages/shared-types/src/journeys.ts
+++ b/packages/shared-types/src/journeys.ts
@@ -696,6 +696,12 @@ export interface EditorPracticeView {
   status: PageStatus;
   /** Poster/thumbnail for the media-slot; null when the content has none. */
   thumbnailUrl: string | null;
+  /**
+   * Runtime of the linked media, or `null` for a written practice / media with no
+   * probed duration. Drives the builder map's "≈ N min in all" cue, which read a
+   * flat 0 while this field was absent — an under-claim on every course.
+   */
+  durationSeconds: number | null;
   sortOrder: number;
 }
 

--- a/packages/validation/src/schemas/journeys.ts
+++ b/packages/validation/src/schemas/journeys.ts
@@ -1,6 +1,6 @@
 import type { BrandTokenOverrides, PageSection } from '@codex/shared-types';
 import { z } from 'zod';
-import { createSlugSchema, uuidSchema } from '../primitives';
+import { createSlugSchema, priceCentsSchema, uuidSchema } from '../primitives';
 
 /**
  * Journey member-surface route inputs (Codex-2pryk · Round-D · Codex-776gg).
@@ -211,32 +211,73 @@ export const pageSectionSchema = z.custom<PageSection>(
  * minus the server-owned `organizationId`/`publishedAt`, which the service
  * derives). `sections`/`brandOverrides` carry their FE types via `z.custom` so
  * the inferred type is assignable to the service input with no boundary cast.
+ *
+ * `.strict()` because this endpoint does NOT own the whole builder draft. The
+ * pricing panel's `offer` belongs to `updateJourneyOfferBodySchema`, and `seo` has
+ * no persistence yet — under Zod's default strip both were accepted, discarded,
+ * and reported as "Page saved". A key this endpoint cannot honour must 400.
  */
-export const saveJourneyPageBodySchema = z.object({
-  id: uuidSchema,
-  pageType: z.string().min(1).max(30),
-  // A plain (transform-free) required slug validator — NOT `createSlugSchema`,
-  // whose `.transform().pipe()` makes SvelteKit's `command()` infer the field as
-  // OPTIONAL, breaking assignability to the (required-slug) service input. Same
-  // format rule, validated not rewritten (the builder sends an already-slugified
-  // value); a malformed slug is rejected rather than silently coerced.
-  slug: z
-    .string()
-    .trim()
-    .min(1)
-    .max(160)
-    .regex(
-      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
-      'Slug must be lowercase letters, numbers and hyphens (no leading/trailing hyphen)'
-    ),
-  title: z.string().trim().min(1).max(500),
-  status: journeyPageStatusSchema,
-  subjectType: z.string().max(30).nullable(),
-  subjectId: uuidSchema.nullable(),
-  brandOverrides: z.custom<BrandTokenOverrides>().nullable(),
-  sections: z.array(pageSectionSchema),
-});
+export const saveJourneyPageBodySchema = z
+  .object({
+    id: uuidSchema,
+    pageType: z.string().min(1).max(30),
+    // A plain (transform-free) required slug validator — NOT `createSlugSchema`,
+    // whose `.transform().pipe()` makes SvelteKit's `command()` infer the field as
+    // OPTIONAL, breaking assignability to the (required-slug) service input. Same
+    // format rule, validated not rewritten (the builder sends an already-slugified
+    // value); a malformed slug is rejected rather than silently coerced.
+    slug: z
+      .string()
+      .trim()
+      .min(1)
+      .max(160)
+      .regex(
+        /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+        'Slug must be lowercase letters, numbers and hyphens (no leading/trailing hyphen)'
+      ),
+    title: z.string().trim().min(1).max(500),
+    status: journeyPageStatusSchema,
+    subjectType: z.string().max(30).nullable(),
+    subjectId: uuidSchema.nullable(),
+    brandOverrides: z.custom<BrandTokenOverrides>().nullable(),
+    sections: z.array(pageSectionSchema),
+  })
+  .strict();
 export type SaveJourneyPageBody = z.infer<typeof saveJourneyPageBodySchema>;
+
+/**
+ * Journey OFFER body — the page's ways-in + their prices (`PATCH
+ * /api/journeys/studio/journeys/:pageId/offer`). Prices are pence, GBP
+ * (`priceCentsSchema`); `null` means "no price set".
+ *
+ * Deliberately `.strict()`: pricing is a commerce mutation, so an unrecognised
+ * key is a client bug that must 400 rather than be silently dropped (the failure
+ * mode that made the pricing panel swallow input while reporting success).
+ *
+ * The toggles carry `.default(false)` so the persisted bag is always TOTAL —
+ * every path is explicitly on or off, never absent-and-therefore-ambiguous.
+ * `.default()` only widens the INPUT type (the field becomes optional for the
+ * caller) while the output stays required, so the inferred body is still
+ * assignable to the service input with no boundary cast.
+ *
+ * The cross-field rule — an ENABLED path needs a price — lives in
+ * `CourseJourneyService.updateJourneyOffer` as a typed `ValidationError`, not
+ * here: it is a business invariant (an enabled-but-priceless path silently
+ * collapses the checkout to "not open for enrolment"), and keeping it out of Zod
+ * avoids wrapping the object in a `ZodEffects` that `command()` mis-infers.
+ */
+export const updateJourneyOfferBodySchema = z
+  .object({
+    tiersEnabled: z.boolean().default(false),
+    subscriptionEnabled: z.boolean().default(false),
+    subscriptionPriceCents: priceCentsSchema,
+    oneOffEnabled: z.boolean().default(false),
+    oneOffPriceCents: priceCentsSchema,
+  })
+  .strict();
+export type UpdateJourneyOfferBody = z.infer<
+  typeof updateJourneyOfferBodySchema
+>;
 
 /**
  * ── STUDIO curriculum-editor inputs (Codex-03cwh · admin two-pane editor) ──

--- a/workers/content-api/src/routes/journeys.ts
+++ b/workers/content-api/src/routes/journeys.ts
@@ -15,6 +15,7 @@ import type {
   JourneyCourseSummary,
   JourneyListItem,
   JourneyPageRecord,
+  PageOffer,
   PracticeCompletionRecord,
 } from '@codex/shared-types';
 import {
@@ -31,6 +32,7 @@ import {
   recordCompletionBodySchema,
   saveCurriculumBodySchema,
   saveJourneyPageBodySchema,
+  updateJourneyOfferBodySchema,
   userEnrollmentsQuerySchema,
 } from '@codex/validation';
 import { procedure } from '@codex/worker-utils';
@@ -585,6 +587,45 @@ app.put(
         ctx.input.body
       );
       return null;
+    },
+  })
+);
+
+/**
+ * PATCH /api/journeys/studio/journeys/:pageId/offer?organizationId=  { ...offer }
+ *
+ * Set the journey's ways-in + prices (pence, GBP). The ONLY write path to a
+ * course's price: it persists the page's offer presentation AND the authoritative
+ * `courses.price_cents` in one transaction, so the sales page and the checkout can
+ * never disagree about whether the journey is buyable.
+ *
+ * Separate from the page save (`PUT :pageId`) deliberately — pricing is a commerce
+ * mutation with a different blast radius than page copy, and a creator must be able
+ * to change a price without republishing the page body. `strict` rate limit for the
+ * same reason (matching the checkout/sensitive-mutation preset).
+ *
+ * The 4-segment path cannot collide with the 3-segment `:pageId` route.
+ * @returns {PageOffer}
+ */
+app.patch(
+  '/studio/journeys/:pageId/offer',
+  procedure({
+    policy: {
+      auth: 'required',
+      requireOrgManagement: true,
+      rateLimit: 'strict',
+    },
+    input: {
+      params: journeyPageParamsSchema,
+      query: journeyOrgQuerySchema,
+      body: updateJourneyOfferBodySchema,
+    },
+    handler: async (ctx): Promise<PageOffer> => {
+      return ctx.services.courseJourney.updateJourneyOffer(
+        ctx.organizationId,
+        ctx.input.params.pageId,
+        ctx.input.body
+      );
     },
   })
 );


### PR DESCRIPTION
Stacked on **#432** (`feat/journeys-studio-audit`). Retarget to `dev` once that merges.

## The bug this fixes

A creator could type a price into the builder's *Access & pricing* panel, get a **"Page saved"** toast, and the journey would still show **"isn't open for enrolment just now"** at checkout.

Two independent silent failures stacked:

1. `courses.price_cents` — the column `deriveCheckoutOffers` reads — had **no write path anywhere in the app**. Every `priceCents` in `packages/access` was a `select`. The working local value had been set by hand in SQL.
2. `PagePricingPanel` wrote `PageBuilderState.offer`, `getSavePayload()` included it, but `saveJourneyPageBodySchema` had no `offer` key — and Zod's default strip discarded it while reporting success.

`landing_pages` also had **no `offer` column and no `seo` column**, despite the `PageOffer`/`PageSeo` doc comments claiming "Backs `landing_pages.offer` jsonb". So there was nowhere to put the data even if it had got through.

## What changed

**Pricing write path**
- migration `0081` adds `landing_pages.offer` jsonb (nullable, additive, no backfill)
- `CourseJourneyService.updateJourneyOffer` — org-scoped, soft-delete aware. Writes the page's offer presentation **and** the authoritative `courses.price_cents` in **one transaction**, so the sales page and the checkout cannot disagree about whether a journey is buyable. A zero-row course update rolls back rather than leaving an offer bag claiming a price no course carries.
- typed `ValidationError`s for the states that silently produce an unsellable offer: an enabled path with no price; a one-off on a plain landing page
- `updateJourneyOfferBodySchema` — `.strict()`, `priceCentsSchema` (GBP pence), toggles `.default(false)` so the persisted bag is always total (never "off vs never set")
- `PATCH /api/journeys/studio/journeys/:pageId/offer` under `requireOrgManagement` + `strict` rate limit — separate from the page save so a price change needs no republish
- `api.ts` method + remote `command()`. The command forwards a 4xx as `error(status, message)` so the service's own guidance reaches the toast
- `getJourneyForBuilder` reads `offer`, so the panel round-trips

**Stop the silent swallow**
- `saveJourneyPageBodySchema` is now `.strict()`, and the builder builds its payload from **named** fields — a key the endpoint cannot honour is a visible error, not a silent drop
- `PageSeoPanel`'s meta fields are **disabled with a note** (no `seo` column, same swallow). `updateSeo()` kept and documented as the seam persistence wires back into
- fixed a controlled-input bug that made **decimal prices untypeable** — the field re-derived its value from pence, so `12.` collapsed to `12` mid-keystroke. Price fields now hold a local draft and normalise on blur

**Data-backed fields**
- `EditorPracticeView.durationSeconds` (from the already-joined media item) + FE mirror — the builder map's "≈ N min in all" no longer reads a flat 0
- declared the props sections already read defensively: `GuideSectionProps.quote`, `ReelSectionProps.caption/captions/tag`, `ProofSectionProps.trustLabel` (+ legacy `trust`), `FeelSectionProps.previewTitle/previewSub/previewDuration`
- `TurnSectionProps.stages` deliberately **not** added — `TurnSection` derives its stage list from `points` by splitting on an em-dash; a second field would be a divergent source

## Drive-by fixes the gate uncovered

- **`AdminAnalyticsService.getTopContent` threw on every call.** Its correlated subquery referenced `purchases.contentId`, which stopped being in the `GROUP BY` when WP-6 (`89df7913`) moved the projection to `content.id`. Postgres rejected the whole statement — *"subquery uses ungrouped column"* — so studio analytics top-content **500'd for every org**. 11 tests in `@codex/admin` were already red for this and now pass. One line.
- **`web#test` was red on the base branch.** The org landing `page.server` test never mocked `$lib/remote/journeys.remote`, so the journeys rail resolved to SvelteKit's *client* remote runtime and all 6 tests died on `app.hooks` undefined. Verified red on the base branch in a separate worktree before touching it.
- **`paraglide/messages/en.js`** — `messages.js` carried the journey cross-link keys but the en locale file did not, so `m.content_detail_journey_part_of_kicker()` had no body in a clean checkout.
- Corrected stale comments: the canvas does **not** render the public components, and the builder no longer supplies mock stages.

## Verification

Browser, not just tests — `of-blood-and-bones.lvh.me:3000`, `price_cents` set to `NULL` first so nothing was pre-cooked:

| Step | Result |
|---|---|
| checkout before | "poihg isn't open for enrolment just now." |
| builder → Pricing → one-off on, type `18.50` → Save | `landing_pages.offer` = full total bag; `courses.price_cents` = `1850` |
| checkout after | radio card **"Own poihg · £18.50 · one-off"** + live Continue |
| clear the price, keep one-off on, Save | inline warning, then *"Page saved, but the pricing was not: Set a one-off price, or turn the one-off path off"* |
| DB after the refusal | unchanged at `1850` — no partial write |

The `£18.50` is itself proof of the decimal-input fix; the old field could only produce whole pounds.

**Tests:** 13 new integration cases for `updateJourneyOffer` (price mirroring, total bag, disable→null, both priceless refusals, landing-page refusal, rollback on a soft-deleted course, IDOR, soft-deleted page, round-trip, no fabricated offer key, cross-org price scoping) + 1 for the duration projection.

**Gate:** `biome check` clean on all changed files · `svelte-check` at the 68 / 43 / 44 baseline with **0 new errors** · `pnpm test` **46/46 tasks** (base branch was red on `web#test` and `@codex/admin`).

## Deliberately not done

`landing_pages.seo` persistence, the checkout submit path, and the placeholder-copy leak are filed rather than smuggled in — see the sweep table in the PR discussion.

Follow-ups filed: `Codex-maf0y` `Codex-eckbx` `Codex-scab9` `Codex-2j8nq` `Codex-tjctg` `Codex-us9ay` `Codex-1e6oc` `Codex-eec4w` `Codex-2y9w4`, plus corrected WP-6 scope on `Codex-2pryk.2.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)