### PR TITLE
fix(journeys): the builder canvas shows the course's real media (Codex-bvhcr)

### DIFF
--- a/apps/web/src/lib/components/page-builder/JourneyBuilderCanvas.svelte
+++ b/apps/web/src/lib/components/page-builder/JourneyBuilderCanvas.svelte
@@ -42,6 +42,7 @@
     builderSalesContext,
     SectionFrame,
     selectRenderableSections,
+    type SellPreview,
   } from '$lib/page-builder/render';
   /* THE COLOUR LADDER. `SectionFrame` carries the axis substrate
      (`journey-design.css` + `journey-sections-shared.css`) but deliberately NOT
@@ -90,6 +91,19 @@
     course?: Pick<JourneyCourseView, 'id' | 'slug' | 'title'>;
     /** The authoritative offer, when loaded. Null ⇒ sections draw a price-less CTA. */
     offer?: CourseOffer | null;
+    /**
+     * The course's RESOLVED sell media — the hero's still and clip, the intro and
+     * reel manifests, the guide's portrait.
+     *
+     * Already-resolved rather than a promise, because `builderSalesContext` wraps
+     * it: the public page streams this off its critical path, and the studio has
+     * it in hand from an ordinary client query.
+     *
+     * Null ⇒ every media-bearing section draws its media-less fallback, which is
+     * the correct answer for a course that has picked no media and was the ONLY
+     * answer before Codex-bvhcr.
+     */
+    sellPreview?: SellPreview | null;
   }
 
   let {
@@ -102,6 +116,7 @@
     stages = [],
     course,
     offer = null,
+    sellPreview = null,
   }: Props = $props();
 
   const sections = $derived(pageBuilder.sections);
@@ -119,12 +134,22 @@
    * The render context the public sections expect, assembled from what the studio
    * has. Rebuilt when its inputs change; `enrolled` is always false so the author
    * sees the pre-purchase page a prospective member sees.
+   *
+   * `sellPreview` was MISSING here (Codex-bvhcr), and because
+   * `builderSalesContext` defaults it to null the omission was silent: `hero`,
+   * `introVideo`, `reel` and `guide` each drew their media-less fallback — a
+   * synthetic plate, no clip, the guide's monogram — while the same stored page
+   * rendered the real media publicly. What an author sees is meant to be what a
+   * visitor gets, which is the entire point of mounting the public components
+   * here, and A75 sharpened the cost: the `media` mode control it added had its
+   * whole effect hidden on the surface where you author it.
    */
   const salesContext = $derived(
     builderSalesContext({
       course: course ?? { id: '', slug: slug, title: pageBuilder.pending?.title ?? '' },
       stages,
       offer,
+      sellPreview,
     })
   );
 

--- a/apps/web/src/lib/components/page-builder/canvas-public-parity.svelte.test.ts
+++ b/apps/web/src/lib/components/page-builder/canvas-public-parity.svelte.test.ts
@@ -40,6 +40,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { PageSection } from '@codex/shared-types';
+import { tick } from 'svelte';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   resolveVariant,
@@ -47,6 +48,7 @@ import {
   SECTION_DESIGN_AXES,
 } from '$lib/page-builder';
 import {
+  builderSalesContext,
   SECTION_COMPONENTS as PUBLIC_COMPONENTS,
   selectRenderableSections,
 } from '$lib/page-builder/render';
