### PR TITLE
fix(journeys): conform JourneyCard to the explore.html jcard (Codex-ycsd8)

### DIFF
--- a/apps/web/src/lib/components/journeys/JourneyCard.svelte
+++ b/apps/web/src/lib/components/journeys/JourneyCard.svelte
@@ -11,6 +11,24 @@
   brands). Transparent-by-default; the accent badge + hover border are the only
   brand touch, via theme-/brand-aware semantic tokens.
 
+  PROTOTYPE CONFORMANCE (Codex-ycsd8). The reference is `.jcard` in
+  `docs/design/course-journeys/prototype/explore.html`, which is where that card's
+  anatomy is DEFINED (1-threshold.html only consumes it). Closed against it: a
+  large/light title (1.7rem @ 400, not a small bold UI label), .2em kicker
+  tracking, stats as segments with the NUMERAL emphasised, no foot divider, the
+  badge as an overlay pill on the cover, and a weight-600 CTA.
+
+  Three prototype traits are DELIBERATELY not reproduced, and the reasons are
+  load-bearing — do not "restore fidelity" without reading them:
+   • Tone gradients (`.jcard__cover.ember/.blood/.clay`) — per-card accent colour
+     contradicts the neutral-palette decision; aspect ratio + layout carry type.
+   • An always-on card background — cards are transparent until hover. The
+     prototype's chrome lives on the `--featured` variant instead, which is what
+     `JourneyCardView.featured` is for.
+   • An italic-SERIF tagline and price — the token set has no `--font-serif`
+     (only sans/heading/mono, both brand-overridable), so a serif here would have
+     to be hardcoded and would fight per-org brand fonts.
+
   COVER (Codex-eqh0z): `journey.coverImageUrl` renders a fixed-ratio cover band.
   The band reserves its space with `aspect-ratio` whether or not there is an
   image, so a cover-less journey shows the typographic fallback — a quiet
@@ -50,20 +68,28 @@
     journey.priceCents != null ? formatPrice(journey.priceCents) : null
   );
 
