### PR TITLE
fix(ecom-api): complete the subscription-webhook module mocks (Codex-4y8pt)

### DIFF
--- a/workers/ecom-api/src/handlers/__tests__/subscription-webhook-invalidation.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/subscription-webhook-invalidation.test.ts
@@ -59,10 +59,48 @@ vi.mock('@codex/subscription', () => ({
   // `invalidateForUser` is a named export from `@codex/subscription` that
   // both webhook handlers import. We spy on it to assert the contract.
   invalidateForUser: vi.fn(),
+  // Codex-4y8pt: the handler constructs CourseSubscriptionService for EVERY
+  // subscription event (course subs are mode=subscription on this same webhook,
+  // discriminated later by `type: 'course_subscription'` metadata). A vi.mock
+  // factory is a CLOSED namespace, so omitting this export made vitest throw on
+  // the ACCESS at subscription-webhook.ts:277 — before any test assertion ran.
+  // Stubbed rather than left bare so a future course-sub test gets a mock method
+  // instead of a TypeError; no test here routes through that branch.
+  // The handler ALSO calls the STATIC `isCourseSubscription` to discriminate
+  // (three sites), so the mock needs both halves: a constructor for the
+  // instance and the static on the mock function itself.
+  CourseSubscriptionService: Object.assign(
+    vi.fn().mockImplementation(() => ({
+      handleCourseSubscriptionCreated: vi.fn().mockResolvedValue(undefined),
+      handleCourseSubscriptionUpdated: vi.fn().mockResolvedValue(undefined),
+      handleCourseSubscriptionDeleted: vi.fn().mockResolvedValue(undefined),
+      handleCourseInvoicePaymentSucceeded: vi.fn().mockResolvedValue(undefined),
+    })),
+    {
+      // MIRRORS the real predicate rather than hardcoding `false`
+      // (course-subscription-service.ts:677 — metadata.type ===
+      // COURSE_SUBSCRIPTION_METADATA_TYPE). A constant `false` would pass today,
+      // because every fixture here is an ORG subscription, and would then
+      // silently mis-route the first test that does add course metadata. The
+      // literal is inlined because a vi.mock factory is hoisted above imports
+      // and so cannot reference the exported constant.
+      isCourseSubscription: vi.fn(
+        (sub: { metadata?: Record<string, string> | null }) =>
+          (sub?.metadata?.type ?? null) === 'course_subscription'
+      ),
+    }
+  ),
 }));
 
 vi.mock('@codex/purchase', () => ({
   PurchaseService: vi.fn(),
+  // Codex-4y8pt (second half): CourseSubscriptionService is constructed with
+  // `feeConfig: new FeeConfigService(...)`. JS evaluates a `new` expression's
+  // CALLEE before its ARGUMENTS, so the CourseSubscriptionService access threw
+  // first and hid this identical gap entirely — the CI log named one missing
+  // export while the code was missing two. Only constructed and passed through,
+  // so a bare mock constructor is sufficient.
+  FeeConfigService: vi.fn(),
 }));
 
 // `createWebhookDbClient` must remain a real export — it forwards to the