@@ -221,5 +223,128 @@ describe('canvas ↔ public: axis emission (CHARACTERISATION — Codex-6nrsk)', 
     expect(emitted).toEqual([...SECTION_DESIGN_AXES]);
 
     unmount(component);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The sell media (Codex-bvhcr)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HERO_STILL = 'https://cdn.test/hero/still.jpg';
+
+/**
+ * One hero on a PLATE-LED composition. `full-bleed` matters: `stage`, `oversized`
+ * and `banner` have nowhere to draw a plate, so they paint no still no matter what
+ * media resolves, and a test built on one of them would pass for the wrong reason.
+ */
+const heroWithPlate: PageSection = {
+  id: 's-hero',
+  type: 'hero',
+  enabled: true,
+  props: {},
+  variant: 'full-bleed',
+} as PageSection;
+
+/**
+ * Let the media reads land: the plate's own `{#await}` plus the `$effect` that
+ * mirrors the same promise into state. Two microtask turns, because the mirror
+ * resolves a `.then` off the promise the await block is already consuming — the
+ * same reason `HeroSection.svelte.test.ts` settles twice.
+ */
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+  await tick();
+}
+
+/**
+ * Mount ONE of the two paths, read the still the hero actually painted, tear it
+ * down. Returning the `src` rather than asserting inside keeps each `it` to one
+ * mount at a time, so no teardown needs a non-null assertion to reach its handle.
+ */
+async function heroStillVia(
+  path: 'canvas' | 'public',
+  section: PageSection,
+  context: JourneySalesContext
+): Promise<string | null> {
+  const component =
+    path === 'canvas'
+      ? mount(SectionFrame, {
+          target: document.body,
+          props: {
+            renderable: selectRenderableSections([section])[0],
+            context,
+            editable: true,
+          },
+        })
+      : mount(PublicSectionRenderer, {
+          target: document.body,
+          props: { sections: [section], context },
+        });
+  flushSync();
+  await settle();
+
+  const src =
+    document.body.querySelector('.hero__img')?.getAttribute('src') ?? null;
+
+  unmount(component);
+  document.body.innerHTML = '';
+  return src;
+}
+
+describe('canvas ↔ public: the sell media (Codex-bvhcr)', () => {
+  it('forwards a sellPreview from the canvas into the shared context', () => {
+    // SOURCE-level, deliberately. This was never a rendering fault:
+    // `builderSalesContext` takes `sellPreview` as OPTIONAL and defaults it to
+    // null, so a canvas that simply never passed one type-checked, mounted and
+    // rendered — showing all four media-bearing sections (`hero`, `introVideo`,
+    // `reel`, `guide`) their media-less fallback. No assertion over the canvas
+    // ALONE could witness it, because "no media" is also the correct output for a
+    // course that has picked none. The defect was the disagreement with the public
+    // page, and what hid it was that the disagreement sat between a DEFAULT and a
+    // value rather than between two visible behaviours.
+    const canvas = readFileSync(
+      join(HERE, 'JourneyBuilderCanvas.svelte'),
+      'utf8'
+    );
+    const opens = canvas.indexOf('builderSalesContext({');
+    expect(opens, 'canvas no longer builds a context here').toBeGreaterThan(-1);
+    const call = canvas.slice(opens, canvas.indexOf('})', opens));
+    expect(
+      call,
+      'builderSalesContext is called without sellPreview — the canvas is blind to the course media again'
+    ).toContain('sellPreview');
+  });
+
+  it('paints the SAME hero still on both paths from one context', async () => {
+    const context = builderSalesContext({
+      course: { id: 'c1', slug: 'demo', title: 'Demo course' },
+      stages: [],
+      offer: null,
+      sellPreview: { intro: null, reel: null, heroImageUrl: HERO_STILL },
+    });
+
+    const canvasSrc = await heroStillVia('canvas', heroWithPlate, context);
+    const publicSrc = await heroStillVia('public', heroWithPlate, context);
+
+    expect(canvasSrc, 'the canvas painted no hero still').toBe(HERO_STILL);
+    expect(publicSrc, 'the two paths disagree on the hero still').toBe(
+      canvasSrc
+    );
+  });
+
+  it('agrees on NO media when the course has picked none', async () => {
+    // The other half, and the reason the case above cannot stand alone: a canvas
+    // that INVENTED media the page does not have would satisfy it just as well.
+    // Parity is an equality, so it needs both directions pinned.
+    const context = builderSalesContext({
+      course: { id: 'c1', slug: 'demo', title: 'Demo course' },
+      stages: [],
+      offer: null,
+    });
+
+    expect(await heroStillVia('canvas', heroWithPlate, context)).toBeNull();
+    expect(await heroStillVia('public', heroWithPlate, context)).toBeNull();
   });
 });

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/+page.svelte
@@ -39,6 +39,7 @@
   import {
     getCourseCurriculum,
     getJourneyForBuilder,
+    resolveSellPreview,
     saveJourneyPage,
     updateJourneyOffer,
   } from '$lib/remote/journeys.remote';
