### PR TITLE
fix(transcoding): local dispatch actually runs, and a dead dispatch i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 .dev.vars.*
 **/.dev.vars
 **/.dev.vars.*
+# ...but the placeholder templates ARE the documentation for local setup.
+# Without these tracked, a working local config only ever exists on one machine
+# (which is how local transcoding silently rotted — see infrastructure/runpod/LOCAL_DEV.md).
+!**/.dev.vars.example
 env.dev
 env.prod
 

--- a/infrastructure/runpod/Dockerfile.local
+++ b/infrastructure/runpod/Dockerfile.local
@@ -34,7 +34,17 @@ COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY handler/ ./handler/
+COPY local_server.py .
 
 ENV PYTHONPATH=/app
 
-CMD ["python3", "-u", "handler/main.py", "--rp_serve_api", "--rp_api_host=0.0.0.0", "--rp_api_port=8000"]
+# Serve via local_server.py, NOT runpod's `--rp_serve_api`.
+#
+# runpod's local `/run` is a stub that never invokes the handler, and its
+# `/runsync` blocks for the whole transcode — which trips media-api's 30s
+# dispatch timeout and makes it mark still-running jobs as failed. local_server
+# reproduces the cloud contract instead: accept, return a job id immediately,
+# transcode on a background thread, webhook on completion.
+#
+# See local_server.py and LOCAL_DEV.md for the full reasoning.
+CMD ["python3", "-u", "local_server.py"]