-  // "N stages · M practices" — singular-aware; a stageless draft shows practices
-  // only (defensive, though a published journey normally has stages).
-  const statsLabel = $derived(
-    [
-      journey.stageCount > 0
-        ? `${journey.stageCount} ${journey.stageCount === 1 ? 'stage' : 'stages'}`
-        : null,
-      `${journey.practiceCount} ${
-        journey.practiceCount === 1 ? 'practice' : 'practices'
-      }`,
-    ]
-      .filter(Boolean)
-      .join(' · ')
-  );
+  // Curriculum stats as SEGMENTS rather than one joined string, so the numeral
+  // can carry the emphasis and the noun stay quiet — the prototype's
+  // `<b>24</b> practices` reading (explore.html `.jcard__stats b`). Singular-aware;
+  // a stageless draft shows practices only (defensive — a published journey
+  // normally has stages).
+  //
+  // Built imperatively rather than with `.filter(Boolean)`: apps/web has
+  // strictNullChecks OFF, so a filtered array of `T | null` does not narrow.
+  const statSegments = $derived.by(() => {
+    const segments: { value: number; label: string }[] = [];
+    if (journey.stageCount > 0) {
+      segments.push({
+        value: journey.stageCount,
+        label: journey.stageCount === 1 ? 'stage' : 'stages',
+      });
+    }
+    segments.push({
+      value: journey.practiceCount,
+      label: journey.practiceCount === 1 ? 'practice' : 'practices',
+    });
+    return segments;
+  });
 
   const statusLabel = $derived.by(() => {
     if (!progress) return null;
@@ -79,12 +105,23 @@
   );
 </script>
 
-<a class="journey-card" {href} class:journey-card--enrolled={Boolean(progress)}>
+<a
+  class="journey-card"
+  {href}
+  class:journey-card--enrolled={Boolean(progress)}
+  class:journey-card--featured={journey.featured}
+>
   <!--
     The band is ALWAYS rendered so its reserved height is identical with and
     without a cover — that is what keeps a mixed rail from shifting.
+
+    The badge sits ON the band (prototype `.jcard__tag`, absolutely placed top-left)
+    rather than above the kicker. It carries its own scrim — a translucent surface
+    wash plus a backdrop blur and a border — so it stays legible over an arbitrary
+    creator-uploaded photo, which a plain-coloured pill would not.
   -->
   <div class="journey-card__cover">
+    <span class="journey-card__badge">Portal</span>
     {#if journey.coverImageUrl}
       <img
         class="journey-card__cover-img"
@@ -101,7 +138,6 @@
   </div>
 
   <div class="journey-card__head">
-    <span class="journey-card__badge">Portal</span>
     {#if journey.kicker}
       <span class="journey-card__kicker">{journey.kicker}</span>
     {/if}
@@ -112,8 +148,15 @@
   </div>
 
   <div class="journey-card__foot">
-    {#if statsLabel}
-      <p class="journey-card__stats">{statsLabel}</p>
+    {#if statSegments.length > 0}
+      <p class="journey-card__stats">
+        {#each statSegments as segment (segment.label)}
+          <span class="journey-card__stat">
+            <b class="journey-card__stat-value">{segment.value}</b>
+            {segment.label}
+          </span>
+        {/each}
+      </p>
     {/if}
 
     {#if progress}
@@ -171,12 +214,25 @@
     outline-offset: var(--space-0-5);
   }
 
+  /*
+    The prototype's `.jcard` always carries a background (`ink-2 @ 55%`), which
+    contradicts the standing decision that cards are transparent by default and
+    only hero/featured tiles earn chrome. `JourneyCardView.featured` already
+    exists in the DTO and the card was ignoring it — so the featured tile is
+    where the prototype's chrome belongs, and a browsing tile stays transparent.
+  */
+  .journey-card--featured {
+    background: var(--color-surface);
+    border-color: var(--color-border-strong);
+  }
+
   /* ── Cover band ───────────────────────────────────────────────────────────
      `aspect-ratio` (not a fixed height) reserves the band's space in BOTH
      states, so the covered and cover-less variants are exactly the same height
      and a mixed rail never shifts. Neutral surface tint only — no per-journey
      accent (a `color-mix(brand, transparent)` plate disappears on dark orgs). */
   .journey-card__cover {
+    position: relative;
     display: grid;
     place-items: center;
     aspect-ratio: 16 / 9;
@@ -196,7 +252,7 @@
   .journey-card__cover-glyph {
     font-family: var(--font-heading);
     font-size: var(--text-3xl);
-    font-weight: var(--font-semibold, var(--font-medium));
+    font-weight: var(--font-semibold);
     line-height: 1;
     color: var(--color-text-muted);
   }
@@ -209,40 +265,70 @@
     flex: 1;
   }
 
+  /*
+    Overlay badge (prototype `.jcard__tag`: absolute, top-left of the cover).
+    It must read over a creator-uploaded photo, so it brings its own scrim —
+    a translucent surface wash + backdrop blur + border — exactly the prototype's
+    approach, rather than relying on the image being dark enough.
+    `--text-2xs` does not exist in the token set; `--text-xs` is the floor.
+  */
   .journey-card__badge {
-    align-self: flex-start;
-    margin-bottom: var(--space-2);
+    position: absolute;
+    top: var(--space-3);
+    left: var(--space-3);
+    z-index: 1;
     padding: var(--space-0-5) var(--space-2);
     border-radius: var(--radius-full);
     border: var(--border-width) var(--border-style)
       color-mix(in oklab, var(--color-interactive) 45%, transparent);
+    background-color: color-mix(
+      in oklab,
+      var(--color-surface) 65%,
+      transparent
+    );
+    backdrop-filter: blur(var(--blur-md));
     color: var(--color-interactive);
-    font-size: var(--text-2xs, var(--text-xs));
-    font-weight: var(--font-semibold, var(--font-medium));
-    letter-spacing: 0.08em;
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    letter-spacing: 0.16em;
     text-transform: uppercase;
   }
 
+  /* Prototype `.jcard__cover .kk` tracks at .2em — much wider than the 0.08em
+     this had, and that openness is most of the card's editorial voice. */
   .journey-card__kicker {
     font-size: var(--text-xs);
     font-weight: var(--font-medium);
-    letter-spacing: 0.08em;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
     color: var(--color-text-muted);
   }
 
+  /*
+    Prototype `.jcard__cover h3` is 1.7rem at weight 400 — LARGE and LIGHT. This
+    was --text-xl semibold, i.e. smaller and heavier, which read as a UI label
+    rather than a title. `--text-2xl` clamps 1.5→1.875rem, bracketing 1.7rem.
+  */
   .journey-card__title {
     margin: 0;
-    font-size: var(--text-xl);
-    font-weight: var(--font-semibold, var(--font-bold));
-    line-height: var(--leading-tight, 1.2);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-normal);
+    line-height: var(--leading-tight);
     color: var(--color-text-primary);
+    /*
+      Titles are creator-authored, so one unbroken word must not widen the tile.
+      `anywhere` rather than `break-word` deliberately: only `anywhere` also
+      shrinks the intrinsic MIN-CONTENT size, which is what the grid/carousel
+      track measures. Verified: a 44-character unbroken title overflowed the card
+      by 368px before this, and the larger --text-2xl title made that likelier.
+    */
+    overflow-wrap: anywhere;
   }
 
   .journey-card__tagline {
     margin: var(--space-1) 0 0;
     font-size: var(--text-sm);
-    line-height: var(--leading-normal, 1.5);
+    line-height: var(--leading-normal);
     color: var(--color-text-secondary);
     /* Clamp to two lines so a long lede never unbalances a rail of cards. */
     display: -webkit-box;
@@ -252,18 +338,43 @@
     overflow: hidden;
   }
 
+  /*
+    No divider. The prototype's `.jcard__body` runs continuously from the cover to
+    the foot — the `margin-top: auto` on `.jcard__foot` does the separating. A
+    border-top here cut the card into three stacked panels.
+  */
   .journey-card__foot {
     display: flex;
     flex-direction: column;
     gap: var(--space-3);
-    padding: var(--space-4) var(--space-5) var(--space-5);
-    border-top: var(--border-width) var(--border-style) var(--color-border);
+    padding: 0 var(--space-5) var(--space-5);
   }
 
+  /* Prototype `.jcard__stats`: a flex row of segments, not one sentence. */
   .journey-card__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1) var(--space-4);
     margin: 0;
     font-size: var(--text-sm);
     color: var(--color-text-muted);
+  }
+
+  /*
+    `.jcard__stats b` — the numeral carries the weight, the noun stays quiet.
+
+    `--color-text`, NOT `--color-text-secondary`. Measured in a real browser on a
+    light-background org: the label's `--color-text-muted` resolves to oklch 0.55
+    in BOTH themes, while `--color-text-secondary` lands at 0.611 dark / 0.65
+    light — so on a light page the "emphasised" numeral came out LIGHTER than the
+    noun it is supposed to outrank, i.e. the emphasis inverted. `--color-text`
+    tracks the theme properly (0.9 dark / 0.05 light), so the numeral is the more
+    prominent of the pair either way. jsdom cannot catch this — it does not
+    resolve oklch — which is why it is asserted in the browser, not in the test.
+  */
+  .journey-card__stat-value {
+    font-weight: var(--font-semibold);
+    color: var(--color-text);
   }
 
   .journey-card__cta {
@@ -275,7 +386,7 @@
 
   .journey-card__price {
     font-size: var(--text-lg);
-    font-weight: var(--font-semibold, var(--font-medium));
+    font-weight: var(--font-semibold);
     color: var(--color-text-primary);
   }
 
@@ -285,12 +396,14 @@
     color: var(--color-text-secondary);
   }
 
+  /* Prototype `.jcard__go` is weight 600 — the CTA is the card's loudest text
+     after the title, and --font-medium under-sold it. */
   .journey-card__go {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
     font-size: var(--text-sm);
-    font-weight: var(--font-medium);
+    font-weight: var(--font-semibold);
     color: var(--color-interactive);
   }
 

--- a/apps/web/src/lib/components/journeys/JourneyCard.svelte.test.ts
+++ b/apps/web/src/lib/components/journeys/JourneyCard.svelte.test.ts
@@ -135,3 +135,158 @@ describe('JourneyCard cover band', () => {
     ).toContain('The Practice of Stillness');
   });
 });