--- a/workers/ecom-api/src/handlers/__tests__/subscription-webhook-revocation.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/subscription-webhook-revocation.test.ts
@@ -51,10 +51,48 @@ vi.mock('@codex/subscription', () => ({
   // invalidateForUser is exercised in the sibling invalidation test; here we
   // only care that it doesn't throw synchronously in revocation scenarios.
   invalidateForUser: vi.fn(),
+  // Codex-4y8pt: the handler constructs CourseSubscriptionService for EVERY
+  // subscription event (course subs are mode=subscription on this same webhook,
+  // discriminated later by `type: 'course_subscription'` metadata). A vi.mock
+  // factory is a CLOSED namespace, so omitting this export made vitest throw on
+  // the ACCESS at subscription-webhook.ts:277 — before any test assertion ran.
+  // Stubbed rather than left bare so a future course-sub test gets a mock method
+  // instead of a TypeError; no test here routes through that branch.
+  // The handler ALSO calls the STATIC `isCourseSubscription` to discriminate
+  // (three sites), so the mock needs both halves: a constructor for the
+  // instance and the static on the mock function itself.
+  CourseSubscriptionService: Object.assign(
+    vi.fn().mockImplementation(() => ({
+      handleCourseSubscriptionCreated: vi.fn().mockResolvedValue(undefined),
+      handleCourseSubscriptionUpdated: vi.fn().mockResolvedValue(undefined),
+      handleCourseSubscriptionDeleted: vi.fn().mockResolvedValue(undefined),
+      handleCourseInvoicePaymentSucceeded: vi.fn().mockResolvedValue(undefined),
+    })),
+    {
+      // MIRRORS the real predicate rather than hardcoding `false`
+      // (course-subscription-service.ts:677 — metadata.type ===
+      // COURSE_SUBSCRIPTION_METADATA_TYPE). A constant `false` would pass today,
+      // because every fixture here is an ORG subscription, and would then
+      // silently mis-route the first test that does add course metadata. The
+      // literal is inlined because a vi.mock factory is hoisted above imports
+      // and so cannot reference the exported constant.
+      isCourseSubscription: vi.fn(
+        (sub: { metadata?: Record<string, string> | null }) =>
+          (sub?.metadata?.type ?? null) === 'course_subscription'
+      ),
+    }
+  ),
 }));
 
 vi.mock('@codex/purchase', () => ({
   PurchaseService: vi.fn(),
+  // Codex-4y8pt (second half): CourseSubscriptionService is constructed with
+  // `feeConfig: new FeeConfigService(...)`. JS evaluates a `new` expression's
+  // CALLEE before its ARGUMENTS, so the CourseSubscriptionService access threw
+  // first and hid this identical gap entirely — the CI log named one missing
+  // export while the code was missing two. Only constructed and passed through,
+  // so a bare mock constructor is sufficient.
+  FeeConfigService: vi.fn(),
 }));
 
 // `createWebhookDbClient` must remain a real export — it forwards to the

--- a/workers/ecom-api/src/handlers/__tests__/subscription-webhook.test.ts
+++ b/workers/ecom-api/src/handlers/__tests__/subscription-webhook.test.ts
@@ -40,6 +40,37 @@ vi.mock('@codex/subscription', () => ({
   // mock is complete. Cache-invalidation contract is tested separately in
   // `subscription-webhook-invalidation.test.ts`.
   invalidateForUser: vi.fn(),
+  // Codex-4y8pt: the handler constructs CourseSubscriptionService for EVERY
+  // subscription event (course subs are mode=subscription on this same webhook,
+  // discriminated later by `type: 'course_subscription'` metadata). A vi.mock
+  // factory is a CLOSED namespace, so omitting this export made vitest throw on
+  // the ACCESS at subscription-webhook.ts:277 — before any test assertion ran.
+  // Stubbed rather than left bare so a future course-sub test gets a mock method
+  // instead of a TypeError; no test here routes through that branch.
+  // The handler ALSO calls the STATIC `isCourseSubscription` to discriminate
+  // (three sites), so the mock needs both halves: a constructor for the
+  // instance and the static on the mock function itself.
+  CourseSubscriptionService: Object.assign(
+    vi.fn().mockImplementation(() => ({
+      handleCourseSubscriptionCreated: vi.fn().mockResolvedValue(undefined),
+      handleCourseSubscriptionUpdated: vi.fn().mockResolvedValue(undefined),
+      handleCourseSubscriptionDeleted: vi.fn().mockResolvedValue(undefined),
+      handleCourseInvoicePaymentSucceeded: vi.fn().mockResolvedValue(undefined),
+    })),
+    {
+      // MIRRORS the real predicate rather than hardcoding `false`
+      // (course-subscription-service.ts:677 — metadata.type ===
+      // COURSE_SUBSCRIPTION_METADATA_TYPE). A constant `false` would pass today,
+      // because every fixture here is an ORG subscription, and would then
+      // silently mis-route the first test that does add course metadata. The
+      // literal is inlined because a vi.mock factory is hoisted above imports
+      // and so cannot reference the exported constant.
+      isCourseSubscription: vi.fn(
+        (sub: { metadata?: Record<string, string> | null }) =>
+          (sub?.metadata?.type ?? null) === 'course_subscription'
+      ),
+    }
+  ),
 }));
 
 // The subscription-webhook handler dispatches emails via `sendEmailToWorker`