--- a/infrastructure/runpod/LOCAL_DEV.md
+++ b/infrastructure/runpod/LOCAL_DEV.md
@@ -1,0 +1,218 @@
+# Local transcoding — how it works and how to run it
+
+Transcoding in local dev runs the **same `handler/main.py` as production**, in a
+CPU-only Docker container, against Miniflare R2 via `dev-cdn`. Only the job
+*dispatch* differs from production, and that difference is where every failure
+in this pipeline has come from. This document is the source of truth for it.
+
+---
+
+## Quick start
+
+```bash
+# 1. Build the image (once, or after changing handler/ or local_server.py)
+pnpm dev:transcoder:build
+
+# 2. Run the container — publishes container :8000 on host :8010
+pnpm dev:transcoder
+
+# 3. Bring up the fleet (needs at least content-api, media-api, dev-cdn)
+pnpm dev
+```
+
+Then upload media as a creator. `media_items.status` should go
+`uploading → uploaded → transcoding → ready`.
+
+`workers/media-api/.dev.vars` must exist — copy it from
+`workers/media-api/.dev.vars.example`, which documents every transcoding
+variable. **Wrangler reads `.dev.vars` at worker start**: if you edit it,
+restart the worker rather than assuming a hot reload took.
+
+---
+
+## The four hops
+
+```
+[1] browser upload
+      → content-api (:4001)   registers media, R2 PUT, status uploading → uploaded
+[2] content-api → media-api   POST {MEDIA_API_URL}/internal/media/:id/transcode
+                              HMAC-SHA256 via workerFetch(…, WORKER_SHARED_SECRET)
+[3] media-api → container     POST {RUNPOD_DIRECT_URL}          ← the dispatch
+                              inside ctx.waitUntil(), NOT on the request path
+[4] container → media-api     POST {TRANSCODING_WEBHOOK_URL}/api/transcoding/webhook
+                              HMAC-SHA256 via RUNPOD_WEBHOOK_SECRET
+```
+
+| hop | variable | set in | local value |
+|---|---|---|---|
+| 2 | `MEDIA_API_URL` | `workers/content-api/wrangler.jsonc` | `http://localhost:4002` |
+| 2 | `WORKER_SHARED_SECRET` | both workers' `.dev.vars` | must match |
+| 3 | `RUNPOD_DIRECT_URL` | `workers/media-api/.dev.vars` | `http://127.0.0.1:8010/run` |
+| 4 | `TRANSCODING_WEBHOOK_URL` | `workers/media-api/.dev.vars` | `http://host.docker.internal:4002` |
+| 4 | `RUNPOD_WEBHOOK_SECRET` | `workers/media-api/.dev.vars` | must match ↓ |
+| 4 | `WEBHOOK_SECRET` | `infrastructure/runpod/local.env` | must match ↑ |
+
+Storage, from the container's side (`local.env`): `R2_ENDPOINT` points at
+`http://host.docker.internal:4100` — **dev-cdn**, which exposes an
+S3-compatible interface over Miniflare R2 so boto3 works unmodified.
+`B2_ENDPOINT` points at MinIO on `:9000` for mezzanine archival.
+
+There is exactly one dispatch call site in the repo (`grep -rn
+"triggerJobInternal"`), so there is never a second path to rule out.
+
+---
+
+## Why the container does NOT use `--rp_serve_api`
+
+This is the single most important thing on this page.
+
+runpod-python ships a local test server (`python handler/main.py
+--rp_serve_api`). Its `/run` route **never invokes your handler**. From
+runpod 1.12.0 `rp_fastapi.py`:
+
+```python
+async def _sim_run(self, job_request):
+    assigned_job_id = f"test-{uuid.uuid4()}"
+    job_list.add({...})                                  # stash only
+    return {"id": assigned_job_id, "status": "IN_PROGRESS"}
+```
+
+It appends the job to a list and returns. Work happens only in `_sim_runsync`,
+or in `_sim_status` when something later polls `GET /status/{id}`.
+
+That leaves no good option against runpod's own server:
+
+| dispatch target | dispatch returns | handler runs? | outcome |
+|---|---|---|---|
+| `--rp_serve_api` `/run` | instantly, with a job id | **never** | silent no-op. Status sits at `transcoding` forever, no error anywhere. |
+| `--rp_serve_api` `/runsync` | only after the full transcode | yes | trips the 30s dispatch timeout (below) on anything non-trivial |
+
+Neither failure prints anything useful, which is why this pipeline has read as
+"the transcoding service isn't receiving anything" more than once. It *was*
+receiving the request and discarding it.
+
+**Production has neither problem**: RunPod's cloud `/run` queues the job and
+returns in under a second, so `/run` + `waitUntil` is correct there.
+
+So the container serves **`local_server.py`** instead, which reproduces the
+cloud contract: accept the job, return an id immediately, transcode on a
+background thread, and let the handler post its own completion webhook. Local
+and production then use the identical `/run` path and the identical semantics.
+
+`handler/main.py` guards its `runpod.serverless.start(...)` under
+`if __name__ == "__main__":` purely so `local_server.py` can import `handler`
+without starting the serverless loop. Production is unaffected — its CMD is
+`python3 -u handler/main.py`, so the guard still fires.
+
+---
+
+## The 30-second dispatch ceiling
+
+`media-api` dispatches inside `ctx.executionCtx.waitUntil(...)` with
+`AbortSignal.timeout(30_000)` (`packages/transcoding/src/services/transcoding-service.ts`,
+`dispatchRunPodJob`). Two independent 30s limits apply:
+
+- `AbortSignal.timeout(this.runpodTimeout)` — 30 000 ms, hardcoded.
+- `ctx.waitUntil` itself — Cloudflare documents a **30 second** limit after the
+  invocation ends, shared across all `waitUntil` calls; over it, tasks are
+  cancelled.
+
+If the dispatch has not returned by then, the fetch aborts and the `catch`
+calls `markTranscodingFailed(...)` — marking the media **failed while the
+container is still successfully transcoding it**. Measured with a blocking
+`/runsync` dispatch on 2026-08-21: abort at exactly t+30s, `markTranscodingFailed`
+attempted, the media saved from a wrong `failed` only because that UPDATE
+happened to fail too (the "Double failure" branch).
+
+An asynchronous `/run` never gets near this, which is the main reason
+`local_server.py` exists. **Do not point `RUNPOD_DIRECT_URL` at a blocking
+endpoint.**
+
+Diagnostic signature, worth memorising:
+
+| observed state | means |
+|---|---|
+| `transcoding` + `runpod_job_id` NULL + no error | dispatch never completed — cancelled `waitUntil`, or the worker died mid-flight |
+| `uploaded` (rolled back) | dispatch failed fast and cleanly |
+| `failed` + error text | dispatch or transcode failed and reported |
+| `transcoding` forever, job id set | dispatch succeeded but the handler never ran (the `--rp_serve_api /run` stub) |
+
+---
+
+## Multipart uploads
+
+boto3 switches to multipart automatically above
+`TransferConfig.multipart_threshold` (8 MB default), so the handler uses it for
+any HLS output of consequence — a single-file `stream.ts` for a 47 MB source is
+well over the line. `dev-cdn` therefore implements the S3 multipart routes
+(`POST ?uploads`, `PUT ?partNumber&uploadId`, `POST ?uploadId`,
+`DELETE ?uploadId`) on top of R2's binding API. Before that existed, every
+local transcode of real-sized media died with:
+
+```
+An error occurred (405) when calling the CreateMultipartUpload operation: Method Not Allowed
+```
+
+This was deliberately **not** fixed by raising the threshold in the Python
+handler: production genuinely uses multipart against real R2, and a local path
+that never exercised it would hide multipart bugs until they reached prod.
+
+---
+
+## Verifying it, and traps
+
+**Ports.** The container listens on 8000 internally and is published on
+**8010**, because host 8000 is frequently taken by unrelated services. If you
+change this, change `RUNPOD_DIRECT_URL` to match.
+
+**Loopback works.** `workerd` under `wrangler dev` can fetch `127.0.0.1`
+(verified 2026-08-21). Prefer it to a LAN IP, which breaks whenever the DHCP
+lease changes.
+
+**Verify the process, not the port.** A dead `pnpm`/`turbo` parent can leave its
+`workerd` child holding the port, so "port 4002 is listening" does not mean your
+current code is serving it. Probe `GET /health` and check the worker's own log
+for its startup banner. To clear everything:
+
+```bash
+ps -eo pid,command | grep "development/Codex" \
+  | grep -Ei "wrangler|workerd|miniflare|turbo run dev" | grep -v grep \
+  | awk '{print $1}' | xargs -r kill -TERM
+```
+
+**Probes that work.**
+
+```bash
+# container is alive and how many jobs it has seen
+curl -s http://127.0.0.1:8010/health
+
+# dev-cdn serves a source object (S3 mode — what the container uses)
+curl -sI http://127.0.0.1:4100/codex-media-test/{creatorId}/originals/{mediaId}/media.mp3
+
+# run one job by hand, synchronously, bypassing media-api entirely
+curl -s -X POST http://127.0.0.1:8010/runsync -H 'content-type: application/json' \
+  -d '{"input":{"mediaId":"…","type":"audio","creatorId":"…","inputKey":"…",
+        "webhookUrl":"http://host.docker.internal:4002/api/transcoding/webhook"}}'
+```
+
+`local_server.py` leaves uvicorn **access logging on**, so `docker logs
+codex-transcoder` shows every request. With `--rp_serve_api` it did not: a POST
+that returned 200 produced no log line, making a working dispatch
+indistinguishable from one that never left the worker.
+
+**A stuck row cannot simply be re-triggered.** `triggerJobInternal` refuses
+anything whose status is not `uploaded` (`InvalidMediaStateError`). Reset first:
+
+```sql
+UPDATE media_items
+   SET status = 'uploaded', runpod_job_id = NULL, transcoding_error = NULL,
+       transcoding_attempts = 0, transcoding_progress = 0
+ WHERE id = '…';
+```
+
+**Never `pnpm test` from the repo root.** `.env.test` points `DATABASE_URL` at
+the local **dev** database and `cleanupDatabase()` deletes real rows. Scope it:
+`pnpm --filter web test`.
+
+**Local migrations** are `pnpm db:local:migrate`. `pnpm db:seed` and
+`pnpm db:reset` TRUNCATE.

