### PR TITLE
fix(journeys): builder top bar holds its layout at real widths (Codex-r4zzu)

### DIFF
--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -370,6 +370,13 @@
         <span class="jb__art-on" aria-current="page">Sales page</span>
       </nav>
 
+      <!--
+        The device switch, history and the four actions share one wrapper so the
+        whole right-hand cluster wraps to a second line AS A UNIT and stays
+        right-aligned. Wrapped individually, Save/Publish stranded themselves
+        bottom-left while the rest of the row stayed put.
+      -->
+      <div class="jb__actions">
       <div class="jb__seg" role="group" aria-label="Device">
         {#each DEVICES as d (d.id)}
           <button type="button" aria-pressed={device === d.id} onclick={() => (device = d.id)}>
@@ -433,6 +440,7 @@
       >
         {saving ? 'Publishing…' : 'Publish'}
       </button>
+      </div>
     </header>
 
     <!-- ── mode tabs ── -->
@@ -497,28 +505,51 @@
 {/if}
 
 <style>
+  /*
+    `minmax(0, 1fr)` on the implicit column is load-bearing: the default `auto`
+    track is sized to its item's max-content, so the top bar's min-content width
+    would push the whole workspace wider than the viewport and give the page a
+    horizontal scrollbar. Capping the track lets the bar wrap instead.
+  */
   .jb {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto auto minmax(0, 1fr);
     height: 100dvh;
     background-color: var(--color-background);
   }
 
-  /* ── top bar ── */
+  /*
+    ── top bar ──
+    Nine controls, so the row is allowed to wrap onto a second line rather than
+    overflow: below roughly 1330px of bar width the right-hand cluster drops
+    whole (its `margin-left: auto` keeps it right-aligned on the new line). The
+    height is a MIN, not a fixed value — a fixed height is what clipped the
+    wrapped action labels before. With one line the bar is still 48px tall.
+  */
   .jb__top {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: var(--space-3);
-    padding: 0 var(--space-4);
-    height: var(--space-12);
+    align-content: center;
+    gap: var(--space-1) var(--space-3);
+    padding: var(--space-1) var(--space-4);
+    min-height: var(--space-12);
     border-bottom: var(--border-width) var(--border-style) var(--color-border);
     background-color: var(--color-surface);
   }
 
+  /*
+    The identity block is the ONLY negotiable item in the bar. Every sibling is
+    `flex: none` (below), so when the row runs short the title yields instead of
+    the whole row squashing — which is what used to clip the action labels.
+  */
   .jb__doc {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
+    flex: 0 1 auto;
+    min-width: 0;
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     white-space: nowrap;
@@ -531,9 +562,11 @@
     font-family: var(--font-heading);
     font-size: var(--text-sm);
     font-weight: var(--font-semibold);
-    min-width: 8rem;
+    flex: 0 1 auto;
+    min-width: var(--space-32);
     padding: var(--space-1);
     border-radius: var(--radius-sm);
+    text-overflow: ellipsis;
   }
 
   .jb__doc-title:hover {
@@ -545,7 +578,16 @@
     box-shadow: var(--shadow-focus-ring);
   }
 
+  /*
+    `width: max-content` is load-bearing. A bare <select> resolves `width: auto`
+    to fill-available (measured: 1800px basis for 100px of content), and since
+    every flex child defaults to `flex-shrink: 1` the algorithm handed this
+    control ~565px of a 1688px bar while clipping the buttons. Sizing it to its
+    own content — and taking it out of the negotiation — is the actual fix.
+  */
   .jb__status {
+    flex: none;
+    width: max-content;
     padding: var(--space-1) var(--space-2);
     border: var(--border-width) var(--border-style) var(--color-border);
     border-radius: var(--radius-md);
@@ -557,6 +599,7 @@
 
   .jb__art {
     display: flex;
+    flex: none;
     gap: var(--space-1);
     padding: var(--space-1);
     border-radius: var(--radius-full);
@@ -570,6 +613,7 @@
     font-size: var(--text-xs);
     color: var(--color-text-secondary);
     text-decoration: none;
+    white-space: nowrap;
   }
 
   .jb__art a:hover {
@@ -581,10 +625,26 @@
     color: var(--color-text);
   }
 
+  /*
+    The right-hand cluster. `margin-left: auto` lives HERE rather than on
+    `.jb__seg` so that when the bar wraps, the whole group moves to the new line
+    together and `justify-content: flex-end` keeps it right-aligned. It wraps
+    internally too, so it degrades to any width without overflowing.
+  */
+  .jb__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-1) var(--space-3);
+    margin-left: auto;
+    min-width: 0;
+  }
+
   .jb__seg {
     display: flex;
+    flex: none;
     gap: var(--space-1);
-    margin-left: auto;
     padding: var(--space-1);
     border-radius: var(--radius-full);
     background-color: var(--color-surface-secondary);
@@ -598,6 +658,7 @@
     color: var(--color-text-secondary);
     font-family: var(--font-sans);
     font-size: var(--text-xs);
+    white-space: nowrap;
     cursor: pointer;
     transition: var(--transition-colors);
   }
@@ -608,6 +669,7 @@
   }
 
   .jb__btn {
+    flex: none;
     padding: var(--space-2) var(--space-3);
     border: var(--border-width) var(--border-style) var(--color-border);
     border-radius: var(--radius-md);
@@ -616,6 +678,7 @@
     font-family: var(--font-sans);
     font-size: var(--text-sm);
     font-weight: var(--font-medium);
+    white-space: nowrap;
     cursor: pointer;
     transition: var(--transition-colors);
   }
