### PR TITLE
fix(library): buying a portal no longer empties everything you own

### DIFF
--- a/apps/web/src/lib/collections/library.ts
+++ b/apps/web/src/lib/collections/library.ts
@@ -74,6 +74,56 @@ export const libraryCollection = browser
   : undefined;
 
 /**
+ * Largest page the API will serve (`paginationSchema.limit.max`). Asking for
+ * more is a validation error, not a bigger page.
+ */
+const LIBRARY_FETCH_PAGE_SIZE = 100;
+
+/**
+ * Hard stop on the paging loop — 100 pages x 100 items. A backstop against a
+ * server that keeps reporting `totalPages`, never a limit real users hit.
+ */
+const LIBRARY_FETCH_PAGE_CAP = 100;
+
+/**
+ * Fetch the member's ENTIRE library, following pagination to exhaustion.
+ *
+ * This collection is a local-first mirror of "everything you own", so a single
+ * page is the wrong shape for it in two ways. The obvious one: with the API's
+ * default `limit: 20`, a member owning 29 items could only ever see 20, with no
+ * way to reach the rest. The subtle and worse one: the reconcile pass below
+ * treats any locally-cached key ABSENT from the fetch as revoked and deletes
+ * it — so a one-page fetch would actively prune everything past item 20 out of
+ * localStorage on every refresh.
+ *
+ * Caveat worth knowing: when several access arms contribute items, the API's
+ * `total` is the sum of per-arm counts while each arm is independently
+ * LIMIT/OFFSET-ed, so page boundaries above `LIBRARY_FETCH_PAGE_SIZE` items are
+ * approximate. At 100 per page a member needs to own >100 items in one org
+ * before that can bite; fixing it properly means merging in SQL rather than
+ * in JS, which is a service-layer change.
+ */
+async function fetchEntireLibrary(): Promise<LibraryItem[]> {
+  const collected: LibraryItem[] = [];
+
+  for (let page = 1; page <= LIBRARY_FETCH_PAGE_CAP; page++) {
+    const result = await getUserLibrary({
+      page,
+      limit: LIBRARY_FETCH_PAGE_SIZE,
+    });
+    const items = result?.items ?? [];
+    collected.push(...items);
+
+    // Stop on a short/empty page as well as on the reported last page — a
+    // server that under-reports `totalPages` must not spin the loop to the cap.
+    const totalPages = result?.pagination?.totalPages ?? 1;
+    if (items.length < LIBRARY_FETCH_PAGE_SIZE || page >= totalPages) break;
+  }
+
+  return collected;
+}
+
+/**
  * Fetch library from server and reconcile with localStorage collection.
  *
  * Called by invalidateCollection('library') when the server-side version
@@ -82,8 +132,7 @@ export const libraryCollection = browser
 export async function loadLibraryFromServer(): Promise<void> {
   if (!libraryCollection) return;
   try {
-    const result = await getUserLibrary({});
-    const freshItems = result?.items ?? [];
+    const freshItems = await fetchEntireLibrary();
 
     // Track existing keys to detect removals (access revoked, etc.)
     const existingKeys = new Set<string>();
@@ -107,8 +156,9 @@ export async function loadLibraryFromServer(): Promise<void> {
     //
     // Copying each top-level field onto the draft records each as a change,
     // which IS what TanStack DB's proxy tracks. `LibraryItem` has a stable
-    // shape (content / accessType / purchase / progress), so `Object.assign`
-    // is sufficient — no stale keys to prune.
+    // shape (content / accessType / purchase / progress / journeys), so
+    // `Object.assign` is sufficient — no stale keys to prune. Shape changes
+    // must bump `LIBRARY_SCHEMA_VERSION` so cached rows are migrated first.
     for (const item of freshItems) {
       const key = item.content.id;
       if (existingKeys.has(key)) {

--- a/apps/web/src/lib/components/journeys/journey-entry-card.ts
+++ b/apps/web/src/lib/components/journeys/journey-entry-card.ts
@@ -267,6 +267,47 @@ export function enrolledCourseTileEntry(
 }
 
 /**
+ * `EnrolledCourseSummary` → the library "Your portals" STRIP card.
+ *
+ * A LANDSCAPE row silhouette, unlike the 3:4 tile this shelf used to render.
+ * The tile is a browsing/showcase treatment: its cover takes height from its
+ * own width, so a shelf of tiles is ~26rem tall and one portal leaves most of
+ * the row empty. In the library the member has already committed — they are not
+ * shopping, they are resuming — so the shelf's job is "which portals am I on,
+ * and where am I in each", which a row answers in about half the height and
+ * lets several portals sit side by side across the page width.
+ *
+ * Distinct from `enrolledCourseRowEntry` (the "Jump back in" rail) even though
+ * both are rows: that rail MIXES portals with standalone practices, so it must
+ * suppress portal-only chrome to read as one system. This strip contains
+ * nothing but portals, so it can afford the status line and the access chip —
+ * and it keeps `kicker: 'Portal'` rather than a cover badge, since a badge on
+ * every card in a shelf titled "Your portals" is pure repetition.
+ */
+export function enrolledCoursePortalStripEntry(
+  course: EnrolledCourseSummary,
+  href: string,
+  extras: EntryExtras = {}
+): JourneyEntryCardProps {
+  return {
+    href,
+    title: course.course.title,
+    kicker: 'Portal',
+    meta: course.progress.nextPracticeTitle
+      ? `Next · ${course.progress.nextPracticeTitle}`
+      : null,
+    coverImageUrl: course.course.coverImageUrl,
+    layout: 'row',
+    progress: {
+      percent: course.progress.percent,
+      label: enrolledStatusLabel(course.progress),
+    },
+    accessLabel: extras.accessLabel ?? null,
+    cta: enrolledCta(course.progress.status),
+  };
+}
+
+/**
  * `EnrolledCourseSummary` → the library "Jump back in" ROW. Same cover
  * treatment as the tile, at a resume silhouette; the meta line names the next
  * practice rather than the curriculum size.

--- a/apps/web/src/lib/library/schema-version.test.ts
+++ b/apps/web/src/lib/library/schema-version.test.ts
@@ -37,6 +37,78 @@ const PAYLOAD = JSON.stringify({
   'content-1': { versionKey: 'v-uuid', data: { content: { id: 'content-1' } } },
 });
 
+describe('librarySchemaMigrations — v1 → v2 (journeys provenance)', () => {
+  /** A v1 row: everything the shape had BEFORE `journeys` existed. */
+  const v1Payload = JSON.stringify({
+    'content-1': {
+      versionKey: 'v-uuid',
+      data: {
+        content: { id: 'content-1', title: 'Tuning Fork Reset' },
+        accessType: 'membership',
+        purchase: null,
+        progress: null,
+      },
+    },
+  });
+
+  it('defaults journeys to [] so a v1 row survives the bump instead of being discarded', () => {
+    const storage = memoryStorage({
+      [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+      [LIBRARY_STORAGE_KEY]: v1Payload,
+    });
+
+    const outcome = reconcileLibrarySchemaVersion(storage);
+
+    // Migrated, NOT discarded — the member keeps a populated library through
+    // the deploy rather than an empty one for the length of the library fetch.
+    expect(outcome).toBe('migrated');
+    expect(storage.peek(LIBRARY_SCHEMA_STORAGE_KEY)).toBe(
+      String(LIBRARY_SCHEMA_VERSION)
+    );
+
+    const migrated = JSON.parse(storage.peek(LIBRARY_STORAGE_KEY) as string);
+    expect(migrated['content-1'].data.journeys).toEqual([]);
+    // Every pre-existing field is preserved verbatim.
+    expect(migrated['content-1'].data.accessType).toBe('membership');
+    expect(migrated['content-1'].data.content.title).toBe('Tuning Fork Reset');
+    expect(migrated['content-1'].versionKey).toBe('v-uuid');
+  });
+
+  it('leaves an already-populated journeys array untouched', () => {
+    const withJourneys = JSON.stringify({
+      'content-1': {
+        versionKey: 'v-uuid',
+        data: {
+          content: { id: 'content-1' },
+          journeys: [{ id: 'j1', title: 'Descent', slug: 'descent' }],
+        },
+      },
+    });
+    const storage = memoryStorage({
+      [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+      [LIBRARY_STORAGE_KEY]: withJourneys,
+    });
+
+    expect(reconcileLibrarySchemaVersion(storage)).toBe('migrated');
+    const migrated = JSON.parse(storage.peek(LIBRARY_STORAGE_KEY) as string);
+    expect(migrated['content-1'].data.journeys).toEqual([
+      { id: 'j1', title: 'Descent', slug: 'descent' },
+    ]);
+  });
+
+  it('falls back to discard when a v1 payload is not the expected shape', () => {
+    // An array, not the `{ [id]: { versionKey, data } }` map — unrecognised, so
+    // the migration must decline rather than write back something it guessed at.
+    const storage = memoryStorage({
+      [LIBRARY_SCHEMA_STORAGE_KEY]: '1',
+      [LIBRARY_STORAGE_KEY]: JSON.stringify([{ nope: true }]),
+    });
+
+    expect(reconcileLibrarySchemaVersion(storage)).toBe('discarded');
+    expect(storage.has(LIBRARY_STORAGE_KEY)).toBe(false);
+  });
+});
+
 describe('reconcileLibrarySchemaVersion', () => {
   describe('current-version data hydrates unchanged', () => {
     it('is a no-op when the stamp already matches the current version', () => {
@@ -75,10 +147,15 @@ describe('reconcileLibrarySchemaVersion', () => {
         [LIBRARY_STORAGE_KEY]: PAYLOAD,
       });
 
-      // Simulate the future course-grouping bump: current is now v2.
+      // `migrations: {}` is what makes this the NO-MIGRATION case. It used to
+      // be omitted, which silently leaned on the real registry being empty — so
+      // the moment a v1 migration was registered (the `journeys` field, v2) this
+      // test started exercising the migrate branch while still asserting
+      // discard. Injecting the empty registry pins the branch under test.
       const outcome = reconcileLibrarySchemaVersion(storage, {
         currentVersion: 2,
         introductionVersion: 1,
+        migrations: {},
       });
 
       expect(outcome).toBe('discarded');

--- a/apps/web/src/lib/library/schema-version.ts
+++ b/apps/web/src/lib/library/schema-version.ts
@@ -8,29 +8,25 @@
  * conflict UUID for cross-tab reconciliation — it is NOT a schema version.
  * Nothing today records the *shape* of the persisted `data`.
  *
- * That is fine until the shape changes. When the course-grouping work lands
- * (SPEC §11, HARDENING risk R-B) `LibraryItem` gains course-entitlement fields
- * and the library page groups by course. On the first load after that ships,
- * the collection would hydrate OLD-shape rows straight out of localStorage;
- * the new grouping/filter code reads fields those rows never had, so items
- * drop out of view — an empty library that stays empty until a server refetch
- * happens to overwrite every row. That is R-B: "schema change strands stale
- * localStorage".
+ * That is fine until the shape changes. Without a stamp, the collection would
+ * hydrate OLD-shape rows straight out of localStorage; code that reads fields
+ * those rows never had drops items out of view — an empty library that stays
+ * empty until a server refetch happens to overwrite every row. That is
+ * HARDENING risk R-B: "schema change strands stale localStorage".
  *
- * This module scaffolds a schema-version stamp plus a branch that runs BEFORE
- * the collection is created, so an incompatible payload is migrated or
- * discarded (discard is self-healing: the collection loads empty, then
+ * This module holds a schema-version stamp plus a branch that runs BEFORE the
+ * collection is created, so an incompatible payload is migrated or discarded
+ * (discard is self-healing: the collection loads empty, then
  * `loadLibraryFromServer()` on mount refetches current-shape rows) instead of
  * hydrated as garbage.
  *
- * IMPORTANT — behaviour today is unchanged. At the introduction version (v1)
- * there is no schema change yet, so:
- *   - a payload already stamped v1 hydrates untouched (the fast path), and
- *   - an UNSTAMPED payload is, by definition, current-shape (it was written by
- *     this same code), so it is adopted (stamped, kept) — no discard, no
- *     empty-library flash for existing users.
- * The discard/migrate branch only fires once `LIBRARY_SCHEMA_VERSION` is
- * bumped for a real shape change.
+ * Version history:
+ *   - v1 — introduction. Stamping did not exist before this, so an UNSTAMPED
+ *     payload found at v1 is by definition current-shape and is adopted
+ *     (stamped, kept) rather than discarded.
+ *   - v2 — `LibraryItem` gained `journeys` (portal provenance). Migrated
+ *     in place from v1 by defaulting the field to `[]`; see
+ *     `librarySchemaMigrations`.
  *
  * @see $lib/collections/library.ts — the collection this guards.
  * @see $lib/library/filter-by-org.ts — the cross-org filter that trusts the
@@ -59,7 +55,7 @@ export const LIBRARY_SCHEMA_STORAGE_KEY = 'codex-library-schema';
  * derived from the old one, register a migration in `librarySchemaMigrations`
  * instead of relying on discard.
  */
-export const LIBRARY_SCHEMA_VERSION = 1;
+export const LIBRARY_SCHEMA_VERSION = 2;
 
 /**
  * The version at which schema-stamping was introduced. Used to distinguish
@@ -76,16 +72,53 @@ const INTRODUCTION_VERSION = 1;
  * migrate — discard instead". Migrations are keyed by the version being
  * migrated FROM.
  *
- * Empty today (the scaffold discards on any mismatch). The course-grouping
- * change can register `{ 1: (raw) => addCourseFields(raw) }` here to preserve
- * a user's local library across the bump instead of forcing a refetch.
+ * Registering a migration is preferred over relying on discard whenever the
+ * new shape is derivable from the old one: discard leaves the library visibly
+ * empty until `loadLibraryFromServer()` returns, and that request takes
+ * several seconds.
  */
 export type LibrarySchemaMigration = (rawPayload: string) => string | null;
 export type LibrarySchemaMigrations = Readonly<
   Record<number, LibrarySchemaMigration>
 >;
 
-export const librarySchemaMigrations: LibrarySchemaMigrations = {};
+export const librarySchemaMigrations: LibrarySchemaMigrations = {
+  /**
+   * v1 → v2: `LibraryItem` gained `journeys` — the portal(s) a practice sits
+   * inside, which drives the library's "part of <portal>" provenance badge.
+   *
+   * Old rows simply lack the field, and `[]` ("stands alone") is the correct
+   * default: it is what the server returns for a practice in no portal, so a
+   * migrated row renders identically to a fresh one for the common case. The
+   * refetch on mount then fills in real provenance for the minority that do
+   * belong to a portal. Migrating rather than discarding means existing users
+   * keep a populated library through the deploy instead of staring at an empty
+   * one for the duration of the library fetch.
+   */
+  1: (rawPayload) => {
+    const parsed: unknown = JSON.parse(rawPayload);
+    // Expected shape is TanStack DB's `{ [contentId]: { versionKey, data } }`.
+    // Anything else is unrecognised — return null to fall back to discard
+    // rather than write a half-understood payload back to storage.
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+
+    for (const row of Object.values(parsed as Record<string, unknown>)) {
+      if (row === null || typeof row !== 'object') return null;
+      const data = (row as { data?: unknown }).data;
+      if (data === null || typeof data !== 'object') return null;
+      const item = data as { journeys?: unknown };
+      if (!Array.isArray(item.journeys)) item.journeys = [];
+    }
+
+    return JSON.stringify(parsed);
+  },
+};
 
 /**
  * Outcome of a reconcile pass, surfaced for observability/tests.

--- a/apps/web/src/lib/subscription/library-access.ts
+++ b/apps/web/src/lib/subscription/library-access.ts
@@ -30,8 +30,23 @@ import { getEffectiveStatus } from './status';
  * Deliberately narrow so we can test without the full `LibraryItem` type.
  */
 interface LibraryAccessInput {
-  /** The library item's accessType — only 'subscription' triggers joins. */
-  accessType: 'purchased' | 'membership' | 'subscription';
+  /**
+   * The library item's accessType — only `'subscription'` triggers joins; every
+   * other route is unconditionally active.
+   *
+   * This lists the FULL union the API returns. It previously named only
+   * `purchased | membership | subscription`, which made the long-shipping
+   * `'free'` and `'followers'` values look impossible — the mismatch stayed
+   * invisible while `@codex/access` published an under-declared copy of the
+   * library contract. Runtime behaviour is unchanged: those values already fell
+   * through the `!== 'subscription'` guard to "active".
+   */
+  accessType:
+    | 'purchased'
+    | 'membership'
+    | 'subscription'
+    | 'free'
+    | 'followers';
   /** Slug of the owning org (join key against subscriptionCollection). */
   organizationSlug: string | null;
 }

--- a/apps/web/src/lib/utils/continue-watching.test.ts
+++ b/apps/web/src/lib/utils/continue-watching.test.ts
@@ -57,6 +57,9 @@ function makeItem(overrides: ItemOverrides = {}): LibraryItem {
     accessType: 'purchased',
     purchase: null,
     progress,
+    // Stands alone (in no portal) — the default these tests care about, since
+    // continue-watching is about resumable MEDIA, not portal membership.
+    journeys: [],
   };
 }
 

--- a/apps/web/src/routes/_org/[slug]/(space)/library/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/(space)/library/+page.svelte
@@ -27,10 +27,12 @@
     loadLibraryFromServer,
     useLiveQuery,
   } from '$lib/collections';
+  import Carousel from '$lib/components/carousel/Carousel.svelte';
   import JourneyEntryCard from '$lib/components/journeys/JourneyEntryCard.svelte';
+  import Skeleton from '$lib/components/ui/Skeleton/Skeleton.svelte';
   import {
+    enrolledCoursePortalStripEntry,
     enrolledCourseRowEntry,
-    enrolledCourseTileEntry,
     resumeProgress,
   } from '$lib/components/journeys/journey-entry-card';
   import type { EnrolledCourseSummary } from '$lib/journeys/types';
@@ -55,7 +57,6 @@
   });
 
   // ── Owned content — client-side, from the localStorage library collection ──
-  let isLoadingFromServer = $state(false);
   const libraryQuery = useLiveQuery(
     (q) =>
       q
@@ -68,17 +69,38 @@
     filterLibraryItemsByOrg((libraryQuery.data ?? []) as LibraryItem[], orgId)
   );
 
+  /**
+   * Has the server refresh finished (either way)? Starts false — including on
+   * the server, where it can never be true.
+   */
+  let serverFetchSettled = $state(false);
+
   onMount(async () => {
-    const hasData = (libraryCollection?.state.size ?? 0) > 0;
-    if (!hasData) isLoadingFromServer = true;
     try {
       await loadLibraryFromServer();
     } catch {
       // Non-fatal — an empty grid degrades gracefully.
     } finally {
-      isLoadingFromServer = false;
+      serverFetchSettled = true;
     }
   });
+
+  /**
+   * "We do not know what you own yet" — as distinct from "you own nothing".
+   *
+   * Derived rather than assigned in `onMount`, because the previous flag started
+   * `false` and only flipped to `true` inside `onMount`. That made the SSR pass —
+   * where `ssrData` is `[]` and no effect has run — indistinguishable from a
+   * settled empty library, so the server baked the first-run onboarding into the
+   * HTML for members who own plenty, and the real content replaced it a beat
+   * later. The library fetch takes several seconds, so that flash was very
+   * visible rather than theoretical.
+   *
+   * Any locally-cached item short-circuits this to `false`, so a return visit
+   * paints from localStorage immediately and never shows a skeleton — the
+   * skeleton is only for members with genuinely nothing cached yet.
+   */
+  const ownedPending = $derived(!serverFetchSettled && ownedItems.length === 0);
 
   // ── Static maps ────────────────────────────────────────────────────────────
   const TYPE_META: Record<string, { label: string; glyph: string }> = {
@@ -122,7 +144,7 @@
     return months <= 1 ? 'Last month' : `${months} months ago`;
   };
 
-  // Access-source → badge. Owned content maps its `accessType`; journey cards
+  // Access-source → badge. Owned content maps its `accessType`; portal cards
   // map the enrollment `source`. Unknown sources render no badge (never guess).
   type Badge = { cls: string; label: string };
   const badgeFor = (via: string | null | undefined): Badge | null => {
@@ -152,13 +174,47 @@
         return null;
     }
   };
-  const sourceGroup = (via: string | null | undefined) => {
-    if (via?.startsWith('course:')) return 'Part of a journey';
-    if (via === 'paid' || via === 'purchased') return 'Purchased';
-    if (via === 'subscribers' || via === 'members' || via === 'membership') {
-      return 'Included with membership';
+  /**
+   * The badge an owned row carries.
+   *
+   * Portal PROVENANCE wins over access route. A practice inside a portal is
+   * almost always ALSO reachable some other way (an owner reaches everything
+   * "via membership"), so showing the access route there would bury the more
+   * useful fact — that opening this practice means stepping into a portal, and
+   * that its progress counts toward one. `+n` when a practice is shared by
+   * several portals, which `stage_practices` permits.
+   */
+  const ownedBadge = (item: LibraryItem): Badge | null => {
+    const portals = item.journeys ?? [];
+    const first = portals[0];
+    if (first) {
+      const extra = portals.length > 1 ? ` +${portals.length - 1}` : '';
+      return { cls: 'course', label: `part of ${first.title}${extra}` };
     }
-    return 'Free';
+    return badgeFor(item.accessType);
+  };
+
+  /**
+   * Bucket for `group by: source`. Exhaustive over the API's real `accessType`
+   * union — `purchased | membership | subscription | free | followers`.
+   *
+   * It previously also tested `'paid'`, `'subscribers'` and `'members'`, which
+   * the API has never returned for a library item. Those branches were
+   * invisible dead code while the published type under-declared the union (see
+   * `@codex/access` types.ts); with the type derived from the service, the
+   * compiler flags them, so they are gone.
+   */
+  const sourceGroup = (item: LibraryItem) => {
+    if ((item.journeys?.length ?? 0) > 0) return 'Part of a portal';
+    switch (item.accessType) {
+      case 'purchased':
+        return 'Purchased';
+      case 'membership':
+      case 'subscription':
+        return 'Included with membership';
+      default:
+        return 'Free';
+    }
   };
 
   // Routed through `buildJourneyUrl` rather than hand-built, so the slug→id
@@ -200,10 +256,9 @@
     ].sort()
   );
 
+  // Only claim "you have nothing" once the server has actually said so.
   const isFirstRun = $derived(
-    !isLoadingFromServer &&
-      enrolledCourses.length === 0 &&
-      ownedItems.length === 0
+    !ownedPending && enrolledCourses.length === 0 && ownedItems.length === 0
   );
 
   const showContinue = $derived(facetKind === 'all' && !q);
@@ -264,8 +319,8 @@
       return groupByKey(list, (i) => typeMeta(i.content?.contentType).label);
     }
     if (groupBy === 'source') {
-      return groupByKey(list, (i) => sourceGroup(i.accessType), [
-        'Part of a journey',
+      return groupByKey(list, (i) => sourceGroup(i), [
+        'Part of a portal',
         'Included with membership',
         'Purchased',
         'Free',
@@ -316,13 +371,23 @@
   </span>
 {/snippet}
 
+<!-- One portal in the "Your portals" carousel. -->
+{#snippet portalCard(c: EnrolledCourseSummary)}
+  {@const badge = badgeFor(c.enrollmentSource)}
+  <JourneyEntryCard
+    {...enrolledCoursePortalStripEntry(c, journeyDashboardHref(c), {
+      accessLabel: badge?.label ?? null,
+    })}
+  />
+{/snippet}
+
 <main class="library" data-testid="member-library">
   {#if isFirstRun}
     <div class="firstrun">
       <p class="firstrun__kicker">Welcome to {orgName}</p>
       <h1 class="firstrun__title">Your library will grow here.</h1>
       <p class="firstrun__sub">
-        As you gather practices and follow journeys, they'll live in this room —
+        As you gather practices and enter portals, they'll live in this room —
         the ones you're on, and the ones you've kept. For now, there's one clear
         place to begin.
       </p>
@@ -332,7 +397,7 @@
           <span class="firstrun__ck">Start here</span>
           <span class="firstrun__ct">Explore {orgName}</span>
           <span class="firstrun__cd">
-            Browse the catalogue and find your first practice or journey.
+            Browse the catalogue and find your first practice or portal.
           </span>
           <span class="firstrun__cta">Browse everything →</span>
         </span>
@@ -345,7 +410,7 @@
         {memberName ? `Welcome back, ${memberName}` : 'Welcome back'}
       </h1>
       <p class="lib-head__sub">
-        Everything you've gathered lives here — journeys you're on, and the
+        Everything you've gathered lives here — portals you're on, and the
         practices you've kept.
       </p>
     </header>
@@ -376,7 +441,7 @@
           <button
             class="chip"
             class:chip--on={facetKind === 'journeys'}
-            onclick={() => selectFacet('journeys')}>Journeys</button
+            onclick={() => selectFacet('journeys')}>Portals</button
           >
         {/if}
         {#if ownedTypes.length > 0}
@@ -397,7 +462,7 @@
       <section class="sec">
         <div class="sec__head">
           <h2>Jump back in</h2>
-          <span class="sec__ct">across your journeys &amp; practices</span>
+          <span class="sec__ct">across your portals &amp; practices</span>
         </div>
         <!--
           Journeys AND standalone practices render through the SAME card
@@ -443,22 +508,38 @@
     {#if showJourneys}
       <section class="sec">
         <div class="sec__head">
-          <h2>Your journeys</h2>
+          <h2>Your portals</h2>
           <span class="sec__ct">{journeysShown.length} in your library</span>
         </div>
         {#if journeysShown.length > 0}
-          <div class="rail">
-            {#each journeysShown as c (c.course.id)}
-              {@const badge = badgeFor(c.enrollmentSource)}
-              <JourneyEntryCard
-                {...enrolledCourseTileEntry(c, journeyDashboardHref(c), {
-                  accessLabel: badge?.label ?? null,
-                })}
-              />
-            {/each}
-          </div>
+          <!--
+            A CAROUSEL, not a wrapping grid. The grid put five portals on two
+            rows and cost ~2x the vertical space for something the member scans
+            once — worst on mobile, where each row is a full card tall. One
+            scrolling row is a fixed height no matter how many portals you own.
+
+            The shared `Carousel` is used rather than a bare scroll container
+            precisely because the naive version of this is bad UX: it gives
+            prev/next arrows that auto-hide at the ends, a visible thin
+            scrollbar, scroll-snap, swipe, and roving focus that scrolls the
+            focused card into view. The rail this replaces hid its scrollbar and
+            offered no arrows, so there was nothing to tell you more existed.
+          -->
+          <!--
+            25rem for the same reason `.cont` (the resume rail) is 26rem: a row
+            card splits its width between cover and text, and at 22rem the text
+            column was ~200px, which wrapped both the title and the
+            "Next · <practice>" line. 25rem is also exactly the carousel item's
+            400px ceiling, so it asks for what it can actually get.
+          -->
+          <Carousel
+            items={journeysShown}
+            itemMinWidth="25rem"
+            ariaLabel="Your portals"
+            renderItem={portalCard}
+          />
         {:else}
-          <p class="empty">No journeys match — try another filter or search.</p>
+          <p class="empty">No portals match — try another filter or search.</p>
         {/if}
       </section>
     {/if}
@@ -468,7 +549,13 @@
       <section class="sec">
         <div class="sec__head">
           <h2>{ownTitle}</h2>
-          <span class="sec__ct">{ownedShown.length} pieces</span>
+          <!-- Suppressed while pending: "0 pieces" is a claim, not a placeholder. -->
+          {#if !ownedPending}
+            <span class="sec__ct">
+              {ownedShown.length}
+              {ownedShown.length === 1 ? 'piece' : 'pieces'}
+            </span>
+          {/if}
           <div class="groupby">
             <span class="groupby__lbl">Group by</span>
             <div class="seg" role="group" aria-label="Group content by">
@@ -491,7 +578,42 @@
           </div>
         </div>
 
-        {#if ownedShown.length > 0}
+        {#if ownedPending}
+          <!--
+            Mirrors the real row silhouette (motif + two text lines + end chip)
+            in the same two-column grid, so the shelf does not reflow when the
+            data lands. Eight rows is roughly a viewport's worth — enough to read
+            as "a library is loading", not so many that it implies a count.
+          -->
+          <div class="rows" aria-hidden="true">
+            {#each { length: 8 } as _, i (i)}
+              <div class="row row--sk">
+                <Skeleton
+                  width="var(--space-12)"
+                  height="var(--space-12)"
+                  class="sk-thumb"
+                />
+                <div class="row--sk__t">
+                  <!--
+                    Title widths vary deterministically by index rather than
+                    randomly: a column of identical bars reads as a table, and
+                    Math.random() in a template would resample on every rerender
+                    and make the bars twitch. Fixed rem rather than % now that
+                    the text column is content-sized — a percentage of a
+                    content-sized box collapses to nothing.
+                  -->
+                  <Skeleton
+                    width="{9 + ((i * 17) % 7)}rem"
+                    height="var(--text-base)"
+                  />
+                  <Skeleton width="3.5rem" height="var(--text-sm)" />
+                </div>
+                <Skeleton width="6.5rem" height="1.5rem" class="sk-chip" />
+              </div>
+            {/each}
+          </div>
+          <p class="sr-only" role="status">Loading your library…</p>
+        {:else if ownedShown.length > 0}
           {#each ownedGroups as group (group.key)}
             <div class="grp">
               {#if group.key}
@@ -502,7 +624,7 @@
               <div class="rows">
                 {#each group.items as item (item.content?.id)}
                   {@const m = typeMeta(item.content?.contentType)}
-                  {@const badge = badgeFor(item.accessType)}
+                  {@const badge = ownedBadge(item)}
                   {@const opened = relativeTime(
                     item.progress?.updatedAt ?? item.purchase?.purchasedAt
                   )}
@@ -512,16 +634,22 @@
                       <span class="row__title">{item.content?.title}</span>
                       <span class="row__meta">{m.label}</span>
                     </span>
-                    <span class="row__end">
-                      {#if opened}
-                        <span class="row__opened">{opened}</span>
-                      {/if}
-                      {#if badge}
-                        <span class="badge badge--{badge.cls}"
-                          >{badge.label}</span
-                        >
-                      {/if}
-                    </span>
+                    {#if badge}
+                      <!-- Sits NEXT TO the title, not at the far right edge:
+                           "part of <portal>" describes the practice, so the two
+                           belong together, and pinning it to the edge of a
+                           full-width row opened a gutter wide enough to read as
+                           a layout mistake. `title` keeps a name clipped by the
+                           chip's max-width recoverable on hover. -->
+                      <span class="badge badge--{badge.cls}" title={badge.label}
+                        >{badge.label}</span
+                      >
+                    {/if}
+                    {#if opened}
+                      <!-- `margin-left: auto` — the only thing that earns the
+                           right edge, and only on rows that have been opened. -->
+                      <span class="row__opened">{opened}</span>
+                    {/if}
                   </a>
                 {/each}
               </div>
@@ -533,7 +661,7 @@
 
         <p class="seam">
           <span class="seam__g" aria-hidden="true">↳</span>
-          Practices that belong to a journey open inside it, so you keep your
+          Practices that belong to a portal open inside it, so you keep your
           place and can mark them complete.
         </p>
       </section>
@@ -771,19 +899,20 @@
   }
 
   /*
-    Both rails now hold `JourneyEntryCard`s, so the per-rail CARD styling that
+    Both shelves hold `JourneyEntryCard`s, so the per-shelf CARD styling that
     used to live here is gone (Codex-tnwnu): `.contcard*` + `.track` (the resume
-    strip) and `.jc*` (the journeys shelf, including its title-hash tone
+    strip) and `.jc*` (the portals shelf, including its title-hash tone
     gradient). What remains is the SCROLLER — a rail owns its own overflow and
     snap behaviour; a card never does.
 
-    Both scrollers set the card track width, since only the page knows how wide a
-    card should be in ITS rail. The journeys shelf is narrower than it looks
-    relative to the old 16.5rem: the shared card is a 3:4 portrait, so the track
-    had to come down or the shelf would be ~26rem tall.
+    These styles are only "Jump back in" now. The portals shelf moved to the
+    shared `Carousel` component, which owns its own track, arrows and scrollbar
+    — this hand-rolled scroller stays for the resume rail alone. Worth
+    collapsing the two onto `Carousel` eventually; the resume rail mixes portals
+    with standalone practices and sizes its cards differently, so that is a
+    separate change rather than a drive-by.
   */
-  .cont,
-  .rail {
+  .cont {
     display: flex;
     gap: var(--space-4);
     overflow-x: auto;
@@ -791,13 +920,12 @@
     scroll-snap-type: x mandatory;
     scrollbar-width: none;
   }
-  .cont::-webkit-scrollbar,
-  .rail::-webkit-scrollbar {
+  .cont::-webkit-scrollbar {
     display: none;
   }
   /*
-    26rem, up from 22rem, for the same reason the `.rail` track below went 13→16:
-    a resume card cannot do its job with the text unreadable.
+    26rem, up from 22rem: a resume card cannot do its job with the text
+    unreadable.
 
     A row card spends its width on TWO columns, so the text gets whatever the
     cover does not. At 22rem the split was 144px cover / 160px text — and a 160px
@@ -807,35 +935,19 @@
     up to 26rem. Together the text column goes 160px → ~248px, which holds a
     two-line title and the full practice name.
 
-    Unlike the `.rail` widening, this one costs NO height: a row's cover takes its
-    height from the text beside it, not from its own width, so a wider track makes
-    the card shorter if anything.
+    This costs NO height: a row's cover takes its height from the text beside it,
+    not from its own width, so a wider track makes the card shorter if anything.
   */
   .cont > :global(*) {
     flex: 0 0 clamp(18rem, 86vw, 26rem);
     scroll-snap-align: start;
   }
   /*
-    16rem, chosen by measurement rather than by eye (Codex-tnwnu). At the previous
-    13rem the shelf could not show a journey's NAME: with the title clamped to two
-    lines, 13rem tops out at an 18px title, which is off the design token ladder
-    (20/24/30/40) — so the fixture's 23-character name truncated to "ASSSS
-    BLASTE…". A shelf whose whole job is "here is what you own" cannot do that job
-    with the names cut off.
-
-    16rem is the narrowest track where a real token (`--text-lg`, 20px) fits a
-    two-line title with margin to spare — its ceiling there is 22px, and it holds
-    titles up to ~30 characters. 17rem would allow `--text-xl` but costs another
-    1.3rem of height for the same 30-character tolerance.
-
-    The cost is height, and it is unavoidable: the cover is 3:4, so height tracks
-    width. 13→16rem takes the card from 23.97rem to 26.43rem — which is where this
-    shelf already was (26.17rem) before the foot was tightened. That reclaimed
-    budget is spent here, on legible names.
+    The portals carousel owns its own track/arrow/scrollbar styling; the page
+    only supplies the space beneath it before "Everything you own".
   */
-  .rail > :global(*) {
-    flex: 0 0 16rem;
-    scroll-snap-align: start;
+  .sec :global(.carousel) {
+    padding-block-end: var(--space-2);
   }
 
   /* ── Group-by segmented control ── */
@@ -894,6 +1006,17 @@
   .grp__n {
     opacity: 0.6;
   }
+  /*
+    ONE row per line. Multi-column was tried and reverted: two columns of
+    title + chip forced the eye to scan in a Z rather than straight down a
+    single list of names, and every column boundary is another place a long
+    practice title or portal name can collide with a chip.
+
+    The dead-gutter problem that motivated columns is solved in the ROW instead
+    (see `.row__t` / `.row__opened`): the provenance chip now sits immediately
+    after the title rather than being flung to the far right edge, so the width
+    is spent on content adjacency instead of whitespace.
+  */
   .rows {
     display: grid;
     gap: var(--space-1);
@@ -914,8 +1037,43 @@
     background: color-mix(in oklab, var(--lib-ink-2) 55%, transparent);
     border-color: color-mix(in oklab, var(--lib-accent) 24%, transparent);
   }
-  .row__t {
+  /*
+    Skeleton rows reuse `.row` for padding/gap so the placeholder and the real
+    row occupy identical boxes and nothing shifts when data lands. They are
+    `div`s, not `<a>`s — a placeholder must not be focusable or clickable.
+  */
+  .row--sk__t {
     flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+  /* Match the real motif's and chip's silhouettes. */
+  .row--sk :global(.sk-thumb) {
+    border-radius: var(--radius-md);
+    flex-shrink: 0;
+  }
+  .row--sk :global(.sk-chip) {
+    border-radius: var(--radius-full, 999px);
+    flex-shrink: 0;
+  }
+  /*
+    `flex: 0 1 24rem` — a fixed BASIS that may shrink but never grows.
+
+    Three behaviours fall out of that, and all three are wanted:
+      - no grow, so the chip is not pushed to the far right edge (the dead
+        gutter that made a full-width row look like a mistake);
+      - a fixed basis, so every chip starts at the SAME x instead of trailing
+        each title at a different offset — adjacency without raggedness;
+      - shrink allowed (with `min-width: 0`), so a phone-width row compresses
+        the title rather than overflowing the card.
+
+    24rem clears the longest practice title in this catalogue
+    ("Working with Copal & Sacred Smoke") on one line at `--text-base`.
+  */
+  .row__t {
+    flex: 0 1 24rem;
     min-width: 0;
     display: flex;
     flex-direction: column;
@@ -932,16 +1090,38 @@
     font-size: var(--text-sm);
     color: var(--color-text-tertiary);
   }
-  .row__end {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    flex-shrink: 0;
-  }
   .row__opened {
+    margin-left: auto;
+    padding-left: var(--space-3);
     font-size: var(--text-sm);
     color: var(--color-text-tertiary);
     white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  /*
+    Below md, a title and a provenance chip cannot share a line. At 390px the
+    row's content box is ~334px, and the chip alone may claim 14rem of it — the
+    title was squeezed under its own longest word and the chip pushed past the
+    viewport edge, clipped mid-word. So the chip takes its own line instead,
+    indented to the title's left edge (past the motif) so the row still reads as
+    one block rather than a stray pill under the artwork.
+  */
+  @media (--below-md) {
+    .row {
+      flex-wrap: wrap;
+      row-gap: var(--space-1);
+      /* Grid items default to `min-width: auto`, which lets a flex row's
+         min-content width force the single-column track wider than the
+         viewport. */
+      min-width: 0;
+    }
+    .row__t {
+      flex: 1 1 8rem;
+    }
+    .badge {
+      margin-left: calc(var(--space-12) + var(--space-3));
+    }
   }
 
   /* ── Badges ── */
@@ -953,7 +1133,10 @@
     border-radius: var(--radius-full, 999px);
     border: var(--border-width) solid transparent;
     white-space: nowrap;
-    align-self: flex-start;
+    /* `center`, not `flex-start`: the chip is now a direct child of the
+       centre-aligned `.row`, where top-aligning it against a two-line
+       title/type block left it visibly floating above the text baseline. */
+    align-self: center;
   }
   .badge--free {
     color: var(--color-text-secondary);
@@ -969,10 +1152,29 @@
     background: color-mix(in oklab, var(--lib-accent) 12%, transparent);
     border-color: color-mix(in oklab, var(--lib-accent) 30%, transparent);
   }
+  /*
+    Provenance chips carry a PROPER NOUN — the portal's title — where every
+    other badge carries a short status word ("purchased", "free"). Two
+    consequences, both handled here rather than by shortening the label:
+
+    1. No uppercase/tracking. Capitalising a title costs ~15% width and reads
+       as shouting a name; "part of Ancestral Threads" is also simply easier to
+       read than "PART OF ANCESTRAL THREADS".
+    2. A hard `max-width` + ellipsis. Portal titles are author-supplied and
+       unbounded, so without a cap a long one crowds the practice name it is
+       meant to annotate. The cap makes that impossible regardless of how a
+       creator names a portal.
+  */
   .badge--course {
     color: var(--lib-accent);
     background: color-mix(in oklab, var(--lib-accent) 12%, transparent);
     border-color: color-mix(in oklab, var(--lib-accent) 32%, transparent);
+    text-transform: none;
+    letter-spacing: normal;
+    max-width: 14rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-shrink: 0;
   }
 
   /* ── Seam + empty ── */

--- a/packages/access/src/services/__tests__/content-access-service-library-course-purchase.test.ts
+++ b/packages/access/src/services/__tests__/content-access-service-library-course-purchase.test.ts
@@ -1,0 +1,341 @@
+/**
+ * `ContentAccessService.listUserLibrary` — course purchases and portal
+ * provenance.
+ *
+ * ## Why this suite exists
+ *
+ * Every non-purchase arm of the library (membership, subscription, free,
+ * followers) excludes content the caller already bought, so `queryPurchased`
+ * stays the single owner of those rows. That exclusion used to be written as
+ *
+ *     content.id NOT IN (SELECT purchases.content_id FROM purchases WHERE …)
+ *
+ * and `purchases.content_id` is NULL for COURSE purchases — those rows point at
+ * `course_id` instead. SQL's three-valued logic then collapses
+ * `x NOT IN (NULL)` → `NOT (x = NULL)` → `NULL`, which is never TRUE, so the
+ * predicate filtered out EVERY row. One journey purchase blanked a member's
+ * entire owned-content library across all four arms simultaneously, while the
+ * portals shelf (a different endpoint) kept working — which is what made it
+ * present as "journeys load but my content doesn't".
+ *
+ * The first test is the regression lock: it is the minimum reproduction of that
+ * bug and fails loudly against the `NOT IN` form. The rest cover the provenance
+ * field the library grid badges with ("part of <portal>").
+ */
+
+import {
+  createR2SigningClientFromEnv,
+  type R2SigningClient,
+} from '@codex/cloudflare-clients';
+import { ContentService, MediaItemService } from '@codex/content';
+import {
+  content,
+  courseStages,
+  courses,
+  organizationMemberships,
+  organizations,
+  purchases,
+  stagePractices,
+} from '@codex/database/schema';
+import { ObservabilityClient } from '@codex/observability';
+import type { PurchaseService } from '@codex/purchase';
+import {
+  createUniqueSlug,
+  type Database,
+  seedTestUsers,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from '@codex/test-utils';
+import { getOriginalKey } from '@codex/transcoding';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { ContentAccessService } from '../ContentAccessService';
+
+describe('listUserLibrary — course purchase + portal provenance', () => {
+  let db: Database;
+  let accessService: ContentAccessService;
+  let contentService: ContentService;
+  let mediaService: MediaItemService;
+  let r2Client: R2SigningClient;
+  let ownerUserId: string;
+  let organizationId: string;
+  let courseId: string;
+  let stageId: string;
+  /** Published, standalone, and NOT attached to any portal. */
+  let soloContentId: string;
+  /** Published and attached to the portal's only stage. */
+  let portalContentId: string;
+
+  beforeAll(async () => {
+    db = setupTestDatabase();
+    const config = { db, environment: 'test' as const };
+
+    contentService = new ContentService(config);
+    mediaService = new MediaItemService(config);
+    r2Client = createR2SigningClientFromEnv();
+
+    accessService = new ContentAccessService({
+      db,
+      r2: r2Client,
+      obs: new ObservabilityClient('library-course-purchase-test', 'test'),
+      purchaseService: {
+        verifyPurchase: vi.fn(async () => false),
+      } as unknown as PurchaseService,
+    });
+
+    const [owner] = await seedTestUsers(db, 1);
+    if (!owner) throw new Error('Failed to seed user');
+    ownerUserId = owner;
+
+    const [org] = await db
+      .insert(organizations)
+      .values({ name: 'Portal Org', slug: createUniqueSlug('portal-org') })
+      .returning();
+    if (!org) throw new Error('Failed to seed org');
+    organizationId = org.id;
+
+    // An OWNER membership is what puts content in the `membership` arm — the
+    // arm the NOT IN bug silently emptied.
+    await db.insert(organizationMemberships).values({
+      userId: ownerUserId,
+      organizationId,
+      role: 'owner',
+      status: 'active',
+    });
+
+    soloContentId = (await createPublishedContent('solo-practice')).id;
+    portalContentId = (await createPublishedContent('portal-practice')).id;
+
+    const [course] = await db
+      .insert(courses)
+      .values({
+        organizationId,
+        creatorId: ownerUserId,
+        slug: createUniqueSlug('the-descent'),
+        title: 'The Descent',
+        status: 'published',
+      })
+      .returning();
+    if (!course) throw new Error('Failed to seed course');
+    courseId = course.id;
+
+    const [stage] = await db
+      .insert(courseStages)
+      .values({ courseId, name: 'Stage One', sortOrder: 1 })
+      .returning();
+    if (!stage) throw new Error('Failed to seed stage');
+    stageId = stage.id;
+
+    await db
+      .insert(stagePractices)
+      .values({ stageId, contentId: portalContentId, sortOrder: 0 });
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  async function createPublishedContent(slugSuffix: string) {
+    const media = await mediaService.create(
+      {
+        title: slugSuffix,
+        mediaType: 'video',
+        mimeType: 'video/mp4',
+        r2Key: getOriginalKey(
+          ownerUserId,
+          crypto.randomUUID(),
+          `${slugSuffix}.mp4`
+        ),
+        fileSizeBytes: 1024,
+      },
+      ownerUserId
+    );
+    await mediaService.markAsReady(
+      media.id,
+      {
+        hlsMasterPlaylistKey: `hls/${slugSuffix}/master.m3u8`,
+        thumbnailKey: `thumbnails/${slugSuffix}.jpg`,
+        durationSeconds: 120,
+      },
+      ownerUserId
+    );
+    const item = await contentService.create(
+      {
+        organizationId,
+        title: slugSuffix,
+        slug: createUniqueSlug(slugSuffix),
+        contentType: 'video',
+        mediaItemId: media.id,
+        visibility: 'public',
+        priceCents: 0,
+        tags: [],
+      },
+      ownerUserId
+    );
+    await contentService.publish(item.id, ownerUserId);
+    return item;
+  }
+
+  /**
+   * A purchase row with a balanced revenue split.
+   *
+   * `purchases` carries `check_revenue_split_equals_total`: platform fee +
+   * organization fee + creator payout must equal the amount paid. The columns
+   * all default to 0, so any insert that sets `amountPaidCents` without the
+   * split violates it.
+   */
+  function purchaseRow(amountPaidCents: number) {
+    const platformFeeCents = Math.round(amountPaidCents * 0.1);
+    return {
+      customerId: ownerUserId,
+      organizationId,
+      amountPaidCents,
+      currency: 'gbp' as const,
+      platformFeeCents,
+      organizationFeeCents: 0,
+      creatorPayoutCents: amountPaidCents - platformFeeCents,
+      stripePaymentIntentId: `pi_test_${crypto.randomUUID()}`,
+      status: 'completed' as const,
+    };
+  }
+
+  /** A COURSE purchase: `course_id` set, `content_id` deliberately NULL. */
+  async function seedCoursePurchase() {
+    await db
+      .insert(purchases)
+      .values({ ...purchaseRow(2999), contentId: null, courseId });
+  }
+
+  const listAll = () =>
+    accessService.listUserLibrary(ownerUserId, {
+      organizationId,
+      page: 1,
+      limit: 50,
+      filter: 'all',
+      sortBy: 'recent',
+      contentType: 'all',
+      accessType: 'all',
+      search: '',
+    });
+
+  describe('a course purchase must not empty the library (regression)', () => {
+    it('returns membership content when the member has NO purchases at all', async () => {
+      const result = await listAll();
+      const ids = result.items.map((i) => i.content.id);
+
+      expect(ids).toContain(soloContentId);
+      expect(ids).toContain(portalContentId);
+    });
+
+    it('STILL returns membership content after a course purchase (content_id IS NULL)', async () => {
+      await seedCoursePurchase();
+
+      const result = await listAll();
+      const ids = result.items.map((i) => i.content.id);
+
+      // Under the old `NOT IN (SELECT content_id …)` form this array was EMPTY:
+      // the subquery yielded a single NULL and every candidate row evaluated to
+      // NULL rather than TRUE. Both items must survive.
+      expect(ids).toContain(soloContentId);
+      expect(ids).toContain(portalContentId);
+      expect(result.pagination.total).toBeGreaterThanOrEqual(2);
+    });
+
+    it('still excludes content bought outright, so the purchased arm owns it', async () => {
+      // A CONTENT purchase (content_id set) must keep being excluded from the
+      // membership arm — the null-safety fix must not weaken the real exclusion.
+      await db
+        .insert(purchases)
+        .values({ ...purchaseRow(999), contentId: soloContentId });
+
+      const result = await listAll();
+      const solo = result.items.filter((i) => i.content.id === soloContentId);
+
+      // Present exactly once, and tagged as purchased rather than membership.
+      expect(solo).toHaveLength(1);
+      expect(solo[0]?.accessType).toBe('purchased');
+    });
+  });
+
+  describe('portal provenance', () => {
+    it('reports the portal a practice belongs to, and leaves standalone practices empty', async () => {
+      const result = await listAll();
+
+      const portalItem = result.items.find(
+        (i) => i.content.id === portalContentId
+      );
+      const soloItem = result.items.find((i) => i.content.id === soloContentId);
+
+      expect(portalItem?.journeys).toEqual([
+        { id: courseId, title: 'The Descent', slug: expect.any(String) },
+      ]);
+      // Provenance is per-practice, not per-org: a practice in no portal must
+      // report none rather than inheriting its neighbours'.
+      expect(soloItem?.journeys).toEqual([]);
+    });
+
+    it('does not attribute a practice to a soft-deleted portal', async () => {
+      await db
+        .update(courses)
+        .set({ deletedAt: new Date() })
+        .where(eq(courses.id, courseId));
+
+      try {
+        const result = await listAll();
+        const portalItem = result.items.find(
+          (i) => i.content.id === portalContentId
+        );
+
+        // An archived portal must stop branding its practices — otherwise the
+        // grid badges a portal the member can no longer open.
+        expect(portalItem?.journeys).toEqual([]);
+      } finally {
+        await db
+          .update(courses)
+          .set({ deletedAt: null })
+          .where(eq(courses.id, courseId));
+      }
+    });
+
+    it('does not attribute a practice through a soft-deleted stage', async () => {
+      await db
+        .update(courseStages)
+        .set({ deletedAt: new Date() })
+        .where(eq(courseStages.id, stageId));
+
+      try {
+        const result = await listAll();
+        const portalItem = result.items.find(
+          (i) => i.content.id === portalContentId
+        );
+
+        expect(portalItem?.journeys).toEqual([]);
+      } finally {
+        await db
+          .update(courseStages)
+          .set({ deletedAt: null })
+          .where(eq(courseStages.id, stageId));
+      }
+    });
+
+    it('keeps a practice out of the grid entirely once unpublished', async () => {
+      // Guards the "published content only" half of the contract the provenance
+      // lookup sits behind — provenance must never resurrect a draft.
+      await db
+        .update(content)
+        .set({ status: 'draft' })
+        .where(eq(content.id, portalContentId));
+
+      try {
+        const result = await listAll();
+        const ids = result.items.map((i) => i.content.id);
+        expect(ids).not.toContain(portalContentId);
+      } finally {
+        await db
+          .update(content)
+          .set({ status: 'published' })
+          .where(eq(content.id, portalContentId));
+      }
+    });
+  });
+});

--- a/packages/access/src/services/content-access/library.ts
+++ b/packages/access/src/services/content-access/library.ts
@@ -17,11 +17,14 @@ import {
 import { type DatabaseClient, toIso } from '@codex/database';
 import {
   content,
+  courseStages,
+  courses,
   mediaItems,
   organizationFollowers,
   organizationMemberships,
   organizations,
   purchases,
+  stagePractices,
   subscriptions,
   subscriptionTiers,
   videoPlayback,
@@ -41,9 +44,18 @@ import {
 } from 'drizzle-orm';
 
 /**
- * User library item with content, access type, purchase, and progress information
+ * User library item with content, access type, purchase, and progress
+ * information.
+ *
+ * Declared as a `type` alias, NOT an `interface`, and it must stay one.
+ * Consumers such as the web app's `LibraryPageView` accept a loose
+ * `{ [key: string]: unknown; content: { id: string } }` shape, and TypeScript
+ * only infers the implicit index signature that makes that assignment legal for
+ * object type ALIASES — an interface is open to declaration merging, so it never
+ * gets one. Converting this back to an interface breaks those call sites with a
+ * confusing "index signature is missing" error far from the change.
  */
-export interface UserLibraryItem {
+export type UserLibraryItem = {
   content: {
     id: string;
     slug: string;
@@ -82,7 +94,23 @@ export interface UserLibraryItem {
     percentComplete: number;
     updatedAt: string;
   } | null;
-}
+  /**
+   * The portal(s) this practice sits inside, resolved through
+   * `stage_practices → course_stages → courses`. Empty when the practice
+   * stands alone.
+   *
+   * Deliberately SEPARATE from `accessType`. Provenance ("this lives inside
+   * the Descent portal") and access route ("you can open it because you're a
+   * member") are orthogonal facts, and a member needs both: the same practice
+   * can be reachable via membership AND belong to a portal. Folding a
+   * `course:` variant into `accessType` — which is what the frontend's badge
+   * helper originally anticipated — would have made the two mutually
+   * exclusive and silently dropped the access route.
+   *
+   * Ordered by title so the rendered badge is stable across requests.
+   */
+  journeys: Array<{ id: string; title: string; slug: string }>;
+};
 
 /**
  * User library response with pagination
@@ -231,6 +259,29 @@ export async function listUserLibrary(
   const contentFilters = buildContentFilters();
   const progressFilters = buildProgressFilters();
 
+  // ── Shared cross-arm exclusion: "not already acquired by purchase" ──
+  //
+  // Every non-purchase arm excludes content the user has bought (or is
+  // mid-buying) so `queryPurchased` stays the single owner of those rows and
+  // the accessType tag is never wrong. Both `completed` (webhook landed) and
+  // `pending` (Stripe redirect beat the webhook) count as "already owned".
+  //
+  // MUST be NOT EXISTS, never `id NOT IN (SELECT content_id ...)`.
+  // `purchases.content_id` is NULL for COURSE purchases (those rows carry
+  // `course_id` instead), so the NOT IN form returned a NULL from its
+  // subquery, and SQL's three-valued logic collapses
+  // `x NOT IN (NULL)` → `NOT (x = NULL)` → `NULL` → not TRUE — filtering out
+  // EVERY row. One journey purchase therefore blanked the entire library
+  // across the membership, subscription, free, and followers arms at once.
+  // The correlated NOT EXISTS below is null-safe: a NULL `content_id` simply
+  // never equals `content.id`, so it matches nothing and the row survives.
+  const notAcquiredByPurchase = sql`NOT EXISTS (
+    SELECT 1 FROM ${purchases}
+    WHERE ${purchases.customerId} = ${userId}
+      AND ${purchases.contentId} = ${content.id}
+      AND ${purchases.status} IN (${PURCHASE_STATUS.COMPLETED}, ${PURCHASE_STATUS.PENDING})
+  )`;
+
   // ── Helper: map a row to UserLibraryItem ──────────────────────────
   const mapProgress = (row: {
     progressPositionSeconds: number | null;
@@ -349,6 +400,9 @@ export async function listUserLibrary(
         priceCents: row.amountPaidCents,
       },
       progress: mapProgress(row),
+      // Populated by `attachJourneyProvenance` once the page is final — one
+      // lookup for the page beats one per arm.
+      journeys: [],
     }));
 
     return { items, count: countResult[0]?.count ?? 0 };
@@ -382,13 +436,9 @@ export async function listUserLibrary(
       membershipContentFilter,
       eq(content.status, CONTENT_STATUS.PUBLISHED),
       isNull(content.deletedAt),
-      // Exclude content the user has acquired or is acquiring via purchase.
-      // Both `completed` (webhook landed) and `pending` (Stripe redirect beat
-      // the webhook — row exists but status hasn't flipped yet) count as
-      // "already owned" for library-categorisation purposes. Without the
-      // `pending` clause, a purchase mid-flight leaks into membership and
-      // shows up with the wrong accessType tag until the webhook lands.
-      sql`${content.id} NOT IN (SELECT ${purchases.contentId} FROM ${purchases} WHERE ${purchases.customerId} = ${userId} AND ${purchases.status} IN (${PURCHASE_STATUS.COMPLETED}, ${PURCHASE_STATUS.PENDING}))`,
+      // Cross-arm exclusion — see `notAcquiredByPurchase`. Without it a
+      // mid-flight purchase leaks into membership with the wrong accessType.
+      notAcquiredByPurchase,
       ...contentFilters,
       ...progressFilters,
     ];
@@ -465,6 +515,9 @@ export async function listUserLibrary(
       accessType: 'membership' as const,
       purchase: null,
       progress: mapProgress(row),
+      // Populated by `attachJourneyProvenance` once the page is final — one
+      // lookup for the page beats one per arm.
+      journeys: [],
     }));
 
     return { items, count: countResult[0]?.count ?? 0 };
@@ -523,16 +576,11 @@ export async function listUserLibrary(
       isNull(content.deletedAt),
       // Must belong to one of the user's subscribed orgs (with tier check)
       or(...subConditions)!,
-      // Exclude content the user has acquired or is acquiring via purchase.
-      // Both `completed` and `pending` count — a `pending` purchase is a
-      // Stripe session whose webhook hasn't landed yet. Without the
-      // `pending` clause, a mid-flight purchase leaks into the subscription
-      // arm (particularly for `accessType='paid'` + `minimumTierId` set
-      // content, which now qualifies for both arms — see 1b6f14a0) and
-      // shows up with the wrong accessType tag on the library. Once the
-      // webhook lands and `status` flips to `completed`, the row continues
-      // to be excluded here and surfaces in the purchased arm instead.
-      sql`${content.id} NOT IN (SELECT ${purchases.contentId} FROM ${purchases} WHERE ${purchases.customerId} = ${userId} AND ${purchases.status} IN (${PURCHASE_STATUS.COMPLETED}, ${PURCHASE_STATUS.PENDING}))`,
+      // Cross-arm exclusion — see `notAcquiredByPurchase`. Matters most in
+      // this arm: paid + tier-gated content qualifies for BOTH it and the
+      // purchased arm (see 1b6f14a0), so without the exclusion a mid-flight
+      // purchase surfaces with the wrong accessType until the webhook lands.
+      notAcquiredByPurchase,
       // Exclude content from management orgs (owner/admin/creator see
       // all their org's content via the membership query).
       ...(managementOrgIds.length > 0
@@ -619,6 +667,9 @@ export async function listUserLibrary(
       accessType: 'subscription' as const,
       purchase: null,
       progress: mapProgress(row),
+      // Populated by `attachJourneyProvenance` once the page is final — one
+      // lookup for the page beats one per arm.
+      journeys: [],
     }));
 
     return { items, count: countResult[0]?.count ?? 0 };
@@ -669,11 +720,11 @@ export async function listUserLibrary(
       isNull(content.deletedAt),
       sql`${content.organizationId} IS NOT NULL`,
       relationshipPredicate!,
-      // Cross-arm exclusion: purchased rows are surfaced by queryPurchased.
-      // Free items shouldn't be purchased, but flag-flips (paid → free)
-      // could create overlap; followers items shouldn't be priced. Both
-      // exclusions are defensive — keeps the priority contract explicit.
-      sql`${content.id} NOT IN (SELECT ${purchases.contentId} FROM ${purchases} WHERE ${purchases.customerId} = ${userId} AND ${purchases.status} IN (${PURCHASE_STATUS.COMPLETED}, ${PURCHASE_STATUS.PENDING}))`,
+      // Cross-arm exclusion — see `notAcquiredByPurchase`. Defensive here:
+      // free/followers items shouldn't be priced, but a flag-flip
+      // (paid → free) could create overlap. Keeps the priority contract
+      // explicit rather than relying on the flags staying clean.
+      notAcquiredByPurchase,
       // Cross-arm exclusion: management orgs are surfaced by queryMembership
       // which returns ALL of an org's content for owners/admins/creators.
       ...(managementOrgIds.length > 0
@@ -762,6 +813,9 @@ export async function listUserLibrary(
       accessType: tag,
       purchase: null,
       progress: mapProgress(row),
+      // Populated by `attachJourneyProvenance` once the page is final — one
+      // lookup for the page beats one per arm.
+      journeys: [],
     }));
 
     return { items, count: countResult[0]?.count ?? 0 };
@@ -795,6 +849,67 @@ export async function listUserLibrary(
     queryFreeRelationship(),
     queryFollowersRelationship(),
   ]);
+
+  // ── Step 5b: Portal provenance for the FINAL page ────────────────
+  //
+  // Runs once, on the page that is actually being returned, rather than
+  // per-arm: five arms each fetch up to `limit` rows but at most `limit`
+  // survive the merge, so joining provenance inside every arm would do up to
+  // 5x the work and throw most of it away. One `IN (page ids)` lookup instead.
+  //
+  // A practice can appear in several portals (`stage_practices` is keyed
+  // `(stage_id, content_id)` and a portal has many stages), so this collects
+  // ALL of them rather than assuming one. Deleted stages and deleted portals
+  // are filtered out — an archived portal must not keep branding a practice.
+  const attachJourneyProvenance = async (
+    pageItems: UserLibraryItem[]
+  ): Promise<UserLibraryItem[]> => {
+    if (pageItems.length === 0) return pageItems;
+
+    const contentIds = pageItems.map((i) => i.content.id);
+    const rows = await db
+      .selectDistinct({
+        contentId: stagePractices.contentId,
+        courseId: courses.id,
+        courseTitle: courses.title,
+        courseSlug: courses.slug,
+      })
+      .from(stagePractices)
+      .innerJoin(
+        courseStages,
+        and(
+          eq(courseStages.id, stagePractices.stageId),
+          isNull(courseStages.deletedAt)
+        )
+      )
+      .innerJoin(
+        courses,
+        and(eq(courses.id, courseStages.courseId), isNull(courses.deletedAt))
+      )
+      .where(inArray(stagePractices.contentId, contentIds));
+
+    if (rows.length === 0) return pageItems;
+
+    const byContentId = new Map<string, UserLibraryItem['journeys']>();
+    for (const row of rows) {
+      const list = byContentId.get(row.contentId);
+      const entry = {
+        id: row.courseId,
+        title: row.courseTitle,
+        slug: row.courseSlug,
+      };
+      if (list) list.push(entry);
+      else byContentId.set(row.contentId, [entry]);
+    }
+    for (const list of byContentId.values()) {
+      list.sort((a, b) => a.title.localeCompare(b.title));
+    }
+
+    return pageItems.map((item) => {
+      const journeys = byContentId.get(item.content.id);
+      return journeys ? { ...item, journeys } : item;
+    });
+  };
 
   // ── Step 6: Merge, sort, and paginate ─────────────────────────────
   // Source priority (first-match-wins on overlap):
@@ -832,7 +947,7 @@ export async function listUserLibrary(
               : followersResult
       : (activeSources[0] ?? purchaseResult);
     return {
-      items: result.items,
+      items: await attachJourneyProvenance(result.items),
       pagination: {
         page: input.page,
         limit: input.limit,
@@ -875,7 +990,9 @@ export async function listUserLibrary(
   }
 
   // Trim to page size (each source may have returned up to limit items)
-  const items = dedupedItems.slice(0, input.limit);
+  const items = await attachJourneyProvenance(
+    dedupedItems.slice(0, input.limit)
+  );
 
   return {
     items,

--- a/packages/access/src/types.ts
+++ b/packages/access/src/types.ts
@@ -5,7 +5,7 @@
  * Previously in @codex/shared-types — moved here for domain ownership.
  */
 
-import type { PaginationMetadata, ProgressData } from '@codex/shared-types';
+import type { ProgressData } from '@codex/shared-types';
 
 /**
  * Response for GET /api/access/content/:id/stream
@@ -40,32 +40,24 @@ export interface PlaybackProgressResponse {
 }
 
 /**
- * Response for GET /api/access/user/library
- * Returns user's library with content and purchase information
+ * Response for GET `/api/access/user/library`.
+ *
+ * RE-EXPORTED from the service that produces it rather than re-declared here.
+ * This file used to hand-declare a parallel copy, and the two drifted badly:
+ * the copy listed `accessType: 'purchased' | 'membership' | 'subscription'`
+ * long after the service started returning `'free'` and `'followers'` too, and
+ * it never gained the `journeys` provenance field. TypeScript could not catch
+ * it — the service's richer object is structurally assignable to the narrower
+ * declaration, so nothing cross-checked them, and every frontend consumer
+ * (which imports this barrel, not the service internals) was typed against
+ * values the API had stopped restricting itself to.
+ *
+ * Deriving it makes that class of drift impossible rather than merely fixed.
  */
-export interface UserLibraryResponse {
-  items: Array<{
-    content: {
-      id: string;
-      slug: string;
-      title: string;
-      description: string;
-      thumbnailUrl: string | null;
-      contentType: string;
-      durationSeconds: number;
-      organizationId: string | null;
-      organizationSlug: string | null;
-    };
-    /** Access type: 'purchased' = bought, 'membership' = org member access, 'subscription' = active subscription */
-    accessType: 'purchased' | 'membership' | 'subscription';
-    purchase: {
-      purchasedAt: string; // ISO 8601 timestamp
-      priceCents: number;
-    } | null;
-    progress: (ProgressData & { percentComplete: number }) | null;
-  }>;
-  pagination: PaginationMetadata;
-}
+export type {
+  UserLibraryItem,
+  UserLibraryResponse,
+} from './services/content-access/library';
 
 /**
  * Response for POST /api/access/content/:id/progress

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -24,6 +24,7 @@
     "db:reset": "pnpm exec tsx scripts/reset-data.ts",
     "db:seed": "pnpm exec tsx scripts/seed-data.ts",
     "db:seed:templates": "pnpm exec tsx scripts/seed-email-templates.ts",
+    "db:seed:portals": "pnpm exec tsx scripts/seed-portals.ts",
     "backfill:stripe-customer-ids": "pnpm exec tsx scripts/backfill-stripe-customer-ids.ts",
     "db:dry-run": "pnpm exec tsx scripts/neon-dry-run.ts",
     "db:studio": "pnpm exec tsx scripts/db-commands.ts studio",

--- a/packages/database/scripts/seed-portals.ts
+++ b/packages/database/scripts/seed-portals.ts
@@ -56,6 +56,7 @@ import {
   courseStages,
   courses,
   entitlements,
+  landingPages,
   organizationMemberships,
   organizations,
   practiceCompletions,
@@ -82,6 +83,12 @@ interface PortalSpec {
   source: 'grant' | 'course_subscription' | 'course_purchase';
   /** One-off price in GBP pence, or null for "included". */
   priceCents: number | null;
+  /**
+   * Promote this portal into the org landing page's "Editor's picks" carousel
+   * (`landing_pages.featured`). Only a couple are featured — a carousel where
+   * every portal is a pick shows nothing about how curation reads.
+   */
+  featured?: boolean;
 }
 
 /**
@@ -103,6 +110,7 @@ const PORTALS: PortalSpec[] = [
     completions: 0,
     source: 'grant',
     priceCents: null,
+    featured: true,
   },
   {
     slug: 'tending-the-grief',
@@ -131,6 +139,7 @@ const PORTALS: PortalSpec[] = [
     completions: 3,
     source: 'course_purchase',
     priceCents: 4900,
+    featured: true,
   },
   {
     slug: 'return-to-the-shoreline',
@@ -202,7 +211,28 @@ async function main(): Promise<void> {
         updatedAt: new Date(),
       })
       .where(eq(courses.id, junk.id));
-    console.log(`  ✎ retitled "${junk.title}" → "The Long Descent"`);
+
+    // Retitle the PAGE too. Renaming only the course left the landing rail still
+    // advertising the junk name, because `listPublishedJourneys` reads
+    // `landingPages.title`, not `courses.title` — the card and the sell page it
+    // opens disagreed. Scoped to this org's page for the same slug; `sections`
+    // is left alone (a human may have authored this one in the builder).
+    const [renamedPage] = await dbWs
+      .update(landingPages)
+      .set({ title: 'The Long Descent', updatedAt: new Date() })
+      .where(
+        and(
+          eq(landingPages.organizationId, org.id),
+          eq(landingPages.slug, 'pricing-smoke-test'),
+          isNull(landingPages.deletedAt)
+        )
+      )
+      .returning({ id: landingPages.id });
+
+    console.log(
+      `  ✎ retitled "${junk.title}" → "The Long Descent"` +
+        (renamedPage ? ' (course + page)' : ' (course only — no page found)')
+    );
   }
 
   // ── 2. Pick practices from content not already in a portal ───────────
@@ -289,12 +319,162 @@ async function main(): Promise<void> {
       );
     }
 
+    // Runs for BOTH branches, and that is the point: the earlier version of this
+    // script created no page at all, so a re-run against courses it had already
+    // seeded is exactly the case that has to backfill one. Reconciling (rather
+    // than inserting inside `createPortal`) is what makes the fix reach rows that
+    // already exist.
+    await reconcilePage(org.id, userId, courseId, spec);
     await reconcileCover(courseId, spec);
     await reconcileEnrollment(userId, org.id, courseId, spec);
     await reconcileCompletions(userId, courseId, spec.completions);
   }
 
   console.log(`\n✓ Done. Sign in as the owner of "${org.name}" to see them.\n`);
+}
+
+/**
+ * Ensure the portal has a PUBLISHED `course`-type landing page bound to it.
+ *
+ * Idempotent by (org, slug): an existing page is updated in place rather than
+ * duplicated, because `landing_pages.slug` is unique per org over non-deleted
+ * rows — a blind insert on a re-run would violate that partial index. Updating
+ * also repairs a page whose title has drifted from its course, which is how the
+ * pre-existing `pricing-smoke-test` portal ended up advertising a junk name on
+ * the landing rail: `listPublishedJourneys` returns `landingPages.title`, and
+ * only the COURSE had been retitled.
+ *
+ * `sections` is rewritten every run so a copy change here reaches already-seeded
+ * rows. Safe precisely because these are seed-owned demo pages — never call this
+ * against a page a human has edited.
+ */
+async function reconcilePage(
+  organizationId: string,
+  creatorId: string,
+  courseId: string,
+  spec: PortalSpec
+): Promise<void> {
+  const existing = await dbWs.query.landingPages.findFirst({
+    where: and(
+      eq(landingPages.organizationId, organizationId),
+      eq(landingPages.slug, spec.slug),
+      isNull(landingPages.deletedAt)
+    ),
+    columns: { id: true },
+  });
+
+  const shared = {
+    pageType: 'course' as const,
+    title: spec.title,
+    status: 'published' as const,
+    publishedAt: new Date(),
+    featured: spec.featured ?? false,
+    subjectType: 'course' as const,
+    subjectId: courseId,
+    sections: buildSections(spec),
+  };
+
+  if (existing) {
+    await dbWs
+      .update(landingPages)
+      .set(shared)
+      .where(eq(landingPages.id, existing.id));
+    return;
+  }
+
+  await dbWs.insert(landingPages).values({
+    organizationId,
+    creatorId,
+    slug: spec.slug,
+    ...shared,
+  });
+}
+
+/**
+ * The sell-page body for a seeded portal.
+ *
+ * WHY A PAGE AT ALL: a portal is a COURSE plus a published `course`-type LANDING
+ * PAGE, and the public rails are built from the page, not the course.
+ * `listPublishedJourneys` — which feeds the org landing "Editor's picks" and the
+ * portals rail — selects `from(landingPages)`, and `listEnrolledJourneys`
+ * INNER JOINs it. So a course seeded without a page is invisible on every
+ * landing surface no matter how complete its curriculum is. (Only
+ * `listPublishedCourses`, the /explore rail, left-joins and shows it anyway,
+ * which is why this gap looked like it worked.)
+ *
+ * Copy is drawn from the portal's OWN kicker/lede rather than lorem or
+ * "Section title here" placeholders. Codex-maf0y exists because placeholder
+ * section copy on a published page gets served to real visitors — demo data
+ * that reads as real copy at real lengths is the whole point of this seed, and
+ * it keeps that bead's failure mode out of the seeded rows.
+ *
+ * A deliberately SMALL set (hero → ache → map → invite): enough that clicking a
+ * card lands on a page with a shape, without pretending to be a finished sales
+ * page nobody wrote.
+ */
+function buildSections(spec: PortalSpec) {
+  const priceLine =
+    spec.priceCents === null
+      ? 'Included with membership'
+      : `£${(spec.priceCents / 100).toFixed(2)} once · yours to keep`;
+
+  return [
+    {
+      id: crypto.randomUUID(),
+      name: 'Hero',
+      type: 'hero',
+      props: {
+        eyebrow: spec.kicker,
+        headline: spec.title,
+        sub: spec.lede,
+        button: 'Begin',
+        bg: 'ember',
+      },
+      enabled: true,
+      variant: 'split',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'The ache',
+      type: 'ache',
+      props: {
+        eyebrow: 'Why this',
+        heading: 'You already know the shape of it.',
+        sub: spec.lede,
+      },
+      enabled: true,
+      variant: 'default',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'The map',
+      type: 'map',
+      props: {
+        eyebrow: 'The whole path',
+        heading: "Everything you'll walk.",
+        sub: spec.stages.map((s) => s.name).join(' · '),
+        note: 'The first ground is already open.',
+      },
+      enabled: true,
+      variant: 'descent',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'The invite',
+      type: 'invite',
+      props: {
+        eyebrow: 'Begin',
+        heading: spec.title,
+        accent: 'is waiting.',
+        sub: 'One key opens everything that grows from here.',
+        price: priceLine,
+        risk: 'Cancel anytime',
+        button: 'Begin',
+      },
+      enabled: true,
+      variant: 'card',
+    },
+  ];
 }
 
 /** Insert the course, its three stages, and the stage→practice links. */

--- a/packages/database/scripts/seed-portals.ts
+++ b/packages/database/scripts/seed-portals.ts
@@ -1,0 +1,577 @@
+/**
+ * Seed PORTALS (courses/journeys) into an existing organization.
+ *
+ * ## Why this is a separate, additive script
+ *
+ * `db:seed` (seed-data.ts) TRUNCATES the application tables and rebuilds the
+ * world. That is the wrong tool for "give this org more portals so the library
+ * looks realistic" — it would destroy the org being worked on. This script only
+ * INSERTS, never truncates, and is idempotent: a portal whose slug already
+ * exists is left alone and only its enrollment/progress state is reconciled.
+ *
+ * ## What it produces
+ *
+ * Four portals whose progress states deliberately span every card and badge
+ * variant the library renders, because a shelf of four identical "0%" portals
+ * proves nothing about the UI:
+ *
+ *   | Portal                   | Progress   | Enrollment source   | Exercises            |
+ *   |--------------------------|------------|---------------------|----------------------|
+ *   | Bone Deep                | untouched  | grant               | 0% bar, "included"   |
+ *   | Tending the Grief        | 1 of 4     | course_subscription | early bar, "via sub" |
+ *   | Ancestral Threads        | 3 of 4     | course_purchase     | mid bar, "purchased" |
+ *   | Return to the Shoreline  | complete   | course_purchase     | 100% + "Completed"   |
+ *
+ * Practices are drawn from the org's EXISTING published content rather than
+ * newly created, so no media/R2/transcode fixtures are needed — the covers and
+ * thumbnails already resolve through dev-cdn.
+ *
+ * Each portal gets a DISTINCT set of practices. `practice_completions` is
+ * UNIQUE on `(user_id, content_id)`, so a practice shared between two portals
+ * would be completed in both at once and the progress states above would not
+ * hold.
+ *
+ * Usage (from the monorepo root):
+ *   pnpm --filter @codex/database db:seed:portals
+ *   pnpm --filter @codex/database db:seed:portals -- --org=of-blood-and-bones
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { config } from 'dotenv';
+import { and, asc, eq, inArray, isNull, notInArray, sql } from 'drizzle-orm';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+config({ path: path.resolve(__dirname, '../../../.env.dev') });
+
+import { dbWs } from '../src';
+import {
+  content,
+  courseEnrollments,
+  courseStages,
+  courses,
+  entitlements,
+  organizationMemberships,
+  organizations,
+  practiceCompletions,
+  stagePractices,
+} from '../src/schema';
+
+/** Practices attached per portal. */
+const PRACTICES_PER_PORTAL = 4;
+
+interface StageSpec {
+  name: string;
+  gloss: string;
+}
+
+interface PortalSpec {
+  slug: string;
+  title: string;
+  kicker: string;
+  lede: string;
+  stages: [StageSpec, StageSpec, StageSpec];
+  /** How many of this portal's practices are marked complete. */
+  completions: number;
+  /** `course_enrollments.source` — drives the access badge on the card. */
+  source: 'grant' | 'course_subscription' | 'course_purchase';
+  /** One-off price in GBP pence, or null for "included". */
+  priceCents: number | null;
+}
+
+/**
+ * Voiced for Of Blood & Bones — ancestral healing, somatic practice and sacred
+ * bodywork on the Stonehaven shoreline. Generic "Course 1/2/3" titles would not
+ * show whether the cards hold real editorial copy at real lengths.
+ */
+const PORTALS: PortalSpec[] = [
+  {
+    slug: 'bone-deep',
+    title: 'Bone Deep',
+    kicker: 'A four-practice descent',
+    lede: 'Where the body keeps what the mind has agreed to forget. Slow work, close to the bone.',
+    stages: [
+      { name: 'Arriving', gloss: 'Settling into the body you actually have.' },
+      { name: 'Listening', gloss: 'What the tissue says before language.' },
+      { name: 'Staying', gloss: 'The practice of not leaving.' },
+    ],
+    completions: 0,
+    source: 'grant',
+    priceCents: null,
+  },
+  {
+    slug: 'tending-the-grief',
+    title: 'Tending the Grief',
+    kicker: 'For the weight you carry',
+    lede: 'Grief is not a problem to be solved. These practices make room for it to move.',
+    stages: [
+      { name: 'Naming', gloss: 'Saying the thing plainly.' },
+      { name: 'Holding', gloss: 'Company for what cannot be fixed.' },
+      { name: 'Letting move', gloss: 'Grief as water, not stone.' },
+    ],
+    completions: 1,
+    source: 'course_subscription',
+    priceCents: null,
+  },
+  {
+    slug: 'ancestral-threads',
+    title: 'Ancestral Threads',
+    kicker: 'Meeting the lineage that made you',
+    lede: 'Every body is an inheritance. This is a way of asking what you were handed, and what you will hand on.',
+    stages: [
+      { name: 'The near ones', gloss: 'Parents, and their weather.' },
+      { name: 'The far ones', gloss: 'Names you were never told.' },
+      { name: 'The thread forward', gloss: 'What you choose to carry.' },
+    ],
+    completions: 3,
+    source: 'course_purchase',
+    priceCents: 4900,
+  },
+  {
+    slug: 'return-to-the-shoreline',
+    title: 'Return to the Shoreline',
+    kicker: 'A closing rite',
+    lede: 'For the end of a long walk — marking what happened, and coming back up into ordinary light.',
+    stages: [
+      { name: 'Looking back', gloss: 'What the walking changed.' },
+      { name: 'Marking it', gloss: 'A rite so the body knows it ended.' },
+      { name: 'Coming up', gloss: 'Re-entry, gently.' },
+    ],
+    completions: PRACTICES_PER_PORTAL,
+    source: 'course_purchase',
+    priceCents: 3500,
+  },
+];
+
+function parseOrgSlug(): string {
+  const arg = process.argv.find((a) => a.startsWith('--org='));
+  return arg ? arg.slice('--org='.length) : 'of-blood-and-bones';
+}
+
+async function main(): Promise<void> {
+  const orgSlug = parseOrgSlug();
+  console.log(`\n▸ Seeding portals into "${orgSlug}"\n`);
+
+  const org = await dbWs.query.organizations.findFirst({
+    where: and(
+      eq(organizations.slug, orgSlug),
+      isNull(organizations.deletedAt)
+    ),
+    columns: { id: true, name: true },
+  });
+  if (!org) throw new Error(`No organization with slug "${orgSlug}"`);
+
+  // The portal owner is the org's owner: `courses.creator_id` is NOT NULL and
+  // FK-restricted, and the same user is who we seed enrollments/progress for so
+  // the library shelf has something to show when signed in as them.
+  const owner = await dbWs.query.organizationMemberships.findFirst({
+    where: and(
+      eq(organizationMemberships.organizationId, org.id),
+      eq(organizationMemberships.role, 'owner'),
+      eq(organizationMemberships.status, 'active')
+    ),
+    columns: { userId: true },
+  });
+  if (!owner) throw new Error(`"${orgSlug}" has no active owner membership`);
+  const userId = owner.userId;
+
+  // ── 1. Retitle any junk placeholder portal ───────────────────────────
+  //
+  // The SLUG is deliberately left alone. It appears in unit-test fixtures and in
+  // a conformance doc, and renaming it would churn those for no user-visible
+  // gain — the offensive part is the title the library card renders.
+  const junk = await dbWs.query.courses.findFirst({
+    where: and(
+      eq(courses.organizationId, org.id),
+      eq(courses.slug, 'pricing-smoke-test')
+    ),
+    columns: { id: true, title: true },
+  });
+  if (junk) {
+    await dbWs
+      .update(courses)
+      .set({
+        title: 'The Long Descent',
+        kicker: 'A twelve-practice descent',
+        lede: 'Bone, breath and smoke — twelve practices for coming all the way down into the body.',
+        updatedAt: new Date(),
+      })
+      .where(eq(courses.id, junk.id));
+    console.log(`  ✎ retitled "${junk.title}" → "The Long Descent"`);
+  }
+
+  // ── 2. Pick practices from content not already in a portal ───────────
+  const alreadyAttached = await dbWs
+    .select({ contentId: stagePractices.contentId })
+    .from(stagePractices);
+  const attachedIds = alreadyAttached.map((r) => r.contentId);
+
+  const available = await dbWs
+    .select({ id: content.id, title: content.title })
+    .from(content)
+    .where(
+      and(
+        eq(content.organizationId, org.id),
+        eq(content.status, 'published'),
+        isNull(content.deletedAt),
+        attachedIds.length > 0 ? notInArray(content.id, attachedIds) : sql`true`
+      )
+    )
+    // Deterministic so re-runs and fresh runs choose the same practices.
+    .orderBy(asc(content.createdAt), asc(content.id));
+
+  // Which of the four already exist? Fetched once, both to size the warning
+  // below against the portals actually being CREATED (a full re-run needs no
+  // practices at all, so "not enough content" would be a false alarm) and to
+  // save a per-portal round trip in the loop.
+  const existingSlugs = new Set(
+    (
+      await dbWs
+        .select({ slug: courses.slug })
+        .from(courses)
+        .where(
+          and(
+            eq(courses.organizationId, org.id),
+            inArray(
+              courses.slug,
+              PORTALS.map((p) => p.slug)
+            )
+          )
+        )
+    ).map((r) => r.slug)
+  );
+
+  const toCreate = PORTALS.filter((p) => !existingSlugs.has(p.slug));
+  const needed = toCreate.length * PRACTICES_PER_PORTAL;
+  if (needed > 0 && available.length < needed) {
+    console.log(
+      `  ! only ${available.length} unattached published items for ${needed} slots — ` +
+        `portals will get fewer practices each`
+    );
+  }
+
+  // ── 3. Create each portal ────────────────────────────────────────────
+  let cursor = 0;
+  for (const spec of PORTALS) {
+    // Existence is checked BEFORE drawing from the practice pool. On a re-run
+    // every practice is already attached, so the pool is empty — and consuming
+    // it first meant an existing portal was skipped for "no practices left"
+    // and never had its enrollment/progress reconciled. Only a portal that is
+    // actually being CREATED needs practices.
+    let courseId: string;
+    if (existingSlugs.has(spec.slug)) {
+      const existing = await dbWs.query.courses.findFirst({
+        where: and(
+          eq(courses.organizationId, org.id),
+          eq(courses.slug, spec.slug)
+        ),
+        columns: { id: true },
+      });
+      if (!existing) throw new Error(`Portal ${spec.slug} vanished mid-run`);
+      courseId = existing.id;
+      console.log(`  = ${spec.title}: already present, reconciling state only`);
+    } else {
+      const slice = available.slice(cursor, cursor + PRACTICES_PER_PORTAL);
+      cursor += slice.length;
+      if (slice.length === 0) {
+        console.log(`  – ${spec.title}: no practices left to attach, skipped`);
+        continue;
+      }
+      courseId = await createPortal(org.id, userId, spec, slice);
+      console.log(
+        `  + ${spec.title}: 3 stages, ${slice.length} practices ` +
+          `(${slice.map((c) => c.title).join(', ')})`
+      );
+    }
+
+    await reconcileCover(courseId, spec);
+    await reconcileEnrollment(userId, org.id, courseId, spec);
+    await reconcileCompletions(userId, courseId, spec.completions);
+  }
+
+  console.log(`\n✓ Done. Sign in as the owner of "${org.name}" to see them.\n`);
+}
+
+/** Insert the course, its three stages, and the stage→practice links. */
+async function createPortal(
+  organizationId: string,
+  creatorId: string,
+  spec: PortalSpec,
+  practices: Array<{ id: string; title: string }>
+): Promise<string> {
+  return await dbWs.transaction(async (tx) => {
+    // Cover is set afterwards by `reconcileCover` — deriving it shells out to
+    // wrangler, and holding a DB transaction open across subprocess calls is a
+    // good way to turn a slow copy into a lock-timeout.
+    const [course] = await tx
+      .insert(courses)
+      .values({
+        organizationId,
+        creatorId,
+        slug: spec.slug,
+        title: spec.title,
+        kicker: spec.kicker,
+        lede: spec.lede,
+        status: 'published',
+        publishedAt: new Date(),
+        priceCents: spec.priceCents,
+      })
+      .returning({ id: courses.id });
+    if (!course) throw new Error(`Failed to insert course ${spec.slug}`);
+
+    const stageRows = await tx
+      .insert(courseStages)
+      .values(
+        spec.stages.map((stage, i) => ({
+          courseId: course.id,
+          name: stage.name,
+          gloss: stage.gloss,
+          sortOrder: i + 1,
+        }))
+      )
+      .returning({ id: courseStages.id, sortOrder: courseStages.sortOrder });
+
+    // Spread practices across the stages, front-loading the remainder so EVERY
+    // stage holds at least one: four practices over three stages gives 2/1/1,
+    // which reads like a progression, where a naive `i % stageCount` or a
+    // `floor(i / perStage)` split leaves the last stage empty.
+    const ordered = [...stageRows].sort((a, b) => a.sortOrder - b.sortOrder);
+    const base = Math.floor(practices.length / ordered.length);
+    const remainder = practices.length % ordered.length;
+
+    const links: Array<{
+      stageId: string;
+      contentId: string;
+      sortOrder: number;
+    }> = [];
+    let next = 0;
+    for (const [stageIndex, stage] of ordered.entries()) {
+      const take = base + (stageIndex < remainder ? 1 : 0);
+      for (let n = 0; n < take; n++) {
+        const practice = practices[next];
+        if (!practice) break;
+        next++;
+        links.push({
+          stageId: stage.id,
+          contentId: practice.id,
+          sortOrder: n,
+        });
+      }
+    }
+
+    await tx.insert(stagePractices).values(links);
+    return course.id;
+  });
+}
+
+/**
+ * The local R2 bucket the dev workers actually read.
+ *
+ * `wrangler dev` binds `preview_bucket_name`, NOT `bucket_name` — so objects
+ * written to `codex-assets-production` are invisible to dev-cdn even though the
+ * upload reports success. See `workers/dev-cdn/wrangler.jsonc`.
+ */
+const DEV_R2_BUCKET = process.env.SEED_R2_BUCKET ?? 'codex-assets-test';
+const R2_PERSIST_PATH = path.resolve(__dirname, '../../../.wrangler/state');
+
+/**
+ * Produce a `courses.cover_image_key` that will actually resolve.
+ *
+ * `resolveCourseCoverUrl` builds `${base}/${coverImageKey}/md.webp`, so the key
+ * must be a variant DIRECTORY prefix, not a file path. Most of this org's
+ * content stores a file-style thumbnail (`…/thumbnails/<slug>/thumb.jpg`), and
+ * using that verbatim yields `…/thumb.jpg/md.webp` — a 404, which renders as a
+ * broken image rather than falling back to the card's brand gradient.
+ *
+ * So: when the source thumbnail is already a variant prefix, reuse it. When it
+ * is file-style, COPY the object to a portal-owned variant path so the `/md.webp`
+ * the resolver demands exists. Returns null if neither is possible, which is the
+ * card's designed no-cover path.
+ */
+async function deriveCoverKey(
+  contentId: string,
+  portalSlug: string
+): Promise<string | null> {
+  const [row] = await dbWs
+    .select({ thumbnailUrl: content.thumbnailUrl })
+    .from(content)
+    .where(eq(content.id, contentId));
+  const url = row?.thumbnailUrl;
+  if (!url) return null;
+
+  // Strip the CDN origin to get the raw R2 key.
+  const base = process.env.R2_PUBLIC_URL_BASE?.replace(/\/+$/, '');
+  const sourceKey =
+    base && url.startsWith(base)
+      ? url.slice(base.length + 1)
+      : url.match(/^https?:\/\/[^/]+\/(.+)$/)?.[1];
+  if (!sourceKey) return null;
+
+  // Already a generated variant set — the prefix is exactly what we want.
+  if (sourceKey.endsWith('/md.webp')) {
+    return sourceKey.slice(0, -'/md.webp'.length);
+  }
+
+  // File-style: copy it into a variant path this portal owns.
+  const ownerPrefix = sourceKey.split('/')[0];
+  if (!ownerPrefix) return null;
+  const coverKey = `${ownerPrefix}/media-thumbnails/portal-${portalSlug}`;
+
+  try {
+    const tmp = path.join(
+      os.tmpdir(),
+      `codex-portal-cover-${portalSlug}-${process.pid}`
+    );
+    run(
+      `npx wrangler r2 object get "${DEV_R2_BUCKET}/${sourceKey}" --file "${tmp}" --local --persist-to "${R2_PERSIST_PATH}"`
+    );
+    run(
+      `npx wrangler r2 object put "${DEV_R2_BUCKET}/${coverKey}/md.webp" --file "${tmp}" --content-type image/jpeg --local --persist-to "${R2_PERSIST_PATH}"`
+    );
+    fs.rmSync(tmp, { force: true });
+    return coverKey;
+  } catch (error) {
+    // A cover is a nice-to-have; the card has a designed gradient fallback. Never
+    // fail the whole seed over it, and never leave a key that would 404.
+    console.log(
+      `    (no cover for ${portalSlug}: ${error instanceof Error ? error.message.split('\n')[0] : error})`
+    );
+    return null;
+  }
+}
+
+function run(command: string): void {
+  execSync(command, { stdio: 'pipe' });
+}
+
+/**
+ * Point the portal's cover at a key that resolves, using its FIRST practice's
+ * artwork.
+ *
+ * Runs on every pass, including for portals that already existed, because an
+ * earlier version of this script wrote file-style keys that 404 through
+ * `resolveCourseCoverUrl`'s `/md.webp` suffix — re-running must repair those
+ * rather than leave broken images behind. The copy is idempotent (same source,
+ * same destination key).
+ */
+async function reconcileCover(
+  courseId: string,
+  spec: PortalSpec
+): Promise<void> {
+  const [firstPractice] = await dbWs
+    .select({ contentId: stagePractices.contentId })
+    .from(stagePractices)
+    .innerJoin(courseStages, eq(courseStages.id, stagePractices.stageId))
+    .where(
+      and(eq(courseStages.courseId, courseId), isNull(courseStages.deletedAt))
+    )
+    .orderBy(asc(courseStages.sortOrder), asc(stagePractices.sortOrder))
+    .limit(1);
+  if (!firstPractice) return;
+
+  const coverImageKey = await deriveCoverKey(
+    firstPractice.contentId,
+    spec.slug
+  );
+  await dbWs
+    .update(courses)
+    .set({ coverImageKey, updatedAt: new Date() })
+    .where(eq(courses.id, courseId));
+}
+
+/** Enrollment + entitlement, both idempotent on their unique constraints. */
+async function reconcileEnrollment(
+  userId: string,
+  organizationId: string,
+  courseId: string,
+  spec: PortalSpec
+): Promise<void> {
+  const completedAt =
+    spec.completions >= PRACTICES_PER_PORTAL ? new Date() : null;
+
+  await dbWs
+    .insert(courseEnrollments)
+    .values({
+      userId,
+      courseId,
+      source: spec.source,
+      lastActivityAt: spec.completions > 0 ? new Date() : null,
+      completedAt,
+    })
+    .onConflictDoNothing();
+
+  // `uq_entitlement_live_course` is partial (WHERE revoked_at IS NULL AND
+  // course_id IS NOT NULL), so onConflictDoNothing needs the same target
+  // predicate to match that index.
+  await dbWs
+    .insert(entitlements)
+    .values({ userId, organizationId, courseId, source: spec.source })
+    .onConflictDoNothing({
+      target: [entitlements.userId, entitlements.courseId, entitlements.source],
+      where: and(
+        isNull(entitlements.revokedAt),
+        sql`${entitlements.courseId} IS NOT NULL`
+      ),
+    });
+}
+
+/**
+ * Mark the first `count` of the portal's practices complete, and clear any
+ * completions beyond that, so re-running the script converges on the declared
+ * progress state instead of only ever ratcheting it upward.
+ */
+async function reconcileCompletions(
+  userId: string,
+  courseId: string,
+  count: number
+): Promise<void> {
+  const practices = await dbWs
+    .select({ contentId: stagePractices.contentId })
+    .from(stagePractices)
+    .innerJoin(courseStages, eq(courseStages.id, stagePractices.stageId))
+    .where(
+      and(eq(courseStages.courseId, courseId), isNull(courseStages.deletedAt))
+    )
+    .orderBy(asc(courseStages.sortOrder), asc(stagePractices.sortOrder));
+
+  const ids = practices.map((p) => p.contentId);
+  if (ids.length === 0) return;
+
+  const shouldBeComplete = ids.slice(0, count);
+  const shouldNotBeComplete = ids.slice(count);
+
+  if (shouldBeComplete.length > 0) {
+    await dbWs
+      .insert(practiceCompletions)
+      .values(
+        shouldBeComplete.map((contentId) => ({
+          userId,
+          contentId,
+          source: 'manual' as const,
+        }))
+      )
+      .onConflictDoNothing();
+  }
+  if (shouldNotBeComplete.length > 0) {
+    await dbWs
+      .delete(practiceCompletions)
+      .where(
+        and(
+          eq(practiceCompletions.userId, userId),
+          inArray(practiceCompletions.contentId, shouldNotBeComplete)
+        )
+      );
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('\n✘ Portal seed failed:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## The bug

The library's cross-arm "already purchased" exclusion was written as:

```sql
content.id NOT IN (SELECT purchases.content_id FROM purchases WHERE ...)
```

A **course purchase** stores `course_id` and leaves `content_id` NULL. So the subquery returned a NULL, and SQL's three-valued logic collapsed the predicate to `NOT (x = NULL)` → `NULL` → never TRUE, for **every** candidate row.

Four of the five library arms share that clause (membership, subscription, free, followers), so a single portal purchase blanked a member's entire owned-content grid, while the portals shelf — a different endpoint — carried on working. That's why it presented as "my journeys load but my content doesn't".

Now a correlated `NOT EXISTS`, extracted to one shared predicate. Verified against real data: **29 → 29** items for a journey-buyer, and **8 → 7** for a genuine content purchase with the bought item still correctly routed to the purchased arm.

## Also here

- **Portal provenance.** Practices report the portal(s) they sit inside, so a row is badged `part of <portal>` alongside — not instead of — how you reached it. Deliberately a separate field from `accessType`: an owner reaches everything "via membership" *and* some of it lives in a portal, and folding a `course:` variant into `accessType` would have made those mutually exclusive.
- **Pagination.** The collection sent no paging at all, so it took the API default of 20 — a member owning 29 could never reach the rest. Worse: the reconcile pass treats a cached key absent from the fetch as revoked, so a one-page fetch was actively pruning everything past item 20 out of localStorage on every refresh.
- **A published type that was lying.** `@codex/access` hand-declared a second copy of the library contract, and the barrel exported *that*. It under-declared `accessType`, so every frontend consumer believed `'free'` and `'followers'` were impossible — values the API had been returning for some time. Now derived from the service, so the drift is structurally impossible rather than merely fixed. (This is why the old `sourceGroup` checked for `'paid'`/`'subscribers'`, which can never occur.)
- **Portals, not journeys**, in the library's own language.
- **Layout.** The shelf is a carousel rather than a wrapping grid of tall posters — one row however many portals you own. Rows keep their provenance chip beside the title rather than flung to the far edge of a full-width row.
- **Loading states.** The grid renders skeletons until the server has actually answered. The old flag started `false`, so the SSR pass baked the first-run "your library will grow here" onboarding into the HTML for members who own plenty.

Cached localStorage payloads **migrate** v1 → v2 (`journeys` defaults to `[]`) rather than being discarded, so an existing member keeps a populated library through the deploy instead of an empty one for the length of the library fetch.

## Verification

| Gate | Result |
|---|---|
| Regression test vs the old `NOT IN` | **Fails** with `expected [] to include '<id>'` — the bug reproduced, then fixed |
| `@codex/access` full suite | 348 passed |
| `apps/web` full suite | 1568 passed |
| `@codex/database` suite | 60 passed |
| `svelte-check` | **69 errors vs 74 baseline**, zero in changed files |
| Browser | Desktop + mobile (390px) checked; no horizontal overflow; zero console errors |

## Deliberately not done

`JourneyEntryCard`'s `@media (--below-sm)` rule stacks the row layout's cover full-width, which keeps the mobile portal card ~350px tall. Making it stay compact would roughly halve the section height again on phones, but that rule is shared with `AudioWall` and `JourneyContinueCard` and trades vertical space for text width on the narrowest screens — a design call, not a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)