### PR TITLE
feat(journeys): give the page builder a way back out (Codex-a1tz6)

### DIFF
--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -345,6 +345,16 @@
   >
     <!-- ── top bar ── -->
     <header class="jb__top">
+      <!--
+        Brand home link (prototype builder.html:203). The builder is a
+        full-bleed surface, so this is the only way back out of it besides the
+        icon rail. It targets the Portals index — the list the builder was
+        opened from, matching the prototype's own `href` — rather than /studio,
+        so it reads as "up one level" from the page you are editing.
+      -->
+      <a class="jb__brand" href="/studio/journeys" title="All portals">
+        Studio<span aria-hidden="true">.</span>
+      </a>
       <span class="jb__doc">
         Journey ·
         <input
@@ -544,6 +554,48 @@
     `flex: none` (below), so when the row runs short the title yields instead of
     the whole row squashing — which is what used to clip the action labels.
   */
+  /*
+    Brand wordmark / home link. The prototype tinted the period with a fixed
+    studio gold (`--st-gold: #cdb489`); we have no such token and every brand
+    colour here is org-overridable, so the period takes `--color-brand-primary`
+    and the mark tints per org rather than pinning one org's palette into the
+    studio chrome.
+
+    Sized with `--text-sm` to sit level with `.jb__doc` next to it — the
+    prototype's .82rem-vs-.8rem split is finer than one step of our type scale,
+    so matching its neighbour is the honest translation. Focus ring comes from
+    the global `:focus-visible` in base.css; hover underlines rather than
+    changing colour, because the mark is already at full `--color-text` and the
+    bar's dim→prominent hover convention (`.jb__art a`) has nowhere to go from
+    there.
+
+    DON'T "fix" the weight: `--font-bold` resolves to the ORG's heading weight,
+    not 700, because org-brand.css re-declares
+    `[data-org-brand] { --font-bold: var(--heading-weight, 700) }`. On this org
+    it computes to 400 — the brand heading font is Archivo Black, a single-weight
+    display face, and 700 would make the browser synthesise a smeared fake bold.
+    The mark reads heavy because the FACE is heavy (`--font-heading`, the same
+    token `.jb__doc-title` beside it uses), not because of the weight axis. An
+    org with a multi-weight heading font gets a real 700 here.
+  */
+  .jb__brand {
+    flex: none;
+    font-family: var(--font-heading);
+    font-size: var(--text-sm);
+    font-weight: var(--font-bold);
+    color: var(--color-text);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .jb__brand span {
+    color: var(--color-brand-primary);
+  }
+
+  .jb__brand:hover {
+    text-decoration: underline;
+  }
+
   .jb__doc {
     display: inline-flex;
     align-items: center;

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/__tests__/builder-top-bar.test.ts
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/__tests__/builder-top-bar.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Builder top-bar brand link (Codex-a1tz6).
+ *
+ * WHY STRUCTURAL ASSERTIONS OVER A RENDERED COMPONENT. The two things that can
+ * actually regress here are a wrong link target and a hardcoded colour, and
+ * neither is observable in jsdom: the builder only mounts behind
+ * `pageBuilder.isOpen` with a loaded draft, and jsdom does no layout and does
+ * not implement the OKLCH/`color-mix` machinery the brand tokens are built from
+ * (see journey-palette.test.ts for the same reasoning). Overflow behaviour is
+ * verified by measuring the real bar in a browser, as PR #435 did.
+ *
+ * What each assertion protects, all of which are silent failures:
+ *   1. the link targets the Portals INDEX, not /studio — the prototype
+ *      contradicts itself here (`href="studio-journeys.html"` but
+ *      `title="Studio home"`), so the resolved choice needs pinning or the next
+ *      reader will "correct" it back from the title;
+ *   2. the period is tinted from `--color-brand-primary`, NOT the prototype's
+ *      literal `--st-gold: #cdb489` — the prototype sits in-repo at
+ *      docs/design/course-journeys/prototype/builder.html, so copying its hex is
+ *      the live risk, and it would pin one org's palette into shared chrome;
+ *   3. the mark precedes the document title, which sets both the visual order
+ *      and the tab order out of the builder;
+ *   4. the period is `aria-hidden` — it is decoration, and screen readers
+ *      otherwise announce the trailing stop.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTE = readFileSync(join(HERE, '..', '+page.svelte'), 'utf8');
+
+/** The `.jb__brand { … }` rule body, so assertions can't drift onto other rules. */
+function brandRule(): string {
+  const match = ROUTE.match(/\.jb__brand\s*\{([^}]*)\}/);
+  if (!match) throw new Error('.jb__brand rule not found');
+  return match[1];
+}
+
+/** The `.jb__brand span { … }` rule body — the period's own declarations. */
+function brandSpanRule(): string {
+  const match = ROUTE.match(/\.jb__brand\s+span\s*\{([^}]*)\}/);
+  if (!match) throw new Error('.jb__brand span rule not found');
+  return match[1];
+}
+
+describe('builder top bar — brand home link', () => {
+  it('renders a brand link targeting the Portals index, not /studio', () => {
+    const anchor = ROUTE.match(/<a\s+class="jb__brand"[^>]*>/);
+    expect(anchor).not.toBeNull();
+    expect(anchor?.[0]).toContain('href="/studio/journeys"');
+    // Guard the near-miss the prototype's own title="Studio home" invites.
+    expect(anchor?.[0]).not.toMatch(/href="\/studio"/);
+  });
+
+  it('reads "Studio." with the period marked decorative', () => {
+    // The visible mark is Studio + a tinted stop; the accessible name is
+    // "Studio", because a trailing full stop carries no meaning aloud.
+    expect(ROUTE).toMatch(/Studio<span aria-hidden="true">\.<\/span>/);
+  });
+
+  it('tints the period from --color-brand-primary', () => {
+    expect(brandSpanRule()).toContain('var(--color-brand-primary)');
+  });
+
+  it("hardcodes no colour — in particular not the prototype's --st-gold hex", () => {
+    const css = `${brandRule()}${brandSpanRule()}`;
+    // The prototype's fixed studio gold, sitting in-repo one directory away.
+    expect(css.toLowerCase()).not.toContain('#cdb489');
+    expect(css).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(css).not.toMatch(/\brgb\(|\bhsl\(/);
+  });
+
+  it('sizes and weights the mark from tokens, never raw units', () => {
+    const css = brandRule();
+    expect(css).toContain('var(--text-sm)');
+    expect(css).toContain('var(--font-bold)');
+    // The prototype's .82rem/.7rem values must not survive the translation.
+    expect(css).not.toMatch(/\d+(\.\d+)?(px|rem|em)\b/);
+  });
+
+  it('places the mark before the document title, fixing visual and tab order', () => {
+    const brandAt = ROUTE.indexOf('class="jb__brand"');
+    const docAt = ROUTE.indexOf('class="jb__doc"');
+    const barAt = ROUTE.indexOf('<header class="jb__top">');
+    expect(brandAt).toBeGreaterThan(barAt);
+    expect(brandAt).toBeLessThan(docAt);
+  });
+
+  it('does not import the builder chrome the brand link was scoped apart from', () => {
+    // Codex-a1tz6 took ONLY the prototype's brand link. The gold uppercase
+    // status pill would have removed the publish/unpublish affordance we ship
+    // as a <select>, so that <select> must still be here.
+    expect(ROUTE).toContain('class="jb__status"');
+    expect(ROUTE).toContain('aria-label="Page status"');
+  });
+});


### PR DESCRIPTION
The builder is a full-bleed surface whose only exit was the studio icon rail. It now carries the prototype's brand wordmark (`builder.html:203`) at the head of the top bar.

**Scope is deliberately just that link** — not the gold uppercase status pill (it would displace the publish/unpublish `<select>` we ship, a real affordance the pill doesn't replace), and not the 52px bar or the 9px/7px radii.

## Two translation decisions the prototype can't settle

**Target.** The prototype contradicts *itself*: `href="studio-journeys.html"` (the Portals index) with `title="Studio home"`. It links to the **Portals index** — the list the builder was opened from, so it reads as "up one level" from the page being edited — and the tooltip says so honestly rather than repeating the mismatched "Studio home".

**The period.** The prototype tints it with a fixed studio gold (`--st-gold: #cdb489`). We have no such token and every brand colour here is org-overridable, so it takes **`--color-brand-primary`** and tints per org instead of pinning one org's palette into shared chrome.

## A gotcha worth reading before you "fix" it

`font-weight: var(--font-bold)` resolves to **400**, not 700 — and that's correct. `org-brand.css:171` re-declares `[data-org-brand] { --font-bold: var(--heading-weight, 700) }`, and the dev org's heading font is **Archivo Black**, a single-weight display face. 700 would make the browser synthesise a smeared fake bold. The mark reads heavy because the *face* is heavy, not the weight axis. An org with a multi-weight heading font gets a real 700. Recorded in a comment at the rule.

## Layout cost — measured, not assumed

I added a control to a bar PR #435 had *just* fixed for overflow, so I measured it in-browser rather than eyeballing:

| | Before | After |
|---|---|---|
| Horizontal overflow, 1920→768 | none | **none** |
| Clipped controls, 1920→768 | none | **none** |
| Single-line threshold (builder width) | 1340px | **1410px** |
| Single-line threshold (viewport) | 1474px | **1544px** |

The mark is 57px, ~70px with its gap. **Viewports in the 1474–1543 band newly wrap the bar to two lines** — that band includes **1512** (13" MacBook default) and **1536**. Nothing breaks: wrapping is #435's designed behaviour and the actions cluster still moves as a unit. Flagged because it slightly narrows a guarantee #435 had just established.

If you'd rather reclaim those 70px, the cheapest lever is dropping the now-largely-redundant `Journey ·` prefix from `.jb__doc` (~60px) — say the word and I'll do it as a follow-up rather than widen this PR.

## Tests

Structural, in the same jsdom-can't-do-this split as `journey-palette.test.ts` (jsdom neither lays out the bar nor evaluates the OKLCH brand tokens). Both mutations verified to kill them:

| Mutation | Result |
|---|---|
| Retarget the link to `/studio` | 1 test fails |
| Copy the prototype's `#cdb489` | 2 tests fail |

Also pinned: the period is `aria-hidden` (a trailing full stop is decoration — the accessible name stays "Studio"), the mark precedes the doc title (visual *and* tab order), and the status `<select>` is still present, so the excluded pill can't be slipped in later.

## Gates (local — CI's Neon quota is exhausted)

typecheck **57/57** · biome **0 errors** · svelte-check **68/43/44** (baseline, none in changed files) · apps/web **1491 pass / 148 files**.

Honest note: the **first** of three suite runs reported 1 failure + 13 skips across 2 files. I did not capture which, and two subsequent full runs were clean (exit 0, zero failures). Recording it rather than labelling it a flake — this change is a route `.svelte` edit plus a self-contained file-reading test, so it can't influence other files' outcomes.

## Verified in browser

Link renders with `href="/studio/journeys"`, period computes to `rgb(251,146,60)` = `#FB923C` (the org's dark-mode primary), `aria-hidden="true"` on the stop, 12px gap to `Journey ·` — reads clearly separated, so the prototype's `border-left` separator was not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)