+
+/**
+ * Prototype-conformance structure (Codex-ycsd8).
+ *
+ * Reference: `.jcard` in docs/design/course-journeys/prototype/explore.html — the
+ * file where that card's anatomy is DEFINED (1-threshold.html only consumes it).
+ *
+ * These assert STRUCTURE, deliberately not computed CSS. jsdom does not implement
+ * `color-mix()` / `oklch()` / `backdrop-filter` and hands custom properties back
+ * as their raw declared string, so a "computed style" assertion here would pass
+ * against a still-broken card. Typography and the scrim were verified instead by
+ * reading computed styles in a real browser (recorded on the bead); what is
+ * mechanised here is the wiring those styles hang off.
+ *
+ * Falsifiability, per test:
+ *   • badge-in-cover — moving the badge back into `__head` fails it.
+ *   • featured — deleting the `class:journey-card--featured` directive fails it,
+ *     and the false-case fails if the class is applied unconditionally.
+ *   • stat segments — reverting to the old single joined `statsLabel` string
+ *     removes `.journey-card__stat-value` and fails it.
+ *   • kicker/tagline — dropping either `{#if}` branch fails it.
+ */
+describe('JourneyCard prototype conformance', () => {
+  let component: ReturnType<typeof mount> | null = null;
+
+  /** Tear the current mount down so the next case starts from a clean document. */
+  function reset() {
+    if (component) unmount(component);
+    component = null;
+    document.body.innerHTML = '';
+  }
+
+  afterEach(reset);
+
+  function render(overrides: Partial<JourneyCardView> = {}) {
+    component = mount(JourneyCard, {
+      target: document.body,
+      props: { journey: cardView(overrides), href: '/journeys/stillness' },
+    });
+    flushSync();
+  }
+
+  test('the badge is an overlay INSIDE the cover band, not a row above the kicker', () => {
+    render();
+
+    const badge = document.querySelector('.journey-card__badge');
+    expect(badge).not.toBeNull();
+    // The prototype places `.jcard__tag` absolutely on the cover. Structurally
+    // that means the badge is a child of the cover band, not of the head.
+    expect(
+      document.querySelector('.journey-card__cover .journey-card__badge')
+    ).toBe(badge);
+    expect(
+      document.querySelector('.journey-card__head .journey-card__badge')
+    ).toBeNull();
+  });
+
+  test('a featured journey earns card chrome; a browsing tile does not', () => {
+    render({ featured: true });
+    expect(
+      document
+        .querySelector('.journey-card')
+        ?.classList.contains('journey-card--featured')
+    ).toBe(true);
+
+    // Reset between the two halves so the negative case is a fresh mount.
+    reset();
+
+    render({ featured: false });
+    expect(
+      document
+        .querySelector('.journey-card')
+        ?.classList.contains('journey-card--featured')
+    ).toBe(false);
+  });
+
+  test('stats render as segments with the numeral carried separately', () => {
+    render({ stageCount: 4, practiceCount: 24 });
+
+    const values = [
+      ...document.querySelectorAll('.journey-card__stat-value'),
+    ].map((el) => el.textContent?.trim());
+    // Prototype `.jcard__stats b` — the number is its own element so it can take
+    // the weight while the noun stays quiet. A single joined string cannot.
+    expect(values).toEqual(['4', '24']);
+
+    const segments = [...document.querySelectorAll('.journey-card__stat')].map(
+      (el) => el.textContent?.replace(/\s+/g, ' ').trim()
+    );
+    expect(segments).toEqual(['4 stages', '24 practices']);
+  });
+
+  test('stats stay singular-aware and drop a stageless segment entirely', () => {
+    render({ stageCount: 1, practiceCount: 1 });
+    expect(
+      [...document.querySelectorAll('.journey-card__stat')].map((el) =>
+        el.textContent?.replace(/\s+/g, ' ').trim()
+      )
+    ).toEqual(['1 stage', '1 practice']);
+
+    reset();
+
+    // A stageless journey shows practices only — no empty leading segment.
+    render({ stageCount: 0, practiceCount: 7 });
+    expect(
+      [...document.querySelectorAll('.journey-card__stat')].map((el) =>
+        el.textContent?.replace(/\s+/g, ' ').trim()
+      )
+    ).toEqual(['7 practices']);
+  });
+
+  test('kicker and tagline render when present and are omitted when null', () => {
+    render({ kicker: 'Foundation course', tagline: 'Eight weeks of sitting.' });
+    expect(
+      document.querySelector('.journey-card__kicker')?.textContent?.trim()
+    ).toBe('Foundation course');
+    expect(
+      document.querySelector('.journey-card__tagline')?.textContent?.trim()
+    ).toBe('Eight weeks of sitting.');
+
+    reset();
+
+    render({ kicker: null, tagline: null });
+    expect(document.querySelector('.journey-card__kicker')).toBeNull();
+    expect(document.querySelector('.journey-card__tagline')).toBeNull();
+  });
+
+  test('the foot shows price + CTA, and swaps to progress when enrolled', () => {
+    render();
+    expect(document.querySelector('.journey-card__cta')).not.toBeNull();
+    expect(document.querySelector('.journey-card__progress')).toBeNull();
+
+    reset();
+
+    component = mount(JourneyCard, {
+      target: document.body,
+      props: {
+        journey: cardView(),
+        href: '/journeys/stillness',
+        progress: {
+          percent: 50,
+          status: 'in-progress' as const,
+          completedPractices: 12,
+          totalPractices: 24,
+        },
+      },
+    });
+    flushSync();
+    expect(document.querySelector('.journey-card__progress')).not.toBeNull();
+    expect(document.querySelector('.journey-card__cta')).toBeNull();
+    expect(
+      document.querySelector('.journey-card__status')?.textContent?.trim()
+    ).toBe('12 of 24 practices');
+  });
+});


