### PR TITLE
fix(journeys): insights reads the journey it was asked for, and says so when it can't (Codex-xo3bl)

### DIFF
--- a/apps/web/src/lib/components/studio/journey-insights/JourneyInsightsPanel.svelte
+++ b/apps/web/src/lib/components/studio/journey-insights/JourneyInsightsPanel.svelte
@@ -6,14 +6,23 @@
   provenance tier of KPICards. Presentation only: it takes the seam's data and
   the pure metric model does the tier grouping.
 
-  Skeletons render until the first data arrives (the studio subtree is an
-  `ssr=false` SPA, so first client paint has no data yet).
+  Three states: `error` (a failed read), `data` (metrics), and neither — the
+  loading skeletons. Skeletons render until the first data arrives (the studio
+  subtree is an `ssr=false` SPA, so first client paint has no data yet).
+
+  `error` takes precedence over the skeletons, because a failed read leaves
+  `data` undefined and would otherwise be INDISTINGUISHABLE from still-loading —
+  the surface then waits forever on a request that already came back (Codex-xo3bl).
+  The error replaces only the metric groups: the header and period toggle stay
+  live so a failed window can be switched away from without a reload.
 
   @prop {JourneyInsightsData | undefined} data   Resolved insights, or undefined while loading.
   @prop {InsightsPeriod} period                  Current reporting window.
   @prop {(p: InsightsPeriod) => void} onPeriodChange  Period change handler.
+  @prop {string | null} [error]                  Failure text, or null when the read is healthy.
 -->
 <script lang="ts">
+  import { Alert } from '$lib/components/ui';
   import MetricTierGroup from './MetricTierGroup.svelte';
   import PeriodToggle from './PeriodToggle.svelte';
   import ProvenanceLegend from './ProvenanceLegend.svelte';
@@ -29,9 +38,10 @@
     data: JourneyInsightsData | undefined;
     period: InsightsPeriod;
     onPeriodChange: (period: InsightsPeriod) => void;
+    error?: string | null;
   }
 
-  const { data, period, onPeriodChange }: Props = $props();
+  const { data, period, onPeriodChange, error = null }: Props = $props();
 
   const groups = $derived(data ? buildJourneyMetricGroups(data) : null);
 
@@ -62,7 +72,12 @@
   <ProvenanceLegend />
 
   <div class="insights__groups">