--- a/infrastructure/runpod/handler/main.py
+++ b/infrastructure/runpod/handler/main.py
@@ -1413,5 +1413,11 @@ def handler(job: dict[str, Any]) -> dict[str, Any]:
         shutil.rmtree(work_dir, ignore_errors=True)
 
 
-# RunPod serverless entry point
-runpod.serverless.start({"handler": handler})
+# RunPod serverless entry point.
+#
+# Guarded so this module can be imported without starting the serverless loop —
+# local_server.py imports `handler` directly to run jobs on a background thread
+# (see LOCAL_DEV.md). Production is unaffected: its CMD is
+# `python3 -u handler/main.py`, so __name__ == "__main__" and this still runs.
+if __name__ == "__main__":
+    runpod.serverless.start({"handler": handler})

--- a/infrastructure/runpod/local_server.py
+++ b/infrastructure/runpod/local_server.py
@@ -1,0 +1,156 @@
+"""
+Local async job server for the Codex transcoder container (development only).
+
+WHY THIS EXISTS
+───────────────
+runpod-python ships a local test server (`--rp_serve_api`), but its `/run`
+route is a stub. From runpod 1.12.0, rp_fastapi.py:
+
+    async def _sim_run(self, job_request):
+        assigned_job_id = f"test-{uuid.uuid4()}"
+        job_list.add({...})                                  # stash only
+        return {"id": assigned_job_id, "status": "IN_PROGRESS"}
+
+The handler is never invoked. Work happens only in `_sim_runsync` (blocks until
+the transcode finishes) or `_sim_status` (same, on a later poll). That leaves no
+good option for Codex:
+
+  · POST /run     → dispatch "succeeds", nothing ever transcodes. Silent no-op.
+  · POST /runsync → blocks for the whole transcode. But media-api dispatches
+                    inside ctx.waitUntil() with AbortSignal.timeout(30_000), so
+                    at t+30s the fetch aborts and dispatchRunPodJob() tries to
+                    mark the media FAILED while the container is still working.
+
+Production has neither problem, because RunPod's cloud `/run` queues the job and
+returns in under a second. This server reproduces that contract locally: accept
+the job, hand back an id immediately, do the work on a background thread, and
+let the handler post its own completion webhook — exactly as in production. So
+`RUNPOD_DIRECT_URL` uses the same `/run` path locally as in the cloud.
+
+Access logging is left ON deliberately. With `--rp_serve_api` a request that
+arrived and returned 200 produced no log line at all, which made a working
+dispatch indistinguishable from one that never left the worker, and cost real
+debugging hours.
+
+See infrastructure/runpod/LOCAL_DEV.md.
+"""
+
+import os
+import threading
+import traceback
+import uuid
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+# Import AFTER the module guard in main.py, so importing does not start
+# runpod's serverless loop.
+from handler.main import handler as transcode_handler
+
+app = FastAPI(title="Codex local transcoder", docs_url=None, redoc_url=None)
+
+# job_id → {"status": ..., "output": ..., "error": ...}
+# In-memory and unbounded: this process is a dev container that gets restarted,
+# and a handful of jobs per session is the realistic ceiling.
+_jobs: dict[str, dict[str, Any]] = {}
+_jobs_lock = threading.Lock()
+
+
+def _set(job_id: str, **fields: Any) -> None:
+    with _jobs_lock:
+        _jobs.setdefault(job_id, {}).update(fields)
+
+
+def _run_job(job_id: str, job_input: dict[str, Any]) -> None:
+    """Execute one job to completion on this thread.
+
+    The handler posts its own success/failure webhook, so nothing here needs to
+    notify media-api. We only record terminal state for GET /status/{job_id}.
+    """
+    _set(job_id, status="IN_PROGRESS")
+    try:
+        output = transcode_handler({"id": job_id, "input": job_input})
+        # The handler returns {"status": "error", ...} for handled failures
+        # rather than raising, so inspect the payload as well.
+        failed = isinstance(output, dict) and output.get("status") == "error"
+        _set(
+            job_id,
+            status="FAILED" if failed else "COMPLETED",
+            output=output,
+        )
+        print(
+            f"[local-server] job {job_id} {'FAILED' if failed else 'COMPLETED'}",
+            flush=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — a dev server must not die on one bad job
+        _set(job_id, status="FAILED", error=str(exc))
+        print(f"[local-server] job {job_id} raised: {exc}", flush=True)
+        traceback.print_exc()
+
+
+@app.post("/run")
+async def run(payload: dict[str, Any]) -> JSONResponse:
+    """Asynchronous dispatch — mirrors RunPod cloud POST /v2/{endpoint}/run."""
+    job_input = payload.get("input")
+    if not isinstance(job_input, dict):
+        return JSONResponse({"error": 'body must be {"input": {...}}'}, status_code=400)
+
+    job_id = f"local-{uuid.uuid4()}"
+    _set(job_id, status="IN_QUEUE")
+    threading.Thread(
+        target=_run_job, args=(job_id, job_input), daemon=True, name=job_id
+    ).start()
+
+    print(f"[local-server] accepted job {job_id}", flush=True)
+    return JSONResponse({"id": job_id, "status": "IN_PROGRESS"})
+
+
+@app.post("/runsync")
+async def runsync(payload: dict[str, Any]) -> JSONResponse:
+    """Synchronous dispatch — for poking the handler by hand from a shell.
+
+    Not for use by media-api: it blocks past the 30s dispatch timeout.
+    """
+    job_input = payload.get("input")
+    if not isinstance(job_input, dict):
+        return JSONResponse({"error": 'body must be {"input": {...}}'}, status_code=400)
+
+    job_id = f"local-sync-{uuid.uuid4()}"
+    _run_job(job_id, job_input)
+    with _jobs_lock:
+        record = dict(_jobs.get(job_id, {}))
+    return JSONResponse({"id": job_id, **record})
+
+
+@app.get("/status/{job_id}")
+async def status(job_id: str) -> JSONResponse:
+    with _jobs_lock:
+        record = dict(_jobs.get(job_id, {}))
+    if not record:
+        return JSONResponse(
+            {"id": job_id, "status": "FAILED", "error": "Job ID not found"},
+            status_code=404,
+        )
+    return JSONResponse({"id": job_id, **record})
+
+
+@app.get("/health")
+async def health() -> dict[str, Any]:
+    with _jobs_lock:
+        running = sum(1 for j in _jobs.values() if j.get("status") == "IN_PROGRESS")
+        total = len(_jobs)
+    return {"status": "ok", "jobs_running": running, "jobs_seen": total}
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host=os.environ.get(
+            "LOCAL_SERVER_HOST", "0.0.0.0"
+        ),  # noqa: S104 — container-internal
+        port=int(os.environ.get("LOCAL_SERVER_PORT", "8000")),
+        access_log=True,
+        log_level=os.environ.get("LOCAL_SERVER_LOG_LEVEL", "info"),
+    )

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:notifications-api": "turbo run dev --filter=notifications-api",
     "dev:dev-cdn": "turbo run dev --filter=dev-cdn",
     "dev:stripe-webhooks": "bash infrastructure/stripe/dev-webhooks.sh",