### PR DESCRIPTION
Closes complaint #8 — *"the course card on the home page is basic — nothing like the prototypes."* Bead `Codex-ycsd8`.

Refined by you as a **fidelity** gap, not a token violation: the card already used the design system correctly.

## Governing prototype

`.jcard` in `docs/design/course-journeys/prototype/explore.html`. Evidence it's the right reference: explore.html **defines** the full BEM anatomy (`__cover`/`__preview`/`__tag`/`__text`/`__body`/`__stats`/`__foot`/`__price`/`__go`) at two grid sizes, while `1-threshold.html` merely **consumes** `.jcard` six times. `library.html` and `course-sell.html` use unrelated card families (`fr-card`/`contcard`, `descent-card`).

## Delta matrix

**Closed (7)**

| | Prototype | Was | Now |
|---|---|---|---|
| Title | `1.7rem` @ weight **400** | `--text-xl` / semibold | `--text-2xl` / `--font-normal` |
| Kicker tracking | `.2em` | `0.08em` | `0.2em` |
| Stats | `<b>N</b> practices` | one joined string | segments, numeral in its own element |
| Foot divider | none | `border-top` | removed |
| Tag | absolute on cover, blurred pill | static in `__head` | overlay with its own scrim |
| CTA weight | 600 | `--font-medium` | `--font-semibold` |
| Card background | always on | transparent | **resolved via `--featured`** ↓ |