-    {#if groups}
+    {#if error}
+      <Alert variant="error">
+        <p class="insights__error-title">Could not load insights</p>
+        <p class="insights__error-detail">{error}</p>
+      </Alert>
+    {:else if groups}
       {#each groups as group (group.tier)}
         <MetricTierGroup {group} />
       {/each}
@@ -114,5 +129,18 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-8);
+  }
+
+  .insights__error-title {
+    font-size: var(--text-sm);
+    font-weight: var(--font-semibold);
+    line-height: var(--leading-normal);
+    margin: 0;
+  }
+
+  .insights__error-detail {
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    margin: var(--space-1) 0 0;
   }
 </style>

--- a/apps/web/src/lib/components/studio/journey-insights/metric-model.ts
+++ b/apps/web/src/lib/components/studio/journey-insights/metric-model.ts
@@ -83,8 +83,11 @@ export type InsightsPeriod = '7d' | '30d' | '90d' | 'all';
 
 /**
  * The seam's return contract — everything the insights surface needs for one
- * course/journey in one period. Produced by `getJourneyInsights` (mocked today,
- * real aggregation at Round-D).
+ * course/journey in one period. Produced by `getJourneyInsights`, which is wired
+ * to the real Round-D aggregation (`CourseInsightsService.getInsights`).
+ *
+ * `courseId` is the SUBJECT COURSE the worker resolved, not the landing-page id
+ * the query was keyed by — the request carries `pageId` (Codex-xo3bl).
  */
 export interface JourneyInsightsData {
   courseId: string;

--- a/apps/web/src/lib/remote/journey-insights.remote.ts
+++ b/apps/web/src/lib/remote/journey-insights.remote.ts
@@ -22,30 +22,33 @@ import { createServerApi } from '$lib/server/api';
 
 const insightsQueryArgsSchema = z.object({
   organizationId: z.string().uuid(),
-  courseId: z.string().uuid(),
+  /**
+   * The journey's LANDING-PAGE id — `page.params.id` on every
+   * `/studio/journeys/[id]/…` route (Codex-xo3bl). The worker resolves it to the
+   * subject course. Named `courseId` originally, which read correctly at the call
+   * site and was wrong on the wire: both ids are UUIDs, so the schema passed and
+   * the aggregation 404'd `Course not found` on every single request.
+   */
+  pageId: z.string().uuid(),
   period: z.enum(['7d', '30d', '90d', 'all']).default('30d'),
 });
 
 /**
- * Studio journey insights for one course in one period.
+ * Studio journey insights for one journey in one period.
  *
  * @example
  * const insights = getJourneyInsights({
  *   organizationId: data.org.id,
- *   courseId: page.params.id,
+ *   pageId: page.params.id,
  *   period: '30d',
  * });
  * // insights.current → JourneyInsightsData
  */
 export const getJourneyInsights = query(
   insightsQueryArgsSchema,
-  async ({
-    organizationId,
-    courseId,
-    period,
-  }): Promise<JourneyInsightsData> => {
+  async ({ organizationId, pageId, period }): Promise<JourneyInsightsData> => {
     const { platform, cookies } = getRequestEvent();
     const api = createServerApi(platform, cookies);
-    return api.access.courseInsights(organizationId, courseId, period);
+    return api.access.courseInsights(organizationId, pageId, period);
   }
 );

--- a/apps/web/src/lib/remote/query-result.test.ts
+++ b/apps/web/src/lib/remote/query-result.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `queryErrorMessage` tests (Codex-xo3bl).
+ *
+ * The bug this replaces: four studio pages read `remoteQuery.error?.message`.
+ * SvelteKit rejects a failed remote query with `HttpError`, which carries its
+ * text at `.body.message` and has NO top-level `.message` — so every one of
+ * those reads returned `undefined`, every error branch stayed unreachable, and
+ * the surfaces sat on their loading skeletons while the request had already
+ * come back 500. The insights page did this for a course-not-found on EVERY
+ * load: seven perpetual "Loading metric" skeletons, no error, no console entry.
+ *
+ * The first test deliberately builds its `HttpError` by catching SvelteKit's own
+ * `error()` rather than hand-rolling `{ status, body }`. A literal would only
+ * assert my belief about the shape; catching the real thing means that if
+ * SvelteKit ever moves the message, THIS test fails instead of the UI going
+ * quiet again.
+ */
+
+import { error } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+import { queryErrorMessage } from './query-result';
+
+/** A genuine SvelteKit `HttpError` instance, not a look-alike literal. */
+function realHttpError(status: number, message: string): unknown {
+  try {
+    error(status, message);
+  } catch (thrown) {
+    return thrown;
+  }
+  throw new Error('error() did not throw — SvelteKit contract changed');
+}
+
+describe('queryErrorMessage', () => {
+  it('reads the text out of a real SvelteKit HttpError', () => {
+    const httpError = realHttpError(500, 'Course not found');
+
+    // Guard the premise: if this ever gains a top-level `message`, the original
+    // `.error?.message` read would have worked and this helper's reason to
+    // exist is gone. Pin it so the assumption cannot rot silently.
+    expect((httpError as { message?: unknown }).message).toBeUndefined();
+    expect((httpError as { body?: { message?: unknown } }).body?.message).toBe(
+      'Course not found'
+    );
+
+    expect(queryErrorMessage(httpError)).toBe('Course not found');
+  });
+
+  it('reads a plain Error, which keeps its text at the top level', () => {
+    // The batched-query path rejects with exactly this — a bare Error, no body.
+    // A body-only helper would return the fallback here and lose the cause.
+    expect(queryErrorMessage(new Error('Failed to execute batch query'))).toBe(
+      'Failed to execute batch query'
+    );
+  });
+
+  it('prefers HttpError.body.message over a top-level message', () => {
+    // Some rejections carry both; the server-authored body text is the useful
+    // one, so it must win rather than losing to a generic wrapper message.
+    expect(
+      queryErrorMessage({
+        status: 404,
+        body: { message: 'Journey course not found' },
+        message: 'Internal Error',
+      })
+    ).toBe('Journey course not found');
+  });
+
+  it('returns null for no error, so the result is a sound "did it fail?" test', () => {
+    expect(queryErrorMessage(null)).toBeNull();
+    expect(queryErrorMessage(undefined)).toBeNull();
+  });
+
+  it('never returns null for a present-but-unreadable error', () => {
+    // The whole failure mode was a falsy result for a real error. Anything
+    // present must produce text, so `{#if message}` can never miss a failure.
+    expect(queryErrorMessage({})).not.toBeNull();
+    expect(queryErrorMessage({ status: 500 })).not.toBeNull();
+    expect(queryErrorMessage({ body: {} })).not.toBeNull();
+    expect(queryErrorMessage({ body: null })).not.toBeNull();
+    expect(queryErrorMessage({ message: '' })).not.toBeNull();
+    expect(queryErrorMessage(0)).not.toBeNull();
+    expect(queryErrorMessage(false)).not.toBeNull();
+  });
+
+  it('passes a bare string rejection through', () => {
+    expect(queryErrorMessage('Course not found')).toBe('Course not found');
+  });
+
+  it('uses the caller-supplied fallback for an unreadable error', () => {
+    expect(queryErrorMessage({ status: 500 }, 'Insights unavailable')).toBe(
+      'Insights unavailable'
+    );
+    expect(queryErrorMessage('', 'Insights unavailable')).toBe(
+      'Insights unavailable'
+    );
+  });
+});

--- a/apps/web/src/lib/remote/query-result.ts
+++ b/apps/web/src/lib/remote/query-result.ts
@@ -8,5 +8,56 @@
 export interface QueryResult<T> {
   current: T | undefined;
   loading?: boolean;
-  error?: { message?: string } | null;
+  /**
+   * The rejection value, once the query has failed.
+   *
+   * DELIBERATELY `unknown` (Codex-xo3bl). SvelteKit rejects a failed remote
+   * query with `HttpError`, whose shape is `{ status, body: { message } }` — it
+   * carries NO top-level `message`. This field used to be typed
+   * `{ message?: string } | null`, which type-checked four studio pages that all
+   * read `error?.message`, got `undefined` forever, and therefore NEVER entered
+   * their error branch: the surface sat on its loading skeletons instead of
+   * reporting the failure. SvelteKit's own types warn the rejection is only
+   * "most often" an `HttpError`, so no single struct is honest here.
+   *
+   * Read it through {@link queryErrorMessage}, never by property access.
+   */
+  error?: unknown;
+}
+
+/**
+ * Human-readable text for a failed remote query, or `null` if it has not failed.
+ *
+ * Handles every rejection shape SvelteKit can produce:
+ *   - `HttpError` — `{ status, body: { message } }`, the normal single-query path
+ *   - `Error` — e.g. `Error('Failed to execute batch query')` from the batched
+ *     path's outer catch, which has `message` but no `body`
+ *   - a bare string, or anything else (→ `fallback`)
+ *
+ * NEVER returns `null` for a present error, so `{#if queryErrorMessage(...)}` is
+ * a sound "did this fail?" test — the property-access version it replaces was
+ * not, and that is precisely how Codex-xo3bl stayed invisible.
+ */
+export function queryErrorMessage(
+  error: unknown,
+  fallback = 'Something went wrong. Please try again.'
+): string | null {
+  if (error === null || error === undefined) return null;
+
+  if (typeof error === 'string') return error.length > 0 ? error : fallback;
+
+  if (typeof error === 'object') {
+    // HttpError puts the text one level down, under `body`.
+    const body = (error as { body?: unknown }).body;
+    if (body !== null && typeof body === 'object') {
+      const nested = (body as { message?: unknown }).message;
+      if (typeof nested === 'string' && nested.length > 0) return nested;
+    }
+
+    // A plain Error (or anything else message-bearing) keeps it at the top.
+    const direct = (error as { message?: unknown }).message;
+    if (typeof direct === 'string' && direct.length > 0) return direct;
+  }
+
+  return fallback;
 }

--- a/apps/web/src/lib/server/api.ts
+++ b/apps/web/src/lib/server/api.ts
@@ -1232,23 +1232,28 @@ export function createServerApi(
         ),
 
       /**
-       * Studio journey INSIGHTS (Codex-2pryk Round-D · WP-7): course-scoped
-       * `live` (financial) + `course` (engagement) aggregation for one reporting
-       * period. Owner/admin only — the content-api route enforces
-       * `requireOrgManagement` and re-derives scope from the session, so the
-       * `organizationId` here is used only for org resolution, never as the
-       * authorization source. Money is GBP pence.
+       * Studio journey INSIGHTS (Codex-2pryk Round-D · WP-7): `live` (financial)
+       * + `course` (engagement) aggregation for one reporting period. Owner/admin
+       * only — the content-api route enforces `requireOrgManagement` and
+       * re-derives scope from the session, so the `organizationId` here is used
+       * only for org resolution, never as the authorization source. Money is GBP
+       * pence.
+       *
+       * Keyed by LANDING-PAGE id (Codex-xo3bl) — the id the studio URL and
+       * `listJourneys` both carry. The worker resolves it to the subject course.
+       * This parameter was named `courseId`, so callers passed `page.params.id`
+       * straight into a `courses.id` lookup and every read 404'd.
        */
       courseInsights: (
         organizationId: string,
-        courseId: string,
+        pageId: string,
         period: string
       ) =>
         request<JourneyInsightsData>(
           'access',
           `/api/journeys/insights?organizationId=${encodeURIComponent(
             organizationId
-          )}&courseId=${encodeURIComponent(courseId)}&period=${encodeURIComponent(
+          )}&pageId=${encodeURIComponent(pageId)}&period=${encodeURIComponent(
             period
           )}`
         ),

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/+page.svelte
@@ -157,9 +157,18 @@
               </p>
             </div>
             <div class="journey-row__actions">
+              <!--
+                Curriculum and Insights are both COURSE artifacts (each resolves
+                the page to its subject course server-side), so both sit behind
+                the same subject-type guard — a non-course journey has neither,
+                and an ungated link would 404.
+              -->
               {#if j.subjectType === 'course'}
                 <a class="journey-row__action" href="/studio/journeys/{j.id}/curriculum">
                   Curriculum
+                </a>
+                <a class="journey-row__action" href="/studio/journeys/{j.id}/insights">
+                  Insights
                 </a>
               {/if}
               <a class="journey-row__action journey-row__action--primary" href="/studio/journeys/{j.id}/page">

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/insights/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/insights/+page.svelte
@@ -6,23 +6,25 @@
   client-side via the `getJourneyInsights` remote query and mirrors the
   studio/analytics auth-guard + URL-param pattern.
 
-  `[id]` is the course id. The reporting window is driven by `?period=`.
-  Data is provenance-tagged: `live` (financial) + `course` (engagement). The
-  data source is the single Round-D seam — see journey-insights.remote.ts.
+  `[id]` is the journey's LANDING-PAGE id — the same id `page/` and `curriculum/`
+  bind under this route segment, and the id the studio index links with. The
+  worker resolves it to the subject course. The reporting window is driven by
+  `?period=`. Data is provenance-tagged: `live` (financial) + `course`
+  (engagement). The data source is the single Round-D seam — see
+  journey-insights.remote.ts.
 
   @prop data - Inherited studio layout data: { org, userRole, ... }.
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
-  import { Alert } from '$lib/components/ui';
   import {
     JourneyInsightsPanel,
     type InsightsPeriod,
     type JourneyInsightsData,
   } from '$lib/components/studio/journey-insights';
   import { getJourneyInsights } from '$lib/remote/journey-insights.remote';
-  import type { QueryResult } from '$lib/remote/query-result';
+  import { queryErrorMessage, type QueryResult } from '$lib/remote/query-result';
 
   let { data } = $props();
 
@@ -44,7 +46,10 @@
     data.userRole === 'admin' || data.userRole === 'owner'
   );
 
-  const courseId = $derived(page.params.id ?? '');
+  // The LANDING-PAGE id, not the course id. This was named `courseId` and passed
+  // straight through as one (Codex-xo3bl): both are UUIDs, so validation passed
+  // and the worker's `courses.id` lookup 404'd on every single request.
+  const pageId = $derived(page.params.id ?? '');
 
   // ─── URL → period ─────────────────────────────────────────────────────
   const VALID_PERIODS: InsightsPeriod[] = ['7d', '30d', '90d', 'all'];
@@ -56,12 +61,12 @@
   });
 
   // ─── Remote query ─────────────────────────────────────────────────────
-  // Re-keys off (orgId, courseId, period) so period changes refetch.
+  // Re-keys off (orgId, pageId, period) so period changes refetch.
   const insightsQuery = $derived(
-    isAuthorized && courseId
+    isAuthorized && pageId
       ? getJourneyInsights({
           organizationId: data.org.id,
-          courseId,
+          pageId,
           period,
         })
       : null
@@ -70,12 +75,18 @@
   const insights = $derived(
     (insightsQuery as QueryResult<JourneyInsightsData> | null)?.current
   );
-  // Deferred error branch: a failed insights fetch renders an error state
-  // rather than crashing the surface (the query rejects on a 4xx/5xx from the
-  // studio route — e.g. a course that no longer resolves in this org).
+  // A failed insights fetch renders an error state rather than sitting on the
+  // loading skeletons (the query rejects on a 4xx/5xx from the studio route —
+  // e.g. a journey that no longer resolves in this org).
+  //
+  // MUST go through `queryErrorMessage`: SvelteKit rejects with `HttpError`,
+  // whose text lives at `.body.message`. This read was `.error?.message`, which
+  // is `undefined` on every HttpError ever thrown — so the branch below was
+  // unreachable and the panel showed 7 skeletons forever (Codex-xo3bl).
   const insightsError = $derived(
-    (insightsQuery as QueryResult<JourneyInsightsData> | null)?.error?.message ??
-      null
+    queryErrorMessage(
+      (insightsQuery as QueryResult<JourneyInsightsData> | null)?.error
+    )
   );
 
   function setPeriod(next: InsightsPeriod) {
@@ -86,9 +97,10 @@
 </script>
 
 {#if isAuthorized}
-  {#if insightsError}
-    <Alert variant="error">Could not load insights: {insightsError}</Alert>
-  {:else}
-    <JourneyInsightsPanel data={insights} {period} onPeriodChange={setPeriod} />
-  {/if}
+  <JourneyInsightsPanel
+    data={insights}
+    {period}
+    onPeriodChange={setPeriod}
+    error={insightsError}
+  />
 {/if}

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -75,6 +75,12 @@
     pageId ? getCourseCurriculum({ pageId }) : null
   );
 
+  // Curriculum and Insights are both COURSE artifacts — each resolves this page
+  // to its subject course server-side — so the artifact switch only offers them
+  // for a course journey. The Curriculum tab was ungated, which pointed a
+  // non-course journey at a guaranteed 404.
+  const isCourse = $derived(draftQuery?.current?.subjectType === 'course');
+
   const stages: JourneyStagePreview[] = $derived(
     (curriculumQuery?.current?.stages ?? []).map((stage) => ({
       name: stage.name,
@@ -366,7 +372,10 @@
       </select>
 
       <nav class="jb__art" aria-label="Journey artifacts">
-        <a href="/studio/journeys/{pageId}/curriculum">Curriculum</a>
+        {#if isCourse}
+          <a href="/studio/journeys/{pageId}/curriculum">Curriculum</a>
+          <a href="/studio/journeys/{pageId}/insights">Insights</a>
+        {/if}
         <span class="jb__art-on" aria-current="page">Sales page</span>
       </nav>
 

--- a/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/payouts/+page.svelte
@@ -53,7 +53,7 @@
     PayoutWithCreator,
   } from '@codex/subscription';
   import type { DateRange } from '@codex/shared-types';
-  import type { QueryResult } from '$lib/remote/query-result';
+  import { queryErrorMessage, type QueryResult } from '$lib/remote/query-result';
 
   type PayoutsPage = {
     items: PayoutWithCreator[];
@@ -169,8 +169,11 @@
     (summaryQuery as QueryResult<PayoutSummary> | null)?.loading ?? true
   );
 
+  // Via `queryErrorMessage` — SvelteKit rejects with `HttpError`, whose text is
+  // at `.body.message`, so the `.error?.message` this replaces was `undefined`
+  // for every real failure and this branch never fired (Codex-xo3bl).
   const queryError = $derived(
-    (payoutsQuery as QueryResult<PayoutsPage> | null)?.error?.message ?? null
+    queryErrorMessage((payoutsQuery as QueryResult<PayoutsPage> | null)?.error)
   );
 
   const items = $derived(payoutsData?.items ?? []);

--- a/apps/web/src/routes/_org/[slug]/studio/sales/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/sales/+page.svelte
@@ -32,7 +32,7 @@
   import { downloadCsv } from '$lib/utils/csv-export';
   import type { SaleListItem, SalesStats } from '@codex/purchase';
   import type { DateRange } from '@codex/shared-types';
-  import type { QueryResult } from '$lib/remote/query-result';
+  import { queryErrorMessage, type QueryResult } from '$lib/remote/query-result';
 
   type SalesPage = {
     items: SaleListItem[];
@@ -126,8 +126,11 @@
     (statsQuery as QueryResult<SalesStats> | null)?.loading ?? true
   );
 
+  // Via `queryErrorMessage` — SvelteKit rejects with `HttpError`, whose text is
+  // at `.body.message`, so the `.error?.message` this replaces was `undefined`
+  // for every real failure and this branch never fired (Codex-xo3bl).
   const queryError = $derived(
-    (salesQuery as QueryResult<SalesPage> | null)?.error?.message ?? null
+    queryErrorMessage((salesQuery as QueryResult<SalesPage> | null)?.error)
   );
 
   const items = $derived(salesData?.items ?? []);

--- a/apps/web/src/routes/_org/[slug]/studio/subscribers/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/subscribers/+page.svelte
@@ -35,7 +35,7 @@
   import { formatDate, formatPrice, getInitials } from '$lib/utils/format';
   import { downloadCsv } from '$lib/utils/csv-export';
   import type { SubscriberListItem } from '@codex/subscription';
-  import type { QueryResult } from '$lib/remote/query-result';
+  import { queryErrorMessage, type QueryResult } from '$lib/remote/query-result';
   import {
     isConnectReady,
     type ConnectReadinessStatus,
@@ -135,9 +135,13 @@
         false) ||
       ((tiersQuery as QueryResult<TierRow[]> | null)?.loading ?? false)
   );
+  // Via `queryErrorMessage` — SvelteKit rejects with `HttpError`, whose text is
+  // at `.body.message`, so the `.error?.message` this replaces was `undefined`
+  // for every real failure and this branch never fired (Codex-xo3bl).
   const queryError = $derived(
-    (subscribersQuery as QueryResult<SubscribersPage> | null)?.error?.message ??
-      null
+    queryErrorMessage(
+      (subscribersQuery as QueryResult<SubscribersPage> | null)?.error
+    )
   );
 
   const items = $derived(subsData?.items ?? []);

--- a/packages/validation/src/schemas/__tests__/journeys.test.ts
+++ b/packages/validation/src/schemas/__tests__/journeys.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Journey studio query-schema tests (Codex-xo3bl).
+ *
+ * The insights query key is the LANDING-PAGE id, and the ONLY thing preventing
+ * it being confused with the course id again is this field's name: both values
+ * are UUIDs, so `uuidSchema` accepted the wrong one happily and the mistake
+ * surfaced two layers away as `NotFoundError('Course not found')` on every
+ * single request. These tests pin the name at the wire boundary.
+ *
+ * Success cases use `parse()` so a failure throws and takes the test with it;
+ * rejection cases use `safeParse().success`. That keeps `data` narrowed without
+ * a cast — `safeParse()` returns a discriminated union whose `data` only exists
+ * on the success branch.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  journeyInsightsQuerySchema,
+  orgJourneyRevenueQuerySchema,
+} from '../journeys';
+
+const ORG_ID = '32300000-0000-4000-8000-000000000002';
+const PAGE_ID = '1a000000-0000-4000-8000-0000000000aa';
+
+describe('journeyInsightsQuerySchema', () => {
+  it('accepts a landing-page id under `pageId` and defaults the period to 30d', () => {
+    const parsed = journeyInsightsQuerySchema.parse({
+      organizationId: ORG_ID,
+      pageId: PAGE_ID,
+    });
+    expect(parsed.pageId).toBe(PAGE_ID);
+    expect(parsed.period).toBe('30d');
+  });
+
+  it('rejects a query keyed by the retired `courseId` instead of `pageId`', () => {
+    // The regression guard. `pageId` is required, so a caller reverting to
+    // `courseId` fails at the boundary (and `courseId` itself is stripped as an
+    // unknown key) rather than sending a page id into a `courses.id` lookup.
+    const parsed = journeyInsightsQuerySchema.safeParse({
+      organizationId: ORG_ID,
+      courseId: PAGE_ID,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('does not carry a `courseId` through to the handler', () => {
+    // Even when a caller sends both, the handler must resolve the course from
+    // the page rather than trusting a client-supplied course id.
+    const parsed = journeyInsightsQuerySchema.parse({
+      organizationId: ORG_ID,
+      pageId: PAGE_ID,
+      courseId: '2c000000-0000-4000-8000-000000000001',
+    });
+    expect(parsed).not.toHaveProperty('courseId');
+  });
+
+  it('rejects a non-UUID pageId', () => {
+    expect(
+      journeyInsightsQuerySchema.safeParse({
+        organizationId: ORG_ID,
+        pageId: 'not-a-uuid',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects an unknown period', () => {
+    expect(
+      journeyInsightsQuerySchema.safeParse({
+        organizationId: ORG_ID,
+        pageId: PAGE_ID,
+        period: 'forever',
+      }).success
+    ).toBe(false);
+  });
+
+  it.each([
+    '7d',
+    '30d',
+    '90d',
+    'all',
+  ] as const)('accepts the %s reporting window', (period) => {
+    const parsed = journeyInsightsQuerySchema.parse({
+      organizationId: ORG_ID,
+      pageId: PAGE_ID,
+      period,
+    });
+    expect(parsed.period).toBe(period);
+  });
+});
+
+describe('orgJourneyRevenueQuerySchema', () => {
+  it('is org-wide — it takes no journey key at all', () => {
+    const parsed = orgJourneyRevenueQuerySchema.parse({
+      organizationId: ORG_ID,
+    });
+    expect(parsed.period).toBe('30d');
+    expect(parsed).not.toHaveProperty('pageId');
+  });
+});

--- a/packages/validation/src/schemas/journeys.ts
+++ b/packages/validation/src/schemas/journeys.ts
@@ -123,10 +123,20 @@ export type ListPublishedJourneysQuery = z.infer<
  * re-derives the authoritative scope from `ctx.organizationId` (session
  * membership) and never trusts this value for authorization. `period` selects
  * the reporting window (defaults to 30 days).
+ *
+ * The journey key is the LANDING-PAGE id, not the course id (Codex-xo3bl). Every
+ * studio journey surface addresses a journey by its landing-page id — that is
+ * what `/studio/journeys/[id]/…` carries and what `listJourneys` returns — so
+ * the route resolves `pageId → courses.id` via `resolveCourseIdForPage` before
+ * the course-keyed aggregation runs, exactly as the curriculum routes do. This
+ * field previously read `courseId`, and the client dutifully sent the page id
+ * into a `courses.id` lookup: every insights request 404'd as
+ * `NotFoundError('Course not found')`. Both are UUIDs, so no validation caught
+ * it — the ONLY guard against re-confusing them is the parameter name.
  */
 export const journeyInsightsQuerySchema = z.object({
   organizationId: uuidSchema,
-  courseId: uuidSchema,
+  pageId: uuidSchema,
   period: z.enum(['7d', '30d', '90d', 'all']).default('30d'),
 });
 export type JourneyInsightsQuery = z.infer<typeof journeyInsightsQuerySchema>;

--- a/workers/content-api/src/routes/__tests__/journey-insights-routes.test.ts
+++ b/workers/content-api/src/routes/__tests__/journey-insights-routes.test.ts
@@ -9,9 +9,15 @@
  *     NEVER the client-supplied `query.organizationId` — a client cannot
  *     redirect the money query to another org's course (the money-scoping IDOR
  *     is the key risk this route guards).
+ *   - The route is keyed by LANDING-PAGE id and resolves it to the subject
+ *     course before aggregating (Codex-xo3bl). `PAGE_ID` and `COURSE_ID` are
+ *     DELIBERATELY different UUIDs so the forwarding assertion can fail: the
+ *     shipped bug was the route treating the page id AS the course id, which a
+ *     fixture reusing one id for both would have waved straight through.
  *   - Response envelope is `{ data }`.
  *   - Service-layer errors propagate through `mapErrorToResponse` — e.g. the
- *     cross-org course guard's `NotFoundError` → 404, no revenue leak.
+ *     cross-org course guard's `NotFoundError` → 404, no revenue leak, and the
+ *     resolver's own `NotFoundError` short-circuits before any aggregation.
  *
  * Harness mirrors the procedure() shim from `sales-routes.test.ts` (the sibling
  * requireOrgManagement studio route): the shim simulates the real policy phases
@@ -137,6 +143,9 @@ import journeyInsights from '../journey-insights';
 
 const MANAGED_ORG_ID = '32300000-0000-4000-8000-000000000002';
 const ROGUE_ORG_ID = '99900000-0000-4000-8000-000000000999';
+/** The landing-page id the studio URL carries — what the client sends. */
+const PAGE_ID = '1a000000-0000-4000-8000-0000000000aa';
+/** The subject course the resolver returns — what `getInsights` must receive. */
 const COURSE_ID = '2c000000-0000-4000-8000-000000000001';
 
 const INSIGHTS_FIXTURE = {
@@ -160,23 +169,41 @@ interface InsightsServiceMock {
   getInsights: ReturnType<typeof vi.fn>;
 }
 
-function createInsightsServiceMock(): InsightsServiceMock {
+interface JourneyServiceMock {
+  resolveCourseIdForPage: ReturnType<typeof vi.fn>;
+}
+
+interface ServicesMock {
+  courseInsights: InsightsServiceMock;
+  courseJourney: JourneyServiceMock;
+}
+
+/**
+ * Both services the route composes. The resolver returns COURSE_ID for any page
+ * id — the org-scoping of that lookup is proven against live Postgres in
+ * `course-curriculum-editor.integration.test.ts`; what this file pins is that
+ * the route calls it and forwards its RESULT.
+ */
+function createServicesMock(): ServicesMock {
   return {
-    getInsights: vi.fn().mockResolvedValue(INSIGHTS_FIXTURE),
+    courseInsights: {
+      getInsights: vi.fn().mockResolvedValue(INSIGHTS_FIXTURE),
+    },
+    courseJourney: {
+      resolveCourseIdForPage: vi.fn().mockResolvedValue(COURSE_ID),
+    },
   };
 }
 
 interface BuildAppArgs {
   user?: { id: string } | null;
-  services?: { courseInsights: InsightsServiceMock };
+  services?: ServicesMock;
   orgRole?: 'owner' | 'admin' | 'member' | undefined;
   organizationId?: string | undefined;
 }
 
 function buildApp(args: BuildAppArgs = {}) {
-  const services = args.services ?? {
-    courseInsights: createInsightsServiceMock(),
-  };
+  const services = args.services ?? createServicesMock();
   const app = new Hono<{ Variables: Record<string, unknown> }>();
   app.use('*', async (c, next) => {
     c.set('__testUser', args.user === undefined ? { id: 'user_1' } : args.user);
@@ -195,14 +222,14 @@ function buildApp(args: BuildAppArgs = {}) {
   return { app, services };
 }
 
-/** A fully-valid query string (org resolver value + validated course/period). */
+/** A fully-valid query string (org resolver value + validated page/period). */
 function insightsReq(
   orgId: string = MANAGED_ORG_ID,
-  courseId: string = COURSE_ID,
+  pageId: string = PAGE_ID,
   period = '30d'
 ): Request {
   return new Request(
-    `http://content-api.test/api/journeys/insights?organizationId=${orgId}&courseId=${courseId}&period=${period}`,
+    `http://content-api.test/api/journeys/insights?organizationId=${orgId}&pageId=${pageId}&period=${period}`,
     { method: 'GET' }
   );
 }
@@ -210,8 +237,8 @@ function insightsReq(
 describe('GET /api/journeys/insights — route → service contract', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('positive: owner GET → 200, getInsights called with ctx.organizationId + courseId + period', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+  it('positive: owner GET → 200, getInsights called with ctx.organizationId + RESOLVED courseId + period', async () => {
+    const services = createServicesMock();
     const bundle = buildApp({ services });
     const res = await bundle.app.request(insightsReq());
     expect(res.status).toBe(200);
@@ -233,45 +260,94 @@ describe('GET /api/journeys/insights — route → service contract', () => {
     expect(periodArg).toBe('30d');
   });
 
+  // ── Codex-xo3bl regression: page id → course id ───────────────────────────
+  it('resolves the LANDING-PAGE id to its subject course and aggregates on the COURSE id, never the page id', async () => {
+    const services = createServicesMock();
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(insightsReq());
+    expect(res.status).toBe(200);
+
+    // The resolver is called with the org-scoped page id from the query.
+    expect(services.courseJourney.resolveCourseIdForPage).toHaveBeenCalledTimes(
+      1
+    );
+    const [resolverOrg, resolverPage] =
+      services.courseJourney.resolveCourseIdForPage.mock.calls[0] ?? [];
+    expect(resolverOrg).toBe(MANAGED_ORG_ID);
+    expect(resolverPage).toBe(PAGE_ID);
+
+    // ...and the aggregation receives its RESULT. The shipped bug passed
+    // PAGE_ID straight through here, so `courses.id` matched nothing and every
+    // request 404'd `Course not found`.
+    const [, courseArg] =
+      services.courseInsights.getInsights.mock.calls[0] ?? [];
+    expect(courseArg).toBe(COURSE_ID);
+    expect(courseArg).not.toBe(PAGE_ID);
+  });
+
+  it('resolver NotFoundError (foreign or non-course page) → 404 BEFORE any aggregation runs', async () => {
+    const services = createServicesMock();
+    services.courseJourney.resolveCourseIdForPage.mockRejectedValueOnce(
+      new NotFoundError('Journey course not found')
+    );
+    const bundle = buildApp({ services });
+    const res = await bundle.app.request(insightsReq());
+    expect(res.status).toBe(404);
+    // Short-circuits: no revenue is aggregated for an unresolvable page.
+    expect(services.courseInsights.getInsights).not.toHaveBeenCalled();
+  });
+
   it('positive: admin GET → 200 (requireOrgManagement = owner OR admin)', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+    const services = createServicesMock();
     const bundle = buildApp({ orgRole: 'admin', services });
     const res = await bundle.app.request(insightsReq());
     expect(res.status).toBe(200);
     expect(services.courseInsights.getInsights).toHaveBeenCalledTimes(1);
   });
 
-  it('negative auth: no session → 401, service NOT called', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+  it('negative auth: no session → 401, neither service called', async () => {
+    const services = createServicesMock();
     const bundle = buildApp({ user: null, services });
     const res = await bundle.app.request(insightsReq());
     expect(res.status).toBe(401);
+    expect(
+      services.courseJourney.resolveCourseIdForPage
+    ).not.toHaveBeenCalled();
     expect(services.courseInsights.getInsights).not.toHaveBeenCalled();
   });
 
-  it('negative role: member on the org → 403, service NOT called', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+  it('negative role: member on the org → 403, neither service called', async () => {
+    const services = createServicesMock();
     const bundle = buildApp({ orgRole: 'member', services });
     const res = await bundle.app.request(insightsReq());
     expect(res.status).toBe(403);
+    expect(
+      services.courseJourney.resolveCourseIdForPage
+    ).not.toHaveBeenCalled();
     expect(services.courseInsights.getInsights).not.toHaveBeenCalled();
   });
 
   it('cross-org safety: a manager of org A cannot query with org B — ctx.organizationId wins over query.organizationId', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+    const services = createServicesMock();
     // Caller manages MANAGED_ORG_ID (set as ctx org); the client injects a
-    // ROGUE org id in the query. The handler MUST forward ctx.organizationId so
-    // no other org's course revenue can ever be aggregated.
+    // ROGUE org id in the query. BOTH the page resolution and the aggregation
+    // MUST use ctx.organizationId so no other org's revenue is ever reachable.
     const bundle = buildApp({ services });
     const res = await bundle.app.request(insightsReq(ROGUE_ORG_ID));
     expect(res.status).toBe(200);
+
+    const [resolverOrg] =
+      services.courseJourney.resolveCourseIdForPage.mock.calls[0] ?? [];
+    expect(resolverOrg).toBe(MANAGED_ORG_ID);
+    expect(resolverOrg).not.toBe(ROGUE_ORG_ID);
+
     const [orgArg] = services.courseInsights.getInsights.mock.calls[0] ?? [];
     expect(orgArg).toBe(MANAGED_ORG_ID);
     expect(orgArg).not.toBe(ROGUE_ORG_ID);
   });
 
   it('cross-org guard: service NotFoundError (course not in managed org) → 404, redacted body', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+    const services = createServicesMock();
     services.courseInsights.getInsights.mockRejectedValueOnce(
       new NotFoundError('Course not found')
     );
@@ -282,13 +358,16 @@ describe('GET /api/journeys/insights — route → service contract', () => {
     expect(payload.error?.code).toBeTruthy();
   });
 
-  it('validation: a non-UUID courseId → 400, service NOT called', async () => {
-    const services = { courseInsights: createInsightsServiceMock() };
+  it('validation: a non-UUID pageId → 400, neither service called', async () => {
+    const services = createServicesMock();
     const bundle = buildApp({ services });
     const res = await bundle.app.request(
       insightsReq(MANAGED_ORG_ID, 'not-a-uuid')
     );
     expect(res.status).toBe(400);
+    expect(
+      services.courseJourney.resolveCourseIdForPage
+    ).not.toHaveBeenCalled();
     expect(services.courseInsights.getInsights).not.toHaveBeenCalled();
   });
 });

--- a/workers/content-api/src/routes/journey-insights.ts
+++ b/workers/content-api/src/routes/journey-insights.ts
@@ -26,13 +26,21 @@ import { Hono } from 'hono';
  * the session membership and sets `ctx.organizationId`. The `organizationId` in
  * the query string is consumed ONLY by the procedure org resolver — the handler
  * forwards `ctx.organizationId`, NEVER the client value, so a client cannot
- * redirect the query to another org. Defence in depth: the service additionally
- * scopes the course to the managed org (a foreign courseId → 404, never a leak).
+ * redirect the query to another org. Defence in depth: both the page→course
+ * resolution and the service additionally scope to the managed org (a foreign
+ * pageId or courseId → 404, never a leak).
  */
 const app = new Hono<HonoEnv>();
 
 /**
- * GET /api/journeys/insights?organizationId=&courseId=&period=
+ * GET /api/journeys/insights?organizationId=&pageId=&period=
+ *
+ * Keyed by LANDING-PAGE id, like every other studio journey route — the studio
+ * URL `/studio/journeys/[id]/insights` carries the page id, and `listJourneys`
+ * returns page ids. The course-keyed aggregation therefore needs one resolution
+ * hop first (Codex-xo3bl): before this, the route took the page id AS a
+ * `courseId` and every request 404'd `Course not found`.
+ *
  * @returns {JourneyInsightsData}
  */
 app.get(
@@ -47,7 +55,16 @@ app.get(
       query: journeyInsightsQuerySchema,
     },
     handler: async (ctx): Promise<JourneyInsightsData> => {
-      const { courseId, period } = ctx.input.query;
+      const { pageId, period } = ctx.input.query;
+
+      // Resolve (and org-scope) the subject course FIRST — the same two-service
+      // composition the curriculum routes use. A foreign, missing or non-course
+      // page throws NotFoundError here, before any aggregation runs.
+      const courseId = await ctx.services.courseJourney.resolveCourseIdForPage(
+        ctx.organizationId,
+        pageId
+      );
+
       return ctx.services.courseInsights.getInsights(
         ctx.organizationId,
         courseId,


### PR DESCRIPTION
## What was wrong

`/studio/journeys/:id/insights` rendered **seven perpetual "Loading metric" skeletons** for a valid published journey — no metrics, no error state, no console entry. **Two independent defects**, either of which alone produces silence.

### 1. The 500 — wrong id on the wire

`[id]` is the **landing-page id**. `page/+page.svelte:56` and `curriculum/+page.svelte:40` both bind it as `pageId` and cross-link with it; `listJourneys` returns page ids. Insights alone bound it as `courseId` and sent it into `getInsights`, which looks up `courses.id` — so **every** request 404'd `NotFoundError('Course not found')`. Both ids are UUIDs, so `uuidSchema` waved it through and the mistake surfaced two layers away.

Proven off the wire before any code changed — the decoded remote payload carried `06b45e59…` (page) where the service expected `408f94d0…` (course).

The route now resolves page → course via the existing, org-scoped, integration-tested `resolveCourseIdForPage` — the same two-service composition the curriculum routes (`journeys.ts:764/848/885`) already use. The wire field is renamed `courseId` → `pageId` across schema, worker route, `api.ts` and the remote: the parameter **name** is the only thing that can stop these being confused again.

### 2. The silence — a dead error branch (affected 4 pages)

The page *had* an error branch. It read `remoteQuery.error?.message`. SvelteKit rejects with `HttpError`, which carries its text at **`.body.message`** and has **no top-level `.message`** (`query.svelte.js:100` → `exports/internal/index.js:8-16`). So that read was `undefined` for every error ever thrown, the branch was unreachable, and the panel could not distinguish *failed* from *still loading*.

The shared `QueryResult.error` type asserted the wrong shape — which is why the same dead branch existed on **payouts**, **subscribers** and **sales**. Three more studio surfaces that would have gone quiet on any backend failure.

`error` is now `unknown`, read through `queryErrorMessage()` — handles `HttpError`, a plain `Error` (the batched-query path rejects with one), and a bare string, and **never returns null for a present error**, so `{#if message}` is a sound "did this fail?" test. All four pages use it. `JourneyInsightsPanel` gains an `error` prop that replaces the metric groups while keeping the header and period toggle live, so a failed window can be switched away from without a reload.

### 3. Entry points — the route was orphaned

No `href` or `goto` to it existed anywhere in the repo; it was reachable only by typing the URL. Insights now sits in the **builder artifact switch** and on the **studio index row**. Both gated on `subjectType === 'course'` (Insights resolves through the subject course). The builder's Curriculum tab was **ungated** and pointed a non-course journey at a guaranteed 404, so it now shares the guard.

## Tests — every one mutation-verified

Each fix was deliberately reverted and the tests confirmed to fail:

| Mutation | Result |
|---|---|
| Route forwards `pageId` to `getInsights` (the shipped bug) | 2 tests fail |
| Schema field renamed back to `courseId` | 7 tests fail |
| `queryErrorMessage` drops the `body` branch (the original bug) | 2 tests fail |
| `queryErrorMessage` returns `null` instead of the fallback | 2 tests fail |

- **`journey-insights-routes.test.ts`** — `PAGE_ID` and `COURSE_ID` are deliberately **different** UUIDs so the forwarding assertion *can* fail (a fixture reusing one id would have waved the bug through). Pins that the route calls the resolver with the page id and aggregates on its **result**, that a resolver `NotFoundError` 404s **before** any aggregation runs, and that both hops use `ctx.organizationId` not the client's.
- **`query-result.test.ts`** — builds its `HttpError` by **catching SvelteKit's own `error()`** rather than hand-rolling `{status, body}`, and pins that the type has no top-level `.message`. If SvelteKit ever moves the text, this test fails instead of the UI going quiet again.
- **`journeys.test.ts`** (validation) — pins `pageId` at the wire boundary, rejects a query keyed by `courseId`.

## Gates (local — CI's Neon compute quota is exhausted)

| Gate | Result | Baseline |
|---|---|---|
| typecheck | **57/57** | 57/57 |
| apps/web tests | **1491 pass / 148 files** | 1484 / 147 |
| content-api | **99 pass, 1 skip** | — |
| @codex/validation | **458 pass** | 448 |
| svelte-check | 68 errors / 43 warnings / 44 files — **none in changed files** | identical |
| biome | **0 errors**, 175 warnings, 5 infos | identical |

## Verified end-to-end on the live fixture

- Metrics render **£25 · 1 one-off purchase · 1 enrolled**, matching the DB exactly (one £24.99 purchase + one enrolment). `h1` is the course title; **0 skeletons**.
- A valid-but-nonexistent page id renders a **visible** `role="alert"` / `data-variant="error"` — *"Could not load insights — Journey course not found"* — with **0 skeletons**. This is the exact case that used to be silent.
- Both entry points render and navigate; the builder top bar holds one line with three tabs.
- Period toggle still re-keys the query (`30d` → `7d` refetch confirmed).
- Fixture verified intact afterwards; nothing mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)