@@ -97,6 +98,31 @@
     slug: draftQuery?.current?.slug ?? '',
     title: draftQuery?.current?.title ?? '',
   });
+
+  // The course's resolved sell media — hero still + clip, intro and reel
+  // manifests, the guide's portrait. The canvas received NOTHING here
+  // (Codex-bvhcr), so its four media-bearing sections drew media-less fallbacks
+  // while the same page rendered the real media publicly.
+  //
+  // The SAME query the public sales load streams (`resolveSellPreview`, no auth
+  // by design — HARDENING §E), called as an ordinary client query because the
+  // studio runs `ssr = false`.
+  //
+  // Both ids must be real UUIDs before calling: the query's schema validates each
+  // as one, and a non-course journey has no `subjectId` to resolve — so the guard
+  // is a precondition, not defensiveness.
+  const sellPreviewQuery = $derived(
+    isCourse && pageId && course.id
+      ? resolveSellPreview({ pageId, courseId: course.id })
+      : null
+  );
+
+  // `.current` is `undefined` both in flight and AFTER A FAILURE — a rejected
+  // remote query puts its reason on `.error` and leaves this untouched
+  // (Codex-xo3bl) — so `?? null` reproduces exactly the `.catch(() => null)` the
+  // public load applies. A sell-media read that fails must cost the author their
+  // media preview, never their canvas.
+  const sellPreview = $derived(sellPreviewQuery?.current ?? null);
 
   // ── Workspace view state ──────────────────────────────────────────────────
   type BuilderMode = 'design' | 'look' | 'pricing' | 'media' | 'brand' | 'seo';
@@ -525,6 +551,7 @@
           {orgDomain}
           {stages}
           {course}
+          {sellPreview}
         />
       </section>
 