@@ -649,11 +712,13 @@
 
   .jb__history {
     display: flex;
+    flex: none;
     gap: var(--space-0-5);
   }
 
   .jb__icon-btn {
     display: grid;
+    flex: none;
     place-items: center;
     width: var(--space-8);
     height: var(--space-8);


### PR DESCRIPTION
Closes complaint #4 (first half) — "top bar badly formatted". Bead `Codex-r4zzu`.

## The bar named in the bead was dead code

`Codex-r4zzu` pointed at `JourneyCanvasToolbar.svelte` (215 lines). **Nothing imports it** — it is only re-exported from the `page-builder` barrel, and the builder route's destructure does not include it. Restyling it would have shipped an invisible change. The real bar is the inline `<header class="jb__top">` in the route file.

## Root cause: measured, not inferred

A bare `<select>` resolves `width: auto` to fill-available. Measured on the live DOM:

| | |
|---|---|
| `.jb__status` max-content | **100px** (widest option "Published" = 61px of text) |
| `.jb__status` `width:auto` outside flex | **1800px** |
| `.jb__status` actual inside flex | **565px** — a third of a 1688px bar |
| CSS rules of ours declaring width/flex on it | **none** — pure UA default |

Every flex child defaults to `flex-shrink: 1`, so the algorithm did not penalise the oversized item — it shrank all nine **in proportion to basis × shrink-factor**, letting the worst offender keep the most space. At an 1800px viewport the children + gaps + padding summed to 1689px against a 1688px container: already at exact capacity on a very wide monitor.

**Observed damage at 1800px:** title input hard-truncated to `ASSSS BLASTER FART K` (letters simply gone, no ellipsis); "Sales page" and "Full width" wrapped to two lines; "View live ↗" wrapped to **three** lines with the arrow **clipped below** the fixed 48px bar.

**At 1280px:** the status dropdown squashed to show `Pub` — a creator could not tell whether the page was Draft or Published. That is a functional failure, not a cosmetic one.

## The fix

1. `.jb__status` → `flex: none; width: max-content`. **565px → 100px.** The load-bearing change.
2. `flex: none` on the controls that already have a correct intrinsic size, plus `white-space: nowrap`, so negotiation falls on the title alone.
3. `.jb__doc-title` becomes the only negotiable item and **ellipsises** instead of hard-truncating. Tokenised the pre-existing raw `8rem` → `var(--space-32)` (identical value).
4. `.jb` → `grid-template-columns: minmax(0, 1fr)`. **A regression I introduced and then fixed:** once everything was rigid, the row's 1331px min-content grew the workspace past the viewport and gave the *page* a horizontal scrollbar (measured `barW 1330` inside a 1280 viewport) — `.jb` declared only `grid-template-rows`, so its implicit column was `auto`, sized to max-content.
5. `.jb__top` → `min-height` instead of a fixed height (the fixed height is what clipped wrapped labels), and allowed to wrap.
6. **Markup:** grouped the device switch, history and four actions into `.jb__actions`, moving `margin-left: auto` onto it. Wrapping as nine independent children stranded Save+Publish **bottom-left**; as a unit the cluster drops together and stays right-aligned. Top-level children: **9 → 4** semantic groups.

## Verified in a real browser

Org `of-blood-and-bones`, page `06b45e59`, title "ASSSS BLASTER FART KING":

| viewport | bar width | rows | bar height | page h-scroll | clipped | select |
|---|---|---|---|---|---|---|
| 1800 | 1688 | 1 | 48 | 0 | 0 | 100px |
| 1512 | 1400 | 1 | 48 | 0 | 0 | 100px |
| 1280 | 1168 | 2 | 89 | 0 | 0 | 100px |
| 1024 | 912 | 2 | 89 | 0 | 0 | 100px |

Single row at 1512+; clean two rows below, identity on line 1 and the full action cluster right-aligned on line 2. **Nothing hidden, iconified or removed.**

- **A11y held:** both `role="group"` + `aria-label` pairs survived the regroup — "Device" (3 buttons), "History" (2 buttons). Select still reports 3 options, enabled, showing its full selected label.
- **Behaviour smoke-tested** after the markup change: "Full width" flips to "Editing", gains `.jb__btn--on`, and collapses both rails to 0 width. Save correctly stays disabled. **Zero console errors.**

## Gates

| Gate | Result |
|---|---|
| svelte-check | **68 errors / 43 warnings / 44 files** — exact pre-existing baseline, 0 new |
| apps/web tests | **1478 pass / 147 files** — baseline |
| biome (full repo) | **0 errors**, 175 warnings, 5 infos — baseline |

CI's red DB-backed jobs are the **Neon compute-time quota** (`compute time quota exceeded; usage:"396363", limit:"396000"` → `branch creation failed`), not this diff — they die before any test runs. `static-analysis` and Storybook pass.

## Deliberately not done

- The title still ellipsises a 23-char all-caps title at 1512 despite slack. Widening it would make the bar wrap ~70px earlier — trading a real layout property for a cosmetic one. `field-sizing: content` would size to content but has **no precedent in this repo** and is Chrome-leaning; not introducing it unilaterally on a builder that must look identical everywhere.
- Prototype deltas vs `prototype/builder.html` are **recorded on the bead for `Codex-a1tz6`**, not chased here (missing "Studio." brand link; missing *Insights* artswitch tab even though the route exists; status-as-badge vs `<select>`; 3 device options vs 2; 48px vs 52px). Per the decision to prioritise working layout over prototype fidelity.
- `JourneyCanvasToolbar.svelte` + its barrel export are dead but **left in place** — out of scope, and `Codex-eckbx` may want it when unifying `render/` and `render-edit/`. Noted on the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)