### PR TITLE
fix(infra): close public worker exposure — workers_dev:false + delete 17 orphaned workers

### DIFF
--- a/.github/workflows/bootstrap-dev-infra.yml
+++ b/.github/workflows/bootstrap-dev-infra.yml
@@ -4,9 +4,20 @@ name: Bootstrap Dev Infrastructure
 # R2 buckets for the dev environment. Re-running is safe — every step
 # checks for the resource and skips if it already exists.
 #
-# Custom domain bindings for each worker are handled automatically by
-# `wrangler deploy --env dev` (via `custom_domain: true` in each
-# workers/*/wrangler.jsonc), so they're not in this workflow.
+# STALE AS OF 2026-08-26 — READ BEFORE RUNNING (Codex-kgrdp.12).
+# This workflow describes a DEPLOYED dev environment that no longer exists.
+# It used to say custom domain bindings were handled by
+# `wrangler deploy --env dev` via `custom_domain: true` in each
+# workers/*/wrangler.jsonc. Neither is true any more:
+#   - no worker config declares a `dev` env (only `test` and `production`);
+#     `apps/web` is the sole exception and routes dev.revelations.studio/*
+#   - no workflow anywhere runs `wrangler deploy --env dev`
+#   - the 8 orphaned *-dev API workers left behind by that removal were
+#     deleted on 2026-08-26 after a credential scanner hit auth-worker-dev
+#     ~6,275 times in 24 minutes, burning account-wide KV write quota
+# So running this provisions DNS + R2 for an environment with no API workers
+# to serve it. Dev is local-only (`pnpm dev`). Retiring the remaining
+# codex-web-dev worker and dev.revelations.studio DNS is tracked separately.
 #
 # Trigger: manual via `gh workflow run "Bootstrap Dev Infrastructure"`
 #          or the GitHub Actions UI → "Run workflow" button.

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "codex-web",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": ".svelte-kit/cloudflare/_worker.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/admin-api/wrangler.jsonc
+++ b/workers/admin-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "admin-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/auth/wrangler.jsonc
+++ b/workers/auth/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "auth-worker",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/content-api/wrangler.jsonc
+++ b/workers/content-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "content-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/dev-cdn/wrangler.jsonc
+++ b/workers/dev-cdn/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "dev-cdn",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "src/index.ts",
   "compatibility_date": "2025-01-01",
 

--- a/workers/ecom-api/wrangler.jsonc
+++ b/workers/ecom-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "ecom-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/identity-api/wrangler.jsonc
+++ b/workers/identity-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "identity-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/media-api/wrangler.jsonc
+++ b/workers/media-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "media-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/notifications-api/wrangler.jsonc
+++ b/workers/notifications-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "notifications-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/workers/organization-api/wrangler.jsonc
+++ b/workers/organization-api/wrangler.jsonc
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "organization-api",
+  // Public exposure: OFF by default (Codex-kgrdp.12).
+  // With this unset, Cloudflare defaults BOTH the workers.dev route and the
+  // preview URL to ENABLED for any deploy that has no `routes` — which is how
+  // 8 orphaned *-dev workers ended up answering the public internet and
+  // absorbing a credential scanner (~6,275 requests in 24 minutes on
+  // auth-worker-dev, 2026-08-26). KV quota is billed per ACCOUNT, so that
+  // traffic burned production's daily write allowance.
+  // Envs that declare `routes` already infer false; being explicit here means
+  // a future env that forgets its routes fails closed instead of open.
+  // MUST live in config: disabling it only in the dashboard is silently
+  // re-enabled by the next `wrangler deploy`.
+  "workers_dev": false,
   "main": "dist/index.js",
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],


### PR DESCRIPTION
Closes the exposure half of **Codex-kgrdp.12**. Config-only — no application code, no runtime behaviour change to any live route.

## Why

A credential scanner hit `auth-worker-dev` with **~6,275 requests in a single ~24-minute window** on 2026-08-26, walking a wordlist (`/mail/.env.production`, `/api/aws.env`, `/.vault-token`, `/email/sendgrid/.env`, `/test/phpinfo.php`).

That worker had **no config in this repo** — only `apps/web` declares a `dev` environment; the other 8 lost theirs while the deployments survived. With no `routes`, Cloudflare defaults **both** the `workers.dev` route and the preview URL to *enabled*, so they were answering the public internet unmonitored.

This is not just noise. **KV quota is billed per account, not per namespace**, and the auth rate limiter does an unconditional `kv.put` per request — so traffic to a dev worker consumed *production's* daily KV write allowance (1,000/day on the free plan). Once exhausted, every KV write fails (session cache, content cache, rate limiting) and each of those paths swallows its error, so the platform degrades silently.

## What changed

**1. `workers_dev: false` in all 10 wrangler configs.** Makes a future env that forgets its `routes` fail *closed*. Envs that declare `routes` already infer `false`, so this changes no current routing. Per Cloudflare's docs this **must** live in config — disabling `workers.dev` only in the dashboard is silently re-enabled by the next `wrangler deploy`.

**2. Deleted 17 orphaned workers** (account 27 → 10): 8 API `*-dev` and all 9 `*-preview-94` (untouched since 2026-02-02).

Because those had no repo config they could never be redeployed *or reconfigured* from the repo — including to turn exposure off — so change 1 was inert against them. Deletion was the only in-repo remedy. That asymmetry is why they survived unnoticed.

**3. Corrected `bootstrap-dev-infra.yml`**, whose header documented a `--env dev` deploy and per-worker `custom_domain: true` entries that no longer exist. Running it would provision DNS + R2 for an environment with no API workers to serve it.

## Verification

Pre-deletion: no workflow runs `wrangler deploy --env dev`; no code or config references a `*-dev` hostname; ran behind an explicit 17-name allowlist with a guard rejecting anything containing `production`/`staging`/`codex-web-dev`; dry-run first.

Post-deletion:
- all 9 `*-production` workers present with **unchanged** deploy timestamps
- `codex-web-dev` retained (it legitimately routes `dev.revelations.studio/*`)
- smoke: `revelations.studio/` 200 · org subdomain 200 · `auth.../health` 200 · `media-api.../health` 200
- `wrangler deploy --dry-run --env production` for auth + organization-api resolves identical bindings and routes

On this rebased base: all 10 configs parse, `workers_dev=false` on each, workflow YAML valid with all 4 steps intact.

## Not fixed here

The **amplifier** remains. This removed the largest traffic source, not the mechanism — production is still probed continuously (`/82.php`, `POST /wordpress/`, `/wp-includes/*`) and each probe still costs a KV write. `Codex-kgrdp.3` (move the rate-limit counter off KV) is the actual fix and is still P0. `Codex-kgrdp.14` adds WAF edge rules, now deployed and verified separately.

Follow-up: `Codex-kgrdp.13` retires `codex-web-dev` + `dev.revelations.studio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)