--- a/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/__tests__/builder-canvas-wiring.test.ts
+++ b/apps/web/src/routes/_org/[slug]/studio/journeys/[id]/page/__tests__/builder-canvas-wiring.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The route → canvas hop for the course's SELL MEDIA (`Codex-bvhcr`).
+ *
+ * WHY THIS EXISTS AS A SEPARATE GUARD. `canvas-public-parity.svelte.test.ts` pins
+ * that the canvas forwards a `sellPreview` into `builderSalesContext`, and that
+ * both mount paths paint the same hero still from one context. Neither witnesses
+ * the hop guarded here: a canvas that dutifully forwards `sellPreview` still shows
+ * nothing if the ROUTE hands it none, and that is precisely the state this bead
+ * found. The gap sat between a default and a value, in a prop the canvas already
+ * declared.
+ *
+ * WHY STRUCTURAL ASSERTIONS OVER A MOUNT. Same reasoning as
+ * `builder-top-bar.test.ts` beside it: this builder only mounts behind a loaded
+ * draft with `pageBuilder` populated, the studio subtree is `ssr = false` so the
+ * data arrives from client queries, and the thing that regresses is a prop
+ * omission in markup. Source text is where a prop omission is observable.
+ *
+ * WHY PER-PROP RATHER THAN "every declared prop must be passed". That stronger,
+ * obviously-better guard FAILS TODAY, and legitimately: `offer` is declared on the
+ * canvas and never passed either, so `InviteSection` draws a price-less CTA in the
+ * canvas while the live page prices itself (`Codex-4wun2`). Generalise this file
+ * the moment that bead lands — the general form is the one that would have caught
+ * both at once, and writing the specific form now is a deliberate stopgap rather
+ * than the intended end state.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTE = readFileSync(join(HERE, '..', '+page.svelte'), 'utf8');
+
+/**
+ * The `<JourneyBuilderCanvas … />` tag body, so a prop mentioned anywhere else in
+ * a 900-line route file cannot satisfy an assertion about what the canvas is
+ * handed. Deliberately not a regex over the whole file for that reason.
+ */
+function canvasTag(): string {
+  const open = ROUTE.indexOf('<JourneyBuilderCanvas');
+  if (open === -1)
+    throw new Error('route no longer mounts JourneyBuilderCanvas');
+  const close = ROUTE.indexOf('/>', open);
+  if (close === -1)
+    throw new Error('JourneyBuilderCanvas tag is not self-closing');
+  return ROUTE.slice(open, close);
+}
+
+describe('builder route → canvas: the sell media reaches the canvas', () => {
+  it('resolves the course sell preview through the shared public query', () => {
+    // The SAME query the public sales load streams. A studio-only re-implementation
+    // is the regression worth naming: it would resolve media by a second code path
+    // and the canvas could then differ from the page while both "worked".
+    expect(ROUTE).toContain('resolveSellPreview');
+  });
+
+  it('hands the resolved preview to the canvas', () => {
+    expect(
+      canvasTag(),
+      'the canvas is mounted without sellPreview — it is blind to the course media again (Codex-bvhcr)'
+    ).toContain('sellPreview');
+  });
+
+  it('gates the query on both ids being present', () => {
+    // `resolveSellPreview`'s schema validates `pageId` and `courseId` as UUIDs, and
+    // a non-course journey has no `subjectId` at all — so calling unguarded means a
+    // validation rejection on every page-builder load for a non-course journey.
+    // This is a precondition of the query, not defensiveness about it.
+    const call = ROUTE.slice(
+      ROUTE.indexOf('const sellPreviewQuery'),
+      ROUTE.indexOf('const sellPreview =')
+    );
+    expect(call, 'sellPreviewQuery not found before sellPreview').not.toBe('');
+    expect(call).toContain('isCourse');
+    expect(call).toContain('course.id');
+  });
+
+  it('degrades a FAILED preview read to no-media rather than to a broken canvas', () => {
+    // A rejected remote query leaves `.current` undefined and puts its reason on
+    // `.error` (Codex-xo3bl), so `?? null` is what reproduces the public load's
+    // `.catch(() => null)`. Without it the canvas would hand `undefined` down and
+    // the sections would read a missing context field instead of an absent preview.
+    expect(ROUTE).toContain('sellPreviewQuery?.current ?? null');
+  });
+});

--- a/docs/design/journey-sections/02-axis-contract.md
+++ b/docs/design/journey-sections/02-axis-contract.md
@@ -1602,3 +1602,73 @@ synthetic plate. Two traps on that path are already paid for elsewhere in this r
 rediscovered: the write path goes through `forwardMultipartUpload()`, because re-forwarding a `File`
 strips the filename in production; and it must be a `form()`/FormData path rather than a `command()`,
 because command arguments serialize through devalue, which has no representation for a `File`.
