### PR TITLE
feat(hero): the hero plays its media — author-chosen mode across all six compositions

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1474,6 +1474,8 @@
   "monetisation_revshare_propose_aria": "Propose a {type} revenue split with {name}",
   "journey_hero_cta_default": "Get started",
   "journey_hero_cta_enrolled": "Go to your dashboard",
+  "journey_hero_media_play": "Watch the film",
+  "journey_hero_media_play_aria": "Play the hero film",
   "journey_reel_tag_default": "Preview",
   "journey_invite_cta_default": "Join now",
   "journey_map_practice_label": "Practice",

--- a/apps/web/src/lib/components/page-builder/SectionEditor.svelte
+++ b/apps/web/src/lib/components/page-builder/SectionEditor.svelte
@@ -37,6 +37,7 @@
     isAxisValue,
   } from './design-vocabulary';
   import { fieldsForSectionType } from './section-fields';
+  import type { SectionFieldDef } from './section-fields';
   import ArrayField from './ArrayField.svelte';
   import VariantPicker from './VariantPicker.svelte';
 
@@ -47,6 +48,24 @@
   const { section }: Props = $props();
 
   const definition = $derived(findSectionDefinition(section.type));
+
+  /**
+   * The axis gate for a field, or null when it is not gated / not currently held.
+   *
+   * A field declaring `disabledWhenAxis` is one whose CONTENT choice a DESIGN axis
+   * can overrule — today only the hero's `mediaMode` under `media: none`. Rather
+   * than let the author pick something with no effect, the control goes disabled
+   * and the returned `reason` is shown in place of its hint.
+   *
+   * `section.design` is a bag of axis→value strings; the cast is to index it by a
+   * declared axis name without widening anything to `any`.
+   */
+  const axisGate = (field: SectionFieldDef) => {
+    const gate = field.disabledWhenAxis;
+    if (!gate) return null;
+    const axes = section.design as Record<string, string | undefined> | undefined;
+    return axes?.[gate.axis] === gate.value ? gate : null;
+  };
   /**
    * ALL EIGHT DECLARED CONTROL KINDS ARE NOW BUILT (`Codex-28ifd` closed).
    *
@@ -282,6 +301,7 @@
           {/if}
         </label>
       {:else}
+      {@const gate = axisGate(field)}
       <label class="section-editor__field">
         <span class="section-editor__field-label">{field.label}</span>
         {#if field.control === 'textarea'}
@@ -290,6 +310,7 @@
             rows="3"
             placeholder={field.placeholder}
             value={valueOf(field.key)}
+            disabled={Boolean(gate)}
             oninput={(e) => onInput(field.key, e)}
           ></textarea>
         {:else if field.control === 'number'}
@@ -298,12 +319,14 @@
             class="section-editor__input"
             placeholder={field.placeholder}
             value={numberOf(field.key)}
+            disabled={Boolean(gate)}
             oninput={(e) => onNumber(field.key, e)}
           />
         {:else if field.control === 'select'}
           <select
             class="section-editor__input"
             value={valueOf(field.key)}
+            disabled={Boolean(gate)}
             onchange={(e) => onInput(field.key, e)}
           >
             {#each field.options ?? [] as opt (opt.value)}
@@ -316,10 +339,15 @@
             class="section-editor__input"
             placeholder={field.placeholder}
             value={valueOf(field.key)}
+            disabled={Boolean(gate)}
             oninput={(e) => onInput(field.key, e)}
           />
         {/if}
-        {#if field.hint}
+        {#if gate}
+          <!-- The reason REPLACES the hint: a hint about what the control does is
+               noise while the control cannot do it. -->
+          <span class="section-editor__hint">{gate.reason}</span>
+        {:else if field.hint}
           <span class="section-editor__hint">{field.hint}</span>
         {/if}
       </label>

--- a/apps/web/src/lib/components/page-builder/section-editor-controls.svelte.test.ts
+++ b/apps/web/src/lib/components/page-builder/section-editor-controls.svelte.test.ts
@@ -162,3 +162,100 @@ describe('SectionEditor — only authorable control kinds reach the DOM', () => 
     expect(unaccounted).toEqual([]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE AXIS GATE (`disabledWhenAxis` · `Codex-uj4jc`)
+//
+// The hero's `mediaMode` chooses WHICH asset appears; the `media` axis decides
+// HOW it is shaped, and `media: none` means "no plate at all" — so the axis
+// necessarily wins. Both alternatives were worse than saying so. Silently
+// ignoring the mode leaves an author picking "silent looping video", seeing
+// nothing, and having no way to find out why. Auto-lifting the axis mutates a
+// DESIGN decision as a side effect of a CONTENT choice, which is exactly the
+// conflation this field set exists to keep apart.
+//
+// `HeroSection.svelte.test.ts` asserts the renderer's half (the axis overrules
+// the mode). This asserts the builder's half: the control is visibly unavailable
+// and the reason is on screen. Both halves are needed — a disabled control with
+// a renderer that ignored the axis would be a lie in the other direction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The `<label>` wrapping a field, found by its visible label text. */
+function fieldByLabel(text: string): HTMLElement | null {
+  const span = [
+    ...document.body.querySelectorAll('.section-editor__field-label'),
+  ].find((s) => s.textContent?.trim() === text);
+  return (span?.closest('.section-editor__field') as HTMLElement) ?? null;
+}
+
+function heroSection(design?: Record<string, string>): PageSection {
+  return {
+    id: 's-hero',
+    type: 'hero',
+    enabled: true,
+    props: {},
+    design,
+  } as PageSection;
+}
+
+describe('SectionEditor — a design axis can gate a content control', () => {
+  it('leaves the media mode authorable while the axis allows a plate', () => {
+    const component = mount(SectionEditor, {
+      target: document.body,
+      props: { section: heroSection({ media: 'bleed' }) },
+    });
+    flushSync();
+
+    const field = fieldByLabel('What the media does');
+    expect(field).not.toBeNull();
+    const select = field?.querySelector('select');
+    expect(select).not.toBeNull();
+    expect(select?.disabled).toBe(false);
+
+    unmount(component);
+  });
+
+  it('disables it under `media: none` and shows the reason instead of the hint', () => {
+    const component = mount(SectionEditor, {
+      target: document.body,
+      props: { section: heroSection({ media: 'none' }) },
+    });
+    flushSync();
+
+    const field = fieldByLabel('What the media does');
+    expect(field?.querySelector('select')?.disabled).toBe(true);
+
+    // The reason REPLACES the hint — a hint about what a control does is noise
+    // while the control cannot do it.
+    const hint =
+      field?.querySelector('.section-editor__hint')?.textContent ?? '';
+    expect(hint).toContain('Media axis');
+    expect(hint).not.toContain('All six layouts');
+
+    unmount(component);
+  });
+
+  it('gates only the field that asked to be gated', () => {
+    // The mechanism is declarative and per-field. If it ever starts keying off
+    // something broader than `disabledWhenAxis`, a hero under `media: none` would
+    // go read-only wholesale — which would be a far worse bug than the one the
+    // gate fixes, and silent.
+    const component = mount(SectionEditor, {
+      target: document.body,
+      props: { section: heroSection({ media: 'none' }) },
+    });
+    flushSync();
+
+    const gated = SECTION_FIELDS.hero.filter((f) => f.disabledWhenAxis).length;
+    expect(gated).toBe(1);
+
+    const disabled = [
+      ...document.body.querySelectorAll<HTMLInputElement>(
+        'input, select, textarea'
+      ),
+    ].filter((el) => el.disabled).length;
+    expect(disabled).toBe(gated);
+
+    unmount(component);
+  });
+});