The prototype's always-on background contradicts the standing transparent-by-default rule. Rather than pick a side: **`JourneyCardView.featured` already existed in the DTO and the card was ignoring it**, so the prototype's chrome now lives on a `--featured` variant and a browsing tile stays transparent.

**Deliberate divergence (1)** — cover tone gradients (`.jcard__cover.ember/.blood/.clay`). Per-card accent colour contradicts the neutral-palette decision; aspect ratio + layout carry the type signal. A `color-mix(brand, transparent)` plate also disappears on dark orgs.

**Blocked — need your decision (4), not attempted**

- **Italic-serif tagline + serif price.** The token set has **no serif** — only `--font-sans`/`--font-heading`/`--font-mono`, and *both* sans and heading resolve through `--brand-font-body`/`--brand-font-heading`, i.e. they're org-overridable. A serif here would be a hardcoded family overriding the creator's brand font. Needs a `--font-serif` token decision.
- **The `<b>{mins}</b> min` stat.** `JourneyCardView` carries **no duration field**. Needs a backend rollup of practice media durations — a separate WP.
- **The hover preview** (text fades to `.12`, shimmer sweeps, scrub bar animates). The prototype's cover is a *gradient*, so fading its text costs nothing; ours is a real photo.
- **Identity text on the cover.** The prototype puts kicker/title/tagline *inside* the cover; we stack below. Same reason — type over an arbitrary creator photo needs a scrim strategy. **This is the biggest remaining fidelity gap.**