+
+## A76 — The canvas gets the course's real media, and the recession's live reach is measured (`Codex-bvhcr`)
+
+### The omission, and why nothing could see it
+
+`JourneyBuilderCanvas` assembles its render context with `builderSalesContext`, whose `sellPreview` is
+**optional and defaults to null**. The canvas never passed one. So `hero`, `introVideo`, `reel` and
+`guide` — the four types that read `context.sellPreview`; `feel` only *mentions* it in comments, its
+taste player being synthetic until `Codex-scab9` — each drew their media-less fallback in the canvas
+while the same stored page rendered the real media publicly.
+
+The defect was invisible for a structural reason worth naming: **the disagreement sat between a default
+and a value, not between two visible behaviours.** "No media" is also the correct output for a course
+that has picked none, so nothing about the canvas alone looked wrong, and no assertion over the canvas
+alone could witness it. Only the comparison with the public page is evidence. A75 sharpened the cost —
+it added a `media` mode control whose entire effect was hidden on the surface where you author it.
+
+The seam already existed and the query already existed. `resolveSellPreview` is the same public,
+auth-free query the public sales load streams; the fix is to call it and pass the result down. Nothing
+new was built.
+
+### Two hops, two guards
+
+A prop can be dropped at either end, so both ends are pinned, in the file that owns each:
+
+| hop | guard | file |
+|---|---|---|
+| canvas → `builderSalesContext` | the call site must mention `sellPreview` | `canvas-public-parity.svelte.test.ts` |
+| route → canvas | the `<JourneyBuilderCanvas>` tag must pass it, gated on both UUIDs, degrading to null | `page/__tests__/builder-canvas-wiring.test.ts` |
+
+Both are SOURCE-level by necessity, not by preference: the builder mounts only behind a loaded draft in
+an `ssr = false` subtree, and a prop omission is observable in markup rather than in a rendered tree.
+Each was negative-controlled — removing the line it guards makes that test, and only that test, fail.
+
+The route guard is deliberately **per-prop** rather than "every declared prop must be passed", because
+the stronger form fails today and legitimately: `offer` is declared on the canvas and never passed
+either, so `InviteSection` draws a price-less CTA in the canvas while the live page prices itself
+(`Codex-4wun2`). Generalise the guard when that lands — the general form is what would have caught both
+at once.
+
+### The recession's live reach: ZERO pages, and the arithmetic behind that
+
+A75's "the atmosphere recedes when real media is painted" was carried forward as *"the seven live pages
+showing a still now render a dimmer ember"*. **It does not reach them, and the number is a
+three-condition chain collapsed into one.** Measured against the dev database:
+
+1. **7** pages carry a `hero_media_id` — this is the real source of "seven";
+2. **5 of those 7 have no `hero` section at all** — they are section-less rows (A25), so no hero
+   component runs;
+3. the **2** that do (`bone-deep`, `pricing-smoke-test`) both store `variant: stage`, and `stage` is
+   **not plate-led** (`plateLed` = `split-media | full-bleed | poster`), so `showPlate` is false and
+   `mediaPresent` cannot become true.
+
+Reaching `resolveMediaMode`'s fallback branch is not the same as resolving to `image`, and resolving to
+`image` is not the same as painting a plate. **DECISION (owner, 2026-08-25): the recession stays keyed
+on `image` OR `loop`.** The rationale is that real media carries the mood and a still photograph is
+real media; narrowing it to `loop` would leave a still competing with the ember, which is the problem
+the recession exists to solve. Recorded here because the misreading invited a "fix" to live behaviour
+that no live page exhibits.
+
+### Verified end to end
+
+On `pricing-smoke-test`, canvas and public page now emit **byte-identical** media across all four
+types: `introVideo` → "Play the 717-second intro film" (the 717 is `intro.durationSeconds`, so the
+label itself proves the preview arrived), `reel` → "Play the practice preview", `guide` → "Play the
+guide clip" plus the same portrait URL, `hero` → nothing on either, correctly, because its stored
+composition is `stage`. Controlled by removing the forwarding line and watching a full 20 s: the
+affordances never appear, while the canvas keeps rendering all 11 sections and their real copy. A 4 s
+window was NOT sufficient to tell "never arrives" from "not yet" — the first attempt at this control
+was invalid for exactly that reason.


### PR DESCRIPTION
## What was wrong

