### PR TITLE
feat(journeys): honour the visitor's light/dark choice on every journey surface (Codex-a1tz6, closes Codex-4i8x5)

### DIFF
--- a/apps/web/src/lib/components/journeys/CurriculumMap.svelte
+++ b/apps/web/src/lib/components/journeys/CurriculumMap.svelte
@@ -213,12 +213,12 @@
   .stage--done .stage__numeral {
     background: color-mix(in oklab, var(--portal-ember) 20%, transparent);
     border-color: transparent;
-    color: var(--portal-ember);
+    color: var(--portal-ember-text);
   }
 
   .stage--current .stage__numeral {
     border-color: var(--portal-ember);
-    color: var(--portal-ember);
+    color: var(--portal-ember-text);
     box-shadow: 0 0 var(--space-3) calc(var(--border-width) * 1)
       color-mix(in oklab, var(--portal-ember) 35%, transparent);
   }
@@ -314,7 +314,7 @@
 
   .lrow__icon--current {
     border-color: var(--portal-ember);
-    color: var(--portal-ember);
+    color: var(--portal-ember-text);
     box-shadow: 0 0 var(--space-2-5) calc(var(--border-width) * 1)
       color-mix(in oklab, var(--portal-ember) 40%, transparent);
   }
@@ -353,7 +353,7 @@
   .lrow__go {
     flex: none;
     font-size: var(--text-sm);
-    color: var(--portal-ember);
+    color: var(--portal-ember-text);
     opacity: 0;
     transition: opacity var(--duration-fast) var(--ease-out);
   }

--- a/apps/web/src/lib/components/journeys/JourneyContinueCard.svelte
+++ b/apps/web/src/lib/components/journeys/JourneyContinueCard.svelte
@@ -174,7 +174,7 @@
     font-size: var(--text-xs);
     letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: var(--portal-ember);