-    "dev:transcoder": "cd infrastructure/runpod && docker run --rm --env-file local.env -p 8000:8000 codex-transcoder-local",
+    "dev:transcoder": "cd infrastructure/runpod && docker run --rm --name codex-transcoder --env-file local.env -p 8010:8000 codex-transcoder-local",
     "dev:transcoder:build": "cd infrastructure/runpod && docker build -f Dockerfile.local -t codex-transcoder-local .",
     "dev": "concurrently \"pnpm docker:up && wait-on tcp:4444 && pnpm dev:web\" \"pnpm dev:admin-api\" \"pnpm dev:auth\" \"pnpm dev:ecom-api\" \"pnpm dev:content-api\" \"pnpm dev:identity-api\" \"pnpm dev:media-api\" \"pnpm dev:organization-api\" \"pnpm dev:notifications-api\" \"pnpm dev:dev-cdn\" \"pnpm dev:stripe-webhooks\"",
     "dev:clean": "pnpm docker:down && rm -rf node_modules/.cache && rm -rf apps/*/dist && rm -rf workers/*/dist && rm -rf packages/*/dist",

--- a/packages/transcoding/CLAUDE.md
+++ b/packages/transcoding/CLAUDE.md
@@ -56,6 +56,28 @@ RunPod's `/run` endpoint is fire-and-forget:
 
 `triggerJob()` returns as soon as RunPod acknowledges the job — it does NOT wait for transcoding to complete.
 
+### The dispatch runs in `ctx.background`, not `waitUntil`
+
+`triggerJobInternal()` returns `{ dispatchPromise }`; the route registers it with
+**`ctx.background(...)`**, not `ctx.executionCtx.waitUntil(...)`. The dispatch
+writes to the DB after the response is sent (the job id on success,
+`status='failed'` on error), and a bare `waitUntil` races `procedure()`'s own
+`waitUntil(cleanup())` — which calls `pool.end()` and reliably wins. Both writes
+then failed silently, so a dead dispatch left the row at `transcoding` with no
+error recorded. Use `ctx.background` for any post-response DB work.
+
+Also note `AbortSignal.timeout(runpodTimeout)` is 30 000 ms, the same as
+Cloudflare's `waitUntil` ceiling. That is fine against RunPod's cloud `/run`
+(returns in <1s) but fatal against any blocking dispatch endpoint.
+
+### Local development
+
+Local dev does **not** talk to RunPod. It posts to a container running
+`infrastructure/runpod/local_server.py` via `RUNPOD_DIRECT_URL`, which
+reproduces the cloud `/run` contract. Do not point it at runpod-python's
+`--rp_serve_api`: that server's `/run` never invokes the handler at all.
+See **[infrastructure/runpod/LOCAL_DEV.md](../../infrastructure/runpod/LOCAL_DEV.md)**.
+
 ## R2 Path Utilities (`paths.ts`)
 
 **Always use these functions — never hardcode R2 paths.**

--- a/packages/worker-utils/src/procedure/binary-upload-procedure.ts
+++ b/packages/worker-utils/src/procedure/binary-upload-procedure.ts
@@ -53,6 +53,7 @@ import type {
 } from './types';
 import {
   buildBaseProcedureContext,
+  createBackgroundTracker,
   runUploadOrchestration,
   sendUploadResponse,
 } from './upload-shared';
@@ -156,6 +157,10 @@ export function binaryUploadProcedure<
     const obs = c.get('obs') as ObservabilityClient | undefined;
     let cleanup: (() => Promise<void>) | undefined;
 
+    // Handler-registered background work (ctx.background); cleanup is
+    // chained after it settles. See createBackgroundTracker.
+    const tracker = createBackgroundTracker();
+
     try {
       // Policy enforcement + service registry (shared scaffold).
       const orchestration = await runUploadOrchestration(c, policy, obs);
@@ -173,7 +178,8 @@ export function binaryUploadProcedure<
           orchestration.organizationId,
           validatedInput,
           orchestration.registry,
-          obs
+          obs,
+          tracker.background
         ),
         file: validatedFile,
       };
@@ -184,8 +190,10 @@ export function binaryUploadProcedure<
       const { statusCode, response } = mapErrorToResponse(error, { obs });
       return c.json(response, statusCode);
     } finally {
+      // Chained after ctx.background work — see createBackgroundTracker.
       if (cleanup) {
-        c.executionCtx.waitUntil(cleanup());
+        const runCleanup = cleanup;
+        c.executionCtx.waitUntil(tracker.settled().then(() => runCleanup()));
       }
     }
   };