`JourneyBuilderCanvas` built its render context with `builderSalesContext` and never passed `sellPreview`. That argument is **optional and defaults to null**, so the omission type-checked, mounted and rendered — and the four section types that read `context.sellPreview` (`hero`, `introVideo`, `reel`, `guide`) each drew their media-less fallback while the same stored page rendered the real media publicly.

The disagreement sat between a **default and a value**, which is why nothing caught it. "No media" is also the correct output for a course that has picked none, so the canvas alone never looked wrong — only the comparison with the public page is evidence. #450 sharpened the cost by adding a media-mode control whose entire effect was hidden on the surface where you author it.

## The fix

Nothing new was built. `resolveSellPreview` is the same public, auth-free query the public sales load already streams; the route now calls it and hands the result down.

- Gated on both ids being real UUIDs — the query's schema validates each as one, and a non-course journey has no subject course.
- Degrades to null on failure: `.current` is `undefined` both in flight and after a rejection (the reason lands on `.error`, Codex-xo3bl), so this reproduces the public load's `.catch(() => null)`. A failed preview read costs the author their media preview, never their canvas.

## Guards

A prop can be dropped at either end, so both hops are pinned in the file that owns each:

| hop | guard |
|---|---|
| canvas → `builderSalesContext` | `canvas-public-parity.svelte.test.ts` |
| route → canvas | new `page/__tests__/builder-canvas-wiring.test.ts` |

Both are source-level **by necessity** — the builder mounts only behind a loaded draft in an `ssr = false` subtree, so a prop omission is observable in markup, not in a rendered tree. Each was negative-controlled: removing the line it guards fails that test and only that test.

The route guard is deliberately per-prop rather than "every declared prop must be passed", because the stronger form fails today — `offer` is declared on the canvas and never passed either, so `InviteSection` draws a price-less CTA in the canvas while the live page prices itself. Filed as **Codex-4wun2**; generalise the guard when it lands.

## A correction recorded in the contract (A76)

A75's atmosphere recession was being carried forward as *"the seven live pages showing a still now render a dimmer ember"*. **It reaches none of them.** Measured against the dev database:

1. **7** pages carry a `hero_media_id` — the real source of "seven";
2. **5 of those 7 have no `hero` section at all** (section-less rows, A25);
3. the **2** that do both store `variant: stage`, which is **not plate-led** (`plateLed` = `split-media | full-bleed | poster`), so `showPlate` is false and `mediaPresent` cannot become true.

Reaching `resolveMediaMode`'s fallback branch is not resolving to `image`, and resolving to `image` is not painting a plate. The recession **stays keyed on `image` OR `loop`** (owner's decision): real media carries the mood and a still photograph is real media, so narrowing it to `loop` would leave a still competing with the ember — the problem the recession exists to solve.

## Verification

Browser-verified on `pricing-smoke-test`. Canvas and public page now emit **byte-identical** media across all four types:

| section | both surfaces |
|---|---|
| `introVideo` | "Play the 717-second intro film" — the 717 is `intro.durationSeconds`, so the label itself proves the preview arrived |
| `reel` | "Play the practice preview" |
| `guide` | "Play the guide clip" + the same portrait URL |
| `hero` | nothing on either — correctly, its stored composition is `stage` |

Controlled by removing the forwarding line and watching a full **20 s**: the affordances never appear while the canvas keeps rendering all 11 sections and their real copy. A first attempt with a 4 s window was invalid — it could not tell "never arrives" from "not yet".

## Gate

| gate | result |
|---|---|
| `pnpm check:ci` | **0 errors**, 179 warnings, 1442 files (baseline 1441 + the new test file) |
| both `check:brand-boundary` | exit 0 · 11 pass / 0 fail |
| `pnpm typecheck --force` | exit 0 · 57/57 · **0 cached** |
| `pnpm --filter web test` | exit 0 · 178 files / 2226 tests (baseline 177 / 2219) |
| `svelte-check` | 63 errors / 37 warnings in 38 files — identical to baseline, **0 in the changed files** |

Closes Codex-bvhcr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)