## Two bugs the browser caught that jsdom could not

**1. Inverted emphasis in light mode.** The numeral first used `--color-text-secondary` against the label's `--color-text-muted`. Both are *distance-from-mid-grey* formulas, so their contrast **order** isn't stable across themes:

| theme | page bg | label L | value L | emphasis |
|---|---|---|---|---|
| dark | `rgb(26,18,7)` | 0.55 | 0.611 | correct |
| light | `rgb(255,251,235)` | 0.55 | **0.65** | **INVERTED** |

On a light-background org the "emphasised" numeral was *lighter* than the text it was meant to outrank. Now `--color-text`, which genuinely inverts (`clamp(0.05, (0.6 - l) * 1000, 0.9)` → 0.9 dark / 0.05 light). Re-verified: **PASS both themes** (0.9 vs 0.55 dark; 0.05 vs 0.55 light).

*General rule worth keeping:* for a contrast **relationship** between two texts, at least one side must be a theme-inverting token.

**2. Long-title overflow.** An unbroken title overflowed the card by **368px** — and enlarging the title made that likelier. Fixed with `overflow-wrap: anywhere`, deliberately not `break-word`: only `anywhere` also shrinks intrinsic **min-content**, which is what the carousel track measures. Verified: 320px card, **zero** overflow, title grows in height (75 → 113 → 150px).

## A false alarm, recorded so nobody re-files it

The org landing page renders **dark** while this org's `--brand-bg` is `#FFFBEB`. That is **not** forced-dark: `localStorage.theme === 'dark'` is an explicit stored viewer preference and the OS prefers light, so the page is correctly following the viewer — the *opposite* of `Codex-gfg50`. Relatedly, `--color-text-muted` measuring `oklch 0.55` in *both* themes is **deliberate** (its `abs(0.5 - l) + 0.3` formula saturates at the same ceiling for both extremes), not a brand-layer bug.

## Verification

Real browser, org `of-blood-and-bones`, on the surface the card actually ships on — the "Guided portals" `Carousel` on the org landing page (`+page.svelte:614`, `itemMinWidth="20rem"` ≈ the prototype's `minmax(330px, 1fr)`). Computed styles confirm every closed delta.

The `--featured` variant was verified **end to end**, not just in a test: temporarily set `landing_pages.featured = true` → card background `rgba(0,0,0,0)` → `rgb(26,18,7)` (`--color-surface`) and border `--color-border` → `--color-border-strong` → **restored to false**. Fixture re-verified: `featured=f`, `status=published`, slug unchanged. `localStorage.theme` restored to `dark`. No other data touched.

**6 new tests (10 in the file)**, asserting structure only and documenting why — jsdom implements neither `color-mix()` nor `oklch()` and hands custom properties back as their raw declared string, so a computed-style colour test there would pass against a broken card. **All 6 mutants killed, none survived:** badge back in `__head`, featured directive deleted, featured applied unconditionally, `stat-value` wrapper removed, stageless guard removed, kicker `{#if}` defeated.

## Gates

| Gate | Result |
|---|---|
| typecheck | **57/57** |
| apps/web tests | **1484 pass / 147 files** (baseline 1478 + 6 new) |
| svelte-check | **68 errors / 43 warnings / 44 files** — exact baseline, 0 new |
| biome | **0 errors**, 175 warnings, 5 infos — baseline |
| brand-boundary | **OK (207 files)** |

CI's DB-backed jobs are red from the **Neon compute-time quota** (`compute time quota exceeded; usage:"396363", limit:"396000"` → `branch creation failed`), not this diff — they die before any test runs.

## Cleanups

`--text-2xs` **does not exist** — the badge was silently falling back through `var(--text-2xs, var(--text-xs))`. Dropped that and the other unnecessary fallbacks (`var(--font-semibold, var(--font-medium))`, `var(--leading-tight, 1.2)`) after verifying each token is real.

## Follow-up

`Codex-oi2w4` (in_progress) owns **where** cards appear. If it lands the Explore grid, re-audit there — the prototype uses **two** grid sizes (`minmax(330px, 1fr)` and `minmax(240px, 1fr)`) and the `--text-2xl` title may need to step down in the narrow one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)