--- a/packages/worker-utils/src/procedure/multipart-procedure.ts
+++ b/packages/worker-utils/src/procedure/multipart-procedure.ts
@@ -49,6 +49,7 @@ import type {
 } from './types';
 import {
   buildBaseProcedureContext,
+  createBackgroundTracker,
   runUploadOrchestration,
   sendUploadResponse,
 } from './upload-shared';
@@ -215,6 +216,10 @@ export function multipartProcedure<
     const obs = c.get('obs') as ObservabilityClient | undefined;
     let cleanup: (() => Promise<void>) | undefined;
 
+    // Handler-registered background work (ctx.background); cleanup is
+    // chained after it settles. See createBackgroundTracker.
+    const tracker = createBackgroundTracker();
+
     try {
       // Policy enforcement + service registry (shared scaffold).
       const orchestration = await runUploadOrchestration(c, policy, obs);
@@ -233,7 +238,8 @@ export function multipartProcedure<
           orchestration.organizationId,
           validatedInput,
           orchestration.registry,
-          obs
+          obs,
+          tracker.background
         ),
         files: validatedFiles as InferFiles<TFiles>,
       };
@@ -244,8 +250,10 @@ export function multipartProcedure<
       const { statusCode, response } = mapErrorToResponse(error, { obs });
       return c.json(response, statusCode);
     } finally {
+      // Chained after ctx.background work — see createBackgroundTracker.
       if (cleanup) {
-        c.executionCtx.waitUntil(cleanup());
+        const runCleanup = cleanup;
+        c.executionCtx.waitUntil(tracker.settled().then(() => runCleanup()));
       }
     }
   };

--- a/packages/worker-utils/src/procedure/procedure.ts
+++ b/packages/worker-utils/src/procedure/procedure.ts
@@ -34,7 +34,10 @@ import type {
   ProcedureHandler,
   ProcedurePolicy,
 } from './types';
-import { buildBaseProcedureContext } from './upload-shared';
+import {
+  buildBaseProcedureContext,
+  createBackgroundTracker,
+} from './upload-shared';
 
 /**
  * Create a tRPC-style procedure handler
@@ -113,6 +116,11 @@ export function procedure<
     let registry: ReturnType<typeof createServiceRegistry>['registry'];
     let cleanup: (() => Promise<void>) | undefined;
 
+    // Handler-registered background work (ctx.background). Cleanup is chained
+    // after this settles — see createBackgroundTracker for why waitUntil alone
+    // is unsafe for background DB access.
+    const tracker = createBackgroundTracker();
+
     try {
       // ====================================================================
       // Step 1: Enforce Policy (auth, RBAC, IP, org membership)
@@ -145,7 +153,7 @@ export function procedure<
       const ctx: ProcedureContext<TPolicy, TInput> = buildBaseProcedureContext<
         TPolicy,
         TInput
-      >(c, organizationId, validatedInput, registry, obs);
+      >(c, organizationId, validatedInput, registry, obs, tracker.background);
 
       // ====================================================================
       // Step 5: Execute Handler
@@ -178,9 +186,12 @@ export function procedure<
       // ====================================================================
       // Step 8: Cleanup Services
       // ====================================================================
-      // Only cleanup if registry was created
+      // Only cleanup if registry was created.
+      // Chained AFTER ctx.background work so tearing down the DB pool cannot
+      // pull the connection out from under a still-running background task.
       if (cleanup) {
-        c.executionCtx.waitUntil(cleanup());
+        const runCleanup = cleanup;
+        c.executionCtx.waitUntil(tracker.settled().then(() => runCleanup()));
       }
     }
   };

--- a/packages/worker-utils/src/procedure/types.ts
+++ b/packages/worker-utils/src/procedure/types.ts
@@ -314,6 +314,26 @@ export interface ProcedureContext<
   // Execution context for non-blocking operations
   executionCtx: ExecutionContext;
 
+  /**
+   * Register background work that must finish BEFORE the service registry's
+   * DB clients are torn down.
+   *
+   * `ctx.executionCtx.waitUntil()` is NOT safe for background work that
+   * touches the database. procedure() schedules its own
+   * `waitUntil(cleanup())` when the handler returns, and cleanup calls
+   * `pool.end()` on the shared per-request client — so the two race, and
+   * cleanup (being near-instant) reliably wins. Any DB write attempted after
+   * that fails with a bare "Failed query", and if it was an error-reporting
+   * write the failure vanishes entirely.
+   *
+   * Use this instead whenever the background task reads or writes the DB;
+   * cleanup is chained after everything registered here settles. Plain
+   * `waitUntil` remains correct for work that never touches the DB.
+   *
+   * Returns the promise it was given, so it can be used inline.
+   */
+  background: <T>(promise: Promise<T>) => Promise<T>;
+
   // Observability client
   obs: ObservabilityClient | undefined;
 