+    color: var(--portal-ember-text);
   }
 
   .cont__title {

--- a/apps/web/src/lib/page-builder/journey-palette.css
+++ b/apps/web/src/lib/page-builder/journey-palette.css
@@ -63,8 +63,12 @@
   /* ── the ink: the page's own background ──────────────────────────────────
      The per-page override (`brandOverrides.backgroundColor` → `--brand-bg` on a
      nested `[data-org-brand]`), else the inherited org brand background, else
-     the neutral design token. This is the ONE input the whole ladder hangs off,
-     which is what makes light and dark both correct with no branch. */
+     the neutral design token. This is the ONE input the whole ladder hangs off:
+     every rung below is auto-contrasted from it, so a light ink and a dark ink
+     are both correct without any rung needing its own branch.
+
+     This declaration is the LIGHT pole. The dark pole re-points this single
+     property and nothing else — see THE DARK POLE below. */
   --jp-ink: var(--brand-bg, var(--color-background));
 
   /* ── auto-contrast ───────────────────────────────────────────────────────
@@ -105,6 +109,21 @@
   --jp-rose: var(--brand-accent, var(--jp-ember));
   --jp-on-ember: oklch(from var(--jp-ember) clamp(0.05, (0.6 - l) * 100, 0.98) 0 0);
 
+  /* ── the ember AS TEXT ───────────────────────────────────────────────────
+     `--jp-ember` is tuned to be a FILL, with `--jp-on-ember` written on top of
+     it. Used directly as small text ON the page it is a legibility bug in both
+     directions: measured on a mid-lightness brand orange it lands at 2.98:1
+     against a dark ink and 2.46:1 against a light one, where AA needs 4.5.
+
+     Pulling it toward `--jp-heading` fixes both readings at once with no branch,
+     because the heading is already auto-contrasted to the ink — so this mix
+     lightens the ember on a dark ink and darkens it on a light one. 60% keeps
+     the hue unmistakably brand while clearing AA on both poles. Chroma rides
+     along with the mix, which is why it stays a warm accent and not grey.
+
+     Use this for accent TEXT. Keep `--jp-ember` for fills, borders and glows. */
+  --jp-ember-text: color-mix(in oklab, var(--jp-ember) 60%, var(--jp-heading));
+
   /* ── atmosphere ─────────────────────────────────────────────────────────
      The ember bloom is a fixed-strength gradient; this veil is what makes its
      APPARENT strength track the ink's darkness. It is the ink's own colour, so
@@ -139,6 +158,50 @@
   --color-text-tertiary: var(--jp-faint);
 }
 
+/* ── THE DARK POLE ──────────────────────────────────────────────────────────
+   (Codex-a1tz6) The rule above delivers the CREATOR's chosen background. It did
+   NOT deliver the VISITOR's light/dark choice: it reads `--brand-bg`, which is
+   only the LIGHT pole, so a journey stayed cream for a visitor in dark mode.
+   Those are two independent axes and both are satisfiable — a creator's cream
+   brand has a dark companion, and dark-mode visitors should get it.
+
+   This is not new infrastructure. `tokens/org-brand.css` already carries a
+   two-pole brand background and switches on theme:
+
+     [data-org-bg]                     → --color-background: var(--brand-bg)
+     [data-theme='dark'] [data-org-bg] → --color-background: var(--brand-bg-dark, var(--brand-bg, …))
+
+   `--brand-bg-dark` is injected by the org layout alongside `--brand-bg`. The
+   chain below is deliberately IDENTICAL to org-brand.css's, so a journey surface
+   resolves its background exactly like every other org surface.
+
+   Re-pointing `--jp-ink` ALONE is sufficient for the whole page. Every rung
+   above — heading, the text ladder, the three insets, all four hairlines, and
+   the atmosphere veil's alpha — is derived from `--jp-ink`'s OWN lightness, so
+   they all invert from this single input with no further branching. The veil in
+   particular returns to alpha 0 on a dark ink, which is what restores the full
+   candlelight bloom.
+
+   ── WHY BOTH SELECTOR FORMS ────────────────────────────────────────────────
+   The theme-init script in `app.html` sets `data-theme` on <html> AND adds a
+   matching `.dark`/`.light` CLASS, and org-brand.css keys its dark branches on
+   BOTH forms. A rule written against only one of them is beaten by the
+   org-brand rule written against the other. Both are required.
+
+   Specificity: `.dark` + three classes = (0,4,0), clearing the (0,3,0) base
+   above and org-brand.css's `[data-theme='dark'] [data-org-brand]` (0,2,0).
+
+   NOTE (known limitation, deliberately not papered over): a page whose
+   `brandOverrides` sets `backgroundColor` injects only `--brand-bg`, so in dark
+   mode `--brand-bg-dark` — inherited from the org — wins and the per-page
+   background applies in light mode only. Deriving a dark companion from the
+   override would be guesswork about the creator's intent; it needs a real
+   decision (and probably a dark-background control in the brand editor). */
+.dark .journey-palette.journey-palette.journey-palette,
+[data-theme='dark'] .journey-palette.journey-palette.journey-palette {
+  --jp-ink: var(--brand-bg-dark, var(--brand-bg, var(--color-background)));
+}
+
 /* ── background / surface / border ──────────────────────────────────────────
    MUST be applied to a DESCENDANT of `.journey-palette`, never the same element
    (see CYCLE SAFETY above). These are the tokens the live sales sections and the
@@ -147,8 +210,22 @@
 
    `--color-brand-*`, `--color-text-on-brand`, `--color-focus` and
    `--color-text-inverse` are deliberately NOT re-pointed anywhere in this file —
-   they are the brand accent and its companions, and they read correctly against
-   either ink. */
+   they are the brand accent and its companions, owned by org-brand.css.
+
+   CAVEAT, measured 2026-07-29 (Codex-a1tz6): the claim that once stood here —
+   that they "read correctly against either ink" — is FALSE for
+   `--color-text-on-brand` in dark mode, and not because of anything in this file.
+   org-brand.css swaps `--color-brand-primary` to `--brand-color-dark` in its dark
+   branch but derives `--color-text-on-brand` from `--brand-color` and never
+   re-derives it, so a primary button paints its background with the DARK brand
+   while contrasting its label against the LIGHT one. Measured on
+   `of-blood-and-bones`: background `#FB923C`, label auto-contrasted against
+   `#552e8e` → white → 2.26:1, where AA needs 4.5.
+
+   This is platform-wide (every org primary button in dark mode whose two brand
+   colours differ in lightness), not journey-specific — it was simply invisible on
+   journeys until they started honouring dark mode. Fixing it belongs in
+   org-brand.css's dark branch, not here. */
 .journey-palette--page {
   --color-background: var(--jp-ink);
   --color-surface: var(--jp-ink-2);

--- a/apps/web/src/lib/page-builder/journey-palette.test.ts
+++ b/apps/web/src/lib/page-builder/journey-palette.test.ts
@@ -45,6 +45,9 @@ const read = (rel: string): string => readFileSync(join(HERE, rel), 'utf8');
 const PALETTE = read('journey-palette.css');
 const SECTIONS_CSS = read('render-edit/journey-sections.css');
 
+/** Comment-free view, for anything that locates a SELECTOR by substring. */
+const PALETTE_CODE = PALETTE.replace(/\/\*[\s\S]*?\*\//g, '');
+
 /**
  * The base rule must out-specify org-brand.css, which sets the same tokens at
  * `[data-org-brand]` (0,1,0) and `[data-theme='dark'] [data-org-brand]` (0,2,0)
@@ -53,11 +56,19 @@ const SECTIONS_CSS = read('render-edit/journey-sections.css');
  */
 const BASE_SELECTOR = '.journey-palette.journey-palette.journey-palette {';
 
-/** Declarations only — `--x: …`, not `var(--x)` reads. */
+/**
+ * Declarations only — `--x: …`, not `var(--x)` reads.
+ *
+ * Comments are stripped FIRST. These files document the token contract by
+ * quoting real declarations in prose (e.g. org-brand.css's two-pole chain), and
+ * without this the helper counts that prose as live CSS — a test that a comment
+ * can break is not measuring the thing it claims to measure.
+ */
 const declarationsOf = (css: string, prop: string): string[] => {
+  const code = css.replace(/\/\*[\s\S]*?\*\//g, '');
   const out: string[] = [];
   const re = new RegExp(`(^|[;{\\s])${prop}\\s*:([^;}]*)`, 'g');
-  for (const m of css.matchAll(re)) out.push(m[2].trim());
+  for (const m of code.matchAll(re)) out.push(m[2].trim());
   return out;
 };
 
@@ -76,18 +87,53 @@ describe('journey palette — one derivation, three surfaces', () => {
     expect(compound).not.toMatch(/[\s>+~]/);
   });
 
-  it('declares the ink ladder in exactly one place', () => {
-    // The ladder's root input. Two declarations means the divergence is back.
-    expect(declarationsOf(PALETTE, '--jp-ink')).toHaveLength(1);
+  it('declares the ink ladder in exactly one place — one declaration per theme pole', () => {
+    // The ladder's root input. Exactly TWO declarations, both in this file: the
+    // light pole and the dark pole (Codex-a1tz6). A third would mean the
+    // divergence this file exists to prevent has come back; a single one would
+    // mean the dark pole was dropped and journeys stopped honouring dark mode.
+    expect(declarationsOf(PALETTE, '--jp-ink')).toHaveLength(2);
     expect(declarationsOf(SECTIONS_CSS, '--jp-ink')).toEqual([]);
     expect(declarationsOf(SECTIONS_CSS, '--jp-heading')).toEqual([]);
   });
 
-  it('derives the ink from the brand BACKGROUND, not the brand primary', () => {
-    const [ink] = declarationsOf(PALETTE, '--jp-ink');
-    expect(ink).toContain('--brand-bg');
-    expect(ink).not.toContain('--color-brand-primary');
-    expect(ink).not.toContain('--brand-color');
+  it('derives the ink from the brand BACKGROUND, not the brand primary, in BOTH themes', () => {
+    const inks = declarationsOf(PALETTE, '--jp-ink');
+    expect(inks).toHaveLength(2);
+    for (const ink of inks) {
+      expect(ink).toContain('--brand-bg');
+      expect(ink).not.toContain('--color-brand-primary');
+      // `--brand-color` is the org PRIMARY. Anchoring the ink on it is the exact
+      // bug this file was created to remove, and the one the member dashboard
+      // still carried (Codex-4i8x5).
+      expect(ink).not.toContain('--brand-color');
+    }
+    const [light, dark] = inks;
+    // The light pole reads the light background only; the dark pole prefers the
+    // org's dark companion and falls back to it.
+    expect(light).not.toContain('--brand-bg-dark');
+    expect(dark).toContain('--brand-bg-dark');
+  });
+
+  it('switches the ink on theme using BOTH selector forms the app emits', () => {
+    // `app.html` sets `data-theme` on <html> AND adds a matching `.dark`/`.light`
+    // class, and org-brand.css keys its dark branches on BOTH. A rule written
+    // against only one form loses to the org-brand rule written against the
+    // other, and the surface silently keeps the light background in dark mode.
+    // (This is also why a browser check that flips only `data-theme` reports a
+    // theme-correct surface as theme-invariant.)
+    const darkRule = PALETTE_CODE.slice(
+      PALETTE_CODE.indexOf('.dark .journey-palette')
+    );
+    const selector = darkRule.slice(0, darkRule.indexOf('{'));
+
+    expect(selector).toContain('.dark .journey-palette');
+    expect(selector).toContain("[data-theme='dark'] .journey-palette");
+    // Each form keeps the triple-class compound, so it clears the (0,3,0) base
+    // rule above it as well as org-brand.css's dark branch.
+    for (const form of selector.split(',')) {
+      expect(form.split('.journey-palette').length - 1).toBe(3);
+    }
   });
 
   it('auto-contrasts the heading off the ink rather than fixing its lightness', () => {
@@ -139,21 +185,87 @@ describe('journey palette — cycle safety', () => {
     // `--color-background: var(--jp-ink)` in the SAME rule is a custom-property
     // cycle: both become invalid at computed-value time and the page paints
     // nothing. So the base class must NOT declare it, and the modifier must.
-    const baseBlock = PALETTE.slice(
-      PALETTE.indexOf(BASE_SELECTOR),
-      PALETTE.indexOf('.journey-palette--page {')
+    const baseBlock = PALETTE_CODE.slice(
+      PALETTE_CODE.indexOf(BASE_SELECTOR),
+      PALETTE_CODE.indexOf('.journey-palette--page {')
     );
-    const pageBlock = PALETTE.slice(
-      PALETTE.indexOf('.journey-palette--page {')
+    const pageBlock = PALETTE_CODE.slice(
+      PALETTE_CODE.indexOf('.journey-palette--page {')
     );
 
-    expect(declarationsOf(baseBlock, '--jp-ink')).toHaveLength(1);
+    // Two `--jp-ink` declarations live here: the light pole and the dark pole.
+    // Both are ABOVE `.journey-palette--page`, which is what keeps the ink and
+    // its re-point on separate elements.
+    expect(declarationsOf(baseBlock, '--jp-ink')).toHaveLength(2);
     expect(declarationsOf(baseBlock, '--color-background')).toEqual([]);
 
     expect(declarationsOf(pageBlock, '--color-background')).toEqual([
       'var(--jp-ink)',
     ]);
     expect(declarationsOf(pageBlock, '--jp-ink')).toEqual([]);
+  });
+});
+
+describe('member dashboard consumes the shared palette (Codex-4i8x5)', () => {
+  const DASHBOARD = read(
+    '../../routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte'
+  );
+
+  it('imports the shared palette and applies both classes on separate elements', () => {
+    expect(DASHBOARD).toContain(
+      "import '$lib/page-builder/journey-palette.css'"
+    );
+    // Base on the outer wrapper, re-points on a DESCENDANT — same split the
+    // renderer and the checkout use. Both on one element is the cycle.
+    expect(DASHBOARD).toContain('class="journey-portal journey-palette"');
+    expect(DASHBOARD).toContain(
+      'class="journey-portal__inner journey-palette--page"'
+    );
+  });
+
+  it('no longer anchors the portal palette on the brand PRIMARY', () => {
+    // The third private derivation: `--portal-anchor: var(--brand-color, …)`,
+    // which made one journey purple on its sales page and orange inside.
+    expect(declarationsOf(DASHBOARD, '--portal-anchor')).toEqual([]);
+    for (const prop of [
+      '--portal-bg',
+      '--portal-bg-deep',
+      '--portal-surface',
+      '--portal-surface-2',
+      '--portal-text',
+      '--portal-text-dim',
+      '--portal-text-faint',
+    ]) {
+      const [decl] = declarationsOf(DASHBOARD, prop);
+      expect(decl, `${prop} must be declared`).toBeDefined();
+      expect(decl, `${prop} must not read the brand primary`).not.toContain(
+        '--brand-color'
+      );
+      expect(decl, `${prop} must come off the shared ladder`).toContain(
+        '--jp-'
+      );
+    }
+  });
+
+  it('fixes no lightness on any portal surface or text token', () => {
+    // The actual 4i8x5 defect was the FORCED lightness (0.15 bg / 0.94 text)
+    // with no light branch — identical in both themes. Any bare numeric
+    // lightness in an `oklch(from …)` here means a pole was hardcoded again.
+    for (const prop of [
+      '--portal-bg',
+      '--portal-bg-deep',
+      '--portal-surface',
+      '--portal-surface-2',
+      '--portal-text',
+      '--portal-text-dim',
+      '--portal-text-faint',
+    ]) {
+      for (const decl of declarationsOf(DASHBOARD, prop)) {
+        expect(decl, `${prop} hardcodes a lightness`).not.toMatch(
+          /oklch\(\s*from\s+[^)]*\)?\s+0?\.\d+/
+        );
+      }
+    }
   });
 });
 

--- a/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/journeys/[journeySlug]/dashboard/+page.svelte
@@ -10,14 +10,17 @@
   server's known completions, and completing a practice in the player updates it
   reactively here (cross-tab + cross-device via `initProgressSync`).
 
-  Surface (prototype `course-dashboard.html`): a warm/dark "descent" portal.
-  Its palette is SELF-DERIVED from the org brand via OKLCH on `.journey-portal`
-  (anchored on `--brand-color`), and the semantic heading/text tokens are
-  RE-POINTED there so the org-brand.css `[data-org-brand] :is(h1..h6)` backstop
-  resolves to the portal palette instead of the neutral org heading colour.
+  Surface (prototype `course-dashboard.html`): the "descent" portal. Its palette
+  comes from the SHARED journey palette (`$lib/page-builder/journey-palette.css`,
+  Codex-gfg50) — the same derivation the sales page and the checkout use — so the
+  member area follows the creator's background AND the visitor's light/dark
+  choice. The `--portal-*` names survive as aliases over that ladder; see the
+  `<style>` block. It previously carried a third private derivation anchored on
+  the brand PRIMARY at forced lightnesses, which honoured neither (Codex-4i8x5).
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
+  import '$lib/page-builder/journey-palette.css';
   import CurriculumMap from '$lib/components/journeys/CurriculumMap.svelte';
   import JourneyContinueCard from '$lib/components/journeys/JourneyContinueCard.svelte';
   import {
@@ -123,8 +126,16 @@
   <title>{dashboard.course.title} · Your journey</title>
 </svelte:head>
 
-<div class="journey-portal">
-  <div class="journey-portal__inner">
+<div class="journey-portal journey-palette">
+  <!--
+    `journey-palette--page` MUST sit on this inner element, not on
+    `.journey-portal`. `--jp-ink` falls back to `--color-background`, so
+    re-pointing `--color-background: var(--jp-ink)` on the SAME element is a
+    custom-property cycle and the page paints nothing. A descendant merely
+    inherits an already-resolved `--jp-ink`.
+    See `$lib/page-builder/journey-palette.css`.
+  -->
+  <div class="journey-portal__inner journey-palette--page">
     <header class="portal-head">
       <p class="portal-head__eyebrow">Your journey</p>
       <h1 class="portal-head__title">{dashboard.course.title}</h1>
@@ -182,34 +193,61 @@
 
 <style>
   .journey-portal {
-    /* ── Warm/dark "descent" portal, self-derived from the org brand ──────────
-       Anchor the whole palette on the brand primary hue, then FORCE lightness
-       for guaranteed contrast on any org colour (light-brand orgs still get a
-       focused dark space; the hue keeps it on-brand). Chroma is scaled down so
-       surfaces read as warm near-neutrals, not saturated blocks. */
-    --portal-anchor: var(--brand-color, var(--color-primary-600));
+    /* ── The `--portal-*` names are now ALIASES over the shared journey palette ─
+       (Codex-a1tz6, closing Codex-4i8x5.) This block used to be a THIRD private
+       derivation: it anchored on the brand PRIMARY and then FORCED lightness
+       (0.15 bg / 0.94 text) for a guaranteed dark space on any org colour. Two
+       consequences made that wrong:
 
-    --portal-bg: oklch(from var(--portal-anchor) 0.15 calc(c * 0.3) h);
-    --portal-bg-deep: oklch(from var(--portal-anchor) 0.1 calc(c * 0.3) h);
-    --portal-surface: oklch(from var(--portal-anchor) 0.2 calc(c * 0.35) h);
-    --portal-surface-2: oklch(from var(--portal-anchor) 0.24 calc(c * 0.42) h);
+         1. It ignored the visitor's light/dark choice — the values were
+            identical in both themes, so a dark-mode-off visitor still got a
+            dark member area. Worse, it was DISCARDING a per-theme background
+            that already resolves correctly one element up: on this very page
+            `[data-org-bg]` gives #FFFBEB in light and #1A1207 in dark.
+         2. It anchored on `--brand-color` (the org PRIMARY) where the sales page
+            anchors on the brand BACKGROUND, so one journey rendered purple on
+            its sales page and orange once you were inside it.
 
-    --portal-text: oklch(from var(--portal-anchor) 0.94 calc(c * 0.08) h);
-    --portal-text-dim: oklch(from var(--portal-anchor) 0.82 calc(c * 0.07) h);
-    --portal-text-faint: oklch(from var(--portal-anchor) 0.64 calc(c * 0.07) h);
+       `journey-palette.css` is the ONE derivation (Codex-gfg50) and already
+       auto-contrasts every rung off the ink's own lightness, in either theme.
+       The token NAMES are kept because `CurriculumMap.svelte` and
+       `JourneyContinueCard.svelte` read them ~30 times between them; only the
+       derivation changes, so no consumer moves.
 
-    /* The glowing accent ("ember") + its dark ink for text on the accent. */
-    --portal-ember: oklch(from var(--portal-anchor) 0.72 calc(c * 0.9) h);
-    --portal-ember-soft: oklch(from var(--portal-anchor) 0.6 calc(c * 0.9) h);
-    --portal-ember-ink: oklch(from var(--portal-anchor) 0.18 calc(c * 0.5) h);
+       Surface ladder: the palette's insets lift TOWARD the contrast colour, so
+       they go lighter on a dark ink and subtly darker on a light one — which is
+       the direction "deeper / raised" wants in BOTH themes. `--portal-bg-deep`
+       therefore means "one step off the paper" rather than the old literal
+       "darker"; that reversal is exactly what makes it theme-correct. */
+    --portal-bg: var(--jp-ink);
+    --portal-bg-deep: var(--jp-ink-2);
+    --portal-surface: var(--jp-ink-3);
+    --portal-surface-2: var(--jp-ink-4);
 
-    /* Re-point the semantic tokens so descendants — and the org-brand.css
-       `[data-org-brand] :is(h1..h6){color:var(--color-heading)}` backstop —
-       resolve to the portal palette instead of fighting its specificity. */
-    --color-heading: var(--portal-text);
-    --color-text: var(--portal-text-dim);
-    --color-text-secondary: var(--portal-text-dim);
-    --color-text-muted: var(--portal-text-faint);
+    /* Text ladder, most → least prominent, all measured off the shared anchors
+       so they follow the ink in either theme.
+
+       The faint rung is NOT `--jp-faint`: it carries 13px meta text
+       (`.lrow__meta`), and both `--jp-faint` (50%) and `--jp-dim` (70%) measure
+       under AA there — 70% lands at 4.41:1 on the dark ink. 76% is the weakest
+       mix that clears 4.5 on both poles, so the rung is pinned there rather than
+       borrowed from a shared name that is tuned for larger text. */
+    --portal-text: var(--jp-heading);
+    --portal-text-dim: var(--jp-text);
+    --portal-text-faint: color-mix(in oklab, var(--jp-heading) 76%, var(--jp-ink));
+
+    /* The accent, its on-accent ink, and the accent AS TEXT. The last is a
+       separate token because the raw ember measured 2.98:1 (dark) / 2.46:1
+       (light) behind `Resume →` and the eyebrows — a pre-existing failure that
+       enabling light mode would otherwise have deepened. */
+    --portal-ember: var(--jp-ember);
+    --portal-ember-soft: oklch(from var(--jp-ember) calc(l - 0.1) c h);
+    --portal-ember-ink: var(--jp-on-ember);
+    --portal-ember-text: var(--jp-ember-text);
+
+    /* The semantic TEXT tokens are re-pointed by `.journey-palette` itself, at
+       (0,3,0) — higher than this rule — so restating them here would be dead
+       weight that could silently drift out of step with the shared ladder. */
 
     min-height: 100dvh;
     background: var(--portal-bg);
@@ -243,7 +281,7 @@
     font-size: var(--text-xs);
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--portal-ember);
+    color: var(--portal-ember-text);
   }
 
   .portal-head__title {

--- a/docs/design/course-journeys/conformance-revalidation-2026-07-29.md
+++ b/docs/design/course-journeys/conformance-revalidation-2026-07-29.md
@@ -1,0 +1,286 @@
+# Journeys/Portals Conformance — RE-VALIDATION, 2026-07-29
+
+**Bead:** `Codex-a1tz6`. **Supersedes the matrix in** `conformance-audit-2026-07-24.md` (kept for the
+audit trail; do not delete). **Base:** `dev` @ `61fd9731` (PRs #432/#433/#434/#435/#436 all merged).
+
+## Why this document exists
+
+The 2026-07-24 matrix could not simply be trusted or re-run:
+
+1. **Its fixture no longer exists.** That audit walked Studio Alpha's "Rootwork" journey (landing
+   page `68479fa3-0ec5-426c-b8ee-eed9249773ca`). The row is gone — wiped by a test suite's
+   `cleanupDatabase` against the shared local `main` DB. Every route in its matrix
+   (`/journeys/rootwork*`) is dead, and its screenshots are gone from the worktree.
+2. **It predates five merged PRs**, and three of its eight rows were provably wrong.
+
+**Fixture used here:** org `of-blood-and-bones` (`ddea4b84-…`), course
+`408f94d0-5442-43d3-a56a-3491110962eb` ("ASSSS BLASTER FART KING"), landing page
+`06b45e59-8058-475a-85b8-b0f717948640`, slug `pricing-smoke-test`, **published**.
+Verified intact: **3 stages / 12 practices** (4 written + 3 video + 2 audio), 1 completed purchase
++ entitlement + enrolment for `luzura@test.com`.
+
+**Method:** all 8 routes probed server-side for status, then walked in a real browser as the owner.
+Structure extracted programmatically rather than by snapshot. Colour measured with a **calibrated**
+OKLab→linear-sRGB→luminance converter (self-checked: white-on-black must return 21.00 — it did, for
+both `rgb()` and `oklab()` inputs). Themes tested by flipping `data-theme` on `<html>` and comparing
+resolved values.
+
+**No fixture was mutated by this re-validation.**
+
+---
+
+## Re-validated matrix
+
+| # | Surface | Route (current) | Prototype | 07-24 said | **07-29 verdict** | Changed? |
+|---|---|---|---|---|---|---|
+| 1 | Sell / landing | `/journeys/pricing-smoke-test` | `course-sell.html` | CLOSE, "6/11 sections" | **CLOSE** — 11 sections render; no light/dark (light pole only) | **YES** (section note void) |
+| 2 | Checkout | `…/checkout` | `checkout.html` | MODERATE-GAP, "payment stubbed" | **CLOSE** — genuinely buyable, 4 tiered offers, "Choose your way in" | **YES — row was wrong** |
+| 3 | Member dashboard | `…/dashboard` | `course-dashboard.html` | CLOSE | **CLOSE** + forced-dark confirmed (`Codex-4i8x5`) + brand-source split | **partly** |
+| 4 | In-course | `…/practice/:slug` | `content-incourse.html` | CLOSE / video broken | **CLOSE** — "Mark complete" present; **light/dark already correct**; video CSP-blocked | **YES** (improved) |
+| 5 | Studio index | `/studio/journeys` | `studio-journeys.html` | CLOSE, revenue missing | **CLOSE** — revenue now renders (`£25 · 30d`) | **YES** (revenue landed) |
+| 6 | Page builder | `/studio/journeys/:id/page` | `builder.html` | CLOSE | **CLOSE** — #435 verified; 3 real deltas remain | **YES — row was wrong** |
+| 7 | Curriculum editor | `…/curriculum` | `course-editor.html` | **MOCK-ONLY** | **CLOSE** — real editor on live DB data | **YES — row was flatly wrong** |
+| 8 | Insights | `…/insights` | `reporting.html` | MAJOR-GAP | **MAJOR-GAP — reproduced** + route is orphaned | no (worse) |
+
+---
+
+## Row-by-row evidence
+
+### 1 — Sell page: the "6/11 sections" note is void
+Renders **11 `.jp-section` blocks** vs the prototype's **10 `<section>`s** (the prototype has
+`intro, ache, turn, reel, descent, feel, proof, guide, faq, invite`). The 07-24 "6/11" figure was a
+property of *Rootwork's authored content*, not a code capability — a different journey with fewer
+blocks configured. On this fixture the page is section-complete.
+
+**Palette fix (`Codex-gfg50`) verified.** `journey-palette.css` resolves `--jp-ink` →
+`var(--brand-bg)` → `#FFFBEB`, giving cream paper with near-black auto-contrasted ink, and
+`--jp-ember` → `#552e8e` (the page-level `primaryColor` override wins). Values are byte-identical
+under dark and light, which the file documents as intentional: a sales page is a browsing surface and
+must follow the background the creator chose.
+
+**That intent has now been superseded by a user decision (2026-07-29): the visitor's light/dark
+choice must be respected here too.** The two goals are not in conflict — see **Theme support**.
+
+The triple-repeated `.journey-palette.journey-palette.journey-palette` selector (line 62) is
+load-bearing — it buys back the specificity point lost when these rules left a Svelte `<style>`.
+Do not "tidy" it.
+
+### 2 — Checkout: row was wrong
+Anonymous render is complete: `h1` = **"Choose your way in"** (the exact prototype heading the audit
+called missing), four offer cards, and a real `startJourneyCheckout` remote form with a submit
+button. Sell-page CTAs deep-link correctly:
+
+```
+?offer=purchase              £24.99
+?offer=subscription-monthly  £27
+?offer=subscription-annual   £270
+?offer=tier%3A33f6c1a1-…     £15
+```
+plus two bare `/checkout` primary CTAs. Entitled users instead get "Go to your dashboard" ×4 +
+"Continue →" — correct owned-state.
+
+### 3 — Member dashboard: content close, palette confirmed broken
+Live data throughout: 3 stages, 12 practices, `0 of 12 practices · 0% through`, per-stage `0/4`, 13
+practice links. The 07-24 LOW note *"'Continue' doesn't name the lesson"* is **fixed** — the CTA now
+reads "Soul Path Mentorship / Stage i · aergaerg · Reflection". No `role=tab` in-page tabs (07-24
+LOW note stands).
+
+**`Codex-4i8x5` reproduced at the named lines.** `dashboard/+page.svelte:190-199`:
+```css
+--portal-anchor: var(--brand-color, var(--color-primary-600));
+--portal-bg:      oklch(from var(--portal-anchor) 0.15 calc(c * 0.3)  h);
+--portal-surface: oklch(from var(--portal-anchor) 0.2  calc(c * 0.35) h);
+--portal-text:    oklch(from var(--portal-anchor) 0.94 calc(c * 0.08) h);
+```
+Hardcoded lightnesses — dark surfaces, light text, unconditionally, identical in both themes. This
+is `gfg50`'s exact bug shape, third copy. Worse than 4i8x5 records: the dashboard is **discarding a
+per-theme background that already works one element up**. On the very same page, its `[data-org-bg]`
+ancestor resolves `--color-background` to `#1A1207` in dark and `#FFFBEB` in light. The
+`.journey-portal` derivation throws that away and re-derives from `--brand-color` instead.
+
+**User decision 2026-07-29: the visitor's light/dark choice must be respected on all journey
+surfaces, the sell page included.** See **Theme support** below.
+
+**New finding (not on any bead): the brand source splits between surfaces.** `--brand-color`
+resolves to `#552e8e` on the sell page (page-level override applied) but `#EA580C` on the dashboard
+(org primary; the override is scoped to the landing-page artefact). Defensible scoping, but one
+journey renders purple when you buy it and orange once you're inside.
+
+### 4 — In-course: improved
+Written practice renders prose correctly, with a 13-link stage rail, a "Here" marker on the current
+practice, per-stage counts and a "Next practice" link. **The 07-24 note that only auto-complete
+shipped is now wrong — an explicit "Mark complete" button is present**, matching the prototype.
+
+The practice route declares **no palette tokens of its own** — no `.journey-portal`, no
+`.journey-palette` — and is therefore the **only journey surface that already honours the visitor's
+light/dark preference**, because it simply consumes the ambient `[data-org-bg]` tokens:
+
+| | dark | light |
+|---|---|---|
+| `--color-background` | `#1A1207` | `#FFFBEB` |
+| painted text colour | `oklch(0.9 0 0)` | `oklch(0.05 0 0)` |
+
+It is **not** a fourth copy of the forced-dark derivation. Do not "fix" it — it is the reference
+behaviour the other two surfaces should be brought up to. See **Theme support** below.
+
+Video remains broken in dev, cause confirmed straight from the response CSP header:
+`media-src 'self' blob: … http://localhost:4100 http://*.nip.io:4100` — no access-worker origin.
+→ `Codex-8tku7`, unchanged.
+
+### 5 — Studio index: revenue landed
+`h1` = "Portals". Row reads **"3 stages · 12 practices · 1 enrolled · £25 · 30d"**. Confirmed in
+source that `£25` is genuine 30-day revenue, not the price: `journeys/+page.svelte:19,50-53,153`
+calls `listJourneyRevenue` (a separate authoritative query keyed by landing-page id) and renders
+`{rev} · 30d`. **`Codex-9p47t` has landed; per-journey revenue is no longer null.**
+
+Still open: filter tabs are status (All/Draft/Published/Archived) vs the prototype's type
+(All/Journeys/Pages/Drafts). Row actions are only "Curriculum" + "Edit page" — no
+publish/unpublish/archive/view-live (`Codex-c3lky`) **and no Insights** (see row 8).
+
+### 6 — Page builder: #435 verified, three real deltas remain
+Top bar is now 4 children, and the `<select>` is `flex: 0 0 auto` at **106px** — the unconstrained
+fill-available basis is gone. Measured every control's true line-box count via
+`Range.getClientRects()`: **all exactly 1 line**, `View live ↗` = 103×40px, bar does not overflow,
+no document overflow. The `r4zzu` regression is genuinely fixed.
+
+(`jb__doc` reports 2 client rects, which is *not* a wrap — it is `white-space: nowrap` containing a
+text node plus a replaced `<input>`; the title is inline-editable, which exceeds the prototype.)
+
+Remaining deltas vs `builder.html`, **for a1tz6 to decide**:
+- **No "Studio." brand home link** (`hasStudioBrandLink: false`).
+- **No "Insights" artswitch tab** (`hasInsightsLink: false`) — nav has only Curriculum + Sales page.
+- Status is a `<select>` where the prototype shows a gold uppercase pill badge.
+- 49px bar vs prototype 52px; `--radius-full` vs prototype's 9px/7px rounded rects.
+- We *exceed* on device options (3: Desktop/Tablet/Mobile vs prototype's 2).
+
+### 7 — Curriculum editor: the 07-24 row was flatly wrong
+Not a mock. All **3 DB stage names** and all **12 DB practice titles** render live, with `Save`,
+`Add a practice`, numbered stage cards ("01 aergaerg … 4 practices") and a `ce__insp` inspector
+pane. This false row is what seeded `Codex-03cwh` (since verified and closed).
+
+**Legibility — now measured, instrument calibrated.** Two real WCAG AA failures, both
+opaque-on-opaque:
+
+| Text | fg → bg | Size/weight | Ratio |
+|---|---|---|---|
+| "Select a practice to see its contents" | `oklch(0.55 0 0)` → `#1A1207` | 15px/400 | **3.82** |
+| Studio rail "Studio" label (×16) | `oklch(0.55 0 0)` → `#1A1207` | 13px/500 | **3.82** |
+| "Of Blood & Bones" (×32) | `oklch(0.610874 0 0)` → `#1A1207` | 15px/600 | 4.90 ✓ |
+| "Save" | `oklch(0 0 0)` → `#FB923C` | 15px/600 | 9.28 ✓ |
+
+Both failures come from the same muted-grey token on the dark studio chrome and appear in the studio
+rail as well as the curriculum pane, so this is a **platform-wide muted-text issue, not a journeys
+conformance delta**. It needs its own bead; fixing it inside a1tz6 would be mis-scoped.
+
+**Discarded measurement:** the `Portals` nav pill reported 1.00, but its background is a 15%-alpha
+layer that my effective-background walk returned *uncomposited*. That number is an artifact of
+skipping alpha compositing, not a finding. (This is exactly the trap that produced the bogus 1.0 /
+1.13 figures previously — any contrast number over a translucent background needs compositing first.)
+
+### 8 — Insights: reproduced, and the route is orphaned
+Reproduced exactly on the new fixture: **7 perpetual "Loading metric" skeletons** (28 skeleton
+nodes), zero metrics rendered, **no error state and no console error** — a textbook silent failure.
+`Codex-xo3bl` unchanged and still P1.
+
+**New, and worse than 07-24 recorded: the route has no entry point anywhere in the app.**
+`/studio/journeys/[id]/insights` is fully implemented (`+page.svelte` importing `getJourneyInsights`
+plus a whole `$lib/components/studio/journey-insights` directory), but a repo-wide search for
+hrefs/`goto` to it returns **nothing**. The studio index row offers only Curriculum + Edit page; the
+builder top bar (`page/+page.svelte:369`) links only Curriculum. It is reachable only by typing the
+URL. Note the sequencing: linking it before `xo3bl` is fixed would surface a permanently-loading page.
+
+---
+
+## Theme support (light/dark) across the three journey surfaces
+
+**User decision, 2026-07-29:** the visitor's light/dark preference must be respected on every journey
+surface, including the landing/sell page. This supersedes the "must not force dark" reasoning written
+into `journey-palette.css`, which delivered *the creator's background* but gave up *the visitor's
+theme*. Those are two independent axes and both can be satisfied.
+
+### The machinery already exists and already works
+
+`tokens/org-brand.css` carries a two-pole brand background and switches on theme:
+
+```css
+[data-org-bg]                     { --color-background: var(--brand-bg, white); }
+.dark [data-org-bg],
+[data-theme='dark'] [data-org-bg] { --color-background: var(--brand-bg-dark, var(--brand-bg, #1a1a2e)); }
+```
+
+Measured on `of-blood-and-bones`, **both poles are populated**: `--brand-bg: #FFFBEB`,
+`--brand-bg-dark: #1A1207`, and `[data-org-bg]` flips correctly between them. So this is **not a new
+feature** — it is two surfaces declining to use working infrastructure.
+
+### Current state
+
+| Surface | Honours visitor theme? | Why |
+|---|---|---|
+| Sell / landing | **No** — cream in both | `--jp-ink: var(--brand-bg, …)` reads only the **light** pole; no theme branch exists |
+| Member dashboard | **No** — dark in both | private `--portal-*` ladder off `--brand-color` at hardcoded lightnesses |
+| In-course | **Yes** ✅ | no bespoke palette; consumes ambient `[data-org-bg]` tokens directly |
+
+### Fix shape
+
+**Sell page — a one-input change.** Every rung of the ladder (`--jp-heading`, `--jp-text/dim/faint`,
+`--jp-ink-2/3/4`, all four hairlines, `--jp-atmos-veil`) is derived from `--jp-ink`'s **own
+lightness** via auto-contrast. The file says so itself: *"This is the ONE input the whole ladder hangs
+off, which is what makes light and dark both correct with no branch."* The author built it to flip
+from a single input and then never wired that input to the theme. Adding a dark branch for `--jp-ink`
+alone makes headings, text, insets, hairlines and the atmosphere veil all correct at once:
+
+```css
+/* same triple-class specificity as the base rule — see the SPECIFICITY note in the file */
+.dark .journey-palette.journey-palette.journey-palette,
+[data-theme='dark'] .journey-palette.journey-palette.journey-palette {
+  --jp-ink: var(--brand-bg-dark, var(--brand-bg, var(--color-background)));
+}
+```
+
+Note both selectors are required: the theme init script sets `data-theme` **and** a `.dark`/`.light`
+class on `<html>`, so a rule keyed on only one of them will be beaten by an org-brand rule keyed on
+the other.
+
+**Dashboard — delete the private ladder.** Adopt `.journey-palette` + `.journey-palette--page`
+instead of the bespoke `--portal-*` derivation. That is what `gfg50` set out to achieve ("the ONE
+derivation, shared by every journey surface") and the dashboard was simply never migrated. It also
+**dissolves the brand-source split** in one move: surfaces would come from `--brand-bg`/
+`--brand-bg-dark` and `--brand-color` would be left doing what it should — the ember accent only.
+
+### Verification requirement
+
+`jsdom` implements neither `oklch()` nor `color-mix()` and returns custom properties as their raw
+declared string, so a jsdom test will pass against a still-broken palette. Colour must be asserted in
+a real browser, and the theme must be flipped by setting **both** `data-theme` and the
+`.dark`/`.light` class — flipping only the attribute leaves `.dark [data-org-bg]` matching and
+silently reports "theme-invariant" for a surface that is in fact theme-correct. (That error was made
+and corrected during this very re-validation; it is what originally made row 4 look broken.)
+
+---
+
+## Net change vs 2026-07-24
+
+**Rows that were wrong and are now corrected:** 2 (checkout), 6 (builder), 7 (curriculum) — as the
+bead predicted. Row 1's "6/11 sections" note is also void (it was per-journey content, not code).
+
+**Improvements found that no bead recorded:** checkout offer grid + "Choose your way in"; dashboard
+"Continue" now names the practice/stage/type; in-course "Mark complete"; studio-index 30-day revenue.
+
+**Still-open, correctly-tracked:** `Codex-xo3bl` (insights), `Codex-8tku7` (CSP media-src),
+`Codex-c3lky` (index row actions), `Codex-4i8x5` (dashboard forced-dark), `Codex-3tmt1` (aria
+duration), `Codex-5xedi` (dead `JourneyCanvasToolbar.svelte`).
+
+**New findings from this pass:**
+1. **Light/dark is unimplemented on 2 of 3 journey surfaces**, while the two-pole
+   `--brand-bg`/`--brand-bg-dark` infrastructure exists and works. Sell page reads only the light
+   pole; dashboard forces dark off `--brand-color`; in-course is already correct. (See **Theme
+   support**.) → user decision: respect the visitor's choice everywhere.
+2. **Insights route is orphaned** — implemented, zero entry points. (Row 8.)
+3. **Brand source splits across surfaces** — page override on sell, org primary on dashboard;
+   dissolved for free by migrating the dashboard onto `journey-palette.css`. (Row 3.)
+4. **Platform-wide muted-text AA failure** at 3.82:1 on dark studio chrome — not journeys-specific. (Row 7.)
+
+**Method correction worth keeping:** flipping only `data-theme` is an insufficient theme flip in this
+codebase (the init script also sets a `.dark`/`.light` class, and `org-brand.css` keys rules on both).
+An incomplete flip reports a theme-correct surface as "theme-invariant" — it made row 4 look broken
+here before being caught.


### PR DESCRIPTION
## What

Journey surfaces delivered the **creator's** chosen background but gave up the **visitor's** light/dark choice. Those are independent axes; both are now satisfied.

Before this change, of three surfaces only the **in-course player** honoured theme — and only because it has no bespoke palette and consumes the ambient org tokens.

| Surface | Before | After |
|---|---|---|
| Sell / landing | cream in both themes | follows theme ✅ |
| Member dashboard | dark in both themes | follows theme ✅ |
| In-course | already correct | unchanged ✅ |

This is **not new infrastructure**. `tokens/org-brand.css` already carries a two-pole brand background (`--brand-bg` / `--brand-bg-dark`) and switches on theme; the org layout injects both poles side by side. The two journey surfaces with their own palettes were declining to use it.

## How

**Sell page / checkout / builder canvas — one input, nothing else.** `journey-palette.css` gains a dark pole for `--jp-ink` alone. Every rung (heading, text ladder, three insets, four hairlines, atmosphere-veil alpha) is auto-contrasted off the ink's own lightness, so the whole ladder inverts from that single input. The veil's alpha ramps on `(l - 0.5)`, so it returns to 0 on a dark ink and the full candlelight bloom comes back for free.

Both selector forms are required: `app.html` sets `data-theme` **and** a `.dark`/`.light` class, and `org-brand.css` keys its dark branches on both. A rule written against only one form loses to the org-brand rule written against the other.

**Member dashboard — drop the third private derivation (closes `Codex-4i8x5`).** It anchored on the brand *primary* at forced lightnesses (`0.15` bg / `0.94` text), honouring neither axis and discarding a per-theme background that already resolved correctly one element up. It also disagreed with the sales page about which brand colour was in play, so one journey rendered purple where you bought it and orange once you were inside.

The `--portal-*` names survive as **aliases** over the shared ladder — `CurriculumMap` and `JourneyContinueCard` read them ~30 times, so only the derivation moves.

## Contrast — measured in a real browser, both themes, calibrated converter

The raw ember is tuned as a **fill**; used as small text it measured 2.98:1 (dark) and 2.46:1 (light). New `--jp-ember-text` pulls it toward `--jp-heading`, which is already auto-contrasted to the ink, so it lightens on dark and darkens on light with no branch. Fills, borders and glows keep the full-strength ember.

| Element | Before | After (dark) | After (light) |
|---|---|---|---|
| \`Resume →\` | 2.98 ✗ | **4.94** ✓ | **6.49** ✓ |
| \`Begin your journey\` | 3.67 ✗ | **6.09** ✓ | **5.99** ✓ |
| \`Your journey\` | 3.43 ✗ | **8.64** ✓ | **9.05** ✓ |
| \`Reflection\` (meta) | 4.41 ✗ | **5.20** ✓ | **10.25** ✓ |

**Dashboard now has zero AA failures in either theme.** All numbers from a calibrated OKLab→linear-sRGB→luminance converter (self-checked: white-on-black must return 21.00) with proper alpha compositing.

## Tests

`jsdom` implements neither `oklch()` nor `color-mix()` and returns custom properties as their raw declared string, so colour is asserted in a browser and only **structure** in jsdom. Added:

- exactly one `--jp-ink` declaration **per theme pole**, both off the brand background, neither off the primary;
- the dark rule carries **both** selector forms at triple-class specificity;
- the dashboard declares no `--portal-anchor`, sources every rung from `--jp-*`, and hardcodes no lightness.

**All four mutation-tested** — each assertion was made to fail before being kept (delete the dark pole → 4 fail; drop `.dark` → 1 fail; restore the hardcoded derivation → 2 fail; remove the class → 1 fail).

`declarationsOf()` now strips comments first: these files document the token contract by quoting real declarations in prose, and a test a comment can break is not measuring what it claims to.

## Also included

`docs/design/course-journeys/conformance-revalidation-2026-07-29.md` — the 8-surface re-validation of the 2026-07-24 matrix, whose own fixture had been wiped by a test suite. Rows 2 (checkout), 6 (builder) and 7 (curriculum) were wrong; row 1's "6/11 sections" note was per-journey content, never a code gap.

## Not fixed here — platform-wide and pre-existing

`org-brand.css` swaps `--color-brand-primary` to `--brand-color-dark` in its dark branch but derives `--color-text-on-brand` from `--brand-color` and never re-derives it. So **every org primary button in dark mode** paints the dark brand and contrasts its label against the light one — measured `#FB923C` behind white text = **2.26:1**. It was invisible on journeys only because they never rendered in dark. The fix belongs in `org-brand.css`'s dark branch (blast radius: every org page), so it is flagged in a comment rather than slipped in here.

Two sell-page faint-rung misses are likewise pre-existing in **both** themes and untouched: `.descent__rn` 3.32/3.80 and `.ache__chapter` 4.22.

## Gates (local — CI's Neon quota is exhausted)

- typecheck: clean
- `apps/web`: **147 files / 1488 pass** (baseline 1484 + 4 new)
- biome: **0 errors**, 175 warnings, 5 infos = baseline
- svelte-check: **68 errors / 43 warnings / 44 files** = baseline, **0 in changed files**

No fixture mutated — verified after: 3 stages / 12 practices / 1 purchase / branding unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)