### PR DESCRIPTION
Fixes the `Ecom API Tests` failure that went red on **#452 (`dev` → `main`)**. Pre-existing since `89df7913` (2026-07-29), tracked as **Codex-4y8pt** (P1).

## The failure

80 of 91 tests across the three subscription-webhook test files, all with one error:

```
No "CourseSubscriptionService" export is defined on the "@codex/subscription" mock.
Did you forget to return it from "vi.mock"?
```

A `vi.mock` factory produces a **closed** module namespace — vitest throws on *access* to any export the factory didn't return. Adding `CourseSubscriptionService` to the handler therefore broke every test that hand-mocked that module, without either the test or the mock being edited.

## Three gaps — CI's log named only one

| # | gap | visible in CI? |
|---|---|---|
| 1 | `@codex/subscription` missing `CourseSubscriptionService`, all 3 files | yes — this is the reported error |
| 2 | `@codex/purchase` missing `FeeConfigService`, 2 files | **no** |
| 3 | `CourseSubscriptionService.isCourseSubscription` is a **static** used at 3 dispatch sites | **no** |

**Why #2 was invisible.** JS evaluates a `new` expression's *callee* before its *arguments*. `new CourseSubscriptionService({ ..., feeConfig: new FeeConfigService(...) })` throws on the callee and never reaches the argument — so fixing only what the log named would have burned a CI cycle rediscovering it. I enumerated every value-import of the SUT against each factory instead of fixing the reported symptom.

**Why #3 was invisible.** It only appears *after* #1 is fixed, as `TypeError: CourseSubscriptionService.isCourseSubscription is not a function`. A constructor mock alone isn't enough; the static goes on the mock function via `Object.assign`.

## One deliberate choice

The static **mirrors the real predicate** (`metadata.type === 'course_subscription'`) rather than returning a constant `false`. Constant-false passes today — every fixture in these files is an org subscription — and would then silently mis-route the first test that *does* attach course metadata. The literal is inlined because a `vi.mock` factory is hoisted above imports and cannot reference the exported constant.

Instance methods are stubbed rather than left bare so a future course-sub test gets a mock method instead of a `TypeError`. No test here routes through that branch today.

## Verification

| gate | result |
|---|---|
| the 3 files | **91 passed / 91** (was 11 passed / 80 failed) |
| full `ecom-api` suite | **exit 0 · 389 passed / 7 skipped** — reconciles exactly with the bead's 80 + 309 |
| `pnpm check:ci` | 0 errors, 179 warnings, 1442 files |
| `pnpm typecheck --force` | exit 0 · 57/57 · **0 cached** |

Re-verified on the committed tip after the pre-commit hook's `biome --write`.

## Why this sat for a month

The worker-test jobs gate their test step **inside** the job on a paths-filter. On PR #451 (`apps/web` only) every step after `Check if worker should run` was `skipped`, so `Ecom API Tests` reported **success having run nothing**:

```
JOB: Ecom API Tests -> success
    success   Check if worker should run
    skipped   Run ecom-api tests        ← never executed
    skipped   Fail if tests failed
```

That's correct behaviour for an unrelated change, but it means a green `Ecom API Tests` is not evidence of coverage — it only surfaced once a worker path was touched. Worth a separate look; not changed here.

## Note on `main`

This targets `dev` per convention. `main` stays red until the next `dev` → `main` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)