### PR TITLE
fix(org surfaces): dark/light auth pages, sidebar rail icon scaling, full-bleed overflow

### DIFF
--- a/apps/web/e2e/studio/settings.spec.ts
+++ b/apps/web/e2e/studio/settings.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
 import { test } from '../fixtures/auth';
-import { expectClickNavigates } from '../helpers/spa-nav';
 import {
   cleanupSharedStudioAuth,
   injectSharedStudioAuth,
@@ -13,11 +12,15 @@ import {
 /**
  * Studio Settings E2E Tests
  *
- * Tests general settings form and branding settings page.
+ * Tests the general settings form and the settings tab strip.
  * Owner role required for settings access.
  *
  * NOTE: Settings tabs use role="tab" (link-based navigation, not Melt UI).
- * NOTE: Color picker has a native color input + text hex input.
+ * NOTE: Branding is NOT a settings tab. It moved to the unified /studio/brand
+ * workspace (Codex-cijzb); `/studio/settings/branding` is now a 301 stub whose
+ * only job is to forward old bookmarks. The brand workspace itself is covered
+ * by studio/navigation.spec.ts and brand-editor-hero-effects.spec.ts — do not
+ * re-test its contents here.
  */
 
 test.describe('Studio Settings - General', () => {
@@ -156,7 +159,7 @@ test.describe('Studio Settings - Tabs', () => {
     await injectSharedStudioAuth(page, sharedAuth);
   });
 
-  test('General and Branding tabs are visible', async ({ page }) => {
+  test('General is the only settings tab', async ({ page }) => {
     await navigateToStudioPage(
       page,
       sharedAuth.member.organization.slug,
@@ -164,7 +167,12 @@ test.describe('Studio Settings - Tabs', () => {
     );
 
     await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
-    await expect(page.getByRole('tab', { name: 'Branding' })).toBeVisible();
+
+    // Assert the COUNT, not just the absence of 'Branding'. A stale name check
+    // would keep passing if a different tab were added, and the point of this
+    // assertion is that the strip has exactly one destination since branding
+    // moved to /studio/brand.
+    await expect(page.getByRole('tab')).toHaveCount(1);
   });
 
   test('General tab is selected on settings root', async ({ page }) => {
@@ -177,32 +185,9 @@ test.describe('Studio Settings - Tabs', () => {
     const generalTab = page.getByRole('tab', { name: 'General' });
     await expect(generalTab).toHaveAttribute('aria-selected', 'true');
   });
-
-  test('clicking Branding tab navigates to branding page', async ({ page }) => {
-    await navigateToStudioPage(
-      page,
-      sharedAuth.member.organization.slug,
-      '/settings'
-    );
-
-    await expectClickNavigates(
-      page,
-      page.getByRole('tab', { name: 'Branding' }),
-      /\/studio\/settings\/branding/,
-      // Settings tabs are stable content-area elements, not rail items. Skip
-      // the hover: an expanded desktop rail (left over from a prior hover)
-      // overlays the tab strip and intercepts the hover, while the native JS
-      // click still bubbles to the SPA router. Per spa-nav.ts: hover:false for
-      // stable elements.
-      { hover: false }
-    );
-
-    const brandingTab = page.getByRole('tab', { name: 'Branding' });
-    await expect(brandingTab).toHaveAttribute('aria-selected', 'true');
-  });
 });
 
-test.describe('Studio Settings - Branding', () => {
+test.describe('Studio Settings - legacy branding redirect', () => {
   test.describe.configure({ mode: 'serial' });
 
   let sharedAuth: SharedStudioAuth;
@@ -219,40 +204,25 @@ test.describe('Studio Settings - Branding', () => {
     await injectSharedStudioAuth(page, sharedAuth);
   });
 
-  test('branding page renders Edit Brand Live + Logo upload', async ({
+  test('/studio/settings/branding forwards to the brand workspace', async ({
     page,
   }) => {
+    // `settings/branding/+page.ts` is a redirect(301, '/studio/brand') stub
+    // kept solely so old bookmarks and inbound links keep working. It runs
+    // under the studio subtree's `ssr = false`, so the redirect fires on the
+    // CLIENT during navigation — which is why this asserts the settled URL
+    // rather than the response status.
     await navigateToStudioPage(
       page,
       sharedAuth.member.organization.slug,
       '/settings/branding'
     );
 
-    // The branding settings page was simplified: it now exposes only a
-    // `Edit Brand Live` CTA (which opens the floating brand editor) and a
-    // logo upload card. Hex/color picker controls live INSIDE the brand
-    // editor (tested separately).
-    await expect(
-      page.getByRole('button', { name: 'Edit Brand Live' })
-    ).toBeVisible();
+    // toHaveURL polls, so it tolerates the client-side hop. Per e2e/CLAUDE.md,
+    // never waitForURL on an ssr=false route — there is no second load event.
+    await expect(page).toHaveURL(/\/studio\/brand$/);
 
-    // Logo card heading is a real <h{N}> via Card.Title.
-    await expect(page.getByRole('heading', { name: 'Logo' })).toBeVisible();
-
-    // Read-only brand summary heading.
-    await expect(
-      page.getByRole('heading', { name: 'Current Brand' })
-    ).toBeVisible();
-  });
-
-  test('Branding tab is selected on branding page', async ({ page }) => {
-    await navigateToStudioPage(
-      page,
-      sharedAuth.member.organization.slug,
-      '/settings/branding'
-    );
-
-    const brandingTab = page.getByRole('tab', { name: 'Branding' });
-    await expect(brandingTab).toHaveAttribute('aria-selected', 'true');
+    // The old path must leave no trace in the settings tab strip.
+    await expect(page.getByRole('tab', { name: 'Branding' })).toHaveCount(0);
   });
 });

--- a/apps/web/src/lib/components/layout/SidebarRail/SidebarRail.svelte
+++ b/apps/web/src/lib/components/layout/SidebarRail/SidebarRail.svelte
@@ -137,7 +137,7 @@
 		onclick={() => onSearchClick?.()}
 		aria-label={m.sidebar_search()}
 	>
-		<SearchIcon size={20} />
+		<SearchIcon />
 		{#if expanded}
 			<span class="rail-search-btn__label">{m.sidebar_search()}</span>
 			<kbd class="rail-search-btn__kbd">&#8984;K</kbd>
@@ -172,7 +172,7 @@
 			class="rail-studio-btn"
 			aria-label={m.nav_studio()}
 		>
-			<LayoutDashboardIcon size={22} />
+			<LayoutDashboardIcon />
 			{#if expanded}
 				<span class="rail-studio-btn__label">{m.nav_studio()}</span>
 			{/if}
@@ -197,6 +197,13 @@
 		--rail-width-expanded: var(--app-sidebar-width-expanded);
 		--rail-glass-bg: color-mix(in oklch, var(--color-surface) 75%, transparent);
 		--rail-glass-border: color-mix(in oklch, var(--color-border) 50%, transparent);
+		/* Nav glyph size, inherited by SidebarRailItem (which falls back to the
+		   same token when used standalone). A density-scaled token rather than a
+		   literal `size={22}` prop, so glyphs grow with the rail instead of
+		   staying pinned while the org's density inflates everything around them.
+		   --space-5-5 IS 22px at density 1, so default rendering is unchanged.
+		   Row rules derive their inline padding from this to centre the glyph. */
+		--rail-glyph: var(--space-5-5);
 
 		position: fixed;
 		left: 0;
@@ -333,10 +340,21 @@
 
 	/* Search button — prominent at top */
 	.rail-search-btn {
+		/* Search reads one step smaller than the nav glyphs by design. */
+		--rail-glyph: var(--space-5);
+
 		display: flex;
 		align-items: center;
 		gap: var(--space-3);
-		padding: var(--space-2) var(--space-3);
+		padding-block: var(--space-2);
+		/* Derived, not literal — see the identical rule in SidebarRailItem for
+		   why: a literal --space-3 only centres the glyph at density 1. max()
+		   guards --app-sidebar-width collapsing to 0px below md, which would
+		   otherwise make this negative and drop the declaration. */
+		padding-inline: max(
+			0px,
+			calc((var(--app-sidebar-width) - 2 * var(--space-2) - var(--rail-glyph)) / 2)
+		);
 		margin: 0 var(--space-2);
 		border-radius: var(--radius-md);
 		color: var(--color-text-secondary);
@@ -351,6 +369,22 @@
 		overflow: hidden;
 		min-height: var(--space-10);
 		text-align: left;
+	}
+
+	/* Glyphs are sized here rather than via a `size` prop so they track density.
+	   CSS width/height outrank the SVG's width/height presentation attributes, so
+	   this wins over IconBase's default without any prop.
+	   `flex-shrink: 0` matters as much as the size: an SVG with a width attribute
+	   is still a shrinkable flex item, so before --app-sidebar-width scaled with
+	   density the growing padding squeezed the glyph instead of the rail. */
+	.rail-search-btn :global(svg),
+	.rail-studio-btn :global(svg) {
+		flex-shrink: 0;
+		/* See SidebarRailItem: reset.css's `max-width: 100%` on svg would cap the
+		   width at the content box while height obeys, squashing the glyph. */
+		max-width: none;
+		width: var(--rail-glyph);
+		height: var(--rail-glyph);
 	}
 
 	.rail-search-btn:hover {
@@ -403,7 +437,12 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-3);
-		padding: var(--space-2) var(--space-3);
+		padding-block: var(--space-2);
+		/* Derived, not literal — see SidebarRailItem for the rationale. */
+		padding-inline: max(
+			0px,
+			calc((var(--app-sidebar-width) - 2 * var(--space-2) - var(--rail-glyph)) / 2)
+		);
 		margin: 0 var(--space-2);
 		border-radius: var(--radius-md);
 		color: var(--color-text-secondary);
@@ -444,6 +483,20 @@
 	/* Theme toggle */
 	.rail-theme-toggle {
 		margin: 0 var(--space-2);
+	}
+
+	/* ThemeToggle is passed `showLabel` so the label can fade in when the rail
+	   hover-expands, but that label is ~80px of nowrap text inside a 64px
+	   collapsed rail. The toggle's glyph defaulted to flex-shrink: 1, so it lost
+	   the space fight to the unshrinkable text and computed to width: 0 — the
+	   theme icon was simply invisible in the rail at every density. Pin the glyph
+	   and let the label be the thing that overflows (it is clipped until
+	   expanded, which is the intended behaviour). */
+	.rail-theme-toggle :global(svg) {
+		flex-shrink: 0;
+		max-width: none;
+		width: var(--rail-glyph);
+		height: var(--rail-glyph);
 	}
 
 	.rail-theme-toggle :global(.theme-toggle__label) {

--- a/apps/web/src/lib/components/layout/SidebarRail/SidebarRailItem.svelte
+++ b/apps/web/src/lib/components/layout/SidebarRail/SidebarRailItem.svelte
@@ -43,7 +43,9 @@
 		aria-label={label}
 		style:--item-index={index}
 	>
-		<IconComponent size={22} />
+		<!-- No `size` prop: the glyph is sized in CSS from --space-5-5 so it
+		     tracks the org's density scale. See the .rail-item svg rule. -->
+		<IconComponent />
 		<span class="rail-item__label">{label}</span>
 	</a>
 {:else}
@@ -55,7 +57,9 @@
 		aria-label={label}
 		use:melt={$trigger}
 	>
-		<IconComponent size={22} />
+		<!-- No `size` prop: the glyph is sized in CSS from --space-5-5 so it
+		     tracks the org's density scale. See the .rail-item svg rule. -->
+		<IconComponent />
 	</a>
 	{#if $open}
 		<div use:melt={$content} class="rail-item__tooltip">
@@ -69,7 +73,29 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-3);
-		padding: var(--space-2) var(--space-3);
+		padding-block: var(--space-2);
+		/* Inline padding is DERIVED from the rail so the icon is centred
+		   structurally rather than by coincidence. The item is a flex row whose
+		   first child is the glyph, so the glyph's left edge sits exactly at
+		   padding-inline — meaning it is centred in the collapsed rail only when
+		   that padding equals half the leftover space. A literal --space-3 (12px)
+		   satisfied that at density 1 by accident, because
+		   (64 - 2*8 margin - 22 icon) / 2 = 13px ≈ 12px. At any other density the
+		   coincidence broke and the glyph drifted off-centre (measured 4.5px at
+		   density 0.8). Expressing it as the real half-of-leftover keeps the
+		   glyph's optical centre on the rail's centre line at every density.
+		   When the rail hover-expands this padding stays put, which is what we
+		   want: the icon column holds its x position while the label reveals to
+		   its right. */
+		/* max() guards the degenerate case: below md --app-sidebar-width collapses
+		   to 0px, which makes the calc negative — and a negative padding is an
+		   invalid value, so the whole declaration would be dropped. */
+		padding-inline: max(
+			0px,
+			calc(
+				(var(--app-sidebar-width) - 2 * var(--space-2) - var(--rail-glyph, var(--space-5-5))) / 2
+			)
+		);
 		margin: 0 var(--space-2);
 		border-radius: var(--radius-md);
 		color: var(--color-text-secondary);
@@ -80,6 +106,28 @@
 		white-space: nowrap;
 		overflow: hidden;
 		min-height: var(--space-10);
+	}
+
+	/* Size the glyph from the density-aware spacing scale instead of a literal
+	   `size={22}` prop. --space-5-5 IS 22px at density 1, so default rendering is
+	   unchanged, but the glyph now grows with the rail instead of staying pinned.
+	   CSS width/height win over the SVG's width/height presentation attributes,
+	   so this overrides IconBase's default without needing a prop.
+	   `flex-shrink: 0` is the important half: an SVG with a width attribute is
+	   still a shrinkable flex item, so when density inflated the padding inside a
+	   frozen 64px rail the glyph absorbed the entire squeeze and collapsed to a
+	   3px-wide sliver. */
+	.rail-item :global(svg) {
+		flex-shrink: 0;
+		/* reset.css applies `max-width: 100%` to svg/img to stop media overflowing.
+		   On a glyph whose size we set deliberately that silently caps the width at
+		   the content box while `height` — which has no max-height counterpart —
+		   obeys, rendering a squashed non-square icon. The derived padding above
+		   makes the content box equal the glyph exactly, so the rail's 1px glass
+		   border is enough to trip the clamp. */
+		max-width: none;
+		width: var(--rail-glyph, var(--space-5-5));
+		height: var(--rail-glyph, var(--space-5-5));
 	}
 
 	.rail-item:hover {

--- a/apps/web/src/lib/components/layout/SidebarRail/SidebarRailUserSection.svelte
+++ b/apps/web/src/lib/components/layout/SidebarRail/SidebarRailUserSection.svelte
@@ -118,7 +118,7 @@
 	{#if expanded}
 		<div class="user-section-unauth">
 			<a href="/login" class="sign-in-link">
-				<LogInIcon size={20} />
+				<LogInIcon />
 				<span class="sign-in-link__label">{m.sidebar_sign_in()}</span>
 			</a>
 			<a href="/register" class="register-link">{m.sidebar_register()}</a>
@@ -130,7 +130,7 @@
 			aria-label={m.sidebar_sign_in()}
 			use:melt={$tooltipTrigger}
 		>
-			<LogInIcon size={22} />
+			<LogInIcon />
 		</a>
 		{#if $tooltipOpen}
 			<div use:melt={$tooltipContent} class="user-tooltip">
@@ -304,6 +304,20 @@
 	.user-section-unauth--collapsed:hover {
 		background-color: var(--color-surface-secondary);
 		color: var(--color-text);
+	}
+
+	/* Rail-strip glyphs are sized from the density-aware scale rather than a
+	   literal `size` prop, so they grow with the rail instead of staying pinned
+	   while the org's density inflates everything around them. --rail-glyph is
+	   inherited from .sidebar-rail; the fallback keeps this component correct in
+	   isolation. `max-width: none` defeats reset.css's `max-width: 100%` on svg,
+	   which would otherwise cap the width at the content box while `height`
+	   obeys, yielding a squashed non-square glyph. */
+	.user-section-unauth :global(svg) {
+		flex-shrink: 0;
+		max-width: none;
+		width: var(--rail-glyph, var(--space-5-5));
+		height: var(--rail-glyph, var(--space-5-5));
 	}
 
 	.sign-in-link {

--- a/apps/web/src/lib/components/subscription/SubscribeCTA.svelte
+++ b/apps/web/src/lib/components/subscription/SubscribeCTA.svelte
@@ -417,12 +417,22 @@
      a rounded promotional card. */
   .subscribe-cta {
     position: relative;
-    /* Escape the parent's max-width by breaking out to full viewport
-       width. `calc(100vw - scrollbar)` isn't bulletproof on all browsers
-       but margin-inline negative works because the parent `.content-area`
-       is centered with max-width. */
-    width: 100vw;
-    margin-inline: calc(50% - 50vw);
+    /* Escape the parent out to the viewport edges — deliberately WITHOUT `vw`.
+       The previous `width: 100vw; margin-inline: calc(50% - 50vw)` carried two
+       compounding errors on org pages:
+         1. `100vw` includes the scrollbar gutter, so on any scrolling page the
+            section was scrollbar-width too wide.
+         2. `calc(50% - 50vw)` only lands at x=0 when the parent is centred in
+            the viewport. `.content-area` is not — it starts at the fixed
+            SidebarRail's edge — so the breakout was pushed right by the rail.
+       Together they pushed the section past the viewport, which gave the org
+       landing page a horizontal scrollbar and left an unpainted strip beside
+       `.content-area`'s gradient/backdrop-filter surface when scrolled into it.
+       Deriving the breakout from the parent's own width plus the rail token is
+       exact at every viewport, needs no scrollbar guesswork, and collapses to a
+       no-op below md where --app-sidebar-width is 0px. */
+    width: calc(100% + var(--app-sidebar-width));
+    margin-inline: calc(-1 * var(--app-sidebar-width)) 0;
     padding-block: var(--space-12);
     padding-inline: var(--space-6);
     display: grid;

--- a/apps/web/src/lib/styles/base.css
+++ b/apps/web/src/lib/styles/base.css
@@ -20,12 +20,48 @@ html {
   /* NOTE: scrollbar-gutter: stable was removed — it creates a visible
      gap with the root background color that can't inherit org branding
      (org brand scopes to [data-org-brand], not :root). */
+
 }
 
 body {
   font-size: var(--text-base);
   font-weight: var(--font-normal);
   min-height: 100vh;
+}
+
+/* Suppress phantom horizontal scrolling.
+
+   Document-level horizontal scrolling is never intentional in this app — every
+   sideways-scrolling surface (carousels, rails, wide tables) is its own
+   `overflow-x: auto` container. A document-level horizontal scrollbar therefore
+   only ever means a decorative full-bleed surface has escaped its parent, and
+   it is actively harmful: the page scrolls a few px sideways while in-flow
+   backgrounds (the org landing `.content-area` gradient and its backdrop blur)
+   stay viewport-width, exposing an unpainted strip down the edge.
+
+   Why the pixels can't just be calc'd away: full-bleed breakouts are built on
+   `vw`, and EVERY viewport unit (`vw`/`dvw`/`svw`/`lvw`) counts the classic
+   scrollbar gutter. No CSS unit means "viewport minus scrollbar", so a
+   `vw`-based breakout is always scrollbar-width too wide. Breakouts that CAN be
+   expressed structurally should be — see SubscribeCTA, which derives its own
+   from --app-sidebar-width and needs none of this. What remains is
+   StickyToolbar's `inset-inline: calc(50% - 50vw)` pseudo-elements, which
+   additionally sit off-centre because their container is inset by the fixed
+   SidebarRail, so no symmetric inset can ever reach both viewport edges.
+
+   `clip`, not `hidden`: `hidden` makes the element a scroll container, which
+   would break the `position: sticky` toolbars nested inside. `clip` pairs
+   legally with `overflow-y: visible` (the "one axis forces the other to auto"
+   rule covers hidden/scroll/auto, not clip), so both boxes stay
+   non-scrolling and sticky keeps working.
+
+   BOTH selectors are required — do not split this rule. `html` is the
+   scrolling element (`document.scrollingElement`), and measured in Chromium:
+   `body` alone still scrolls 40px, `html` alone still scrolls 40px, together
+   they scroll 0. */
+html,
+body {
+  overflow-x: clip;
 }
 
 /* ========================================

--- a/apps/web/src/lib/styles/tokens/org-brand.css
+++ b/apps/web/src/lib/styles/tokens/org-brand.css
@@ -97,6 +97,17 @@
   --space-20: calc(var(--space-unit) * 20);
   --space-24: calc(var(--space-unit) * 24);
 
+  /* App chrome widths are derived from the spacing scale, so they must be
+     re-declared here for the same reason the scale itself is. `layout.css`
+     declares `--app-sidebar-width: var(--space-16)` on :root, where the var()
+     resolves against :root's --space-unit ONCE; descendants inherit the
+     already-substituted px. So without this line the SidebarRail keeps its
+     density-1 width of 64px while everything inside it — item min-height,
+     padding, gaps — rescales with the org's density. The padding then devours
+     the fixed-width rail and flex-shrinks the nav icons: measured 3px wide at
+     density 1.5. */
+  --app-sidebar-width: var(--space-16);
+
   /* ─── TYPOGRAPHY ────────────────────────────────────────────────────── */
   --font-body: var(--brand-font-body, var(--font-sans));
   --font-heading: var(--brand-font-heading, var(--font-sans));
@@ -162,6 +173,21 @@
   /* ─── CARD INTERACTION ──────────────────────────────────────────── */
   --card-hover-scale: var(--brand-card-hover-scale, 1.02);
   --card-image-hover-scale: var(--brand-card-image-hover-scale, 1.05);
+}
+
+/* Mirror layout.css's mobile rail collapse at org scope.
+
+   layout.css collapses --app-sidebar-width to 0 below md, because the rail is
+   display:none there and consumers (the `main` offset, full-bleed calcs) must
+   reclaim the full viewport. That override lives on `:root`, which has the same
+   (0,1,0) specificity as `[data-org-brand]` — and org-brand.css is imported
+   AFTER layout.css, so the org-scope re-declaration above would otherwise win
+   even inside the media query and leave `main` with a phantom 64px margin
+   against an invisible rail. Keep these two in lockstep. */
+@media (--below-md) {
+  [data-org-brand] {
+    --app-sidebar-width: 0px;
+  }
 }
 
 /* Typography weight overrides — re-declare the weight tokens at org scope

--- a/apps/web/src/routes/(auth)/+layout.svelte
+++ b/apps/web/src/routes/(auth)/+layout.svelte
@@ -14,7 +14,11 @@
   import type { Snippet } from 'svelte';
   import { setContext } from 'svelte';
   import AuthShaderPane from '$lib/components/auth/AuthShaderPane.svelte';
-  import { tokenOverridesToCssVars } from '$lib/brand-editor';
+  import {
+    darkTokenOverridesToCssVars,
+    parseDarkColorOverrides,
+    tokenOverridesToCssVars,
+  } from '$lib/brand-editor';
   import type { LayoutData } from './$types';
 
   interface Props {
@@ -31,28 +35,70 @@
   const brandSecondary = $derived(branding?.brandColors?.secondary ?? undefined);
   const brandAccent = $derived(branding?.brandColors?.accent ?? undefined);
   const brandBackground = $derived(branding?.brandColors?.background ?? undefined);
+  // Dark-mode colour overrides. org-brand.css gates its dark tokens on
+  // `var(--brand-bg-dark, var(--brand-bg, …))`, so WITHOUT these the dark rules
+  // still match but fall straight back to the LIGHT brand colours. That is what
+  // broke dark mode here: `.auth-form-pane`'s background resolved inside the
+  // brand scope and stayed the org's light background, while its text colour is
+  // inherited from `html { color: var(--color-text-primary) }` — resolved at
+  // :root, where the theme DOES flip. The result was near-white text on a light
+  // brand surface. Mirrors _org/[slug]/+layout.svelte; a per-field absence is
+  // handled by that same CSS fallback chain.
+  const darkColorOverrides = $derived(
+    parseDarkColorOverrides(branding?.brandFineTune?.darkModeOverrides)
+  );
+  const brandPrimaryDark = $derived(darkColorOverrides?.primaryColor ?? undefined);
+  const brandSecondaryDark = $derived(
+    darkColorOverrides?.secondaryColor ?? undefined
+  );
+  const brandAccentDark = $derived(darkColorOverrides?.accentColor ?? undefined);
+  const brandBackgroundDark = $derived(
+    darkColorOverrides?.backgroundColor ?? undefined
+  );
+
   const brandFontBody = $derived(branding?.brandFonts?.body ?? undefined);
   const brandFontHeading = $derived(branding?.brandFonts?.heading ?? undefined);
   const brandRadius = $derived.by(() => {
     const v = Number(branding?.brandRadius);
     return Number.isFinite(v) ? `${v}rem` : undefined;
   });
+  // Density was missing for the same reason as the dark colours: the auth shell
+  // claims org brand context via [data-org-brand], so it inherits the org-scoped
+  // spacing scale re-declaration, but never supplied the multiplier it reads.
+  const brandDensity = $derived.by(() => {
+    const v = Number(branding?.brandDensity);
+    return Number.isFinite(v) ? String(v) : undefined;
+  });
   const brandLogoUrl = $derived(branding?.logoUrl ?? undefined);
 
   // SSR-render tokenOverrides as inline CSS vars so the shader has its
   // preset/intensity/grain values on first paint — mirrors the org layout
   // pattern at _org/[slug]/+layout.svelte.
-  const tokenOverrideStyle = $derived.by(() => {
-    const raw = branding?.brandFineTune?.tokenOverrides;
-    if (!raw) return undefined;
-    let parsed: Record<string, string | null>;
+  const parseOverrides = (raw: string | null | undefined) => {
+    if (!raw) return null;
     try {
-      parsed = JSON.parse(raw) as Record<string, string | null>;
+      const parsed = JSON.parse(raw) as Record<string, string | null>;
+      return Object.keys(parsed).length > 0 ? parsed : null;
     } catch {
-      return undefined;
+      return null;
     }
-    if (!parsed || Object.keys(parsed).length === 0) return undefined;
-    const vars = tokenOverridesToCssVars(parsed);
+  };
+
+  const tokenOverrideStyle = $derived.by(() => {
+    // Light AND dark override sets, same as the org layout. The dark set is
+    // emitted as `--brand-{key}-dark` / `--color-{key}-dark` so org-brand.css's
+    // dark gate can pick it up; emitting only the light set left per-theme
+    // fine-tuning inert on the auth shell.
+    const lightOverrides = parseOverrides(branding?.brandFineTune?.tokenOverrides);
+    const darkOverrides = parseOverrides(
+      branding?.brandFineTune?.darkTokenOverrides
+    );
+    if (!lightOverrides && !darkOverrides) return undefined;
+    const vars: Record<string, string> = {};
+    if (lightOverrides) Object.assign(vars, tokenOverridesToCssVars(lightOverrides));
+    if (darkOverrides) {
+      Object.assign(vars, darkTokenOverridesToCssVars(darkOverrides));
+    }
     const entries = Object.entries(vars);
     if (entries.length === 0) return undefined;
     return entries.map(([prop, value]) => `${prop}: ${value}`).join('; ');
@@ -77,6 +123,11 @@
   style:--brand-secondary={brandSecondary}
   style:--brand-accent={brandAccent}
   style:--brand-bg={brandBackground}
+  style:--brand-color-dark={brandPrimaryDark}
+  style:--brand-secondary-dark={brandSecondaryDark}
+  style:--brand-accent-dark={brandAccentDark}
+  style:--brand-bg-dark={brandBackgroundDark}
+  style:--brand-density={brandDensity}
   style:--brand-radius={brandRadius}
   style:--brand-font-body={brandFontBody ? `'${brandFontBody}'` : undefined}
   style:--brand-font-heading={brandFontHeading ? `'${brandFontHeading}'` : undefined}
@@ -98,6 +149,17 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     background: var(--color-background);
+    /* Both halves of the contrast pair MUST resolve in the same scope. This
+       element carries [data-org-brand]/[data-org-bg], so `background` above
+       resolves against the org's brand tokens — but without this line `color`
+       was inherited from `html { color: var(--color-text-primary) }`, which
+       resolves at :root where the light/dark theme flips independently of the
+       brand. On a branded org that produced near-white text on the org's light
+       brand surface in dark mode. Pairing them here also keeps orgs that have
+       NO dark-mode override readable: their surface legitimately stays light in
+       dark mode, and the brand-derived text stays dark to match it.
+       Matches .org-layout in _org/[slug]/+layout.svelte. */
+    color: var(--color-text);
   }
 
   .auth-form-pane {


### PR DESCRIPTION
## Summary

Three org-surface polish fixes, already landed on this branch:

- `a2b74fc4` — full-bleed surfaces no longer push the page sideways
- `4cee982e` — sidebar rail icons scale and stay centred at every brand density
- `4aea4bfc` — org auth pages follow dark and light mode

## Context

This is the branch that preceded the `ux-polish` effort. `ux-polish` is cut from this
HEAD, so these commits are already included downstream — merging here keeps `dev`
current and avoids the integration branch carrying them alone.

## Verification

Visual checks were performed when each commit landed. CI on this PR is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)