--- a/packages/worker-utils/src/procedure/upload-shared.ts
+++ b/packages/worker-utils/src/procedure/upload-shared.ts
@@ -78,6 +78,38 @@ export async function runUploadOrchestration(
  * structurally a `ProcedureContext<TPolicy, TInput>` since
  * `ProcedureContext.services` is `ServiceRegistry`.
  */
+/**
+ * Collects handler-registered background work so the caller can tear down the
+ * service registry only after that work has settled.
+ *
+ * Exists because `waitUntil(cleanup())` and a handler's own
+ * `waitUntil(backgroundTask)` are siblings, not ordered: cleanup calls
+ * `pool.end()` on the shared per-request DB client and, being near-instant,
+ * reliably wins. Any DB access the background task attempts afterwards fails
+ * with a bare "Failed query" — and when the task's whole purpose was to record
+ * a failure, that failure disappears silently.
+ */
+export interface BackgroundTracker {
+  /** Register a task; returns the same promise so it can be used inline. */
+  background: <T>(promise: Promise<T>) => Promise<T>;
+  /** Resolves once every registered task has settled (never rejects). */
+  settled: () => Promise<unknown>;
+}
+
+export function createBackgroundTracker(): BackgroundTracker {
+  const tasks: Promise<unknown>[] = [];
+
+  return {
+    background: (promise) => {
+      tasks.push(promise);
+      return promise;
+    },
+    // allSettled attaches handlers, so a rejecting task cannot surface as an
+    // unhandled rejection, and one failure never skips cleanup.
+    settled: () => Promise.allSettled(tasks),
+  };
+}
+
 export function buildBaseProcedureContext<
   TPolicy extends ProcedurePolicy,
   TInput extends InputSchema | undefined,
@@ -86,11 +118,13 @@ export function buildBaseProcedureContext<
   organizationId: string | undefined,
   validatedInput: unknown,
   registry: ServiceRegistry,
-  obs: ObservabilityClient | undefined
+  obs: ObservabilityClient | undefined,
+  background: BackgroundTracker['background']
 ): Omit<ProcedureContext<TPolicy, TInput>, 'services'> & {
   services: ServiceRegistry;
 } {
   return {
+    background,
     user: c.get('user') as ProcedureContext<TPolicy, TInput>['user'],
     session: c.get('session') as ProcedureContext<TPolicy, TInput>['session'],
     input: validatedInput as ProcedureContext<TPolicy, TInput>['input'],

--- a/workers/dev-cdn/src/index.ts
+++ b/workers/dev-cdn/src/index.ts
@@ -223,6 +223,37 @@ async function handleS3Request(
   bucket: R2Bucket,
   key: string
 ): Promise<Response> {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Multipart upload (Codex: local transcoding of real-sized media)
+  //
+  // boto3 switches to multipart automatically once a file exceeds
+  // TransferConfig.multipart_threshold (8 MB by default), so the Python
+  // transcoding handler uses it for any HLS output of consequence — a
+  // single-file `stream.ts` for a 47 MB source is comfortably over the line.
+  // Without these four routes dev-cdn answered `POST ?uploads` with 405 and
+  // every large local transcode died at the upload step.
+  //
+  // Not skipped by raising the threshold in the Python handler on purpose:
+  // production DOES use multipart against real R2, and a local dev path that
+  // never exercises it would hide multipart bugs until they reached prod.
+  // ─────────────────────────────────────────────────────────────────────────
+  const params = new URL(request.url).searchParams;
+  const uploadId = params.get('uploadId');
+  const partNumber = params.get('partNumber');
+
+  if (request.method === 'POST' && params.has('uploads')) {
+    return handleS3CreateMultipart(bucket, key);
+  }
+  if (request.method === 'PUT' && uploadId && partNumber) {
+    return handleS3UploadPart(request, bucket, key, uploadId, partNumber);
+  }
+  if (request.method === 'POST' && uploadId) {
+    return handleS3CompleteMultipart(request, bucket, key, uploadId);
+  }
+  if (request.method === 'DELETE' && uploadId) {
+    return handleS3AbortMultipart(bucket, key, uploadId);
+  }
+
   switch (request.method) {
     case 'GET':
       return handleS3Get(request, bucket, key);
@@ -235,6 +266,145 @@ async function handleS3Request(
     default:
       return new Response('Method Not Allowed', { status: 405 });
   }
+}
+
+/** Escape the five XML entities so keys with `&` or quotes cannot break the document. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function xmlResponse(xml: string, status = 200): Response {
+  return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n${xml}`, {
+    status,
+    headers: { 'content-type': 'application/xml', ...CORS_HEADERS },
+  });
+}
+
+/** S3 CreateMultipartUpload — `POST /{bucket}/{key}?uploads` */
+async function handleS3CreateMultipart(
+  bucket: R2Bucket,
+  key: string
+): Promise<Response> {
+  const upload = await bucket.createMultipartUpload(key);
+
+  return xmlResponse(
+    `<InitiateMultipartUploadResult>
+  <Bucket>local</Bucket>
+  <Key>${escapeXml(key)}</Key>
+  <UploadId>${escapeXml(upload.uploadId)}</UploadId>
+</InitiateMultipartUploadResult>`
+  );
+}
+
+/**
+ * S3 UploadPart — `PUT /{bucket}/{key}?partNumber=N&uploadId=X`
+ *
+ * The ETag returned here is R2's, and boto3 echoes it back verbatim in the
+ * CompleteMultipartUpload body. `complete()` rejects any part whose etag does
+ * not match, so this value must round-trip untouched.
+ */
+async function handleS3UploadPart(
+  request: Request,
+  bucket: R2Bucket,
+  key: string,
+  uploadId: string,
+  partNumber: string
+): Promise<Response> {
+  const part = Number(partNumber);
+  if (!Number.isInteger(part) || part < 1 || part > 10_000) {
+    return s3Error('InvalidArgument', `Bad partNumber: ${partNumber}`, 400);
+  }
+
+  const upload = bucket.resumeMultipartUpload(key, uploadId);
+  const body = await request.arrayBuffer();
+
+  try {
+    const uploaded = await upload.uploadPart(part, body);
+    const headers = new Headers(CORS_HEADERS);
+    headers.set('etag', `"${uploaded.etag}"`);
+    return new Response(null, { status: 200, headers });
+  } catch (error) {
+    return s3Error(
+      'NoSuchUpload',
+      `Upload ${uploadId} part ${part} failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      404
+    );
+  }
+}
+
+/**
+ * S3 CompleteMultipartUpload — `POST /{bucket}/{key}?uploadId=X`
+ *
+ * Parses the part list from the request body. A regex is adequate here: this
+ * worker is never deployed, and the only client is boto3's fixed serialiser.
+ */
+async function handleS3CompleteMultipart(
+  request: Request,
+  bucket: R2Bucket,
+  key: string,
+  uploadId: string
+): Promise<Response> {
+  const xml = await request.text();
+  const parts: R2UploadedPart[] = [];
+
+  for (const block of xml.match(/<Part>[\s\S]*?<\/Part>/g) ?? []) {
+    const num = /<PartNumber>\s*(\d+)\s*<\/PartNumber>/.exec(block);
+    const tag = /<ETag>\s*(?:&quot;|")?(.*?)(?:&quot;|")?\s*<\/ETag>/.exec(
+      block
+    );
+    const partNumber = num?.[1];
+    const etag = tag?.[1];
+    if (partNumber !== undefined && etag !== undefined) {
+      parts.push({ partNumber: Number(partNumber), etag });
+    }
+  }
+
+  if (parts.length === 0) {
+    return s3Error('MalformedXML', 'No <Part> entries in completion body', 400);
+  }
+
+  const upload = bucket.resumeMultipartUpload(key, uploadId);
+
+  try {
+    const object = await upload.complete(parts);
+    return xmlResponse(
+      `<CompleteMultipartUploadResult>
+  <Location>${escapeXml(key)}</Location>
+  <Bucket>local</Bucket>
+  <Key>${escapeXml(key)}</Key>
+  <ETag>${escapeXml(object.httpEtag)}</ETag>
+</CompleteMultipartUploadResult>`
+    );
+  } catch (error) {
+    return s3Error(
+      'InvalidPart',
+      `Completing ${uploadId} failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      400
+    );
+  }
+}
+
+/** S3 AbortMultipartUpload — `DELETE /{bucket}/{key}?uploadId=X` */
+async function handleS3AbortMultipart(
+  bucket: R2Bucket,
+  key: string,
+  uploadId: string
+): Promise<Response> {
+  try {
+    await bucket.resumeMultipartUpload(key, uploadId).abort();
+  } catch {
+    // An already-aborted or unknown upload is not worth failing the caller for.
+  }
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
 }
 
 /** S3 GetObject — returns the object body, honouring Range with a 206 when present */

--- a/workers/media-api/.dev.vars.example
+++ b/workers/media-api/.dev.vars.example
@@ -1,0 +1,71 @@
+# Media API Worker (port 4002) — local development variables
+#
+# Copy to `.dev.vars` (gitignored). Every value below is a LOCAL placeholder —
+# none of these are real credentials. See infrastructure/runpod/LOCAL_DEV.md for
+# the full local transcoding walkthrough.
+#
+# Wrangler reads .dev.vars at worker START. If you edit it, restart the worker —
+# do not assume a hot reload picked it up.
+
+# ---------------------------------------------------------------------------
+# Database — LOCAL_PROXY mode (db_method is set in wrangler.jsonc)
+# ---------------------------------------------------------------------------
+DATABASE_URL_LOCAL_PROXY=postgres://postgres:postgres@db.localtest.me:5432/main
+
+# BetterAuth secret (min 32 characters)
+BETTER_AUTH_SECRET=local-dev-secret-key-min-32-chars-long-for-auth
+
+# ---------------------------------------------------------------------------
+# RunPod — NOT used against the real RunPod API in local dev
+# ---------------------------------------------------------------------------
+# These two are only required because TranscodingService validates their
+# presence in its constructor. When RUNPOD_DIRECT_URL is set they are unused
+# for routing (the key is still sent as a Bearer token and ignored locally).
+RUNPOD_API_KEY=local-dev-not-used
+RUNPOD_ENDPOINT_ID=local-dev-not-used
+
+# HMAC secret the container signs its completion webhook with.
+# MUST match WEBHOOK_SECRET in infrastructure/runpod/local.env.
+RUNPOD_WEBHOOK_SECRET=local-webhook-secret-for-testing
+
+# ---------------------------------------------------------------------------
+# RUNPOD_DIRECT_URL — the local transcoder container
+# ---------------------------------------------------------------------------
+# Used AS-IS by TranscodingService (skips RunPod's /v2/{endpoint}/run path
+# construction). Three parts of this value are load-bearing:
+#
+#   · /run — the same path production uses. The local container serves
+#     infrastructure/runpod/local_server.py, which reproduces RunPod's cloud
+#     contract: it returns a job id immediately and transcodes on a background
+#     thread. Do NOT point this at runpod-python's own `--rp_serve_api`, whose
+#     `/run` is a stub that never invokes the handler (silent no-op) and whose
+#     `/runsync` blocks for the whole transcode — tripping media-api's 30s
+#     dispatch timeout, which then marks still-running jobs as failed.
+#
+#   · port 8010 — the container listens on 8000 internally, but host port 8000
+#     is commonly taken, so `pnpm dev:transcoder` publishes it on 8010.
+#
+#   · 127.0.0.1 is fine: workerd under `wrangler dev` CAN fetch loopback
+#     (verified 2026-08-21). A LAN IP also works but breaks whenever your
+#     DHCP lease changes.
+RUNPOD_DIRECT_URL=http://127.0.0.1:8010/run
+
+# ---------------------------------------------------------------------------
+# Webhook callback — container → host
+# ---------------------------------------------------------------------------
+# The container needs a host-reachable address, so this is host.docker.internal
+# rather than localhost. TranscodingService appends /api/transcoding/webhook.
+TRANSCODING_WEBHOOK_URL=http://host.docker.internal:4002
+
+# ---------------------------------------------------------------------------
+# Worker-to-worker HMAC — must match content-api's .dev.vars
+# ---------------------------------------------------------------------------
+WORKER_SHARED_SECRET=test-worker-shared-secret
+
+# ---------------------------------------------------------------------------
+# B2 (MinIO) — mezzanine archival storage
+# ---------------------------------------------------------------------------
+B2_ENDPOINT=http://localhost:9000
+B2_KEY_ID=minioadmin
+B2_APP_KEY=minioadmin
+B2_BUCKET=codex-mezzanine-dev

--- a/workers/media-api/src/routes/transcoding.ts
+++ b/workers/media-api/src/routes/transcoding.ts
@@ -53,11 +53,19 @@ app.post(
       const { dispatchPromise } =
         await ctx.services.transcoding.triggerJobInternal(id, priority);
 
-      // dispatchRunPodJob is internally try/caught (marks media failed on
-      // error), so dispatchPromise should never reject. The .catch is
-      // belt-and-suspenders: any future change that lets a rejection
-      // escape will surface in obs instead of evaporating silently.
-      ctx.executionCtx.waitUntil(
+      // ctx.background, NOT ctx.executionCtx.waitUntil: the dispatch writes to
+      // the DB after the response is sent (the RunPod job id on success,
+      // status='failed' on error). A bare waitUntil races procedure()'s own
+      // waitUntil(cleanup()), which calls pool.end() and reliably wins — so
+      // both of those writes failed, every time. The success write was merely
+      // cosmetic (the webhook matches on mediaId), but the failure write is
+      // how a dead dispatch becomes visible at all; without it the row sits at
+      // 'transcoding' forever with no error recorded.
+      //
+      // dispatchRunPodJob is internally try/caught, so dispatchPromise should
+      // never reject. The .catch is belt-and-suspenders: any future change that
+      // lets a rejection escape will surface in obs instead of evaporating.
+      ctx.background(
         dispatchPromise.catch((err: unknown) => {
           ctx.obs?.error('Transcoding dispatch failed (waitUntil fallback)', {
             mediaId: id,

--- a/workers/notifications-api/.dev.vars.example
+++ b/workers/notifications-api/.dev.vars.example
@@ -1,0 +1,8 @@
+# Notifications API Worker - Development Environment Variables
+# Copy to .dev.vars and fill in actual values
+#
+# Note: DB_METHOD is set to LOCAL_PROXY in wrangler.jsonc,
+# so you need DATABASE_URL_LOCAL_PROXY (not DATABASE_URL)
+
+# Database (LOCAL_PROXY mode)
+DATABASE_URL_LOCAL_PROXY=postgres://postgres:postgres@db.localtest.me:5432/main

--- a/workers/organization-api/.dev.vars.example
+++ b/workers/organization-api/.dev.vars.example
@@ -1,0 +1,10 @@
+DATABASE_URL=postgres://postgres:postgres@db.localtest.me:5432/main
+DATABASE_URL_LOCAL_PROXY=postgres://postgres:postgres@db.localtest.me:5432/main
+DB_METHOD=LOCAL_PROXY
+BETTER_AUTH_SECRET=test-secret-key-min-32-chars-long-for-testing
+BETTER_AUTH_URL=http://localhost:42069
+AUTH_TRUST_HOST=true
+
+# Local CDN override — serves Miniflare R2 files via dev-cdn worker (port 4100)
+# Run `pnpm dev:dev-cdn` alongside this worker for org logos to load on reload
+R2_PUBLIC_URL_BASE=http://localhost:4100


### PR DESCRIPTION
…s visible

Local transcoding has been silently doing nothing. Four separate faults, only the first of which was a local-dev concern.

1. RUNPOD_DIRECT_URL pointed at /run. On runpod-python's --rp_serve_api, `_sim_run` stashes the job in a list and returns IN_PROGRESS without ever invoking the handler. The dispatch "succeeded" and nothing transcoded, with no log line and no error. Its /runsync does run the handler, but blocks for the whole transcode — which trips (2).

   The container now serves infrastructure/runpod/local_server.py, which reproduces the cloud contract: accept, return a job id immediately, transcode on a background thread, webhook on completion. Local and production therefore use the identical /run path. handler/main.py guards runpod.serverless.start() under __main__ so the module is importable; production is unaffected (its CMD is `python3 -u handler/main.py`).

2. AbortSignal.timeout(30_000) matches Cloudflare's documented 30s waitUntil ceiling, so a blocking dispatch aborts and markTranscodingFailed marks the media failed while the container is still successfully transcoding it. Measured at exactly t+30s. An async /run never approaches it.

3. dev-cdn implemented no S3 multipart routes. boto3 goes multipart above 8MB, so every HLS output of real size died with 405 CreateMultipartUpload — a 47MB source produces a 35MB stream.ts. Implemented on R2's binding API rather than raising the threshold in the Python handler, because production genuinely uses multipart and a local path that skipped it would hide multipart bugs until prod.

4. procedure() schedules waitUntil(cleanup()) — pool.end() — as a sibling of any handler-registered waitUntil work, and being near-instant it reliably wins. Every post-response DB write from the transcode dispatch therefore failed: 0 of 1083 media_items rows had ever stored a runpod_job_id. The job id was cosmetic (the webhook matches on mediaId), but markTranscodingFailed could not write either, so a dead dispatch left the row at 'transcoding' with no error recorded — indistinguishable from work in progress.

   Adds ctx.background(promise); cleanup is chained after it settles. Applied to all three procedures, which shared the race. Plain waitUntil remains correct for background work that never touches the DB.

Verified end to end: 488KB audio ready in ~20s; 47MB audio ready at t+348s with 35MB + 18MB stream.ts uploaded via multipart (previously failed at 405); a dead dispatch target now yields status=failed with the error text in ~2s.

Also: `pnpm dev:transcoder` published -p 8000:8000, which collides with a commonly-occupied host port and so could not work; now 8010. There was no committed source of truth for any local transcoding config — .gitignore swallowed .dev.vars.example even though five siblings were already tracked — so the working setup only ever existed in one shell's history. Fixed, with infrastructure/runpod/LOCAL_DEV.md as the reference.

Gates: typecheck 57/57, worker-utils 101 passed, media-api 27 passed, biome clean.