--- a/apps/web/src/lib/components/page-builder/section-fields.ts
+++ b/apps/web/src/lib/components/page-builder/section-fields.ts
@@ -92,6 +92,24 @@ export interface SectionFieldDef {
    */
   readonly mediaSlot?: JourneySellMediaSlot;
   /**
+   * Grey this control out while a design axis holds a given value, and say why.
+   *
+   * The case this exists for: the hero's `mediaMode` selects WHICH asset appears,
+   * while the `media` axis decides HOW it is shaped — and `media: none` means "no
+   * plate at all", so it necessarily wins. The alternative designs were both
+   * worse. Silently ignoring the mode leaves an author picking "silent looping
+   * video" and seeing nothing, with no explanation. Auto-lifting the axis mutates
+   * a DESIGN decision as a side effect of a CONTENT choice, which is the same
+   * conflation this field set exists to keep apart.
+   *
+   * So the control is visibly unavailable and the reason is on screen.
+   */
+  readonly disabledWhenAxis?: {
+    readonly axis: string;
+    readonly value: string;
+    readonly reason: string;
+  };
+  /**
    * For `control: 'repeater'` — the fields of ONE entry in the object array.
    *
    * Nesting is allowed exactly one level deep: an entry field may be a `list`
@@ -236,6 +254,32 @@ export const SECTION_FIELDS: Readonly<
       control: 'media',
       mediaSlot: 'heroMediaId',
       hint: 'The image the hero shows. Pick a ready item from your media library — its still frame is used.',
+    },
+    {
+      key: 'mediaMode',
+      label: 'What the media does',
+      control: 'select',
+      options: [
+        { value: '', label: 'Automatic — the still, if there is one' },
+        { value: 'none', label: 'Nothing — atmosphere only' },
+        { value: 'image', label: 'Still image' },
+        { value: 'loop', label: 'Silent looping video' },
+        { value: 'click', label: 'Video, played on click' },
+      ],
+      hint: 'All six layouts can carry media. The three with a media panel show it there; the other three offer a watch link beside the buttons instead.',
+      disabledWhenAxis: {
+        axis: 'media',
+        value: 'none',
+        reason:
+          'The Media axis is set to “none”, which removes the media panel entirely. Change it to choose what the media does.',
+      },
+    },
+    {
+      key: 'mediaLabel',
+      label: 'Watch link label',
+      control: 'text',
+      placeholder: 'Watch the film',
+      hint: 'Shown on the layouts that offer the video rather than displaying it. Yours to word, because the hero plays whichever clip you picked above — not necessarily an intro.',
     },
     {
       key: 'bg',

--- a/apps/web/src/lib/components/ui/HeroLoopVideo/HeroLoopVideo.svelte
+++ b/apps/web/src/lib/components/ui/HeroLoopVideo/HeroLoopVideo.svelte
@@ -1,0 +1,173 @@
+<!--
+  @component HeroLoopVideo
+
+  An ambient, silent, looping backdrop for a journey hero's media plate — the
+  `loop` value of the hero's `heroMedia` mode (`Codex-uj4jc`).
+
+  This is NOT a player. There are no controls, no sound, no playhead and nothing
+  focusable: the footage is decoration in exactly the sense the hero's ember glow
+  and motes are decoration, which is why the element is `aria-hidden`. Anything a
+  visitor is meant to WATCH belongs in the `click` mode, which opens
+  `IntroVideoModal` with real controls and a caption slot.
+
+  ── WHY REDUCED MOTION GETS THE POSTER, NOT A PAUSED VIDEO ─────────────────
+  A looping backdrop is continuous decoration, which is the precise category
+  `prefers-reduced-motion` and the `motion: none` axis exist to remove
+  (`docs/design/journey-sections/02-axis-contract.md`). So under reduced motion
+  this component never constructs a player at all — it renders the poster still
+  and stops. That is cheaper than pausing a video (no manifest fetch, no MSE, no
+  hls.js bundle) and it is the same still the `image` mode would have shown, so
+  the hero looks deliberate rather than broken.
+
+  ── AUTOPLAY ───────────────────────────────────────────────────────────────
+  Muted autoplay is permitted by every current browser; unmuted is not, and
+  `playsinline` is required or iOS Safari takes the video fullscreen. If `play()`
+  is still refused, the `poster` attribute keeps the frame on screen, so a
+  blocked autoplay degrades to exactly the `image` mode rather than to a black
+  box. `muted` is set as an attribute AND imperatively, because a late-set
+  property is what some engines actually consult.
+
+  ── TEARDOWN ───────────────────────────────────────────────────────────────
+  `createHlsPlayer` returns a HANDLE, `{ hls, cleanup }`, not a player. Calling
+  `.destroy()` on the handle throws and leaves the real instance alive, which is
+  the bug that leaked an hls.js worker on every open of `IntroVideoModal` and
+  `HeroInlineVideo` until `28e5daba`. Both halves are needed: `cleanup()` removes
+  the Safari native `error` listener, `hls.destroy()` kills the MSE player.
+-->
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import type Hls from 'hls.js';
+  import { createHlsPlayer } from '$lib/components/VideoPlayer/hls';
+
+  interface Props {
+    /** HLS manifest URL — the 30s public sell preview, not the full asset. */
+    src: string;
+    /** The frame shown before, instead of, and underneath the footage. */
+    posterUrl?: string | null;
+  }
+
+  const { src, posterUrl = null }: Props = $props();
+
+  let videoEl = $state<HTMLVideoElement | undefined>(undefined);
+  let hlsInstance = $state<Hls | null>(null);
+  let hlsCleanup = $state<(() => void) | null>(null);
+
+  /**
+   * True when the visitor has asked for less motion. Read once per mount and
+   * kept live, so flipping the OS preference mid-session takes effect — the
+   * hero's own enhancement gate does the same.
+   */
+  let reduced = $state(false);
+
+  $effect(() => {
+    if (!browser) return;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduced = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      reduced = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  /** See the component comment: the handle's two halves are both required. */
+  function teardownHls() {
+    if (hlsCleanup) {
+      hlsCleanup();
+      hlsCleanup = null;
+    }
+    if (hlsInstance) {
+      hlsInstance.destroy();
+      hlsInstance = null;
+    }
+  }
+
+  $effect(() => {
+    if (!browser || reduced || !videoEl || !src) return;
+
+    let destroyed = false;
+    const media = videoEl;
+
+    async function init() {
+      try {
+        const handle = await createHlsPlayer({ media, src });
+        if (destroyed) {
+          handle.cleanup();
+          handle.hls?.destroy();
+          return;
+        }
+        hlsInstance = handle.hls;
+        hlsCleanup = handle.cleanup;
+
+        media.muted = true;
+        media.loop = true;
+        try {
+          await media.play();
+        } catch {
+          // Autoplay refused — the poster attribute is already showing the
+          // frame, so this degrades to the `image` mode. Nothing to report.
+        }
+      } catch {
+        // A backdrop that cannot load is not an error a visitor can act on, and
+        // the poster is already in place. Staying silent is the correct
+        // behaviour here specifically because nothing is being withheld.
+      }
+    }
+
+    init();
+
+    return () => {
+      destroyed = true;
+      teardownHls();
+    };
+  });
+</script>
+
+{#if reduced || !src}
+  <!-- Continuous decoration, removed by preference. The still is the fallback. -->
+  {#if posterUrl}
+    <img class="hero-loop__still" src={posterUrl} alt="" decoding="async" />
+  {:else}
+    <span class="hero-loop__plate" aria-hidden="true"></span>
+  {/if}
+{:else}
+  <!--
+    No caption track, and no `svelte-ignore` for one either: Svelte's
+    `a11y_media_has_caption` rule exempts `muted` elements, so suppressing it
+    would be suppressing a warning that never fires. (Prose after a
+    `svelte-ignore` code is also parsed as further codes, so a justification
+    belongs in a comment like this one rather than on that line.) The backdrop is
+    silent, `aria-hidden` and carries nothing the hero's own copy does not —
+    anything meant to be watched belongs in the `click` mode, which has captions.
+  -->
+  <video
+    bind:this={videoEl}
+    class="hero-loop__video"
+    poster={posterUrl ?? undefined}
+    muted
+    loop
+    playsinline
+    preload="metadata"
+    aria-hidden="true"
+    tabindex="-1"
+  ></video>
+{/if}
+
+<style>
+  .hero-loop__video,
+  .hero-loop__still {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+    /* The plate's own radius/mask comes from the `media` axis on the ancestor,
+       so this element deliberately declares no shape of its own. */
+  }
+
+  .hero-loop__plate {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    background: var(--jp-media-plate, var(--color-surface-secondary));
+  }
+</style>

--- a/apps/web/src/lib/components/ui/HeroLoopVideo/index.ts
+++ b/apps/web/src/lib/components/ui/HeroLoopVideo/index.ts
@@ -1,0 +1,1 @@
+export { default as HeroLoopVideo } from './HeroLoopVideo.svelte';

--- a/apps/web/src/lib/page-builder/render/sections/HeroSection.svelte
+++ b/apps/web/src/lib/page-builder/render/sections/HeroSection.svelte
@@ -44,11 +44,17 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { ChevronDownIcon } from '$lib/components/ui/Icon';
+  import { ChevronDownIcon, PlayIcon } from '$lib/components/ui/Icon';
+  import IntroVideoModal from '$lib/components/ui/IntroVideoModal/IntroVideoModal.svelte';
   import * as m from '$paraglide/messages';
   import CtaLink from '../CtaLink.svelte';
   import { aliasKeys, asString, asStringFrom } from '../coerce';
-  import type { HeroSectionProps, JourneySalesContext } from '../types';
+  import { HeroLoopVideo } from '$lib/components/ui/HeroLoopVideo';
+  import type {
+    HeroSectionProps,
+    JourneySalesContext,
+    SellPreview,
+  } from '../types';
   import type { ResolvedSectionDesign, SectionProps } from '$lib/page-builder';
   import type { HTMLAttributes } from 'svelte/elements';
 
@@ -66,6 +72,28 @@
     felt?: string;
     /** Atmosphere treatment: `ember` (default) · `blood` · `still`. */
     bg?: string;
+    /**
+     * What the hero does with its media: `none` · `image` · `loop` · `click`.
+     *
+     * NOT named `heroMedia`: that key is already taken by the media PICKER field,
+     * whose `key` is only an `{#each}` key because a `control: 'media'` writes the
+     * `courses.heroMediaId` column rather than section props. Two field defs
+     * sharing a key would collide in the editor's loop.
+     *
+     * A CONTENT choice, not a design axis — it selects which asset appears, while
+     * the `media` axis (`bleed`/`frame`/`mask`/`inset`/`none`) still decides how
+     * that asset is shaped. Absent on every page authored before this field, and
+     * `resolveMediaMode` deliberately resolves absence to today's appearance.
+     */
+    mediaMode?: string;
+    /**
+     * Label for the play affordance on the three compositions that have no plate.
+     *
+     * Authorable because the hero's clip and the `introVideo` section's film are
+     * separate slots pointing wherever the creator aimed them — so a hardcoded
+     * "Watch intro" would be a claim about content this section does not own.
+     */
+    mediaLabel?: string;
   }
 
   interface Props {
@@ -97,6 +125,8 @@
     secondaryHref: asString(config, 'secondaryHref'),
     trust: asString(config, 'trust'),
     bg: asString(config, 'bg'),
+    mediaMode: asString(config, 'mediaMode'),
+    mediaLabel: asString(config, 'mediaLabel'),
   });
 
   const eyebrow = $derived(p.eyebrow ?? context.course.kicker ?? undefined);
@@ -125,14 +155,117 @@
   const motionOff = $derived(design?.motion === 'none');
   const mediaOff = $derived(design?.media === 'none');
 
-  // `split-media`, `full-bleed` and `poster` are image-led; the other three never
-  // draw a plate. `media: none` suppresses it even on the three that would.
-  const wantsMedia = $derived(
-    !mediaOff &&
-      (composition === 'split-media' ||
-        composition === 'full-bleed' ||
-        composition === 'poster')
+  // ── MEDIA: WHERE IT GOES, vs WHETHER THERE IS ANY ────────────────────────
+  // Two questions, and conflating them is what confined the hero's media to three
+  // of its six compositions. WHERE: `split-media`, `full-bleed` and `poster` have
+  // a plate in their layout; `stage`, `oversized` and `banner` do not, so on those
+  // the media becomes an invitation in the actions row rather than a backdrop.
+  // WHETHER: the authored `heroMedia` mode, gated by the axis.
+  //
+  // `media: none` stays AUTHORITATIVE over the mode. The axis governs treatment,
+  // the field governs content, and a design axis must not be silently overturned
+  // by a content choice — so the builder greys the mode control while the axis is
+  // `none` and says why, rather than quietly lifting it.
+  const plateLed = $derived(
+    composition === 'split-media' ||
+      composition === 'full-bleed' ||
+      composition === 'poster'
   );
+
+  const MEDIA_MODES = ['none', 'image', 'loop', 'click'];
+
+  /**
+   * The media mode for a resolved preview.
+   *
+   * The fallback is deliberately "what this page looks like today", not a nicer
+   * default. A page authored before this field carries no stored intent, and A33's
+   * lesson is that absent or ignored data is not evidence of one — seven live
+   * journey pages resolve through this branch and none of them may change shape on
+   * deploy.
+   */
+  const resolveMediaMode = (preview: SellPreview | null | undefined) => {
+    if (mediaOff) return 'none';
+    if (MEDIA_MODES.includes(p.mediaMode)) return p.mediaMode;
+    return preview?.heroImageUrl ? 'image' : 'none';
+  };
+
+  /**
+   * Whether a resolved preview has footage that can actually play. `heroClip` is
+   * OPTIONAL-additive, so an older worker deployment answers `false` here and
+   * every playing mode degrades to its still. Callers check the CLIP rather than
+   * trusting the mode, because the mode is authored and the clip is a fact.
+   */
+  const canPlay = (preview: SellPreview | null | undefined) =>
+    Boolean(preview?.heroClip?.playlistUrl);
+
+  /** Whether this composition draws a plate at all. `media: none` removes it. */
+  const showPlate = $derived(plateLed && !mediaOff);
+
+  /**
+   * The resolved sell preview, mirrored into state.
+   *
+   * The plate consumes `context.sellPreview` directly through `{#await}`, so it
+   * streams and costs no layout shift. Three things OUTSIDE that block need the
+   * same resolved value: the modal's `src`, the play affordance, and whether the
+   * atmosphere should recede. Awaiting again would wrap three pieces of non-media
+   * markup in their own `{#await}` blocks, so it is mirrored here once.
+   *
+   * Null on the server, deliberately. That keeps the SSR baseline identical to
+   * today's — full atmosphere, no affordance — and a button whose only job is to
+   * open a JS modal is worth nothing without JS, so rendering it only once the
+   * client has resolved is the honest behaviour rather than a limitation.
+   */
+  let resolvedPreview = $state<SellPreview | null>(null);
+
+  $effect(() => {
+    let alive = true;
+    context.sellPreview
+      .then((v) => {
+        if (alive) resolvedPreview = v ?? null;
+      })
+      .catch(() => {
+        if (alive) resolvedPreview = null;
+      });
+    return () => {
+      alive = false;
+    };
+  });
+
+  let introOpen = $state(false);
+
+  const mediaMode = $derived(resolveMediaMode(resolvedPreview));
+  const clipUrl = $derived(resolvedPreview?.heroClip?.playlistUrl ?? '');
+
+  /**
+   * Real media is on screen, so the synthetic atmosphere yields to it.
+   *
+   * Only true for the modes that actually PAINT something (`image`, `loop`) and
+   * only where a plate exists to paint into — a `click` affordance on a
+   * plate-less `stage` hero leaves the ember doing all the work, so the ember
+   * stays.
+   */
+  const mediaPresent = $derived(
+    showPlate &&
+      (mediaMode === 'image' || mediaMode === 'loop') &&
+      Boolean(resolvedPreview?.heroImageUrl || clipUrl)
+  );
+
+  /**
+   * The plate-less compositions OFFER the film instead of showing it.
+   *
+   * `loop` lands here too, and that is the point: `stage`, `oversized` and
+   * `banner` have nowhere to loop footage, so the author's intent to feature a
+   * video becomes an invitation rather than being silently dropped.
+   */
+  const showWatch = $derived(
+    !mediaOff &&
+      !plateLed &&
+      Boolean(clipUrl) &&
+      (mediaMode === 'loop' || mediaMode === 'click')
+  );
+
+  /** Authored, because this section does not own what the creator pointed it at. */
+  const watchLabel = $derived(p.mediaLabel ?? m.journey_hero_media_play());
 
   // The scroll cue points BELOW the fold, so it is meaningless on the two
   // compositions that do not fill the viewport, and it is continuous decoration,
@@ -228,15 +361,29 @@
     {#await context.sellPreview}
       <span class="hero__plate" aria-hidden="true"></span>
     {:then preview}
-      {#if preview?.heroImageUrl}
-        <img
-          class="hero__img"
-          src={preview.heroImageUrl}
-          alt=""
-          decoding="async"
-        />
+      {@const mode = resolveMediaMode(preview)}
+      {@const clip = preview?.heroClip ?? null}
+      {@const still = preview?.heroImageUrl ?? clip?.posterUrl ?? null}
+      {#if mode === 'none'}
+        <span class="hero__plate" aria-hidden="true"></span>
+      {:else if mode === 'loop' && canPlay(preview)}
+        <HeroLoopVideo src={clip.playlistUrl} posterUrl={still} />
+      {:else if still}
+        <img class="hero__img" src={still} alt="" decoding="async" />
       {:else}
         <span class="hero__plate" aria-hidden="true"></span>
+      {/if}
+      {#if mode === 'click' && canPlay(preview)}
+        <!-- On a plate-led composition the invitation sits ON the media, over
+             the scrim, rather than in the actions row. -->
+        <button
+          class="hero__play"
+          type="button"
+          aria-label={m.journey_hero_media_play_aria()}
+          onclick={() => (introOpen = true)}
+        >
+          <PlayIcon size="1.5rem" />
+        </button>
       {/if}
     {:catch}
       <span class="hero__plate" aria-hidden="true"></span>
@@ -271,6 +418,12 @@
       <CtaLink href={p.secondaryHref} variant="secondary" size="lg">
         {p.secondaryLabel}
       </CtaLink>
+    {/if}
+    {#if showWatch}
+      <button class="hero__watch" type="button" onclick={() => (introOpen = true)}>
+        <PlayIcon size="1rem" />
+        <span>{watchLabel}</span>
+      </button>
     {/if}
   </div>
 {/snippet}
@@ -329,6 +482,7 @@
   class="hero"
   class:hero--enhanced={enhanced}
   class:hero--still={motionOff}
+  class:hero--media-present={mediaPresent}
   data-hero={composition}
   data-hero-bg={p.bg || 'ember'}
 >
@@ -342,22 +496,31 @@
     <div class="hero__vignette"></div>
   </div>
 
-  {#if composition === 'full-bleed' && wantsMedia}
+  {#if composition === 'full-bleed' && showPlate}
     {@render plate()}
   {/if}
 
-  {#if composition === 'split-media' && wantsMedia}
+  {#if composition === 'split-media' && showPlate}
     <div class="hero__inner">
       <div class="hero__col">{@render copy()}</div>
       {@render plate()}
     </div>
-  {:else if composition === 'poster' && wantsMedia}
+  {:else if composition === 'poster' && showPlate}
     <div class="hero__inner">
       {@render plate()}
       <div class="hero__col">{@render copy()}</div>
     </div>
   {:else}
     <div class="hero__inner">{@render copy()}</div>
+  {/if}
+
+  {#if clipUrl}
+    <IntroVideoModal
+      open={introOpen}
+      src={clipUrl}
+      title={headline}
+      onclose={() => (introOpen = false)}
+    />
   {/if}
 
   {#if showCue}
@@ -435,6 +598,81 @@
     z-index: 0;
     pointer-events: none;
     opacity: var(--jp-sec-atmos);
+  }
+
+  /* Real footage carries the mood, so the synthetic ember yields rather than
+     competing with it.
+
+     Composed as a MULTIPLIER on `--jp-sec-atmos` rather than replacing it, so the
+     `surface` axis keeps the final say: a section that gates its atmosphere to
+     zero stays at zero here too. The markup stays mounted either way, which is
+     the same reason the gate is an opacity and not an `{#if}` — a late-resolving
+     streamed preview must cost no layout shift. */
+  .hero--media-present .hero__atmos {
+    opacity: calc(var(--jp-sec-atmos, 1) * 0.4);
+  }
+
+  /* The invitation ON the media — plate-led compositions in `click` mode. Sits
+     above the scrim so it stays legible over any frame. */
+  .hero__play {
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    z-index: 2;
+    display: grid;
+    place-items: center;
+    inline-size: var(--space-8);
+    block-size: var(--space-8);
+    border: 0;
+    border-radius: var(--radius-full);
+    background: var(--color-surface);
+    color: var(--color-heading);
+    cursor: pointer;
+    transform: translate(-50%, -50%);
+    transition: var(--transition-transform);
+  }
+
+  .hero__play:hover {
+    transform: translate(-50%, -50%) scale(1.06);
+  }
+
+  .hero__play:focus-visible {
+    outline: 2px solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  /* The invitation IN the actions row — the three plate-less compositions.
+     Deliberately third-tier: it sits beside the CTAs without competing, because
+     the conversion path is the CTA and watching a film is a detour from it. */
+  .hero__watch {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: none;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition: var(--transition-colors);
+  }
+
+  .hero__watch:hover {
+    color: var(--color-heading);
+  }
+
+  .hero__watch:focus-visible {
+    outline: 2px solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  /* Reduced motion: the hover growth is decoration, and the loop backdrop has
+     already declined to construct itself (see HeroLoopVideo). */
+  @media (prefers-reduced-motion: reduce) {
+    .hero__play:hover {
+      transform: translate(-50%, -50%);
+    }
   }
 
   /* Breathing warm core — the "living light" behind the headline.

--- a/apps/web/src/lib/page-builder/render/sections/HeroSection.svelte.test.ts
+++ b/apps/web/src/lib/page-builder/render/sections/HeroSection.svelte.test.ts
@@ -443,3 +443,221 @@ describe('HeroSection — the edit seam', () => {
     expect(edits).toEqual([['headline', 'Typed in the canvas']]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MEDIA MODES (`Codex-uj4jc`)
+//
+// Before this, the hero drew media on three of its six compositions and could
+// only ever draw a STILL, because the projection reduced `courses.heroMediaId`
+// to a poster frame through `toStill` and discarded the manifest. These cases
+// pin the two decisions that replaced it: WHAT appears (the `mediaMode` field,
+// overruled by the `media` axis) and WHERE it appears (a plate on the three
+// layouts that have one, an invitation beside the CTAs on the three that do not).
+//
+// Playback itself is not asserted here and cannot be: jsdom has no MSE, so
+// `createHlsPlayer` could never construct a real player. What IS assertable — and
+// what actually regressed historically — is which ELEMENT the component chose.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HERO_CLIP = {
+  playlistUrl: 'https://cdn.test/hero/preview.m3u8',
+  posterUrl: 'https://cdn.test/hero/poster.jpg',
+  durationSeconds: 30,
+};
+
+const HERO_STILL = 'https://cdn.test/hero/still.jpg';
+
+function sellPreview(over: Partial<SellPreview> = {}): SellPreview {
+  return { intro: null, reel: null, ...over };
+}
+
+/**
+ * Let both media reads land: the plate's own `{#await}` and the `$effect` that
+ * mirrors the same promise into state for the modal / affordance / atmosphere.
+ * Two microtask turns, because the mirror resolves a `.then` off the promise the
+ * await block is already consuming.
+ */
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+  await tick();
+}
+
+describe('HeroSection — media modes', () => {
+  it('with no stored mode, a page showing a still today keeps showing it', async () => {
+    // The forward-compat case, and the one that matters most: seven live journey
+    // pages have no `mediaMode`. Absence is not intent (A33), so it must resolve
+    // to today's appearance rather than to a nicer default.
+    render({
+      variant: 'split-media',
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroImageUrl: HERO_STILL })),
+      }),
+    });
+    await settle();
+
+    expect(document.body.querySelector('.hero__img')?.getAttribute('src')).toBe(
+      HERO_STILL
+    );
+    expect(document.body.querySelector('.hero-loop__video')).toBeNull();
+  });
+
+  it('with no stored mode and no still, draws the synthetic plate', async () => {
+    render({ variant: 'split-media' });
+    await settle();
+
+    expect(document.body.querySelector('.hero__plate')).not.toBeNull();
+    expect(document.body.querySelector('.hero__img')).toBeNull();
+  });
+
+  it('`loop` renders the silent backdrop rather than the still', async () => {
+    render({
+      variant: 'full-bleed',
+      config: { headline: 'A headline', mediaMode: 'loop' },
+      context: context({
+        sellPreview: Promise.resolve(
+          sellPreview({ heroImageUrl: HERO_STILL, heroClip: HERO_CLIP })
+        ),
+      }),
+    });
+    await settle();
+
+    expect(document.body.querySelector('.hero-loop__video')).not.toBeNull();
+    expect(document.body.querySelector('.hero__img')).toBeNull();
+  });
+
+  it('`loop` degrades to the still when the worker omits `heroClip`', async () => {
+    // `heroClip` is OPTIONAL-additive, so an older worker deployment answers with
+    // no clip at all. The authored mode must not produce an empty plate: the mode
+    // is authored, the clip is a fact, and the fact wins.
+    render({
+      variant: 'full-bleed',
+      config: { headline: 'A headline', mediaMode: 'loop' },
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroImageUrl: HERO_STILL })),
+      }),
+    });
+    await settle();
+
+    expect(document.body.querySelector('.hero-loop__video')).toBeNull();
+    expect(document.body.querySelector('.hero__img')?.getAttribute('src')).toBe(
+      HERO_STILL
+    );
+  });
+
+  it('`click` puts the invitation ON the plate, over the media', async () => {
+    render({
+      variant: 'poster',
+      config: { headline: 'A headline', mediaMode: 'click' },
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroClip: HERO_CLIP })),
+      }),
+    });
+    await settle();
+
+    const play = document.body.querySelector('.hero__play');
+    expect(play).not.toBeNull();
+    // Inside the media box, not loose in the copy column.
+    expect(play?.closest('.hero__media')).not.toBeNull();
+    expect(document.body.querySelector('.hero__watch')).toBeNull();
+  });
+
+  it('a plate-less composition offers the film beside the CTAs instead', async () => {
+    // `stage` has nowhere to put a backdrop, so the author's intent to feature a
+    // video becomes an invitation rather than being silently dropped.
+    render({
+      variant: 'stage',
+      config: { headline: 'A headline', mediaMode: 'loop' },
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroClip: HERO_CLIP })),
+      }),
+    });
+    await settle();
+
+    const watch = document.body.querySelector('.hero__watch');
+    expect(watch).not.toBeNull();
+    expect(watch?.closest('.hero__actions')).not.toBeNull();
+    expect(document.body.querySelector('.hero__media')).toBeNull();
+  });
+
+  it('`mediaLabel` words the invitation, since the hero does not own the clip', async () => {
+    render({
+      variant: 'stage',
+      config: {
+        headline: 'A headline',
+        mediaMode: 'click',
+        mediaLabel: 'See the practice',
+      },
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroClip: HERO_CLIP })),
+      }),
+    });
+    await settle();
+
+    expect(document.body.querySelector('.hero__watch')?.textContent).toContain(
+      'See the practice'
+    );
+  });
+
+  it('`media: none` overrules any authored mode, plate and invitation alike', async () => {
+    // The axis governs treatment, the field governs content, and a content choice
+    // must not overturn a design decision. The builder greys the control to say so
+    // (`section-editor-controls.svelte.test.ts`); here the renderer must agree.
+    render({
+      variant: 'full-bleed',
+      design: { ...CANDLELIT, media: 'none' },
+      config: { headline: 'A headline', mediaMode: 'loop' },
+      context: context({
+        sellPreview: Promise.resolve(
+          sellPreview({ heroImageUrl: HERO_STILL, heroClip: HERO_CLIP })
+        ),
+      }),
+    });
+    await settle();
+
+    expect(document.body.querySelector('.hero__media')).toBeNull();
+    expect(document.body.querySelector('.hero-loop__video')).toBeNull();
+    expect(document.body.querySelector('.hero__watch')).toBeNull();
+  });
+
+  it('the atmosphere recedes when media is actually painted', async () => {
+    render({
+      variant: 'full-bleed',
+      config: { headline: 'A headline', mediaMode: 'loop' },
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroClip: HERO_CLIP })),
+      }),
+    });
+    await settle();
+
+    expect(
+      document.body
+        .querySelector('.hero')
+        ?.classList.contains('hero--media-present')
+    ).toBe(true);
+  });
+
+  it('the atmosphere holds when the film is merely OFFERED', async () => {
+    // `stage` has no plate, so nothing is painted and the ember is still doing
+    // the whole job of carrying the mood. Dimming it here would leave the hero
+    // flatter than before the author added a video, which is the opposite of the
+    // intent. Split from the case above rather than sharing a mount: two mounts
+    // in one `it` needed a manual `unmount(component!)`, and a non-null assertion
+    // is a poor trade for a saved test block.
+    render({
+      variant: 'stage',
+      config: { headline: 'A headline', mediaMode: 'click' },
+      context: context({
+        sellPreview: Promise.resolve(sellPreview({ heroClip: HERO_CLIP })),
+      }),
+    });
+    await settle();
+
+    expect(
+      document.body
+        .querySelector('.hero')
+        ?.classList.contains('hero--media-present')
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/page-builder/render/types.ts
+++ b/apps/web/src/lib/page-builder/render/types.ts
@@ -87,6 +87,19 @@ export interface SellPreview {
    */
   heroImageUrl?: string | null;
   /**
+   * The HERO clip — the same `courses.heroMediaId` item as `heroImageUrl`, but
+   * resolved through `toClip` so the hero can PLAY it. FE mirror of
+   * `CourseSellPreview.heroClip`.
+   *
+   * `heroImageUrl` remains the poster for the playing modes and the whole picture
+   * for the still ones, so a hero reads BOTH: the clip decides whether playback is
+   * possible, the still decides what shows before and instead of it.
+   *
+   * OPTIONAL-additive: an older worker deployment omits it and the hero degrades
+   * to the still, then to its synthetic plate.
+   */
+  heroClip?: PreviewMedia | null;
+  /**
    * The guide's SIGNATURE mark — a public CDN URL, or null when unset (A27).
    * `guide.letter` signs off with it; WT-6 owns that composition.
    */

--- a/apps/web/src/paraglide/messages/en.js
+++ b/apps/web/src/paraglide/messages/en.js
@@ -11815,6 +11815,22 @@ export const journey_hero_cta_enrolled = () => `Go to your dashboard`
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
+export const journey_hero_media_play = () => `Watch the film`
+
+
+/**
+ * 
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export const journey_hero_media_play_aria = () => `Play the hero film`
+
+
+/**
+ * 
+ * @returns {string}
+ */
+/* @__NO_SIDE_EFFECTS__ */
 export const journey_reel_tag_default = () => `Preview`
 
 

--- a/docs/design/journey-sections/02-axis-contract.md
+++ b/docs/design/journey-sections/02-axis-contract.md
@@ -1530,3 +1530,75 @@ one". A `??` in a `bd close --reason` string was glob-expanded and truncated the
 **Write any prose containing backticks, `??`, or globs via `git commit -F -` with a QUOTED heredoc
 (`<<'MSG'`), or single-quote the argument.** The failure is silent in every case: you get a commit,
 a closed bead, or an empty grep result, and nothing tells you a word went missing.
+
+## A75 — The hero plays its media, all six compositions carry it, and the atmosphere yields (`Codex-uj4jc`)
+
+A32 recorded that a hero "image" can only be a video's poster frame and deferred the fix. This closes
+the half that needed no migration, and in doing so found that the deferral had been hiding a second,
+larger omission.
+
+**The hero never received the video at all.** `getCourseSellPreview` projected `courses.heroMediaId`
+through `toStill` only:
+
+```
+heroImageUrl: toStill(courseRow.heroMediaId),   // the thumbnail
+                                               // ...and toClip was never called
+```
+
+`toClip` sat in the same function, ten lines above, already resolving `intro`, `reel` and `guideClip`
+into `{ playlistUrl, posterUrl, durationSeconds }`. So a creator uploaded a video, the projection
+reduced it to a poster URL, and the manifest the hero needed was discarded at the boundary. The hero
+could not have played its own media however the component was written. `heroClip` is now projected
+beside `heroImageUrl` — the same item resolved both ways, OPTIONAL-additive like `guideClip`, so an
+older worker deployment degrades to the still.
+
+### Three decisions, and what each rejects
+
+**1 · `mediaMode` is CONTENT; `media` is DESIGN; the axis wins.** The section gains an authored
+`mediaMode` (`none` · `image` · `loop` · `click`) choosing WHICH asset appears, while the `media` axis
+keeps deciding HOW it is shaped. `media: none` means "no plate at all", so it necessarily overrules the
+mode. Both alternatives were worse. Ignoring the mode silently leaves an author picking "silent looping
+video", seeing nothing, and having no way to learn why. Auto-lifting the axis mutates a design decision
+as a side effect of a content choice — the precise conflation the axis/field split exists to prevent.
+So `SectionFieldDef.disabledWhenAxis` greys the control and puts the reason where the hint was. The
+renderer and the builder are guarded separately, because a disabled control over a renderer that
+ignored the axis would be a lie in the other direction.
+
+**2 · All six compositions carry media, and the three without a plate OFFER it.** `wantsMedia` used to
+fold two different questions together — whether media is wanted, and whether this layout has anywhere
+to put it — which is what confined media to `split-media`, `full-bleed` and `poster`. They are now
+separate: `plateLed` answers WHERE, `mediaMode` answers WHAT. `stage`, `oversized` and `banner` have no
+plate in their layout, so on those a video becomes an invitation beside the CTAs rather than being
+silently dropped. `loop` lands there too — there is nowhere to loop footage, so the author's intent to
+feature a video is honoured as a link instead of discarded.
+
+The affordance's label is AUTHORED. The hero's clip and the `introVideo` section's film are separate
+slots pointing wherever the creator aimed them, so a hardcoded "Watch intro" would be this section
+making a claim about content it does not own.
+
+**3 · The atmosphere recedes when real media is painted.** `.hero__atmos` already multiplied its whole
+opacity by the `--jp-sec-atmos` 0/1 gate, keyed on the `surface` axis. That gate now also reads whether
+media is present, as a MULTIPLIER rather than a replacement — so `surface` keeps the final say and a
+section gated to zero stays at zero. Composed this way for the same reason the gate is an opacity and
+not an `{#if}`: the markup stays mounted, so a late-resolving streamed preview costs no layout shift.
+
+"Painted", not "present". A `click` affordance on a plate-less `stage` hero leaves the ember doing the
+whole job of carrying the mood, so it must not dim — only `image` and `loop`, and only where a plate
+exists, recede it.
+
+### The forward-compatibility rule this had to obey
+
+Seven live journey pages have no `mediaMode`. Absence resolves to **today's appearance** —
+`heroImageUrl ? 'image' : 'none'` — not to a nicer default. This is A33's lesson applied in the
+inverse direction: a stored value the renderer ignored is not evidence of intent, and neither is no
+stored value at all. The builder therefore offers an explicit "Automatic" choice, so returning to that
+state stays authorable rather than becoming unreachable once a mode is set.
+
+### What is still open
+
+`Codex-490z7` — real image upload, so a hero image need not be a video's poster frame — now depends on
+this and lands as the `image` mode's second source: `heroImageKey ?? heroMediaId`'s poster `?? ` the
+synthetic plate. Two traps on that path are already paid for elsewhere in this repo and must not be
+rediscovered: the write path goes through `forwardMultipartUpload()`, because re-forwarding a `File`
+strips the filename in production; and it must be a `form()`/FormData path rather than a `command()`,
+because command arguments serialize through devalue, which has no representation for a `File`.

--- a/packages/access/src/services/__tests__/course-journey-sell-media.integration.test.ts
+++ b/packages/access/src/services/__tests__/course-journey-sell-media.integration.test.ts
@@ -622,7 +622,10 @@ describe('CourseJourneyService sell media + cover (journey media write path)', (
       );
 
       const [heroMedia] = await db
-        .select({ thumbnailKey: mediaItems.thumbnailKey })
+        .select({
+          thumbnailKey: mediaItems.thumbnailKey,
+          hlsPreviewKey: mediaItems.hlsPreviewKey,
+        })
         .from(mediaItems)
         .where(eq(mediaItems.id, heroId))
         .limit(1);
@@ -642,6 +645,16 @@ describe('CourseJourneyService sell media + cover (journey media write path)', (
       expect(preview?.signatureUrl).toBe(
         `${CDN}/${signatureMedia?.thumbnailKey}`
       );
+
+      // ...AND `toClip` for the same item, which is what `Codex-uj4jc` added. The
+      // manifest used to be discarded here: the hero was handed only a poster URL,
+      // so a creator's video could never do anything but sit still. Asserted as a
+      // RELATIONSHIP to the row rather than a literal, because whether the fixture
+      // has a transcoded preview is the factory's business — what must hold is that
+      // the projection stops throwing the manifest away.
+      expect(preview?.heroClip?.playlistUrl ?? null).toBe(
+        heroMedia?.hlsPreviewKey ? `${CDN}/${heroMedia.hlsPreviewKey}` : null
+      );
     });
 
     it('projects null for both when the slots are cleared', async () => {
@@ -649,6 +662,7 @@ describe('CourseJourneyService sell media + cover (journey media write path)', (
 
       const preview = await svc.getCourseSellPreview(courseId, CDN);
       expect(preview?.heroImageUrl).toBeNull();
+      expect(preview?.heroClip).toBeNull();
       expect(preview?.signatureUrl).toBeNull();
     });
 
@@ -662,6 +676,9 @@ describe('CourseJourneyService sell media + cover (journey media write path)', (
       const preview = await svc.getCourseSellPreview(courseId, undefined);
       // A bare R2 key served to a browser is a broken image, not a degraded one.
       expect(preview?.heroImageUrl).toBeNull();
+      // Same for the manifest: an unresolvable playlist URL would leave the player
+      // erroring rather than falling back to the plate.
+      expect(preview?.heroClip).toBeNull();
     });
   });
 });

--- a/packages/access/src/services/course-journey-service.ts
+++ b/packages/access/src/services/course-journey-service.ts
@@ -643,6 +643,11 @@ export class CourseJourneyService extends BaseService {
         // is the item's `thumbnailKey`. `hero.full-bleed` / `hero.poster` /
         // `guide.letter` are named after media that, until now, no column held.
         heroImageUrl: toStill(courseRow.heroMediaId),
+        // The SAME item, resolved both ways: `toStill` for the modes that only
+        // draw it, `toClip` for the modes that play it. Before this the manifest
+        // was thrown away here, so a creator's hero video could only ever appear
+        // as its own poster frame (Codex-uj4jc).
+        heroClip: toClip(courseRow.heroMediaId),
         signatureUrl: toStill(courseRow.signatureMediaId),
       };
     } catch (error) {

--- a/packages/shared-types/src/journeys.ts
+++ b/packages/shared-types/src/journeys.ts
@@ -1013,6 +1013,25 @@ export interface CourseSellPreview {
    */
   heroImageUrl?: string | null;
   /**
+   * The HERO clip — the SAME `courses.heroMediaId` item as {@link
+   * CourseSellPreview.heroImageUrl}, resolved through `toClip` instead of
+   * `toStill` so the hero can PLAY it rather than only draw its poster frame.
+   *
+   * Until this field the manifest was discarded at the projection boundary: a
+   * creator uploaded a video, `toStill` reduced it to its `thumbnailKey`, and the
+   * hero had no way to reach the playable preview it already had. `heroImageUrl`
+   * stays for the still-only modes and as the poster for the playing ones, so the
+   * two are complements, not alternatives.
+   *
+   * Null when the course has no hero media or its preview has not transcoded —
+   * the same condition `intro`/`reel`/`guideClip` use.
+   *
+   * OPTIONAL-additive (like {@link CourseSellPreview.guidePortraitUrl}): an older
+   * worker deployment omits it and the hero falls back to the still, then to its
+   * synthetic plate.
+   */
+  heroClip?: CourseSellPreviewClip | null;
+  /**
    * The guide's SIGNATURE mark — a public CDN URL resolved from the thumbnail of
    * `courses.signatureMediaId` (A27). `guide.letter` signs off with it; null
    * leaves the letter unsigned. Same `toStill` resolution as the portrait.


### PR DESCRIPTION
## What this is

The journey hero can now play its media, and all six compositions carry media
instead of three. `Codex-uj4jc`; contract amendment **A75**.

## The finding

The hero's inability to play video was never a missing capability. `toClip` was
already in `getCourseSellPreview`, ten lines above the line that discarded the
manifest:

```ts
intro: toClip(courseRow.introVideoMediaId),
reel:  toClip(courseRow.previewVideoMediaId),
// ...
heroImageUrl: toStill(courseRow.heroMediaId),   // ← and toClip was never called
```

So a creator uploaded a video, the projection reduced it to a `thumbnailKey`, and
the playable manifest was thrown away at the boundary. `A32` had even documented
the *consequence* — "to set a hero image they must upload a video and accept its
poster frame" — without anyone noticing the same row already carried a manifest.

`heroClip` now sits beside `heroImageUrl`: the same item resolved both ways,
because they are complements. The still is what shows before and instead of
playback; the clip is what makes playback possible. OPTIONAL-additive like
`guideClip` / `signatureUrl`, so an older worker deployment degrades to the still.

## Three decisions

**`mediaMode` is content, the `media` axis is design, and the axis wins.** Four
modes (`none` / `image` / `loop` / `click`) choose which asset appears; the axis
still decides how it is shaped. `media: none` means "no plate at all", so it
overrules the mode — and `SectionFieldDef.disabledWhenAxis` greys the control and
puts the reason where the hint was. Both alternatives were worse: ignoring the mode
leaves an author picking "silent looping video", seeing nothing, with no way to
find out why; auto-lifting the axis mutates a design decision as a side effect of a
content choice. Renderer and builder are guarded separately, because a disabled
control over a renderer that ignored the axis would be a lie in the other
direction.

**All six compositions carry media; the three without a plate offer it.**
`wantsMedia` folded two questions into one — is media wanted, and does this layout
have anywhere to put it — which is what confined media to `split-media`,
`full-bleed` and `poster`. Now `plateLed` answers where and `mediaMode` answers
what, so `stage`, `oversized` and `banner` offer the film beside the CTAs. `loop`
lands there too, deliberately: there is nowhere to loop footage, so the intent to
feature a video becomes an invitation rather than being dropped. The label is
authored, because the hero's clip and the `introVideo` section's film are separate
slots and a hardcoded "Watch intro" would claim something this section does not
own.

**The atmosphere yields to real footage** — as a multiplier on the existing
`--jp-sec-atmos` gate, so `surface` keeps the final say and a section gated to zero
stays there. Kept as an opacity rather than an `{#if}` for the same reason the gate
exists: the markup stays mounted, so a late-resolving streamed preview costs no
layout shift. "Painted", not "present" — a `click` affordance on a plate-less
`stage` hero leaves the ember doing the whole job, so it must not dim.

`HeroLoopVideo` is a backdrop, not a player: no controls, no sound, nothing
focusable, `aria-hidden`. Under `prefers-reduced-motion` it never constructs a
player and renders the poster instead — a looping backdrop is exactly the
continuous decoration that preference removes, and declining to build one is
cheaper than pausing it. Teardown calls `cleanup()` **and** `hls.destroy()`, the
handle-vs-player distinction that leaked an instance per open until `28e5daba`.

## Forward compatibility

Seven live journey pages have no `mediaMode`, so absence resolves to **today's
appearance** (`heroImageUrl ? image : none`), not to a nicer default — A33's lesson
in the inverse direction. The builder offers an explicit "Automatic" choice so that
state stays reachable once a mode is set.

## Verified in a browser

`of-blood-and-bones/pricing-smoke-test`, Chrome, against media transcoded through
the local pipeline. Bytes checked first, because a manifest 200 is not playability:
manifest HTTP 200, segments HTTP **206 with real bytes** on a Range request, poster
a 21 KB `image/webp`.

**Forward-compat (no stored mode)** — `split-media`, still decoded at 800×450, no
loop video, no synthetic plate, no affordances. Unchanged.

**`mediaMode: loop`** —

```
currentSrc   blob:http://of-blood-and-bones.lvh.me:3000/804690f1…   (MSE, not the manifest)
readyState   4          duration 30.05s        1280x720
muted/loop   true/true  paused   false
currentTime  advanced 2.50s over 2.50s wall clock
buffered     0.0–30.1   video.error null       aria-hidden true
```

A `blob:` src is the specific proof that hls.js was constructed rather than the
manifest being handed to `video.src` — the `canPlayType` trap fixed in `446c4695`
would have shown a `.m3u8` here.

**Builder** — "What the media does" renders enabled, reads the stored `loop`, and
offers all five options; "Watch link label" sits beside it. **0 console errors and
0 warnings** on both surfaces.

## Gate

| gate | result |
|---|---|
| `pnpm check:ci` | 0 errors, 179 warnings — baseline |
| `check:brand-boundary` + `:test` | 0 / 0 |
| `pnpm typecheck --force` | 0 — 57/57, **0 cached** |
| `pnpm --filter web test` | 0 — 177 files, **2219 tests** (+13) |
| `svelte-check` | 63 errors / 37 warnings — baseline, none in changed files |

Thirteen new cases: nine on the renderer (forward-compat, both null paths,
loop-degrades-without-a-clip, plate vs actions placement, the authored label, the
axis overrule, and the recession's painted/offered split), three on the builder
(enabled; gated with its reason; and that **only** the field which asked to be
gated is disabled — a hero going read-only wholesale under `media: none` would be a
worse and quieter bug than the one the gate fixes), plus four assertions on the
projection. The projection assertions are written as a RELATIONSHIP to the seeded
row rather than a literal, because whether a fixture has a transcoded preview is
the factory's business; what must hold is that the manifest stops being discarded.

## Two things for the reviewer

**1 · The canvas still shows no media at all, and that is pre-existing —
`Codex-bvhcr` (P2, filed).** `JourneyBuilderCanvas.svelte:124` calls
`builderSalesContext({ course, stages, offer })` and never passes `sellPreview`,
which `builder-context.ts:148` defaults to `null`. So the hero draws its synthetic
plate, `introVideo` and `reel` show no clip, and the guide falls back to its
monogram — while the same page renders all of it publicly. Not caused here, but
this PR makes it consequential: the new control's effect is invisible in the
canvas. Left out because fixing it changes what the canvas shows for five section
types at once, which wants the owner's eyes rather than a hero PR.

**2 · The atmosphere recession applies to `image` as well as `loop`, so the seven
existing pages that show a still will have a dimmer ember.** That follows "when
there's media present the atmosphere should step back", but the brief said
"particularly our video", which could equally mean video-only. Restricting it is a
one-line change to `mediaPresent`. Flagging rather than deciding, since it is a
visible change to live pages.

## Still open

`Codex-490z7` (real image upload, so a hero image need not be a video's poster
frame) now depends on this and lands as the `image` mode's second source:
`heroImageKey ?? heroMediaId`'s poster `?? ` the synthetic plate. Two traps on that
path are already paid for in this repo and are recorded on the bead — the write
path must go through `forwardMultipartUpload()`, and it must be a `form()`/FormData
path rather than a `command()`, because command arguments serialize through devalue
which cannot represent a `File` (the `uploadJourneyCover` bug fixed in `b6433fc1`).

Please **merge, don't squash** — each commit records the measurement that justified
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
